### PR TITLE
Add `userId` to Metadata

### DIFF
--- a/pkgs/packages/api/src/models/biometrics.ts
+++ b/pkgs/packages/api/src/models/biometrics.ts
@@ -2,7 +2,6 @@ import { BloodGlucose } from "./common/blood-glucose";
 import { BloodPressure } from "./common/blood-pressure";
 import { HeartRate } from "./common/heart-rate";
 import { HeartRateVariability } from "./common/heart-rate-variability";
-import { Metadata } from "./common/metadata";
 import { Respiration } from "./common/respiration";
 import { Temperature } from "./common/temperature";
 import { MetriportData } from "./metriport-data";

--- a/pkgs/packages/api/src/models/body.ts
+++ b/pkgs/packages/api/src/models/body.ts
@@ -1,4 +1,3 @@
-import {Metadata} from "./common/metadata";
 import { MetriportData } from "./metriport-data";
 
 export interface Body extends MetriportData {

--- a/pkgs/packages/api/src/models/common/metadata.ts
+++ b/pkgs/packages/api/src/models/common/metadata.ts
@@ -2,6 +2,7 @@ import { ProviderSource } from "./provider-source";
 
 export interface Metadata {
   date: string;
+  userId: string;
   source: ProviderSource;
   error?: string;
 }

--- a/pkgs/packages/api/src/models/user.ts
+++ b/pkgs/packages/api/src/models/user.ts
@@ -1,5 +1,4 @@
 import { Sex } from "./common/sex";
-import { Metadata } from "./common/metadata";
 import { MetriportData } from "./metriport-data";
 
 export interface User extends MetriportData {


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/43

Add `userId` to Metadata, so the webhook payload can identify which user the data refers to.

This only changes the data package.

### Release plan
- [ ] Release this to NPN (minor version)
- [ ] Merge `master` back into `develop`
- [ ] Update the next feature branch of #43 to refer to the new data package version from NPM
  - Heads up: this will break existing mappings and require change on how we convert data into the shared data package