### PR TITLE
Removes old attribute from SettingsDTO

### DIFF
--- a/api/app/src/routes/settings.ts
+++ b/api/app/src/routes/settings.ts
@@ -16,8 +16,7 @@ class SettingsDTO {
     public webhookUrl: string | null,
     public webhookKey: string | null,
     public webhookEnabled: boolean,
-    public webhookStatusDetail: string | null,
-    public webhookStatus: string | null // temporary, for compatibility while deployment
+    public webhookStatusDetail: string | null
   ) {}
 
   static fromEntity(s: Settings): SettingsDTO {
@@ -26,8 +25,7 @@ class SettingsDTO {
       s.webhookUrl,
       s.webhookKey,
       s.webhookEnabled,
-      s.webhookStatusDetail ?? null,
-      s.webhookStatusDetail ?? null // temporary, for compatibility while deployment
+      s.webhookStatusDetail ?? null
     );
   }
 }


### PR DESCRIPTION
Ticket: #43

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/148
- Downstream: https://github.com/metriport/metriport/pull/10

### Description

Removes SettingsDTO unused attribute, was left there for backwards compatibility during the release of the upstream dependency.

### Release Plan

- [ ] Release upstream dependency
- [ ] Release this