### PR TITLE
Make garmin schemas optional/null, not types

### DIFF
--- a/api/app/src/default-error-handler.ts
+++ b/api/app/src/default-error-handler.ts
@@ -27,7 +27,7 @@ const zodResponseBody = (err: ZodError): string => {
   return JSON.stringify({
     status: status.BAD_REQUEST,
     name: status[status.BAD_REQUEST],
-    title: 'Missing or invalid parameters',
+    title: "Missing or invalid parameters",
     details: err.issues,
   });
 };
@@ -45,6 +45,17 @@ export const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
       .status(status.BAD_REQUEST)
       .send(zodResponseBody(err));
   }
+  if (err.statusCode) {
+    return res
+      .contentType("json")
+      .status(err.statusCode)
+      .send(
+        defaultResponseBody({
+          status: err.statusCode,
+          title: err.message,
+        })
+      );
+  }
   console.log(`Error: `, err);
   return res
     .contentType("json")
@@ -52,7 +63,8 @@ export const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
     .send(
       defaultResponseBody({
         status: status.INTERNAL_SERVER_ERROR,
-        title: 'Internal server error, please try again or reach out to help@metriport.ai',
+        title:
+          "Internal server error, please try again or reach out to help@metriport.ai",
       })
     );
 };

--- a/api/app/src/mappings/garmin/body-composition.ts
+++ b/api/app/src/mappings/garmin/body-composition.ts
@@ -52,12 +52,12 @@ export const garminBodyCompositionToBody = (
 export const garminBodyCompositionSchema = z.object({
   measurementTimeInSeconds: garminTypes.startTime,
   // measurementTimeOffsetInSeconds: -21600,  // always return UTC
-  muscleMassInGrams: garminTypes.muscleMass.optional().nullable(),
-  boneMassInGrams: garminTypes.boneMass.optional().nullable(),
-  // bodyWaterInPercent: t.bodyWaterInPercent.optional().nullable(), // we don't store this
-  bodyFatInPercent: garminTypes.bodyFatInPercent.optional().nullable(),
-  // bodyMassIndex: t.bodyMassIndex.optional().nullable(), // we don't store this
-  weightInGrams: garminTypes.weight.optional().nullable(),
+  muscleMassInGrams: garminTypes.muscleMass.nullable().optional(),
+  boneMassInGrams: garminTypes.boneMass.nullable().optional(),
+  // bodyWaterInPercent: t.bodyWaterInPercent.nullable().optional(), // we don't store this
+  bodyFatInPercent: garminTypes.bodyFatInPercent.nullable().optional(),
+  // bodyMassIndex: t.bodyMassIndex.nullable().optional(), // we don't store this
+  weightInGrams: garminTypes.weight.nullable().optional(),
 });
 export type GarminBodyComposition = z.infer<typeof garminBodyCompositionSchema>;
 

--- a/api/app/src/mappings/garmin/index.ts
+++ b/api/app/src/mappings/garmin/index.ts
@@ -1,5 +1,10 @@
 import { MetriportData } from "@metriport/api/lib/models/metriport-data";
+import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
 import { z } from "zod";
+import { ISO_DATE } from "../../shared/date";
+
+dayjs.extend(customParseFormat);
 
 export const garminMetaSchema = z.object({
   userAccessToken: z.string(),
@@ -23,13 +28,13 @@ export interface UserData<T extends MetriportData> {
 }
 
 export const garminUnits = {
-  date: z.string(), // or regex('yyyy-mm-dd')
+  date: z.string().refine((v) => dayjs(v, ISO_DATE, true).isValid()),
   time: z.number().int(),
   timeKey: z.string().transform((v) => Number(v)),
   sleep: z.number(),
   kilocalories: z.number(),
   duration: z.number().int(),
-  distance: z.number().int(),
+  distance: z.number(),
   intensityDuration: z.number().int(),
   floorsClimbed: z.number().int(),
   heartRate: z.number().int(),
@@ -55,11 +60,10 @@ export const garminUnits = {
   weightInGrams: z.number().int(),
 };
 
-export const timeRange = z
-  .object({
-    startTimeInSeconds: garminUnits.time,
-    endTimeInSeconds: garminUnits.time,
-  });
+export const timeRange = z.object({
+  startTimeInSeconds: garminUnits.time,
+  endTimeInSeconds: garminUnits.time,
+});
 
 export const sleepLevelsSchema = z.object({
   deep: z.array(timeRange),

--- a/api/app/src/mappings/garmin/index.ts
+++ b/api/app/src/mappings/garmin/index.ts
@@ -23,18 +23,18 @@ export interface UserData<T extends MetriportData> {
 }
 
 export const garminUnits = {
-  date: z.string().optional().nullable(), // or regex('yyyy-mm-dd')
+  date: z.string(), // or regex('yyyy-mm-dd')
   time: z.number().int(),
   timeKey: z.string().transform((v) => Number(v)),
-  sleep: z.number().nullable().optional(),
-  kilocalories: z.number().nullable().optional(),
-  duration: z.number().int().nullable().optional(),
-  distance: z.number().int().nullable().optional(),
-  intensityDuration: z.number().int().nullable().optional(),
-  floorsClimbed: z.number().int().nullable().optional(),
-  heartRate: z.number().int().nullable().optional(),
-  steps: z.number().int().nullable().optional(),
-  stressLevel: z.number().int().nullable().optional(),
+  sleep: z.number(),
+  kilocalories: z.number(),
+  duration: z.number().int(),
+  distance: z.number().int(),
+  intensityDuration: z.number().int(),
+  floorsClimbed: z.number().int(),
+  heartRate: z.number().int(),
+  steps: z.number().int(),
+  stressLevel: z.number().int(),
   stressQualifier: z.enum([
     "unknown",
     "calm",
@@ -59,9 +59,7 @@ export const timeRange = z
   .object({
     startTimeInSeconds: garminUnits.time,
     endTimeInSeconds: garminUnits.time,
-  })
-  .nullable()
-  .optional();
+  });
 
 export const sleepLevelsSchema = z.object({
   deep: z.array(timeRange),
@@ -86,29 +84,23 @@ export const garminTypes = {
   lightSleepDuration: garminUnits.sleep,
   remSleep: garminUnits.sleep,
   awakeDuration: garminUnits.sleep,
-  sleepLevels: sleepLevelsSchema.nullable().optional(),
-  sleepValidation: z
-    .enum([
-      "MANUAL",
-      "DEVICE",
-      "OFF_WRIST",
-      "AUTO_TENTATIVE",
-      "AUTO_FINAL",
-      "AUTO_MANUAL",
-      "ENHANCED_TENTATIVE",
-      "ENHANCED_FINAL",
-    ])
-    .nullable()
-    .optional(),
-  timeOffsetSleepRespiration: respirationMeasurements.nullable().optional(),
-  timeOffsetSleepSpo2: spo2Measurements.nullable().optional(),
-  overallSleepScore: z
-    .object({
-      value: z.number(),
-      qualifierKey: z.string(),
-    })
-    .nullable()
-    .optional(),
+  sleepLevels: sleepLevelsSchema,
+  sleepValidation: z.enum([
+    "MANUAL",
+    "DEVICE",
+    "OFF_WRIST",
+    "AUTO_TENTATIVE",
+    "AUTO_FINAL",
+    "AUTO_MANUAL",
+    "ENHANCED_TENTATIVE",
+    "ENHANCED_FINAL",
+  ]),
+  timeOffsetSleepRespiration: respirationMeasurements,
+  timeOffsetSleepSpo2: spo2Measurements,
+  overallSleepScore: z.object({
+    value: z.number(),
+    qualifierKey: z.string(),
+  }),
   //
   activeKilocalories: garminUnits.kilocalories,
   bmrKilocalories: garminUnits.kilocalories,

--- a/api/app/src/mappings/garmin/sleep.ts
+++ b/api/app/src/mappings/garmin/sleep.ts
@@ -7,7 +7,7 @@ import { groupBy } from "lodash";
 import { z } from "zod";
 import { garminMetaSchema, garminTypes, User, UserData } from ".";
 import { PROVIDER_GARMIN } from "../../shared/constants";
-import { toISODate, toISODateTime } from "../../shared/date";
+import { toISODateTime } from "../../shared/date";
 
 export const mapToSleep = (sleepList: GarminSleepList): UserData<Sleep>[] => {
   const type = "sleep";
@@ -27,7 +27,7 @@ export const mapToSleep = (sleepList: GarminSleepList): UserData<Sleep>[] => {
 export const garminSleepToSleep = (gSleep: GarminSleep): Sleep => {
   const res: Sleep = {
     metadata: {
-      date: toISODate(gSleep.startTimeInSeconds),
+      date: gSleep.calendarDate,
       source: PROVIDER_GARMIN,
     },
   };
@@ -106,7 +106,7 @@ export const toBiometrics = (
 };
 
 export const garminSleepSchema = z.object({
-  // calendarDate: t.date, // getting this from 'startTimeInSeconds'
+  calendarDate: garminTypes.date,
   startTimeInSeconds: garminTypes.startTime,
   // startTimeOffsetInSeconds: -21600, // always return UTC
   durationInSeconds: garminTypes.duration.nullable().optional(),

--- a/api/app/src/mappings/garmin/sleep.ts
+++ b/api/app/src/mappings/garmin/sleep.ts
@@ -109,19 +109,19 @@ export const garminSleepSchema = z.object({
   // calendarDate: t.date, // getting this from 'startTimeInSeconds'
   startTimeInSeconds: garminTypes.startTime,
   // startTimeOffsetInSeconds: -21600, // always return UTC
-  durationInSeconds: garminTypes.duration,
-  unmeasurableSleepInSeconds: garminTypes.unmeasurableSleep,
-  deepSleepDurationInSeconds: garminTypes.deepSleepDuration,
-  lightSleepDurationInSeconds: garminTypes.lightSleepDuration,
-  remSleepInSeconds: garminTypes.remSleep,
-  awakeDurationInSeconds: garminTypes.awakeDuration,
-  sleepLevelsMap: garminTypes.sleepLevels,
+  durationInSeconds: garminTypes.duration.nullable().optional(),
+  unmeasurableSleepInSeconds: garminTypes.unmeasurableSleep.nullable().optional(),
+  deepSleepDurationInSeconds: garminTypes.deepSleepDuration.nullable().optional(),
+  lightSleepDurationInSeconds: garminTypes.lightSleepDuration.nullable().optional(),
+  remSleepInSeconds: garminTypes.remSleep.nullable().optional(),
+  awakeDurationInSeconds: garminTypes.awakeDuration.nullable().optional(),
+  sleepLevelsMap: garminTypes.sleepLevels.nullable().optional(),
   // relays the validation state of the sleep data and its date range
   // could be used to filter out data - see docs
-  validation: garminTypes.sleepValidation,
-  timeOffsetSleepRespiration: garminTypes.timeOffsetSleepRespiration,
-  timeOffsetSleepSpo2: garminTypes.timeOffsetSleepSpo2,
-  overallSleepScore: garminTypes.overallSleepScore,
+  validation: garminTypes.sleepValidation.nullable().optional(),
+  timeOffsetSleepRespiration: garminTypes.timeOffsetSleepRespiration.nullable().optional(),
+  timeOffsetSleepSpo2: garminTypes.timeOffsetSleepSpo2.nullable().optional(),
+  overallSleepScore: garminTypes.overallSleepScore.nullable().optional(),
 });
 export type GarminSleep = z.infer<typeof garminSleepSchema>;
 


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/118

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/17
- Downstream: https://github.com/metriport/metriport/pull/19

### Description

Each Garmin schema determines whether a given property is optional/nullable or not, and not the generic Garmin type.

### Release Plan

- anytime