### PR TITLE
Mark WH request as failed when no WH config

### DIFF
--- a/api/app/src/command/webhook/webhook.ts
+++ b/api/app/src/command/webhook/webhook.ts
@@ -183,6 +183,11 @@ export const processRequest = async (
       `Missing webhook config, skipping sending it ` +
         `(url: ${webhookUrl}, key: ${webhookKey ? "<defined>" : null}`
     );
+    // mark this request as failed on the DB - so it can be retried later
+    await updateWebhookRequestStatus({
+      id: webhookRequest.id,
+      status: "failure",
+    });
     return false;
   }
   // TODO Separate preparing the payloads with the actual sending of that data over the wire


### PR DESCRIPTION
Ticket: #118

### Dependencies

- Upstream: none
- Downstream: none

### Description

Currently, when there's no Webhook (WH) config on settings, we just skip processing the request. But the logic to re-send/retry WH request on the settings page only processes failed requests - `processing` is supposed to be a temporary state while they are actually being sent to the partner/account.

### Release Plan

- anytime