### PR TITLE
Add support for client keys #274

### DIFF
--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -375,6 +375,47 @@ export class APIStack extends Stack {
       dynamoDBTokenTable,
     });
 
+    // add webhook path for apple health clients
+    const appleHealthResource = webhookResource.addResource("apple");
+    const integrationApple = new apig.Integration({
+      type: apig.IntegrationType.HTTP,
+      options: {
+        connectionType: apig.ConnectionType.VPC_LINK,
+        vpcLink: link,
+      },
+      integrationHttpMethod: "POST",
+      uri: `http://${fargateService.loadBalancer.loadBalancerDnsName}${appleHealthResource.path}`,
+    });
+    appleHealthResource.addMethod("POST", integrationApple, {
+      apiKeyRequired: true,
+    });
+
+    // add another usage plan for Publishable (Client) API keys
+    // everything is throttled to 0 - except explicitely permitted routes
+    const appleHealthThrottleKey = `${appleHealthResource.path}/POST`;
+    const clientPlan = new apig.CfnUsagePlan(this, "APIClientUsagePlan", {
+      usagePlanName: "Client Plan",
+      description: "Client Plan for API",
+      apiStages: [
+        {
+          apiId: api.restApiId,
+          stage: api.deploymentStage.stageName,
+          throttle: {
+            "*/*": { burstLimit: 0, rateLimit: 0 },
+            [appleHealthThrottleKey]: { burstLimit: 10, rateLimit: 50 },
+          },
+        },
+      ],
+      throttle: {
+        burstLimit: 10,
+        rateLimit: 50,
+      },
+      quota: {
+        limit: this.isProd(props) ? 10000 : 500,
+        period: apig.Period.DAY,
+      },
+    });
+
     //-------------------------------------------
     // Output
     //-------------------------------------------
@@ -413,6 +454,10 @@ export class APIStack extends Stack {
     new CfnOutput(this, "APIUsagePlan", {
       description: "API Usage Plan",
       value: plan.usagePlanId,
+    });
+    new CfnOutput(this, "ClientAPIUsagePlan", {
+      description: "Client API Usage Plan",
+      value: clientPlan.attrId,
     });
     new CfnOutput(this, "APIDBCluster", {
       description: "API DB Cluster",

--- a/pkgs/packages/commonwell-jwt-maker/README.md
+++ b/pkgs/packages/commonwell-jwt-maker/README.md
@@ -32,7 +32,7 @@ Absolute path to the RSA256 private key file corresponding to the specified orga
 
 `--role <practitioner-role>`
 
-The practitioner role of the entity making this request. Valid role values: http://hl7.org/fhir/R4/valueset_practitioner_role.html
+The practitioner role of the entity making this request. Valid role values: https://hl7.org/fhir/R4/valueset-practitioner-role.html
 
 `--subject-id <subject-id>`
 

--- a/pkgs/packages/commonwell-jwt-maker/src/index.ts
+++ b/pkgs/packages/commonwell-jwt-maker/src/index.ts
@@ -23,7 +23,7 @@ program
   )
   .requiredOption(
     `--${roleOpt} <practitioner-role>`,
-    "The practitioner role of the entity making this request. Valid role values: http://hl7.org/fhir/R4/valueset_practitioner_role.html"
+    "The practitioner role of the entity making this request. Valid role values: https://hl7.org/fhir/R4/valueset-practitioner-role.html"
   )
   .requiredOption(
     `--${subjectIdOpt} <subject-id>`,

--- a/pkgs/packages/commonwell-sdk/src/common/make-jwt.ts
+++ b/pkgs/packages/commonwell-sdk/src/common/make-jwt.ts
@@ -18,7 +18,7 @@ const payloadHashClaim = "urn:commonwell-alliance:payload-hash";
  * @param rsaPrivateKey   The RSA256 private key corresponding to the specified organization's
  *                        public key (certificate) - used for signing the JWT.
  * @param role            The practitioner role of the entity making this request. Valid role
- *                        values: http://hl7.org/fhir/R4/valueset_practitioner_role.html
+ *                        values: https://hl7.org/fhir/R4/valueset-practitioner-role.html
  * @param subjectId       Free text field used for audit purposes. The value should be user ID or
  *                        user name of staff using the CommonWell enabled system. Can be a system
  *                        user if the API call is generated from an automated process instead


### PR DESCRIPTION
Ticket: metriport/metriport-internal#274

### Dependencies

- Upstream: N/A
- Downstream: https://github.com/metriport/metriport-internal/pull/278

### Description

Add support for client keys for mobile clients that will be sending data to the Metriport API.

Updating docs is still a TODO here.

### Release Plan

- [ ] Merge this PR.
- [ ] Merge downstream deps.
