### PR TITLE
Fix nodejs version on build and deploy

### DIFF
--- a/.github/workflows/_reusable_build.yml
+++ b/.github/workflows/_reusable_build.yml
@@ -27,7 +27,7 @@ jobs:
       # Lint and build/compile the code
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "lts/*"
       - name: Install environment
         run: |
           pwd
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "lts/*"
       - name: Install environment
         run: |
           pwd

--- a/.github/workflows/_reusable_deploy.yml
+++ b/.github/workflows/_reusable_deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "lts/*"
       - run: env
         shell: bash
       - run: |


### PR DESCRIPTION
Ref #92

### Dependencies

- none

### Description

Update all CI/CD jobs to use NodeJS latest LTS version.

For reference, a job failing bc of wrong NodeJS version (semantic version requires 18+):

https://github.com/metriport/metriport/actions/runs/4007547608/jobs/6880530895

### Release Plan

- asap