### PR TITLE
Commitlint to require footer

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,2 +1,9 @@
 /*global module*/
-module.exports = {extends: ['@commitlint/config-conventional']};
+module.exports = {
+    // Resolve and load @commitlint/config-conventional from node_modules. Referenced packages must be installed
+    extends: ["@commitlint/config-conventional"],
+    // Any rules defined here will override rules from @commitlint/config-conventional
+    rules: {
+        "footer-empty": [2, "never"],
+    },
+};


### PR DESCRIPTION
Ref. metriport/metriport-internal#143

### Dependencies

- Upstream: none
- Downstream: none

### Description

Commitlint to require footer on commit messages.

- A footer is a line after the first one, with at least one empty line between it and the previous line.
- It requires an issue reference, `#123`. 
- The issue reference can include the org/repo, like `metriport/metriport-internal#143` 

To test the configuration local, one can issue this on the command line and play with the contents of `echo`:

```shell
$ echo "build: something\n\nadditional context\n\nRef. metriport/metriport-internal#123" | npx commitlint
```

### Release Plan

- anytime