### PR TITLE
fix: set max request body size to 2MB on API

### DIFF
--- a/api/app/src/app.ts
+++ b/api/app/src/app.ts
@@ -10,8 +10,8 @@ import mountRoutes from "./routes/index";
 
 const app: Application = express();
 app.use(helmet()); // needs to come before any route declaration, including cors()
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
+app.use(express.json({ limit: 2_000 }));
+app.use(express.urlencoded({ extended: false, limit: 2_000 }));
 app.use(cors());
 
 mountRoutes(app);

--- a/api/app/src/app.ts
+++ b/api/app/src/app.ts
@@ -10,8 +10,8 @@ import mountRoutes from "./routes/index";
 
 const app: Application = express();
 app.use(helmet()); // needs to come before any route declaration, including cors()
-app.use(express.json({ limit: 2_000 }));
-app.use(express.urlencoded({ extended: false, limit: 2_000 }));
+app.use(express.json({ limit: "2mb" }));
+app.use(express.urlencoded({ extended: false, limit: "2mb" }));
 app.use(cors());
 
 mountRoutes(app);

--- a/utils/src/mock-webhook.ts
+++ b/utils/src/mock-webhook.ts
@@ -1,8 +1,8 @@
 import express, { Application, Request, Response } from "express";
 
 const app: Application = express();
-app.use(express.json({ limit: 2_000 }));
-app.use(express.urlencoded({ extended: false, limit: 2_000 }));
+app.use(express.json({ limit: "2mb" }));
+app.use(express.urlencoded({ extended: false, limit: "2mb" }));
 
 app.post("/", (req: Request, res: Response) => {
   console.log(`BODY: ${JSON.stringify(req.body, undefined, 2)}`);

--- a/utils/src/mock-webhook.ts
+++ b/utils/src/mock-webhook.ts
@@ -1,8 +1,8 @@
 import express, { Application, Request, Response } from "express";
 
 const app: Application = express();
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
+app.use(express.json({ limit: 2_000 }));
+app.use(express.urlencoded({ extended: false, limit: 2_000 }));
 
 app.post("/", (req: Request, res: Response) => {
   console.log(`BODY: ${JSON.stringify(req.body, undefined, 2)}`);


### PR DESCRIPTION
Ref. metriport/metriport-internal#334

### Dependencies

- none

### Description

Set max request body size to 2MB on API.

### Release Plan

- asap