### PR TITLE
fix: default error handler to have 4 params

### DIFF
--- a/api/app/src/default-error-handler.ts
+++ b/api/app/src/default-error-handler.ts
@@ -26,7 +26,8 @@ const zodResponseBody = (err: ZodError): string => {
   });
 };
 
-export const errorHandler: ErrorRequestHandler = (err, req, res) => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
   if (err instanceof MetriportError) {
     return res.contentType("json").status(err.status).send(metriportResponseBody(err));
   }


### PR DESCRIPTION
Ref. metriport/metriport-internal#343

### Dependencies

- Upstream: none
- Downstream: none

### Description

⚠️ This is pointing to `master` - see release plan.

Default error handler to have 4 params - we removed the fourth bc of lint issues, and this makes Express to treat it like a regular middleware function, throwing 500 when executed.

### Release Plan

- release asap as a patch