### PR TITLE
fix: reenable lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint-staged -v
+npm run lint-staged


### PR DESCRIPTION
Ref. metriport/metriport-internal#331

### Dependencies

none

### Description

#331 updated the Husky hook to execute lint-staged introducing the `-v` parameter - likely to bypass validation?

If needed, one can issue `git commit --no-verify` to skip hooks.

### Release Plan

- asap so we bring back lint on commited changes