### PR TITLE
refactor: proxy to http FHIR server instead of https

### DIFF
--- a/api/app/src/routes/fhir-proxy.ts
+++ b/api/app/src/routes/fhir-proxy.ts
@@ -20,7 +20,7 @@ const updateQueryString = (path: string, params: string): string | undefined => 
 };
 
 // TODO make this dynamic/config/secret
-const router = proxy("https://fhir.staging.metriport.com", {
+const router = proxy("http://fhir.staging.metriport.com", {
   // const router = proxy("http://host.docker.internal:8888", {
   proxyReqPathResolver: function (req) {
     console.log(`ORIGINAL URL: `, req.url);
@@ -38,11 +38,12 @@ const router = proxy("https://fhir.staging.metriport.com", {
     // const orgRegex = /"Organization\/(.+)"/g;
     // const orgReplace = `"Organization/urn:oid:$1"`;
     // eslint-disable-next-line no-useless-escape
-    const urlRegex = /https\:\/\/fhir\.staging\.metriport\.com/g;
-    const urlReplace = `https://api.staging.metriport.com`;
-    const updatedPayload = payloadString
-      // .replace(orgRegex, orgReplace)
-      .replace(urlRegex, urlReplace);
+    // const urlRegex = /https\:\/\/fhir\.staging\.metriport\.com/g;
+    // const urlReplace = `https://api.staging.metriport.com`;
+    const updatedPayload = payloadString;
+    // const updatedPayload = payloadString
+    //   // .replace(orgRegex, orgReplace)
+    //   .replace(urlRegex, urlReplace);
     const payload = JSON.parse(updatedPayload);
     if (payload.entry) {
       // payload.entry

--- a/packages/packages/commonwell-sdk/src/models/document.ts
+++ b/packages/packages/commonwell-sdk/src/models/document.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { humanNameSchema } from "./human-name";
 import { identifierUseCodesSchema } from "./identifier";
 import { isoDateTimeSchema } from "./iso-datetime";
 import { periodSchema } from "./period";
@@ -10,7 +11,7 @@ import { periodSchema } from "./period";
 // Bundle, DocumentReference, Organization, Practitioner
 const resourceTypeSchema = z.string().optional();
 
-const docIdentifierSchema = z.object({
+const identifierSchema = z.object({
   use: identifierUseCodesSchema.optional(),
   system: z.string().optional(),
   value: z.string(),
@@ -32,7 +33,8 @@ const codeableConceptSchema = z.object({
 const containedSchema = z.object({
   resourceType: resourceTypeSchema,
   id: z.string(),
-  name: z.string().optional(),
+  identifier: z.array(identifierSchema).optional(),
+  name: z.string().or(z.array(humanNameSchema)).optional(),
   organization: z
     .object({
       reference: z.string(),
@@ -51,8 +53,8 @@ export const contentSchema = z.object({
   // _links: resourceTypeSchema, // What's the structure here? -	A reserved property for presenting the link relations for this resource.
   resourceType: resourceTypeSchema,
   contained: z.array(containedSchema),
-  masterIdentifier: docIdentifierSchema,
-  identifier: z.array(docIdentifierSchema).optional(),
+  masterIdentifier: identifierSchema,
+  identifier: z.array(identifierSchema).optional(),
   subject: z.object({
     reference: z.string(), // Supposed to be one of these, but sandbox doesn't match it: Patient | Practitioner | Group | Device
   }),


### PR DESCRIPTION
Ref. metriport/metriport-internal#228

### Dependencies

- Upstream: none
- Downstream: none

### Description

- proxy to http FHIR server instead of https
- fix document parsing to support Document containing Patient

### Release Plan

Asap - need this to validate FHIR infra on staging