### PR TITLE
feat: add proxy to FHIR server

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ $ echo "WHOOP_CLIENT_ID=<YOUR-KEY>" >> api/app/.env
 $ echo "WHOOP_CLIENT_SECRET=<YOUR-KEY>" >> api/app/.env
 $ echo "WITHINGS_CLIENT_ID=<YOUR-SECRET>" >> api/app/.env
 $ echo "WITHINGS_CLIENT_SECRET=<YOUR-SECRET>" >> api/app/.env
+$ echo "FHIR_SERVER_URL=<FHIR-SERVER-URL>" >> api/app/.env # optional
 ```
 
 Additionally, define your System Root [OID](https://en.wikipedia.org/wiki/Object_identifier). This will be the base identifier to represent your system in any medical data you create - such as organizations, facilities, patients, and etc.
@@ -340,6 +341,14 @@ $ npm i -g ts-node # only needs to be run once
 $ cd api/app
 $ ts-node src/sequelize/cli
 ```
+
+Alternatively, you can use a shortcut for migrations on local environment:
+
+```shell
+$ npm run db-local -- <cmd>
+```
+
+> Note: the double dash `--` is required so parameters after it go to sequelize cli; without it, parameters go to `npm`
 
 Umzug's CLI is still in development at the time of this writing, so that's how one uses it:
 

--- a/api/app/package.json
+++ b/api/app/package.json
@@ -12,7 +12,8 @@
     "lint": "npx eslint . --ext .ts",
     "lint-fix": "npm run lint --fix",
     "prettier-fix": "npx prettier '**/*.ts' --write",
-    "test": "echo \"No test specified yet\""
+    "test": "echo \"No test specified yet\"",
+    "db-local": "DB_CREDS='{\"username\":\"admin\",\"password\":\"admin\",\"dbname\":\"db\",\"engine\":\"postgres\",\"host\":\"localhost\",\"port\":5432}' ts-node src/sequelize/cli"
   },
   "keywords": [],
   "author": "",

--- a/api/app/src/default-error-handler.ts
+++ b/api/app/src/default-error-handler.ts
@@ -1,28 +1,30 @@
 import { ErrorRequestHandler } from "express";
 import status from "http-status";
-import MetriportError from "./errors/metriport-error";
 import { ZodError } from "zod";
+import MetriportError from "./errors/metriport-error";
+import { httpResponseBody } from "./routes/util";
 
 // https://www.rfc-editor.org/rfc/rfc7807
-const defaultResponseBody = ({ status, title }: { status: number; title: string }): string => {
-  return JSON.stringify({
-    status,
-    title,
-  });
-};
+const defaultResponseBody = httpResponseBody;
+
 const metriportResponseBody = (err: MetriportError): string => {
   return JSON.stringify({
-    status: err.status,
-    title: err.message,
+    ...httpResponseBody({
+      status: err.status,
+      title: err.message,
+    }),
     name: err.name,
   });
 };
+
 const zodResponseBody = (err: ZodError): string => {
   return JSON.stringify({
-    status: status.BAD_REQUEST,
+    ...httpResponseBody({
+      status: status.BAD_REQUEST,
+      title: "Missing or invalid parameters",
+      detail: JSON.stringify(err.issues),
+    }),
     name: status[status.BAD_REQUEST],
-    title: "Missing or invalid parameters",
-    details: err.issues,
   });
 };
 

--- a/api/app/src/routes/fhir-proxy.ts
+++ b/api/app/src/routes/fhir-proxy.ts
@@ -1,7 +1,26 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { Request, Response } from "express";
 import proxy from "express-http-proxy";
+import Router from "express-promise-router";
+import httpStatus from "http-status";
+import { Config } from "../shared/config";
+import { asyncHandler, httpResponseBody } from "./util";
 
-// const URN_OID_PREFIX = "urn:oid:";
+const fhirServerUrl = Config.getFHIRServerUrl();
+
+const dummyRouter = Router();
+dummyRouter.all(
+  "/*",
+  asyncHandler(async (req: Request, res: Response) => {
+    const status = httpStatus.NOT_FOUND;
+    return res.status(status).send(
+      httpResponseBody({
+        title: "FHIR server is disabled",
+        status,
+      })
+    );
+  })
+);
 
 const updateDocumentReferenceQueryString = (params: string): string => {
   const decodedParams = decodeURIComponent(decodeURI(params));
@@ -19,51 +38,28 @@ const updateQueryString = (path: string, params: string): string | undefined => 
   return undefined;
 };
 
-// TODO make this dynamic/config/secret
-const router = proxy("http://fhir.staging.metriport.com", {
-  // const router = proxy("http://host.docker.internal:8888", {
-  proxyReqPathResolver: function (req) {
-    console.log(`ORIGINAL URL: `, req.url);
-    const parts = req.url.split("?");
-    const path = parts[0];
-    const queryString = parts.length > 1 ? updateQueryString(path, parts[1]) : undefined;
-    const updatedURL = "/fhir" + path + (queryString ? "?" + queryString : "");
-    console.log(`UPDATED URL: `, updatedURL);
-    return updatedURL;
-  },
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  userResDecorator: function (proxyRes, proxyResData, userReq, userRes) {
-    const payloadString = proxyResData.toString("utf8");
-    console.log(`ORIGINAL RESPONSE: `, JSON.stringify(JSON.parse(payloadString), undefined, 2));
-    // const orgRegex = /"Organization\/(.+)"/g;
-    // const orgReplace = `"Organization/urn:oid:$1"`;
-    // eslint-disable-next-line no-useless-escape
-    // const urlRegex = /https\:\/\/fhir\.staging\.metriport\.com/g;
-    // const urlReplace = `https://api.staging.metriport.com`;
-    const updatedPayload = payloadString;
-    // const updatedPayload = payloadString
-    //   // .replace(orgRegex, orgReplace)
-    //   .replace(urlRegex, urlReplace);
-    const payload = JSON.parse(updatedPayload);
-    if (payload.entry) {
-      // payload.entry
-      //   .filter((e: any) => e.resource?.resourceType === `DocumentReference`)
-      //   .forEach((e: any) => {
-      //     e.resource.id = URN_OID_PREFIX + e.resource.id;
-      //     // const contained = e.resource?.contained;
-      //     // if (contained) {
-      //     //   contained
-      //     //     .filter((c: any) => c.resourceType === `Organization`)
-      //     //     .forEach((c: any) => (c.id = URN_OID_PREFIX + c.id));
-      //     // }
-      //   });
-      // payload.entry
-      //   .filter((e: any) => e.resource?.resourceType === `Organization`)
-      //   .map((e: any) => e.resource)
-      //   .forEach((r: any) => (r.id = URN_OID_PREFIX + r.id));
-    }
-    console.log(`UPDATED RESPONSE: `, JSON.stringify(payload, undefined, 2));
-    return JSON.stringify(payload);
-  },
-});
+const router = fhirServerUrl
+  ? proxy(fhirServerUrl, {
+      proxyReqPathResolver: function (req) {
+        console.log(`ORIGINAL HEADERS: `, JSON.stringify(req.headers));
+        console.log(`ORIGINAL URL: `, req.url);
+        const parts = req.url.split("?");
+        const path = parts[0];
+        const queryString = parts.length > 1 ? updateQueryString(path, parts[1]) : undefined;
+        const updatedURL = "/fhir" + path + (queryString ? "?" + queryString : "");
+        console.log(`UPDATED URL: `, updatedURL);
+        return updatedURL;
+      },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      userResDecorator: function (proxyRes, proxyResData, userReq, userRes) {
+        const payloadString = proxyResData.toString("utf8");
+        console.log(`ORIGINAL RESPONSE: `, JSON.stringify(JSON.parse(payloadString)));
+        const updatedPayload = payloadString;
+        const payload = JSON.parse(updatedPayload);
+        console.log(`UPDATED RESPONSE: `, JSON.stringify(payload));
+        return JSON.stringify(payload);
+      },
+    })
+  : dummyRouter;
+
 export default router;

--- a/api/app/src/routes/util.ts
+++ b/api/app/src/routes/util.ts
@@ -20,6 +20,24 @@ export const asyncHandler =
     }
   };
 
+// https://www.rfc-editor.org/rfc/rfc7807
+export type HttpResponseBody = { status: number; title: string; detail?: string };
+export const httpResponseBody = ({
+  status,
+  title,
+  detail,
+}: {
+  status: number;
+  title: string;
+  detail?: string;
+}): HttpResponseBody => {
+  return {
+    status,
+    title,
+    detail,
+  };
+};
+
 export const getCxId = (req: Request): string | undefined => req.cxId;
 export const getCxIdOrFail = (req: Request): string => {
   const cxId = getCxId(req);

--- a/api/app/src/shared/config.ts
+++ b/api/app/src/shared/config.ts
@@ -90,6 +90,10 @@ export class Config {
     return getEnvVar("USAGE_URL");
   }
 
+  static getFHIRServerUrl(): string | undefined {
+    return getEnvVar("FHIR_SERVER_URL");
+  }
+
   static getSystemRootOID(): string {
     return getEnvVarOrFail("SYSTEM_ROOT_OID");
   }

--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -188,7 +188,7 @@ export class APIStack extends Stack {
             ...secrets,
           },
           environment: {
-            NODE_ENV: "production",
+            NODE_ENV: "production", // Determines its being run in the cloud, the logical env is set on ENV_TYPE
             ENV_TYPE: props.config.environmentType,
             TOKEN_TABLE_NAME: dynamoDBTokenTable.tableName,
             API_URL: `https://${props.config.subdomain}.${props.config.domain}`,
@@ -196,6 +196,9 @@ export class APIStack extends Stack {
             SYSTEM_ROOT_OID: props.config.systemRootOID,
             ...(props.config.usageReportUrl && {
               USAGE_URL: props.config.usageReportUrl,
+            }),
+            ...(props.config.fhirServerUrl && {
+              FHIR_SERVER_URL: props.config.fhirServerUrl,
             }),
           },
         },

--- a/infra/lib/env-config.ts
+++ b/infra/lib/env-config.ts
@@ -36,6 +36,7 @@ export type EnvConfig = {
     WHOOP_CLIENT_SECRET: string;
   };
   usageReportUrl?: string;
+  fhirServerUrl?: string;
   systemRootOID: string;
 } & (
   | {

--- a/packages/packages/commonwell-cert-runner/src/document-consumption.ts
+++ b/packages/packages/commonwell-cert-runner/src/document-consumption.ts
@@ -52,10 +52,10 @@ export async function retrieveDocument(
   console.log(`>>> E2c: Retrieve documents using FHIR (REST)`);
 
   // store the query result as well
-  const queryFileName = `./commonwell_queried_${doc.id ?? "ID"}_${makeId()}.query.file`;
+  const queryFileName = `./cw_consumption_${doc.id ?? "ID"}_${makeId()}.response.file`;
   fs.writeFileSync(queryFileName, JSON.stringify(doc));
 
-  const fileName = `./commonwell_queried_${doc.id ?? "ID"}_${makeId()}.file`;
+  const fileName = `./cw_consumption_${doc.id ?? "ID"}_${makeId()}.contents.file`;
   // the default is UTF-8, avoid changing the encoding if we don't know the file we're downloading
   const outputStream = fs.createWriteStream(fileName, { encoding: null });
   console.log(`File being created at ${process.cwd()}/${fileName}`);

--- a/packages/packages/commonwell-cert-runner/src/document-contribution.ts
+++ b/packages/packages/commonwell-cert-runner/src/document-contribution.ts
@@ -85,7 +85,11 @@ export async function documentContribution({
   for (const doc of documents) {
     console.log(`DOCUMENT: ${JSON.stringify(doc, undefined, 2)}`);
 
-    const fileName = `./commonwell_contributed_${doc.id ?? "ID"}_${makeId()}.file`;
+    // store the query result as well
+    const queryFileName = `./cw_contribution_${doc.id ?? "ID"}_${makeId()}.response.file`;
+    fs.writeFileSync(queryFileName, JSON.stringify(doc));
+
+    const fileName = `./cw_contribution_${doc.id ?? "ID"}_${makeId()}.contentsfile`;
     // the default is UTF-8, avoid changing the encoding if we don't know the file we're downloading
     const outputStream = fs.createWriteStream(fileName, { encoding: null });
     console.log(`File being created at ${process.cwd()}/${fileName}`);


### PR DESCRIPTION
Ref. metriport/metriport-internal#228

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/381

### Description

- add (final version of) proxy to FHIR server
- add default httpResponseBody() on util
- store document response and contents on cert-runner

### Release Plan

STAGING
- [x] update repository secret `INFRA_CONFIG_STAGING` with new config files prior to merging this
- [ ] merge this (new deployment)

PRODUCTION
- [ ] update repository secret `INFRA_CONFIG_PRODUCTION ` with new config files prior to deploying this (can't do it much sooner otherwise intermediate deploys might fail, like [this one](https://github.com/metriport/metriport/actions/runs/4264627529/jobs/7422975661))

Might need to update the release notes when merging to `master` because there was a [previous commit](https://github.com/metriport/metriport/commit/f07cd23bde6e1e13cd49a4dd3692a21347cfeec5) with `feat: wip fhir server` that shouldn't be `feat`