### PR TITLE
feat: custom cognito user pool subdomain

### DIFF
--- a/infra/config/example.ts
+++ b/infra/config/example.ts
@@ -6,9 +6,10 @@ export const config: EnvConfig = {
   secretsStackName: "MetriportSecretsStack",
   environmentType: EnvType.production,
   region: "us-east-1",
-  subdomain: "api",
   host: "myhealthapp.com",
   domain: "myhealthapp.com",
+  subdomain: "api",
+  authSubdomain: "auth",
   dbName: "my_db",
   dbUsername: "my_db_user",
   providerSecretNames: {

--- a/infra/lib/env-config.ts
+++ b/infra/lib/env-config.ts
@@ -14,9 +14,10 @@ export type EnvConfig = {
   environmentType: EnvType;
   region: string;
   secretReplicaRegion?: string;
-  subdomain: string;
-  host: string;
-  domain: string;
+  host: string; // DNS Zone
+  domain: string; // Base domain
+  subdomain: string; // API subdomain
+  authSubdomain: string; // Authentication subdomain
   dbName: string;
   dbUsername: string;
   providerSecretNames: {

--- a/packages/packages/commonwell-cert-runner/src/document-contribution.ts
+++ b/packages/packages/commonwell-cert-runner/src/document-contribution.ts
@@ -89,7 +89,7 @@ export async function documentContribution({
     const queryFileName = `./cw_contribution_${doc.id ?? "ID"}_${makeId()}.response.file`;
     fs.writeFileSync(queryFileName, JSON.stringify(doc));
 
-    const fileName = `./cw_contribution_${doc.id ?? "ID"}_${makeId()}.contentsfile`;
+    const fileName = `./cw_contribution_${doc.id ?? "ID"}_${makeId()}.contents.file`;
     // the default is UTF-8, avoid changing the encoding if we don't know the file we're downloading
     const outputStream = fs.createWriteStream(fileName, { encoding: null });
     console.log(`File being created at ${process.cwd()}/${fileName}`);


### PR DESCRIPTION
Ref. metriport/metriport-internal#228

### Dependencies

- Upstream: none
- Downstream:
  - https://github.com/metriport/metriport/pull/122
  - https://github.com/metriport/metriport-internal/pull/383

### Description

As per discussed and specified on https://github.com/metriport/metriport-internal/issues/228, we want to have a custom authentication subdomain so our setup on Commonwell and other 3rd party applications is not tied to Cognito (see task `create a custom domain for OAuth2`).

This PR introduces this new subdomain.

It adds a new user pool, instead of replacing the previous one. This is so we can validate the creation of the new user pool without impacting CW's authentication on our platform.

### Release Plan

STAGING
- [ ] update the repository secret `INFRA_CONFIG_STAGING` with new config file prior to merging this
- [ ] merge this (new deployment)
- [ ] validate the new user pool is working as expected
- [ ] update CW's orgs to point to this new user pool
- [ ] create a new PR removing the old user pool from the code

PRODUCTION
- :warning: Requires updating the repository secret `INFRA_CONFIG_PRODUCTION`