### PR TITLE
refactor: remove old cognito user pool

### DIFF
--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -529,22 +529,11 @@ export class APIStack extends Stack {
   }
 
   private setupOAuthUserPool(config: EnvConfig, certificate: ICertificate): cognito.IUserPool {
-    // TODO remove `userPool` once `newUserPool` is proven to be working
-    const userPool = new cognito.UserPool(this, "oauth-client-secret-user-pool", {
+    const userPool = new cognito.UserPool(this, "oauth-client-secret-user-pool2", {
       accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
       removalPolicy: RemovalPolicy.DESTROY,
     });
-    // TODO make this a custom domain
-    userPool.addDomain("metriport-cognito-domain", {
-      cognitoDomain: {
-        domainPrefix: "metriport", // TODO make this dynamic/config
-      },
-    });
-    const newUserPool = new cognito.UserPool(this, "oauth-client-secret-user-pool2", {
-      accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
-      removalPolicy: RemovalPolicy.DESTROY,
-    });
-    newUserPool.addDomain("metriport-custom-cognito-domain", {
+    userPool.addDomain("metriport-custom-cognito-domain", {
       customDomain: {
         domainName: `${config.authSubdomain}.${config.domain}`,
         certificate,

--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -328,14 +328,8 @@ export class APIStack extends Stack {
     // setup /token path with token auth
     this.setupAPIGWApiTokenResource(id, api, link, tokenAuth, apiServerAddress);
 
-    const { old: userPoolClientSecret, new: userPoolClientSecret2 } = this.setupOAuthUserPool(
-      props.config,
-      publicZone
-    );
-    // TODO #228 remove this one
+    const userPoolClientSecret = this.setupOAuthUserPool(props.config, publicZone);
     const oauthScopes = this.enableFHIROnUserPool(userPoolClientSecret);
-    // TODO #228 keep this one
-    this.enableFHIROnUserPool2(userPoolClientSecret2);
     const oauthAuth = this.setupOAuthAuthorizer(userPoolClientSecret);
     // TODO #228 point this to oauthAuth2
     this.setupAPIGWOAuthResource(id, api, link, oauthAuth, oauthScopes, apiServerAddress);
@@ -534,22 +528,7 @@ export class APIStack extends Stack {
     return apiTokenResource;
   }
 
-  private setupOAuthUserPool(
-    config: EnvConfig,
-    dnsZone: r53.IHostedZone
-  ): { old: cognito.IUserPool; new: cognito.IUserPool } {
-    // TODO #228 remove `userPool` once `newUserPool` is proven to be working
-    const userPool = new cognito.UserPool(this, "oauth-client-secret-user-pool", {
-      accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
-      removalPolicy: RemovalPolicy.DESTROY,
-    });
-    // TODO make this a custom domain
-    userPool.addDomain("metriport-cognito-domain", {
-      cognitoDomain: {
-        domainPrefix: "metriport", // TODO make this dynamic/config
-      },
-    });
-    // TDOO #228 new one (remove this comment)
+  private setupOAuthUserPool(config: EnvConfig, dnsZone: r53.IHostedZone): cognito.IUserPool {
     const domainName = `${config.authSubdomain}.${config.domain}`;
     const newUserPool = new cognito.UserPool(this, "oauth-client-secret-user-pool2", {
       accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
@@ -568,40 +547,10 @@ export class APIStack extends Stack {
       zone: dnsZone,
       target: r53.RecordTarget.fromAlias(new r53_targets.UserPoolDomainTarget(userPoolDomain)),
     });
-    return { old: userPool, new: newUserPool };
+    return newUserPool;
   }
 
-  // TODO #228 remove this
   private enableFHIROnUserPool(userPool: cognito.IUserPool): cognito.OAuthScope[] {
-    const scopes = [
-      {
-        scopeName: "document",
-        scopeDescription: "query and retrieve document references",
-      },
-    ];
-    const resourceServerScopes = scopes.map(s => new cognito.ResourceServerScope(s));
-    const resourceServer = userPool.addResourceServer("FHIR-resource-server", {
-      identifier: "fhir",
-      scopes: resourceServerScopes,
-    });
-    const oauthScopes = resourceServerScopes.map(s =>
-      cognito.OAuthScope.resourceServer(resourceServer, s)
-    );
-    // Commonwell specific client
-    userPool.addClient("commonwell-client", {
-      generateSecret: true,
-      supportedIdentityProviders: [cognito.UserPoolClientIdentityProvider.COGNITO],
-      oAuth: {
-        flows: {
-          clientCredentials: true,
-        },
-        scopes: oauthScopes,
-      },
-    });
-    return oauthScopes;
-  }
-  // TODO #228 rename this
-  private enableFHIROnUserPool2(userPool: cognito.IUserPool): cognito.OAuthScope[] {
     const scopes = [
       {
         scopeName: "document",

--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -559,7 +559,7 @@ export class APIStack extends Stack {
     ];
     const resourceServerScopes = scopes.map(s => new cognito.ResourceServerScope(s));
     const resourceServer = userPool.addResourceServer("FHIR-resource-server2", {
-      identifier: "fhir2",
+      identifier: "fhir",
       scopes: resourceServerScopes,
     });
     const oauthScopes = resourceServerScopes.map(s =>


### PR DESCRIPTION
Ref. metriport/metriport-internal#228

### Dependencies

- Upstream:
  - https://github.com/metriport/metriport/pull/121
  - https://github.com/metriport/metriport/pull/123
  - https://github.com/metriport/metriport/pull/124
- Downstream: none

### Description

Remove old cognito user pool, left over from upstream PR.

### Release Plan

After the upstream PR is merged and tasks from its release plan are done, then we can merge this at any time.