### PR TITLE
chore: keep new user pool's resources names diff than original

### DIFF
--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -529,7 +529,7 @@ export class APIStack extends Stack {
 
   private setupOAuthUserPool(config: EnvConfig, dnsZone: r53.IHostedZone): cognito.IUserPool {
     const domainName = `${config.authSubdomain}.${config.domain}`;
-    const userPool = new cognito.UserPool(this, "oauth-client-secret-user-pool", {
+    const userPool = new cognito.UserPool(this, "oauth-client-secret-user-pool2", {
       accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
       removalPolicy: RemovalPolicy.DESTROY,
     });
@@ -557,7 +557,7 @@ export class APIStack extends Stack {
       },
     ];
     const resourceServerScopes = scopes.map(s => new cognito.ResourceServerScope(s));
-    const resourceServer = userPool.addResourceServer("FHIR-resource-server", {
+    const resourceServer = userPool.addResourceServer("FHIR-resource-server2", {
       identifier: "fhir",
       scopes: resourceServerScopes,
     });
@@ -565,7 +565,7 @@ export class APIStack extends Stack {
       cognito.OAuthScope.resourceServer(resourceServer, s)
     );
     // Commonwell specific client
-    userPool.addClient("commonwell-client", {
+    userPool.addClient("commonwell-client2", {
       generateSecret: true,
       supportedIdentityProviders: [cognito.UserPoolClientIdentityProvider.COGNITO],
       oAuth: {


### PR DESCRIPTION
Ref. metriport/metriport-internal#228

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/122
- Downstream: none

### Description

Keep the new cognito user pool with IDs/names diff than the original ones, the deploy to AWS doesn't work if we try to rename them as we did on the upstream PR.

### Release Plan

- asap