### PR TITLE
refactor: fhir proxy response transformer w/ try/catch

### DIFF
--- a/api/app/src/routes/fhir-proxy.ts
+++ b/api/app/src/routes/fhir-proxy.ts
@@ -52,12 +52,18 @@ const router = fhirServerUrl
       },
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       userResDecorator: function (proxyRes, proxyResData, userReq, userRes) {
-        const payloadString = proxyResData.toString("utf8");
-        console.log(`ORIGINAL RESPONSE: `, JSON.stringify(JSON.parse(payloadString)));
-        const updatedPayload = payloadString;
-        const payload = JSON.parse(updatedPayload);
-        console.log(`UPDATED RESPONSE: `, JSON.stringify(payload));
-        return JSON.stringify(payload);
+        try {
+          const payloadString = proxyResData.toString("utf8");
+          console.log(`ORIGINAL RESPONSE: `, JSON.stringify(JSON.parse(payloadString)));
+          const updatedPayload = payloadString;
+          const payload = JSON.parse(updatedPayload);
+          console.log(`UPDATED RESPONSE: `, JSON.stringify(payload));
+          return JSON.stringify(payload);
+        } catch (err) {
+          console.log(`Error parsing/transforming response: `, err);
+          console.log(`RAW, ORIGINAL RESPONSE: `, proxyResData);
+          return proxyResData;
+        }
       },
     })
   : dummyRouter;


### PR DESCRIPTION
Ref. metriport/metriport-internal#228

### Dependencies

- Upstream: none
- Downstream: none

### Description

While testing, I noticed we have errors when CW queries for docs for this org, `2.16.840.1.113883.3.3330.8889429.1620.1` - which is not the one being debugged for document retrieval.

The error seems to happen while we're processing the response from the FHIR server. I tried to replicate this local but couldn't. [Link to the log on AWS](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/StagingAPIInfrastructureStack-APIFargateServiceTaskDefAPIServerLogGroup35E9518F-fDzCkr8Zml1k/log-events/APIFargateService$252FAPI-Server$252F6d9e76939c2f42bcbb9696a7d1eb0350$3Fstart$3D1677376451436$26refEventId$3D37406744847719786488407891515299710312535207453298262020)

<img width="1793" alt="image" src="https://user-images.githubusercontent.com/2132564/221388872-f14f8132-c16a-4e07-b5be-3b84ac1f27b2.png">

Since this seems related to a response diff than JSON from the FHIR server, I'm assuming its a 404 or some other error, with a HTML response of sorts.

To simplify the solution, I propose we just return whatever the FHIR server responds, avoiding an error that changes not only the response by status codes as well - potentially turning a regular 404 not found into a 500 server error.

### Release Plan

- asap