### PR TITLE
feat(commonwell-sdk): add new API calls and more

### DIFF
--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -17836,7 +17836,7 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.2.3-alpha.0",
+      "version": "1.2.3-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^2.0.0-alpha.0",
@@ -17856,6 +17856,16 @@
         "typescript": "^4.9.4"
       }
     },
+    "packages/commonwell-cert-runner/node_modules/@metriport/commonwell-sdk": {
+      "version": "2.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-2.0.0-alpha.0.tgz",
+      "integrity": "sha512-0LNKeZLDUUG0pHkNWe7du35kai4sUfcw9iqJYswLZy06wh4ql7wSWfEqVgLf7dL/BJ1MjjiWKvxBASxQrtUfdg==",
+      "dependencies": {
+        "http-status": "^1.6.2",
+        "jsonwebtoken": "^9.0.0",
+        "zod": "^3.20.2"
+      }
+    },
     "packages/commonwell-cert-runner/node_modules/dotenv": {
       "version": "16.0.3",
       "license": "BSD-2-Clause",
@@ -17865,7 +17875,7 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.2.2-alpha.1",
+      "version": "1.2.2-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^2.0.0-alpha.0",
@@ -17881,9 +17891,19 @@
         "typescript": "^4.9.4"
       }
     },
+    "packages/commonwell-jwt-maker/node_modules/@metriport/commonwell-sdk": {
+      "version": "2.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-2.0.0-alpha.0.tgz",
+      "integrity": "sha512-0LNKeZLDUUG0pHkNWe7du35kai4sUfcw9iqJYswLZy06wh4ql7wSWfEqVgLf7dL/BJ1MjjiWKvxBASxQrtUfdg==",
+      "dependencies": {
+        "http-status": "^1.6.2",
+        "jsonwebtoken": "^9.0.0",
+        "zod": "^3.20.2"
+      }
+    },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "http-status": "^1.6.2",
@@ -17906,7 +17926,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "0.1.1-alpha.1",
+      "version": "0.1.1-alpha.2",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -17828,7 +17828,7 @@
     },
     "packages/api": {
       "name": "@metriport/api",
-      "version": "1.2.0-alpha.0",
+      "version": "1.2.4-alpha.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.4"
@@ -17836,10 +17836,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.2.0-alpha.0",
+      "version": "1.2.3-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^1.2.0",
+        "@metriport/commonwell-sdk": "^2.0.0-alpha.0",
         "commander": "^9.5.0",
         "dotenv": "^16.0.3",
         "lodash": "^4.17.21",
@@ -17865,10 +17865,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.2.0-alpha.0",
+      "version": "1.2.2-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^1.2.0",
+        "@metriport/commonwell-sdk": "^2.0.0-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -17883,7 +17883,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "1.2.0",
+      "version": "2.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "http-status": "^1.6.2",
@@ -17906,7 +17906,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "0.1.0-alpha.0",
+      "version": "0.1.1-alpha.1",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -17828,7 +17828,7 @@
     },
     "packages/api": {
       "name": "@metriport/api",
-      "version": "1.2.4-alpha.1",
+      "version": "1.2.4-alpha.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.4"
@@ -17836,7 +17836,7 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.2.3-alpha.1",
+      "version": "1.2.3-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^2.0.0-alpha.0",
@@ -17875,7 +17875,7 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.2.2-alpha.2",
+      "version": "1.2.2-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^2.0.0-alpha.0",
@@ -17903,7 +17903,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "2.0.1-alpha.0",
+      "version": "2.0.1-alpha.2",
       "license": "MIT",
       "dependencies": {
         "http-status": "^1.6.2",
@@ -17926,7 +17926,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "0.1.1-alpha.2",
+      "version": "0.1.1-alpha.4",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"

--- a/packages/packages/api/package.json
+++ b/packages/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api",
-  "version": "1.2.4-alpha.1",
+  "version": "1.2.4-alpha.3",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/api/package.json
+++ b/packages/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api",
-  "version": "1.2.0-alpha.0",
+  "version": "1.2.4-alpha.1",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-cert-runner/package.json
+++ b/packages/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.2.3-alpha.1",
+  "version": "1.2.3-alpha.3",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-cert-runner/package.json
+++ b/packages/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.2.0-alpha.0",
+  "version": "1.2.3-alpha.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -46,7 +46,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^1.2.0",
+    "@metriport/commonwell-sdk": "^2.0.0-alpha.0",
     "commander": "^9.5.0",
     "dotenv": "^16.0.3",
     "lodash": "^4.17.21",

--- a/packages/packages/commonwell-cert-runner/package.json
+++ b/packages/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.2.3-alpha.0",
+  "version": "1.2.3-alpha.1",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-cert-runner/src/document-consumption.ts
+++ b/packages/packages/commonwell-cert-runner/src/document-consumption.ts
@@ -23,8 +23,8 @@ export async function queryDocuments(
 
   const { personId, patientId } = await findOrCreatePerson(commonWell, queryMeta, makeDocPerson());
 
-  if (!personId) throw new Error(`[E1c] personId is undefined before calling getPatientsLinks()`);
-  const respLinks = await commonWell.getPatientsLinks(queryMeta, patientId);
+  if (!personId) throw new Error(`[E1c] personId is undefined before calling getNetworkLinks()`);
+  const respLinks = await commonWell.getNetworkLinks(queryMeta, patientId);
   console.log(respLinks);
   const allLinks = respLinks._embedded.networkLink;
   const lola1Links = allLinks.filter(isLOLA1);

--- a/packages/packages/commonwell-cert-runner/src/document-contribution.ts
+++ b/packages/packages/commonwell-cert-runner/src/document-contribution.ts
@@ -64,7 +64,7 @@ export async function documentContribution({
   console.log(`patientId: ${patientIdNewOrg}`);
 
   console.log(`Get patients links`);
-  const respGetLinks = await apiNewOrg.getPatientsLinks(queryMeta, patientIdNewOrg);
+  const respGetLinks = await apiNewOrg.getNetworkLinks(queryMeta, patientIdNewOrg);
   console.log(respGetLinks);
 
   const allLinks = respGetLinks._embedded.networkLink;

--- a/packages/packages/commonwell-cert-runner/src/link-management.ts
+++ b/packages/packages/commonwell-cert-runner/src/link-management.ts
@@ -18,7 +18,7 @@ export async function linkManagement(commonWell: CommonWell, queryMeta: RequestM
   );
   const patientId = getIdTrailingSlash(respPatient);
   const referenceLink = respPatient._links.self.href;
-  const respC5a = await commonWell.patientLink(queryMeta, personId, referenceLink);
+  const respC5a = await commonWell.addPatientLink(queryMeta, personId, referenceLink);
   console.log(respC5a);
 
   console.log(`>>> C5b : Upgrade Patient link from LOLA 2 to LOLA 3 (with Strong ID).`);

--- a/packages/packages/commonwell-cert-runner/src/patient-management.ts
+++ b/packages/packages/commonwell-cert-runner/src/patient-management.ts
@@ -65,7 +65,7 @@ export async function patientManagement(
   // Main Account Link
   const person = await commonWell.enrollPerson(queryMeta, personStrongId);
   const personId = getId(person);
-  await commonWell.patientLink(queryMeta, personId, referenceLink);
+  await commonWell.addPatientLink(queryMeta, personId, referenceLink);
   // Sandbox Account Link
   const payloadSandboxPatient = cloneDeep(patient);
   payloadSandboxPatient.identifier[0].system = `urn:oid:${commonwellSandboxOID}`;
@@ -74,9 +74,9 @@ export async function patientManagement(
   const sandboxPatient = await commonwellSandbox.registerPatient(queryMeta, payloadSandboxPatient);
   const sandboxPatientId = getIdTrailingSlash(sandboxPatient);
   const sandboxReferenceLink = sandboxPatient._links.self.href;
-  await commonwellSandbox.patientLink(queryMeta, personId, sandboxReferenceLink);
+  await commonwellSandbox.addPatientLink(queryMeta, personId, sandboxReferenceLink);
   await commonWell.searchPersonByPatientDemo(queryMeta, patientId);
-  const respD5a = await commonWell.getPatientsLinks(queryMeta, patientId);
+  const respD5a = await commonWell.getNetworkLinks(queryMeta, patientId);
   console.log(respD5a);
 
   // D6: Upgrade/Downgrade a Network link

--- a/packages/packages/commonwell-cert-runner/src/shared-person.ts
+++ b/packages/packages/commonwell-cert-runner/src/shared-person.ts
@@ -26,7 +26,7 @@ export async function findOrCreatePerson(
     console.log(respPerson);
     const personId = getId(respPerson);
 
-    const respLink = await commonWell.patientLink(
+    const respLink = await commonWell.addPatientLink(
       queryMeta,
       personId,
       patientLink,
@@ -103,7 +103,7 @@ export async function findOrCreatePatient(
       : undefined;
     if (personId) {
       // Link the patient to the person
-      const respLink = await commonWell.patientLink(
+      const respLink = await commonWell.addPatientLink(
         queryMeta,
         personId,
         patientLink,

--- a/packages/packages/commonwell-jwt-maker/package.json
+++ b/packages/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.2.0-alpha.0",
+  "version": "1.2.2-alpha.1",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -45,7 +45,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^1.2.0",
+    "@metriport/commonwell-sdk": "^2.0.0-alpha.0",
     "commander": "^9.5.0"
   }
 }

--- a/packages/packages/commonwell-jwt-maker/package.json
+++ b/packages/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.4",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-jwt-maker/package.json
+++ b/packages/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-sdk/package.json
+++ b/packages/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "2.0.1-alpha.0",
+  "version": "2.0.1-alpha.2",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-sdk/package.json
+++ b/packages/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.1-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-sdk/package.json
+++ b/packages/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "1.2.0",
+  "version": "2.0.0-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-sdk/src/client/commonwell.ts
+++ b/packages/packages/commonwell-sdk/src/client/commonwell.ts
@@ -61,7 +61,7 @@ export class CommonWell {
   // V2
   static DOCUMENT_QUERY_ENDPOINT = "/v2/documentReference";
 
-  private api: AxiosInstance;
+  readonly api: AxiosInstance;
   private rsaPrivateKey: string;
   private orgName: string;
   private _oid: string;

--- a/packages/packages/commonwell-sdk/src/client/commonwell.ts
+++ b/packages/packages/commonwell-sdk/src/client/commonwell.ts
@@ -27,6 +27,8 @@ import {
 import {
   PatientLink,
   patientLinkSchema,
+  PatientLinkSearchResp,
+  patientLinkSearchRespSchema,
   Person,
   personSchema,
   PersonSearchResp,
@@ -453,6 +455,18 @@ export class CommonWell {
   }
 
   /**
+   * @deprecated use addPatientLink() instead
+   */
+  async patientLink(
+    meta: RequestMetadata,
+    personId: string,
+    patientUri: string,
+    patientStrongId?: StrongId
+  ): Promise<PatientLink> {
+    return this.addPatientLink(meta, personId, patientUri, patientStrongId);
+  }
+
+  /**
    * Add patient link to person.
    * See: https://specification.commonwellalliance.org/services/patient-identity-and-linking/protocol-operations#8721
    *
@@ -462,7 +476,7 @@ export class CommonWell {
    * @param [patientStrongId] The patient's strong ID, if available (optional).
    * @returns {PatientLink}
    */
-  async patientLink(
+  async addPatientLink(
     meta: RequestMetadata,
     personId: string,
     patientUri: string,
@@ -475,9 +489,7 @@ export class CommonWell {
         patient: patientUri,
         ...patientStrongId,
       },
-      {
-        headers,
-      }
+      { headers }
     );
     return patientLinkSchema.parse(resp.data);
   }
@@ -495,10 +507,22 @@ export class CommonWell {
     const resp = await this.api.put(
       `${CommonWell.PERSON_ENDPOINT}/${id}/unenroll`,
       {},
-      {
-        headers,
-      }
+      { headers }
     );
+    return personSchema.parse(resp.data);
+  }
+
+  /**
+   * Re-enrolls a person.
+   * See: https://specification.commonwellalliance.org/services/patient-identity-and-linking/protocol-operations#875-person-unenrollment
+   *
+   * @param meta    Metadata about the request.
+   * @param id      The person to be re-enrolled.
+   * @returns       Commonwell response with enrollment information
+   */
+  async reenrollPerson(meta: RequestMetadata, id: string): Promise<Person> {
+    const headers = await this.buildQueryHeaders(meta);
+    const resp = await this.api.put(`${CommonWell.PERSON_ENDPOINT}/${id}/enroll`, {}, { headers });
     return personSchema.parse(resp.data);
   }
 
@@ -638,16 +662,16 @@ export class CommonWell {
    * Get Patient's Network Links.
    * See: https://specification.commonwellalliance.org/services/record-locator-service/protocol-operations-record-locator-service#8771-retrieving-network-links
    *
-   * @param meta    Metadata about the request.
-   * @param id      Patient for which to get the network links.
+   * @param meta        Metadata about the request.
+   * @param patientId   Patient for which to get the network links.
    * @returns
    */
-  async getPatientsLinks(meta: RequestMetadata, id: string): Promise<PatientNetworkLinkResp> {
+  async getNetworkLinks(meta: RequestMetadata, patientId: string): Promise<PatientNetworkLinkResp> {
     const headers = await this.buildQueryHeaders(meta);
     // Error handling: https://github.com/metriport/metriport-internal/issues/322
     try {
       const resp = await this.api.get(
-        `${CommonWell.ORG_ENDPOINT}/${this.oid}/patient/${id}/networkLink`,
+        `${CommonWell.ORG_ENDPOINT}/${this.oid}/patient/${patientId}/networkLink`,
         {
           headers,
         }
@@ -656,7 +680,7 @@ export class CommonWell {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
       // when there's no NetworkLink, CW's API return 412
-      if (err.response?.status === 412) return {};
+      if (err.response?.status === 412) return { _embedded: { networkLink: [] } };
       throw err;
     }
   }
@@ -674,7 +698,6 @@ export class CommonWell {
     await this.api.delete(`${CommonWell.ORG_ENDPOINT}/${this.oid}/patient/${id}/`, {
       headers,
     });
-
     return;
   }
 
@@ -699,15 +722,7 @@ export class CommonWell {
     const headers = await this.buildQueryHeaders(meta);
     const url = `${CommonWell.DOCUMENT_QUERY_ENDPOINT}?subject.id=${subjectId}`;
     const res = await this.api.get(url, { headers });
-    try {
-      return documentQueryResponseSchema.parse(res.data);
-    } catch (err) {
-      console.log(
-        `[queryDocuments] Failed to parse response: `,
-        JSON.stringify(res.data, undefined, 2)
-      );
-      throw err;
-    }
+    return documentQueryResponseSchema.parse(res.data);
   }
 
   /**
@@ -793,6 +808,30 @@ export class CommonWell {
     );
 
     return patientLinkSchema.parse(resp.data);
+  }
+
+  /**
+   * Get a person's links to patients.
+   * See: https://specification.commonwellalliance.org/services/patient-identity-and-linking/protocol-operations#8721
+   *
+   * @param meta                Metadata about the request.
+   * @param personId            The person id to be link to a patient.
+   * @param [limitToOrg=true]   Whether to limit the search to the current organization (optional).
+   * @returns Response with list of links to Patients
+   */
+  async getPatientLinks(
+    meta: RequestMetadata,
+    personId: string,
+    limitToOrg = true
+  ): Promise<PatientLinkSearchResp> {
+    const headers = await this.buildQueryHeaders(meta);
+    const resp = await this.api.get(`${CommonWell.PERSON_ENDPOINT}/${personId}/patientLink`, {
+      headers,
+      params: {
+        ...(limitToOrg ? { orgId: this.oid } : undefined),
+      },
+    });
+    return patientLinkSearchRespSchema.parse(resp.data);
   }
 
   /**

--- a/packages/packages/commonwell-sdk/src/client/commonwell.ts
+++ b/packages/packages/commonwell-sdk/src/client/commonwell.ts
@@ -487,7 +487,7 @@ export class CommonWell {
       `${CommonWell.PERSON_ENDPOINT}/${personId}/patientLink`,
       {
         patient: patientUri,
-        ...patientStrongId,
+        ...(patientStrongId ? { identifier: patientStrongId } : undefined),
       },
       { headers }
     );

--- a/packages/packages/commonwell-sdk/src/client/commonwell.ts
+++ b/packages/packages/commonwell-sdk/src/client/commonwell.ts
@@ -518,7 +518,7 @@ export class CommonWell {
    *
    * @param meta    Metadata about the request.
    * @param id      The person to be re-enrolled.
-   * @returns       Commonwell response with enrollment information
+   * @returns       Person with enrollment information
    */
   async reenrollPerson(meta: RequestMetadata, id: string): Promise<Person> {
     const headers = await this.buildQueryHeaders(meta);

--- a/packages/packages/commonwell-sdk/src/models/person.ts
+++ b/packages/packages/commonwell-sdk/src/models/person.ts
@@ -40,3 +40,10 @@ export const patientLinkSchema = z.object({
 });
 
 export type PatientLink = z.infer<typeof patientLinkSchema>;
+
+export const patientLinkSearchRespSchema = z.object({
+  _embedded: z.object({ patientLink: z.array(patientLinkSchema) }),
+  _links: z.object({ self: linkSchema }),
+});
+
+export type PatientLinkSearchResp = z.infer<typeof patientLinkSearchRespSchema>;

--- a/packages/packages/react-native-sdk/package.json
+++ b/packages/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "0.1.1-alpha.2",
+  "version": "0.1.1-alpha.4",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/react-native-sdk/package.json
+++ b/packages/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.1-alpha.1",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/react-native-sdk/package.json
+++ b/packages/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "0.1.1-alpha.1",
+  "version": "0.1.1-alpha.2",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",


### PR DESCRIPTION
Ref. metriport/metriport-internal#369

### Dependencies

- Upstream: none
- Downstream: API TBD

### Description

BREAKING CHANGE:
- rename packages/commonwell-sdk's `getPatientsLinks` to `getNetworkLinks`

Regular changes:
- add `reenrollPerson`
- add `getPatientLinks`
- add `addPatientLink`
- deprecate `patientLink`
- (renamed) `getNetworkLinks` returns empty array when nothing found

### Release Plan

- release a major update to the `commonwell-sdk` package: `2.0.0`