### PR TITLE
feat(sdk): split org mgmt create and update

### DIFF
--- a/api/app/src/routes/medical/dtos/organizationDTO.ts
+++ b/api/app/src/routes/medical/dtos/organizationDTO.ts
@@ -1,0 +1,19 @@
+import { Organization, OrgType } from "../../../models/medical/organization";
+import { AddressDTO } from "./addressDTO";
+
+export type OrganizationDTO = {
+  id: string;
+  name: string;
+  type: OrgType;
+  location: AddressDTO;
+};
+
+export function dtoFromModel(org: Organization): OrganizationDTO {
+  const { name, type, location } = org.data;
+  return {
+    id: org.id,
+    name,
+    type,
+    location,
+  };
+}

--- a/api/app/src/routes/medical/organization.ts
+++ b/api/app/src/routes/medical/organization.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import Router from "express-promise-router";
 import status from "http-status";
 import { createOrganization } from "../../command/medical/organization/create-organization";
-import { getOrganization } from "../../command/medical/organization/get-organization";
+import { getOrganizationOrFail } from "../../command/medical/organization/get-organization";
 import { updateOrganization } from "../../command/medical/organization/update-organization";
 import cwCommands from "../../external/commonwell";
 import { asyncHandler, getCxIdOrFail, getFromParamsOrFail } from "../util";
@@ -17,7 +17,7 @@ const router = Router();
  * Creates a new organization at Metroport and HIEs.
  *
  * @param req.body The data to create the organization.
- * @return The newly created organization.
+ * @returns The newly created organization.
  */
 router.post(
   "/",
@@ -43,7 +43,7 @@ router.post(
  * Updates the organization at Metriport and HIEs.
  *
  * @param req.body The data to udpate the organization.
- * @return The updated organization.
+ * @returns The updated organization.
  */
 router.put(
   "/:id",
@@ -69,16 +69,16 @@ router.put(
  *
  * Gets the org corresponding to the customer ID.
  *
- * @return  {LocalOrg}  The organization.
+ * @returns The organization.
  */
 router.get(
   "/",
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
 
-    const org = await getOrganization({ cxId });
+    const org = await getOrganizationOrFail({ cxId });
 
-    return res.status(status.OK).json(org ? { id: org.id, ...org.data } : undefined);
+    return res.status(status.OK).json(dtoFromModel(org));
   })
 );
 

--- a/api/app/src/routes/medical/organization.ts
+++ b/api/app/src/routes/medical/organization.ts
@@ -5,50 +5,62 @@ import { createOrganization } from "../../command/medical/organization/create-or
 import { getOrganization } from "../../command/medical/organization/get-organization";
 import { updateOrganization } from "../../command/medical/organization/update-organization";
 import cwCommands from "../../external/commonwell";
-import { Organization, OrganizationData } from "../../models/medical/organization";
-import { asyncHandler, getCxIdOrFail } from "../util";
+import { asyncHandler, getCxIdOrFail, getFromParamsOrFail } from "../util";
+import { dtoFromModel } from "./dtos/organizationDTO";
 import { organizationSchema } from "./schemas/organization";
 
 const router = Router();
 
-type OrganizationDTO = Pick<Organization, "id"> & OrganizationData;
-
-// TODO split this in two, one to create "POST /" and another to update "POST /:id"
 /** ---------------------------------------------------------------------------
  * POST /organization
  *
- * Updates or creates the organization if it doesn't exist already.
+ * Creates a new organization at Metroport and HIEs.
  *
- * @return  {OrganizationDTO}  The organization.
+ * @param req.body The data to create the organization.
+ * @return The newly created organization.
  */
 router.post(
   "/",
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
+    const data = organizationSchema.parse(req.body);
 
-    const reqOrgData = organizationSchema.parse(req.body);
-    const org = {
-      ...reqOrgData,
-      location: {
-        ...reqOrgData.location,
-        addressLine2: reqOrgData.location.addressLine2 ?? undefined,
-      },
-    };
+    const org = await createOrganization({ cxId, data });
 
-    let localOrg: Organization;
+    // TODO declarative, event-based integration: https://github.com/metriport/metriport-internal/issues/393
+    cwCommands.organization.create(org).then(undefined, (err: unknown) => {
+      // TODO #156 Send this to Sentry
+      console.error(`Failure while creating organization ${org.id} @ CW: `, err);
+    });
 
-    if (org.id) {
-      const data = { ...org };
-      delete data.id;
-      localOrg = await updateOrganization({ id: org.id, cxId, data });
-      await cwCommands.organization.update(localOrg);
-    } else {
-      localOrg = await createOrganization({ cxId, data: org });
-      await cwCommands.organization.create(localOrg);
-    }
+    return res.status(status.CREATED).json(dtoFromModel(org));
+  })
+);
 
-    const responsePayload: OrganizationDTO = { id: localOrg.id, ...localOrg.data };
-    return res.status(status.OK).json(responsePayload);
+/** ---------------------------------------------------------------------------
+ * PUT /organization/:id
+ *
+ * Updates the organization at Metriport and HIEs.
+ *
+ * @param req.body The data to udpate the organization.
+ * @return The updated organization.
+ */
+router.put(
+  "/:id",
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getCxIdOrFail(req);
+    const orgId = getFromParamsOrFail("id", req);
+    const data = organizationSchema.parse(req.body);
+
+    const org = await updateOrganization({ id: orgId, cxId, data });
+
+    // TODO declarative, event-based integration: https://github.com/metriport/metriport-internal/issues/393
+    cwCommands.organization.update(org).then(undefined, (err: unknown) => {
+      // TODO #156 Send this to Sentry
+      console.error(`Failure while updating organization ${org.id} @ CW: `, err);
+    });
+
+    return res.status(status.OK).json(dtoFromModel(org));
   })
 );
 

--- a/api/app/src/routes/medical/schemas/organization.ts
+++ b/api/app/src/routes/medical/schemas/organization.ts
@@ -1,12 +1,10 @@
 import { z } from "zod";
 import { OrgType } from "../../../models/medical/organization";
 import { addressSchema } from "./address";
-import { optionalString } from "./shared";
 
 export const orgTypeSchema = z.nativeEnum(OrgType);
 
 export const organizationSchema = z.object({
-  id: optionalString(z.string()),
   name: z.string().min(1),
   type: orgTypeSchema,
   location: addressSchema,

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -16972,6 +16972,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/ts-essentials": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.3.1.tgz",
+      "integrity": "sha512-9CChSvQMyVRo29Vb1A2jbs+LKo3d/bAf+ndSaX0T8cEiy/HChVaRN/HY5DqUryZ8hZ6uol9bEgCnGmnDbwBR9Q==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -17828,19 +17837,22 @@
     },
     "packages/api": {
       "name": "@metriport/api",
-      "version": "1.3.0-alpha.12",
+      "version": "1.3.0-alpha.13",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.4",
         "zod": "^3.20.4"
+      },
+      "devDependencies": {
+        "ts-essentials": "^9.3.1"
       }
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.2.5-alpha.10",
+      "version": "1.2.5-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^2.1.0-alpha.14",
+        "@metriport/commonwell-sdk": "^2.1.0-alpha.15",
         "commander": "^9.5.0",
         "dotenv": "^16.0.3",
         "lodash": "^4.17.21",
@@ -17866,10 +17878,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.2.2-alpha.17",
+      "version": "1.2.2-alpha.18",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^2.1.0-alpha.14",
+        "@metriport/commonwell-sdk": "^2.1.0-alpha.15",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -17884,7 +17896,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "2.1.0-alpha.14",
+      "version": "2.1.0-alpha.15",
       "license": "MIT",
       "dependencies": {
         "http-status": "^1.6.2",
@@ -17907,7 +17919,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "0.1.1-alpha.16",
+      "version": "0.1.1-alpha.17",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"

--- a/packages/packages/api/package.json
+++ b/packages/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api",
-  "version": "1.3.0-alpha.12",
+  "version": "1.3.0-alpha.13",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -37,5 +37,8 @@
   "dependencies": {
     "axios": "^1.3.4",
     "zod": "^3.20.4"
+  },
+  "devDependencies": {
+    "ts-essentials": "^9.3.1"
   }
 }

--- a/packages/packages/api/src/index.ts
+++ b/packages/packages/api/src/index.ts
@@ -19,7 +19,14 @@ export {
   facilitySchema,
 } from "./medical/models/facility";
 export { Link, MedicalDataSource, PatientLinks } from "./medical/models/link";
-export { Organization, OrgType } from "./medical/models/organization";
+export {
+  Organization,
+  OrganizationCreate,
+  organizationCreateSchema,
+  organizationSchema,
+  OrgType,
+  orgTypeSchema,
+} from "./medical/models/organization";
 export {
   Patient,
   PatientCreate,

--- a/packages/packages/api/src/medical/client/metriport.ts
+++ b/packages/packages/api/src/medical/client/metriport.ts
@@ -3,7 +3,7 @@ import axios, { AxiosInstance, AxiosStatic } from "axios";
 import { DocumentReference, documentReferenceSchema } from "../models/document";
 import { Facility, FacilityCreate, facilityListSchema, facilitySchema } from "../models/facility";
 import { MedicalDataSource, PatientLinks } from "../models/link";
-import { Organization } from "../models/organization";
+import { Organization, OrganizationCreate, organizationSchema } from "../models/organization";
 import {
   Patient,
   PatientCreate,
@@ -48,15 +48,32 @@ export class MetriportMedicalApi {
   }
 
   /**
-   * Creates an org or updates one if it already exists
+   * Creates a new organization.
    *
-   * @param organization The org you want to create or update
-   * @returns The created or updated org.
+   * @param data The data to be used to create a new organization.
+   * @returns The created organization.
    */
-  async createOrUpdateOrganization(organization: Organization): Promise<Organization> {
-    const resp = await this.api.post<Organization>(this.ORGANIZATION_URL, organization);
-    if (!resp.data) throw new Error(`Create or update didn't return Organization`);
-    return resp.data;
+  async createOrganization(data: OrganizationCreate): Promise<Organization> {
+    const resp = await this.api.post(this.ORGANIZATION_URL, data);
+    if (!resp.data) throw new Error(`Did not receive an organization from the server`);
+    return organizationSchema.parse(resp.data);
+  }
+
+  /**
+   * Updates an organization.
+   *
+   * @param organization The organization data to be updated.
+   * @return The updated organization.
+   */
+  async updateOrganization(organization: Organization): Promise<Organization> {
+    type FieldsToOmit = "id";
+    const payload: Omit<Organization, FieldsToOmit> & Partial<Pick<Organization, FieldsToOmit>> = {
+      ...organization,
+      id: undefined,
+    };
+    const resp = await this.api.put(`${this.ORGANIZATION_URL}/${organization.id}`, payload);
+    if (!resp.data) throw new Error(`Did not receive an organization from the server`);
+    return organizationSchema.parse(resp.data);
   }
 
   /**
@@ -65,9 +82,9 @@ export class MetriportMedicalApi {
    * @returns The organization, or undefined if no organization has been created.
    */
   async getOrganization(): Promise<Organization | undefined> {
-    const resp = await this.api.get<Organization | undefined>(this.ORGANIZATION_URL);
+    const resp = await this.api.get(this.ORGANIZATION_URL);
     if (!resp.data) return undefined;
-    return resp.data;
+    return organizationSchema.parse(resp.data);
   }
 
   /**

--- a/packages/packages/api/src/medical/models/organization.ts
+++ b/packages/packages/api/src/medical/models/organization.ts
@@ -1,4 +1,5 @@
-import { Address } from "./common/address";
+import { z } from "zod";
+import { addressSchema } from "./common/address";
 
 export enum OrgType {
   acuteCare = "acuteCare",
@@ -8,9 +9,19 @@ export enum OrgType {
   pharmacy = "pharmacy",
   postAcuteCare = "postAcuteCare",
 }
-export interface Organization {
-  id?: string | null;
-  name: string;
-  type: OrgType;
-  location: Address;
-}
+
+export const orgTypeSchema = z.nativeEnum(OrgType);
+
+export const organizationCreateSchema = z.object({
+  name: z.string(),
+  type: orgTypeSchema,
+  location: addressSchema,
+});
+export type OrganizationCreate = z.infer<typeof organizationCreateSchema>;
+
+export const organizationSchema = organizationCreateSchema.merge(
+  z.object({
+    id: z.string(),
+  })
+);
+export type Organization = z.infer<typeof organizationSchema>;

--- a/packages/packages/commonwell-cert-runner/package.json
+++ b/packages/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.2.5-alpha.10",
+  "version": "1.2.5-alpha.11",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -46,7 +46,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^2.1.0-alpha.14",
+    "@metriport/commonwell-sdk": "^2.1.0-alpha.15",
     "commander": "^9.5.0",
     "dotenv": "^16.0.3",
     "lodash": "^4.17.21",

--- a/packages/packages/commonwell-jwt-maker/package.json
+++ b/packages/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.2.2-alpha.17",
+  "version": "1.2.2-alpha.18",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -45,7 +45,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^2.1.0-alpha.14",
+    "@metriport/commonwell-sdk": "^2.1.0-alpha.15",
     "commander": "^9.5.0"
   }
 }

--- a/packages/packages/commonwell-sdk/package.json
+++ b/packages/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "2.1.0-alpha.14",
+  "version": "2.1.0-alpha.15",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/react-native-sdk/package.json
+++ b/packages/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "0.1.1-alpha.16",
+  "version": "0.1.1-alpha.17",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",


### PR DESCRIPTION
Ref. metriport/metriport-internal#438

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/441

### Description

BREAKING CHANGE:
- split org mgmt createOrUpdate in individual create and update endpoints

### Release Plan

- anytime along dependencies
- alpha SDK already deployed