### PR TITLE
fix(api): allow all headers (CORS)

### DIFF
--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -281,6 +281,7 @@ export class APIStack extends Stack {
       defaultIntegration: integration,
       defaultCorsPreflightOptions: {
         allowOrigins: ["*"],
+        allowHeaders: ["*"],
       },
     });
 


### PR DESCRIPTION
Ref. https://github.com/metriport/metriport-internal/issues/474

### Dependencies

- Upstream: none
- Downstream: none

### Description

Allow all headers (CORS).

The main change is on API GW. Left the change at the API's `app.ts` because of [this](https://www.npmjs.com/package/cors#enabling-cors-pre-flight).

### Release Plan

Nothing special, asap.