### PR TITLE
refactor(api): rejig OID generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,9 @@ To do it manually:
 1. Go to API Gateway;
 1. Create a Usage Plan if you don't already have one;
 1. Create an API Key;
+   - the `value` field must follow this pattern: base 64 of "`<KEY>:<UUID>`", where:
+   - `KEY` is a random key (e.g., generated with `nanoid`); and
+   - `UUID` is the customer ID (more about this on [Initialization](#initialization))
 1. Add the newly created API Key to a Usage Plan.
 
 Now you can make requests to endpoints that require the an API Key by setting the `x-api-key` header.

--- a/README.md
+++ b/README.md
@@ -434,7 +434,17 @@ Check the scripts on the folder's [package.json](https://github.com/metriport/me
 
 ### **API Key Setup**
 
-TODO
+Most endpoints require an API Gateway [API Key](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html). You can do it manually on AWS console or programaticaly through AWS CLI or SDK.
+
+To do it manually:
+
+1. Login to the AWS console;
+1. Go to API Gateway;
+1. Create a Usage Plan if you don't already have one;
+1. Create an API Key;
+1. Add the newly created API Key to a Usage Plan.
+
+Now you can make requests to endpoints that require the an API Key by setting the `x-api-key` header.
 
 ### **Environment Setup**
 
@@ -471,6 +481,20 @@ Note: if you need help with the `deploy.sh` script at any time, you can run:
 ```shell
 $ ./deploy.sh -h
 ```
+
+### **Initialization**
+
+The API Server works with the concept of "Customer", which is basically a tenant on the API Server DB.
+There must be at least one customer on the API Server DB - you can think of it as your account in case you're
+planning to have only one.
+
+Each new Customer on the API Server should be initialized by calling the "init" endpoint with said customer ID:
+
+```
+POST /internal/init?cxId=<customer-id>
+```
+
+The customer ID must be a UUID.
 
 ## License
 

--- a/api/app/docker-compose.dev.yml
+++ b/api/app/docker-compose.dev.yml
@@ -56,6 +56,7 @@ services:
   postgres:
     image: postgres:14.4-alpine
     restart: always
+    command: -c 'max_connections=200'
     environment:
       # You can set the value of environment variables
       # in your docker-compose.yml file

--- a/api/app/src/command/account-init.ts
+++ b/api/app/src/command/account-init.ts
@@ -1,0 +1,57 @@
+import _ from "lodash";
+import { CustomerSequenceModel, DataType, dataTypes } from "../models/medical/customer-sequence";
+import { FacilityModel } from "../models/medical/facility";
+import { OrganizationModel } from "../models/medical/organization";
+import { PatientModel } from "../models/medical/patient";
+import { Config } from "../shared/config";
+import { OID_ID_START } from "../shared/oid";
+
+/**
+ * Initialize customer/main account.
+ * Should be idempotent, so it can be called multiple times without side effects.
+ *
+ * @param cxId the customer/account ID
+ */
+export async function accountInit(cxId: string): Promise<void> {
+  await initSequences(cxId);
+}
+
+export async function initSequences(cxId: string): Promise<void> {
+  // only initialize customer sequence for data types that are not "organization"
+  const cxDataTypesForSeq = _.difference<DataType>(dataTypes, ["organization"]);
+  const existingEntries = await CustomerSequenceModel.findAll({
+    where: { id: [cxId] },
+  });
+  const diff = _.difference(
+    cxDataTypesForSeq,
+    existingEntries.map(e => e.dataType)
+  );
+  for (const dataType of diff) {
+    const currSeq = await getMaxSeq(dataType, cxId);
+    const seqNumber = currSeq ? currSeq + 1 : OID_ID_START;
+    await CustomerSequenceModel.create({ id: cxId, dataType, sequence: seqNumber });
+  }
+
+  // make sure organization sequence is initialized
+  const rootID = Config.getSystemRootOID();
+  const orgEntry = await CustomerSequenceModel.findOne({
+    where: { id: [rootID], dataType: "organization" },
+  });
+  if (!orgEntry) {
+    const maxOrgNumber = await getMaxSeq("organization");
+    await CustomerSequenceModel.create({
+      id: rootID,
+      dataType: "organization",
+      sequence: maxOrgNumber ? Number(maxOrgNumber) + 1 : OID_ID_START,
+    });
+  }
+}
+
+async function getMaxSeq(dataType: DataType, cxId?: string): Promise<number | undefined> {
+  const mapping: { [key in DataType]: () => Promise<number | undefined> } = {
+    organization: () => OrganizationModel.max("organizationNumber"),
+    facility: () => FacilityModel.max("facilityNumber", { where: { cxId } }),
+    patient: () => PatientModel.max("patientNumber", { where: { cxId } }),
+  };
+  return mapping[dataType]();
+}

--- a/api/app/src/command/medical/customer-sequence/create-id.ts
+++ b/api/app/src/command/medical/customer-sequence/create-id.ts
@@ -1,0 +1,52 @@
+import { CustomerSequenceModel, DataType } from "../../../models/medical/customer-sequence";
+import { Config } from "../../../shared/config";
+import { makeFacilityOID, makeOrganizationOID, makePatientOID } from "../../../shared/oid";
+import { getOrganizationOrFail } from "../organization/get-organization";
+
+export async function createOrganizationId(): Promise<{ id: string; organizationNumber: number }> {
+  const organizationNumber = await nextSeq(Config.getSystemRootOID(), "organization");
+  const id = makeOrganizationOID(organizationNumber);
+  return { id, organizationNumber };
+}
+
+export async function createFacilityId(
+  cxId: string
+): Promise<{ id: string; facilityNumber: number }> {
+  const facilityNumber = await nextSeq(cxId, "facility");
+  const org = await getOrganizationOrFail({ cxId });
+  const id = makeFacilityOID(org.id, facilityNumber);
+  return { id, facilityNumber };
+}
+
+export async function createPatientId(
+  cxId: string
+): Promise<{ id: string; patientNumber: number }> {
+  const patientNumber = await nextSeq(cxId, "patient");
+  const org = await getOrganizationOrFail({ cxId });
+  const id = makePatientOID(org.id, patientNumber);
+  return { id, patientNumber };
+}
+
+export async function nextSeq(cxId: string, dataType: DataType): Promise<number> {
+  const sequelize = CustomerSequenceModel.sequelize;
+  if (!sequelize) throw new Error("Missing sequelize");
+
+  const transaction = await sequelize.transaction();
+  try {
+    const res = await CustomerSequenceModel.findOne({
+      where: { id: cxId, dataType },
+      transaction,
+      lock: true, // row lock
+    });
+    if (!res) throw new Error(`Missing customer sequence for cxId ${cxId} and ${dataType}`);
+
+    const sequence = res.sequence + 1;
+    await res.update({ sequence }, { transaction });
+
+    await transaction.commit();
+    return sequence;
+  } catch (err) {
+    await transaction.rollback();
+    throw err;
+  }
+}

--- a/api/app/src/command/medical/facility/create-facility.ts
+++ b/api/app/src/command/medical/facility/create-facility.ts
@@ -1,4 +1,5 @@
 import { FacilityData, FacilityModel } from "../../../models/medical/facility";
+import { createFacilityId } from "../customer-sequence/create-id";
 
 export const createFacility = async ({
   cxId,
@@ -7,9 +8,10 @@ export const createFacility = async ({
   cxId: string;
   data: FacilityData;
 }): Promise<FacilityModel> => {
+  const { id, facilityNumber } = await createFacilityId(cxId);
   return FacilityModel.create({
-    id: "", // the facility id will be generated on the beforeCreate hook
-    facilityNumber: 0, // this will be generated on the beforeCreate hook
+    id,
+    facilityNumber,
     cxId,
     data,
   });

--- a/api/app/src/command/medical/patient/create-patient.ts
+++ b/api/app/src/command/medical/patient/create-patient.ts
@@ -1,4 +1,5 @@
 import { Patient, PatientCreate, PatientData, PatientModel } from "../../../models/medical/patient";
+import { createPatientId } from "../customer-sequence/create-id";
 import { sanitize, validate } from "./shared";
 
 type Identifier = Pick<Patient, "cxId"> & { facilityId: string };
@@ -7,15 +8,16 @@ export type PatientCreateCmd = PatientNoExternalData & Identifier;
 
 export const createPatient = async (patient: PatientCreateCmd): Promise<Patient> => {
   const { cxId, facilityId } = patient;
-
   const sanitized = sanitize(patient);
   validate(sanitized);
-
   const { firstName, lastName, dob, genderAtBirth, personalIdentifiers, address, contact } =
     sanitized;
-  const patientCreate: PatientCreate & Pick<Patient, "id"> = {
-    id: "", // the patient id will be generated on the beforeCreate hook
-    patientNumber: 0, // this will be generated on the beforeCreate hook
+
+  const { id, patientNumber } = await createPatientId(cxId);
+
+  const patientCreate: PatientCreate = {
+    id,
+    patientNumber,
     cxId,
     facilityIds: [facilityId],
     data: { firstName, lastName, dob, genderAtBirth, personalIdentifiers, address, contact },

--- a/api/app/src/external/commonwell/document.ts
+++ b/api/app/src/external/commonwell/document.ts
@@ -3,7 +3,7 @@ import mime from "mime-types";
 import * as stream from "stream";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
 import { Patient } from "../../models/medical/patient";
-import { oid, patientId as makePatientId } from "../../shared/oid";
+import { makePatientOID, oid } from "../../shared/oid";
 import { Util } from "../../shared/util";
 import { makeCommonWellAPI, organizationQueryMeta } from "./api";
 import { getPatientData, PatientDataCommonwell } from "./patient-shared";
@@ -87,7 +87,7 @@ export async function downloadDocument({
 }
 
 function getFileName(patient: Patient, doc: Document): string {
-  const prefix = "document_" + makePatientId("", patient.patientNumber).substring(1);
+  const prefix = "document_" + makePatientOID("", patient.patientNumber).substring(1);
   const display = doc.content?.type?.coding?.length
     ? doc.content?.type.coding[0].display
     : undefined;

--- a/api/app/src/external/commonwell/organization.ts
+++ b/api/app/src/external/commonwell/organization.ts
@@ -61,15 +61,21 @@ export async function organizationToCommonwell(
 }
 
 export const create = async (org: Organization): Promise<void> => {
-  const { log } = Util.out(`CW create - M orgId ${org.id}`);
+  const { log, debug } = Util.out(`CW create - M orgId ${org.id}`);
   const cwOrg = await organizationToCommonwell(org);
   try {
     const commonWell = makeCommonWellAPI(
       Config.getMetriportOrgName(),
       Config.getMemberManagementOID()
     );
-    await commonWell.createOrg(metriportQueryMeta, cwOrg);
-    await commonWell.addCertificateToOrg(metriportQueryMeta, certificate, org.id);
+    const respCreate = await commonWell.createOrg(metriportQueryMeta, cwOrg);
+    debug(`resp respCreate: ${JSON.stringify(respCreate, null, 2)}`);
+    const respAddCert = await commonWell.addCertificateToOrg(
+      metriportQueryMeta,
+      certificate,
+      org.id
+    );
+    debug(`resp respAddCert: ${JSON.stringify(respAddCert, null, 2)}`);
   } catch (error) {
     const msg = `Failure creating Org`;
     log(`${msg} - payload: `, cwOrg);

--- a/api/app/src/models/_default.ts
+++ b/api/app/src/models/_default.ts
@@ -12,21 +12,14 @@ import { Util } from "../shared/util";
 
 export type ModelSetup = (sequelize: Sequelize) => void;
 
-export const defaultModelOptions = <M extends Model>(sequelize: Sequelize): InitOptions<M> => ({
-  sequelize,
-  freezeTableName: true,
-  underscored: true,
-  timestamps: true,
-  createdAt: "created_at",
-  updatedAt: "updated_at",
-  version: true, // requires a `version` column; override it to false if you don't want versioning
-});
-
-export interface IBaseModel {
+export interface IBaseModelCreate {
   id: string;
-  createdAt: CreationOptional<Date>;
-  updatedAt: CreationOptional<Date>;
-  eTag: CreationOptional<string>;
+}
+
+export interface IBaseModel extends IBaseModelCreate {
+  createdAt: Date;
+  updatedAt: Date;
+  eTag: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,7 +33,7 @@ export abstract class BaseModel<T extends Model<any, any>>
   private declare version: CreationOptional<number>;
   declare eTag: CreationOptional<string>;
 
-  static baseAttributes() {
+  static attributes() {
     return {
       id: {
         type: DataTypes.STRING,
@@ -60,11 +53,22 @@ export abstract class BaseModel<T extends Model<any, any>>
       },
       eTag: {
         type: DataTypes.VIRTUAL,
-        //eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         get<T extends Model<any, any>>(this: BaseModel<T>): string {
           return Util.md5(this.id + "_" + this.version);
         },
       },
+    };
+  }
+  static modelOptions<M extends Model>(sequelize: Sequelize): InitOptions<M> {
+    return {
+      sequelize,
+      freezeTableName: true,
+      underscored: true,
+      timestamps: true,
+      createdAt: "created_at",
+      updatedAt: "updated_at",
+      version: true, // requires a `version` column; override it to false if you don't want versioning
     };
   }
 }

--- a/api/app/src/models/connected-user.ts
+++ b/api/app/src/models/connected-user.ts
@@ -1,6 +1,6 @@
 import { DataTypes, Sequelize } from "sequelize";
 import { ProviderOptions } from "../shared/constants";
-import { BaseModel, defaultModelOptions, ModelSetup } from "./_default";
+import { BaseModel, ModelSetup } from "./_default";
 
 export type ProviderMapItem = {
   token: string; // user authorization token
@@ -22,7 +22,7 @@ export class ConnectedUser extends BaseModel<ConnectedUser> {
   static setup: ModelSetup = (sequelize: Sequelize) => {
     ConnectedUser.init(
       {
-        ...BaseModel.baseAttributes(),
+        ...BaseModel.attributes(),
         id: {
           type: DataTypes.UUID,
           primaryKey: true,
@@ -38,7 +38,7 @@ export class ConnectedUser extends BaseModel<ConnectedUser> {
         },
       },
       {
-        ...defaultModelOptions(sequelize),
+        ...BaseModel.modelOptions(sequelize),
         tableName: ConnectedUser.NAME,
       }
     );

--- a/api/app/src/models/db.ts
+++ b/api/app/src/models/db.ts
@@ -4,6 +4,7 @@ import updateDB from "../sequelize";
 import { Config, getEnvVarOrFail } from "../shared/config";
 import { ConnectedUser } from "./connected-user";
 import { initDDBDev } from "./db-dev";
+import { CustomerSequenceModel } from "./medical/customer-sequence";
 import { FacilityModel } from "./medical/facility";
 import { MAPIAccess } from "./medical/mapi-access";
 import { OrganizationModel } from "./medical/organization";
@@ -21,6 +22,7 @@ const models: ModelSetup[] = [
   FacilityModel.setup,
   PatientModel.setup,
   MAPIAccess.setup,
+  CustomerSequenceModel.setup,
 ];
 
 export type MetriportDB = {

--- a/api/app/src/models/medical/customer-sequence.ts
+++ b/api/app/src/models/medical/customer-sequence.ts
@@ -1,0 +1,41 @@
+import { DataTypes, InferAttributes, InferCreationAttributes, Model, Sequelize } from "sequelize";
+import { ModelSetup } from "../_default";
+
+export const dataTypes = ["organization", "facility", "patient"] as const;
+export type DataType = (typeof dataTypes)[number];
+
+export interface CustomerSequence {
+  id: string; // Customer ID
+  dataType: DataType;
+  sequence: number;
+}
+
+export class CustomerSequenceModel
+  extends Model<
+    InferAttributes<CustomerSequenceModel>,
+    InferCreationAttributes<CustomerSequenceModel>
+  >
+  implements CustomerSequence
+{
+  static NAME = "customer_sequence";
+  declare id: string;
+  declare dataType: DataType;
+  declare sequence: number;
+
+  static setup: ModelSetup = (sequelize: Sequelize) => {
+    CustomerSequenceModel.init(
+      {
+        id: { type: DataTypes.STRING, primaryKey: true },
+        dataType: { type: DataTypes.STRING, primaryKey: true },
+        sequence: { type: DataTypes.INTEGER, allowNull: false, autoIncrement: true },
+      },
+      {
+        sequelize,
+        tableName: CustomerSequenceModel.NAME,
+        freezeTableName: true,
+        timestamps: false,
+        underscored: true,
+      }
+    );
+  };
+}

--- a/api/app/src/models/medical/mapi-access.ts
+++ b/api/app/src/models/medical/mapi-access.ts
@@ -1,5 +1,5 @@
 import { Sequelize } from "sequelize";
-import { BaseModel, defaultModelOptions, ModelSetup } from "../_default";
+import { BaseModel, ModelSetup } from "../_default";
 
 export class MAPIAccess extends BaseModel<MAPIAccess> {
   static NAME = "mapi_access";
@@ -7,10 +7,10 @@ export class MAPIAccess extends BaseModel<MAPIAccess> {
   static setup: ModelSetup = (sequelize: Sequelize) => {
     MAPIAccess.init(
       {
-        ...BaseModel.baseAttributes(),
+        ...BaseModel.attributes(),
       },
       {
-        ...defaultModelOptions(sequelize),
+        ...BaseModel.modelOptions(sequelize),
         tableName: MAPIAccess.NAME,
       }
     );

--- a/api/app/src/models/settings.ts
+++ b/api/app/src/models/settings.ts
@@ -1,5 +1,5 @@
 import { DataTypes, Sequelize } from "sequelize";
-import { BaseModel, defaultModelOptions, ModelSetup } from "./_default";
+import { BaseModel, ModelSetup } from "./_default";
 
 export const DATE_FORMAT = "YYYY-MM";
 export const WEBHOOK_STATUS_OK = "OK";
@@ -16,7 +16,7 @@ export class Settings extends BaseModel<Settings> {
   static setup: ModelSetup = (sequelize: Sequelize) => {
     Settings.init(
       {
-        ...BaseModel.baseAttributes(),
+        ...BaseModel.attributes(),
         id: {
           type: DataTypes.UUID,
           primaryKey: true,
@@ -35,7 +35,7 @@ export class Settings extends BaseModel<Settings> {
         },
       },
       {
-        ...defaultModelOptions(sequelize),
+        ...BaseModel.modelOptions(sequelize),
         tableName: Settings.NAME,
       }
     );

--- a/api/app/src/models/webhook-request.ts
+++ b/api/app/src/models/webhook-request.ts
@@ -1,5 +1,5 @@
 import { DataTypes, Sequelize } from "sequelize";
-import { BaseModel, defaultModelOptions, ModelSetup } from "./_default";
+import { BaseModel, ModelSetup } from "./_default";
 
 export type WebhookRequestStatus = "processing" | "success" | "failure";
 
@@ -13,7 +13,7 @@ export class WebhookRequest extends BaseModel<WebhookRequest> {
   static setup: ModelSetup = (sequelize: Sequelize) => {
     WebhookRequest.init(
       {
-        ...BaseModel.baseAttributes(),
+        ...BaseModel.attributes(),
         id: {
           type: DataTypes.UUID,
           primaryKey: true,
@@ -29,7 +29,7 @@ export class WebhookRequest extends BaseModel<WebhookRequest> {
         },
       },
       {
-        ...defaultModelOptions(sequelize),
+        ...BaseModel.modelOptions(sequelize),
         tableName: WebhookRequest.NAME,
       }
     );

--- a/api/app/src/routes/index.ts
+++ b/api/app/src/routes/index.ts
@@ -14,12 +14,14 @@ import sleep from "./sleep";
 import user from "./user";
 import webhook from "./webhook";
 import medical from "./medical";
+import internal from "./internal";
 
 export default (app: Application) => {
   app.use(requestLogger);
 
   // internal only routes, should be disabled at API Gateway
   app.use("/webhook", webhook);
+  app.use("/internal", internal);
 
   // routes with API key auth
   app.use("/settings", processAPIKey, settings);

--- a/api/app/src/routes/internal.ts
+++ b/api/app/src/routes/internal.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from "express";
+import Router from "express-promise-router";
+import status from "http-status";
+import { accountInit } from "../command/account-init";
+import { asyncHandler, getFromQueryOrFail } from "./util";
+
+const router = Router();
+
+/** ---------------------------------------------------------------------------
+ * POST /internal/init
+ *
+ * Initialize a (customer's) account. This is an idempotent operation, which
+ * means it can be called multiple times without side effects.
+ *
+ * @param req.query.cxId - The customer/account's ID.
+ * @return 200 Indicating the account has been initialized.
+ */
+router.post(
+  "/init",
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getFromQueryOrFail("cxId", req);
+    await accountInit(cxId);
+    return res.sendStatus(status.OK);
+  })
+);
+
+export default router;

--- a/api/app/src/routes/middlewares/auth.ts
+++ b/api/app/src/routes/middlewares/auth.ts
@@ -2,6 +2,7 @@ import base64url from "base64url";
 import { NextFunction, Request, Response } from "express";
 import { MAPIAccess } from "../../models/medical/mapi-access";
 import status from "http-status";
+import { getCxIdOrFail } from "../util";
 
 /**
  * Process the API key and get the customer id.
@@ -33,7 +34,8 @@ export const checkMAPIAccess = async (
 ): Promise<void> => {
   let hasMAPIAccess = false;
   try {
-    const mapiAccess = await MAPIAccess.findOne({ where: { id: req.cxId } });
+    const cxId = getCxIdOrFail(req);
+    const mapiAccess = await MAPIAccess.findOne({ where: { id: cxId } });
     hasMAPIAccess = mapiAccess != null;
   } catch (error) {
     console.error(`Failed checking MAPI access with error ${error}`);

--- a/api/app/src/sequelize/migrations/20230324144300_create-customer-sequence.ts
+++ b/api/app/src/sequelize/migrations/20230324144300_create-customer-sequence.ts
@@ -1,0 +1,105 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { DataTypes, Sequelize, Transaction } from "sequelize";
+import type { Migration } from "..";
+import { Config } from "../../shared/config";
+import { OID_ID_START } from "../../shared/oid";
+
+const tableName = "customer_sequence";
+const dataTypes = ["organization", "facility", "patient"] as const;
+type DataType = (typeof dataTypes)[number];
+
+// Use 'Promise.all' when changes are independent of each other
+// Docs: https://sequelize.org/api/v6/class/src/dialects/abstract/query-interface.js~queryinterface
+export const up: Migration = async ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.createTable(
+      tableName,
+      {
+        id: { type: DataTypes.STRING, primaryKey: true },
+        dataType: { type: DataTypes.STRING, primaryKey: true, field: "data_type" },
+        sequence: { type: DataTypes.INTEGER, allowNull: false, autoIncrement: true },
+      },
+      { transaction }
+    );
+
+    for (const dataType of dataTypes) {
+      const cxIDs =
+        dataType === "organization"
+          ? [Config.getSystemRootOID()]
+          : await getCxIDs(queryInterface.sequelize, dataType, transaction);
+      for (const cxId of cxIDs) {
+        const maxSeq = await getMaxSeq(queryInterface.sequelize, cxId, dataType, transaction);
+        const currSeq = getSeq(maxSeq);
+        const nextSeq = currSeq ? currSeq + 1 : OID_ID_START;
+        await queryInterface.sequelize.query(
+          `insert into ${tableName} (id, data_type, sequence) ` +
+            `values ('${cxId}', '${dataType}', ${nextSeq})`,
+          { transaction }
+        );
+      }
+    }
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.dropTable(tableName, { transaction });
+  });
+};
+
+async function getCxIDs(
+  sequelize: Sequelize,
+  dataType: DataType,
+  transaction: Transaction
+): Promise<string[]> {
+  const [res] = await sequelize.query(
+    `select cx_id from organization ` +
+      `where cx_id::text not in (` +
+      `  select id from ${tableName} where data_type = '${dataType}'` +
+      `) ` +
+      `union all ` +
+      `select cx_id from connected_user ` +
+      `where cx_id::text not in (` +
+      `  select id from ${tableName} where data_type = '${dataType}'` +
+      `)`,
+    { transaction }
+  );
+  return res && res.length ? (res as any[]).map(r => r.cx_id) : [];
+}
+
+async function getMaxSeq(
+  sequelize: Sequelize,
+  cxId: string,
+  dataType: DataType,
+  transaction: Transaction
+): Promise<string> {
+  let tableName: string;
+  let filterByCustomer = false;
+  switch (dataType) {
+    case "organization":
+      tableName = "organization";
+      break;
+    case "facility":
+      tableName = "facility";
+      filterByCustomer = true;
+      break;
+    case "patient":
+      tableName = "patient";
+      filterByCustomer = true;
+      break;
+    default:
+      throw new Error(`Invalid data type: ${dataType}`);
+  }
+  const [res] = await sequelize.query(
+    `select max("id") from "${tableName}" ${filterByCustomer ? `where cx_id = '${cxId}'` : ""}`,
+    { transaction }
+  );
+  return res && res.length ? (res[0] as any)["max"] : undefined;
+}
+
+function getSeq(id: string | undefined): number | undefined {
+  if (!id) return undefined;
+  const parts = id.split(".");
+  if (!parts || parts.length <= 0) return undefined;
+  return Number(parts[parts.length - 1]);
+}

--- a/api/app/src/shared/oid.ts
+++ b/api/app/src/shared/oid.ts
@@ -1,3 +1,4 @@
+import { Config } from "./config";
 import { USState } from "./geographic-locations";
 
 export const OID_ID_START = 100;
@@ -23,7 +24,15 @@ export function oid(id: string): string {
   return `${OID_PREFIX}${id}`;
 }
 
-export function patientId(orgId: string, patientNumber: string | number): string {
+export function makeOrganizationOID(orgNumber: string | number): string {
+  return `${Config.getSystemRootOID()}.${OIDNode.organizations}.${orgNumber}`;
+}
+
+export function makeFacilityOID(orgId: string, facilityNumber: string | number): string {
+  return `${orgId}.${OIDNode.locations}.${facilityNumber}`;
+}
+
+export function makePatientOID(orgId: string, patientNumber: string | number): string {
   return `${orgId}.${OIDNode.patients}.${patientNumber}`;
 }
 

--- a/utils/src/load-test.sh
+++ b/utils/src/load-test.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Inspired by https://gist.github.com/bigomega/4de7dbc395be0e0f33b4
+# TODO: allow multiple headers
+# TODO: call curl with optional parameters so the code is not duplicated (DRY)
+
+############################################################
+# Help                                                     #
+############################################################
+Help()
+{
+   # Display Help
+   echo
+   echo "Syntax: load-test.sh -[h|u|r|H|d]"
+   echo "options:"
+   echo "  h - Print this help."
+   echo "  u - The URL to be executed/called"
+   echo "  r - The rate of calls per second"
+   echo "  H - [optional] The header to be passed to curl"
+   echo "  d - [optional] The data to be passed to curl (POST)"
+   echo
+   echo "Example: load-test.sh -r 10 -u \"http://domain.com/path\""
+   echo
+}
+
+############################################################
+# Execute                                                  #
+############################################################
+Execute () {
+  if [ "$header" ]; then
+    if [[ "$data" ]]; then
+      curl -s -v "$url" --header "$header" --data "$data" --header "Content-Type: application/json" 2>&1 | tr '\r\n' '\n' | awk -v date="$(date '+%Y-%m-%dT%H:%M:%S')" '{print date $0}' >> /tmp/perf-test.log
+    else
+      curl -s -v "$url" --header "$header" 2>&1 | tr '\r\n' '\\n' | awk -v date="$(date '+%Y-%m-%dT%H:%M:%S')" '{print date $0}' >> /tmp/perf-test.log
+    fi
+  else
+    if [[ "$data" ]]; then
+      curl -s -v "$url" --data "$data" --header "Content-Type: application/json" 2>&1 | tr '\r\n' '\\n' | awk -v date="$(date '+%Y-%m-%dT%H:%M:%S')" '{print date $0}' >> /tmp/perf-test.log
+    else
+      curl -s -v "$url" 2>&1 | tr '\r\n' '\n' | awk -v date="$(date '+%Y-%m-%dT%H:%M:%S')" '{print date $0}' >> /tmp/perf-test.log
+    fi
+  fi
+}
+
+############################################################
+# Main                                                     #
+############################################################
+Main () {
+  echo "URL: $url"
+  echo "Rate: $rate"
+  echo "Header: $header"
+  echo "Data: $data"
+  echo "Starting load test in 2s..."
+  sleep 2
+  while true
+  do
+    echo $(($(date +%s) - START)) | awk '{print int($1/60)":"int($1%60)}'
+    sleep 1
+
+    for i in `seq 1 $rate`
+    do
+      Execute &
+    done
+  done
+}
+
+############################################################
+# Plumbing                                                 #
+############################################################
+while getopts ":hu:r:H:d:" option; do
+   case $option in
+      h) Help
+         echo "Simple load test script."
+         exit;;
+      u) url=$OPTARG;;
+      r) rate=$OPTARG;;
+      H) header=$OPTARG;;
+      d) data=$OPTARG;;
+      \?) echo "Error: Invalid option"
+          exit;;
+   esac
+done
+
+if [[ -z "$url" ]]; then
+    echo "No URL specified"
+    Help
+    exit
+fi
+if [[ -z "$rate" ]]; then
+    echo "No rate specified"
+    Help
+    exit
+fi
+
+Main


### PR DESCRIPTION
Ref. metriport/metriport-internal#366

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/485

### Description

- OID generation with sequence per customer
- add account/customer init
  - ⚠️ this endpoint doesn't has auth, relies on internal's endpoint `/internal` created on API GW to close public access
- add API DNS entry on private zone
- update README w/ acc init & API Key setup

### Release Plan

- ⚠️ Contains DB migration
- ⚠️ Contains Infra update (auto applied upon merge)