### PR TITLE
fix(api): fix OID migration script

### DIFF
--- a/api/app/src/sequelize/migrations/20230324144300_create-customer-sequence.ts
+++ b/api/app/src/sequelize/migrations/20230324144300_create-customer-sequence.ts
@@ -53,7 +53,8 @@ async function getCxIDs(
   transaction: Transaction
 ): Promise<string[]> {
   const [res] = await sequelize.query(
-    `select cx_id from organization ` +
+    `select distinct cx_id from (` +
+      `select cx_id from organization ` +
       `where cx_id::text not in (` +
       `  select id from ${tableName} where data_type = '${dataType}'` +
       `) ` +
@@ -61,7 +62,7 @@ async function getCxIDs(
       `select cx_id from connected_user ` +
       `where cx_id::text not in (` +
       `  select id from ${tableName} where data_type = '${dataType}'` +
-      `)`,
+      `)) x`,
     { transaction }
   );
   return res && res.length ? (res as any[]).map(r => r.cx_id) : [];


### PR DESCRIPTION
Ref. metriport/metriport-internal#366

### Dependencies

- Upstream:https://github.com/metriport/metriport/pull/178
- Downstream: none

### Description

Fix the migration script, the previous version was returning the same customer ID multiple times, leading to error while inserting as that's part of the PK.

Context: https://metriport.slack.com/archives/C04FZ9859FZ/p1680016514274639?thread_ts=1680014828.936219&cid=C04FZ9859FZ

### Release Plan

- asap