### PR TITLE
ci: temp disable sentry

### DIFF
--- a/.github/workflows/_reusable_deploy.yml
+++ b/.github/workflows/_reusable_deploy.yml
@@ -92,7 +92,10 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-        if: env.SENTRY_AUTH_TOKEN != null && env.SENTRY_ORG != null
+        # TODO: #156 disabled bc its not working, waiting Sentry support
+        # https://metriport.slack.com/archives/C04FZ9859FZ/p1680112432771159?thread_ts=1680110062.829999&cid=C04FZ9859FZ
+        # if: env.SENTRY_AUTH_TOKEN != null && env.SENTRY_ORG != null
+        if: false
         with:
           environment: ${{ inputs.deploy_env }}
           version: ${{ github.sha }}


### PR DESCRIPTION
Ref. metriport/metriport-internal#156

### Dependencies

- Upstream: none
- Downstream: none

### Description

Temp disable sentry on CI/CD.
Was using CI/CD so we can push source maps; meanwhile, will use the regular Github integration.

More context here: https://metriport.slack.com/archives/C04FZ9859FZ/p1680112432771159?thread_ts=1680110062.829999&cid=C04FZ9859FZ

### Release Plan

- [ ] enable default Github integration
- [ ] merge this asap