### PR TITLE
refactor: send cxId to Sentry through auth

### DIFF
--- a/api/app/src/command/webhook/retry-failed.ts
+++ b/api/app/src/command/webhook/retry-failed.ts
@@ -1,5 +1,5 @@
 import { WebhookRequest } from "../../models/webhook-request";
-import { captureError } from "../../shared/notifications";
+import { capture } from "../../shared/notifications";
 import { Util } from "../../shared/util";
 import { getSettingsOrFail } from "../settings/getSettings";
 import { processRequest } from "./webhook";
@@ -33,7 +33,7 @@ export const retryFailedRequests = async (cxId: string): Promise<void> => {
         if (success) await Util.sleep(Math.random() * 200);
       }
     } catch (err) {
-      captureError(err, { extra: { cxId, context: `webhook.retryFailedRequests` } });
+      capture.error(err, { extra: { context: `webhook.retryFailedRequests` } });
     }
   };
   // intentionally asynchronous

--- a/api/app/src/command/webhook/webhook.ts
+++ b/api/app/src/command/webhook/webhook.ts
@@ -9,7 +9,7 @@ import { AppleWebhookPayload } from "../../mappings/apple";
 import { DataType, TypedData, UserData } from "../../mappings/garmin";
 import { Settings, WEBHOOK_STATUS_OK } from "../../models/settings";
 import { WebhookRequest } from "../../models/webhook-request";
-import { captureError } from "../../shared/notifications";
+import { capture } from "../../shared/notifications";
 import { Util } from "../../shared/util";
 import { getConnectedUserOrFail, getConnectedUsers } from "../connected-user/get-connected-user";
 import { getUserTokenByUAT } from "../cx-user/get-user-token";
@@ -56,6 +56,7 @@ export const processData = async <T extends MetriportData>(data: UserData<T>[]):
         const connectedUsers = (
           await Promise.all(
             userTokens.map(async ut => {
+              // not setting user on capture bc this is running in parallel/asynchronously
               return getConnectedUsers({
                 cxId: ut.cxId,
                 ids: [ut.userId],
@@ -127,15 +128,15 @@ export const processData = async <T extends MetriportData>(data: UserData<T>[]):
         } catch (err) {
           const msg = getErrorMessage(err);
           log(`Failed to process data of customer ${cxId}: ${msg}`);
-          captureError(err, {
-            extra: { cxId, context: `webhook.processData.customer` },
+          capture.error(err, {
+            extra: { context: `webhook.processData.customer` },
           });
         }
       })
     );
   } catch (err) {
     log(`Error on processData: `, err);
-    captureError(err, {
+    capture.error(err, {
       extra: { context: `webhook.processData.global` },
     });
   }
@@ -156,8 +157,8 @@ export const processAppleData = async (
     reportUsage(connectedUser.cxId, [connectedUser.cxUserId]);
   } catch (err) {
     log(`Error on processAppleData: `, err);
-    captureError(err, {
-      extra: { cxId, metriportUserId, context: `webhook.processAppleData` },
+    capture.error(err, {
+      extra: { metriportUserId, context: `webhook.processAppleData` },
     });
   }
 };
@@ -166,7 +167,7 @@ const reportUsage = (cxId: string, cxUserIds: string[]): void => {
   cxUserIds.forEach(cxUserId => [
     reportUsageCmd({ cxId, cxUserId, apiType: ApiTypes.devices }).catch(err => {
       log(`Failed to report usage (${{ cxId, cxUserId, apiType: ApiTypes.devices }}): `, err);
-      captureError(err, { extra: { cxId, cxUserId, apiType: ApiTypes.devices } });
+      capture.error(err, { extra: { cxUserId, apiType: ApiTypes.devices } });
     }),
   ]);
 };
@@ -239,7 +240,7 @@ export const processRequest = async (
     return true;
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (err: any) {
-    captureError(err, {
+    capture.error(err, {
       extra: { webhookRequestId: webhookRequest.id, webhookUrl, context: `webhook.processRequest` },
     });
     try {
@@ -250,7 +251,7 @@ export const processRequest = async (
       });
     } catch (err2) {
       console.log(`Failed to store failure state on WH log`, err2);
-      captureError(err2, {
+      capture.error(err2, {
         extra: {
           webhookRequestId: webhookRequest.id,
           webhookUrl,
@@ -274,7 +275,7 @@ export const processRequest = async (
       });
     } catch (err2) {
       console.log(`Failed to store failure state on WH settings`, err2);
-      captureError(err2, {
+      capture.error(err2, {
         extra: {
           webhookRequestId: webhookRequest.id,
           webhookUrl,

--- a/api/app/src/external/commonwell/link/create.ts
+++ b/api/app/src/external/commonwell/link/create.ts
@@ -1,7 +1,7 @@
 import { isLOLA1, NetworkLink } from "@metriport/commonwell-sdk";
 import { reset } from ".";
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
-import { captureError } from "../../../shared/notifications";
+import { capture } from "../../../shared/notifications";
 import { oid } from "../../../shared/oid";
 import { makeCommonWellAPI, organizationQueryMeta } from "../api";
 import { setCommonwellId } from "../patient-external-data";
@@ -78,7 +78,7 @@ export const create = async (
               .upgradeOrDowngradeNetworkLink(queryMeta, link._links.upgrade.href)
               .catch(err => {
                 console.log(`Failed to upgrade link: `, err);
-                captureError(err, { extra: { cxId, cwPatientId, personId, context } });
+                capture.error(err, { extra: { cwPatientId, personId, context } });
                 throw err;
               })
           );
@@ -87,7 +87,7 @@ export const create = async (
       await Promise.allSettled(requests);
     }
   } catch (error) {
-    captureError(error, { extra: { cxId, cwPatientId, personId, context } });
+    capture.error(error, { extra: { cwPatientId, personId, context } });
     throw error;
   }
 };

--- a/api/app/src/external/commonwell/link/get.ts
+++ b/api/app/src/external/commonwell/link/get.ts
@@ -3,7 +3,7 @@ import { PatientLinkResp } from "@metriport/commonwell-sdk/lib/models/patient";
 import { uniqBy } from "lodash";
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 import { Patient } from "../../../models/medical/patient";
-import { captureMessage } from "../../../shared/notifications";
+import { capture } from "../../../shared/notifications";
 import { oid } from "../../../shared/oid";
 import { makeCommonWellAPI, organizationQueryMeta } from "../api";
 import { setCommonwellId } from "../patient-external-data";
@@ -77,9 +77,8 @@ export const findCurrentLink = async (
       const msg =
         "Got 404 when trying to query person's patient links @ CW - Removing person ID from DB.";
       console.log(msg);
-      captureMessage(msg, {
+      capture.message(msg, {
         extra: {
-          cxId: patient.cxId,
           patientId: patient.id,
           cwPatientId: patientCWId,
           personId,

--- a/api/app/src/external/commonwell/patient-shared.ts
+++ b/api/app/src/external/commonwell/patient-shared.ts
@@ -13,7 +13,7 @@ import { Facility } from "../../models/medical/facility";
 import { Organization } from "../../models/medical/organization";
 import { Patient, PatientExternalDataEntry } from "../../models/medical/patient";
 import { filterTruthy } from "../../shared/filter-map-utils";
-import { captureError, captureMessage } from "../../shared/notifications";
+import { capture } from "../../shared/notifications";
 import { driversLicenseURIs } from "../../shared/oid";
 import { Util } from "../../shared/util";
 import { makePersonForPatient } from "./patient-conversion";
@@ -47,7 +47,7 @@ export async function findOrCreatePerson({
       const subject = "Found more than one person for patient personal IDs";
       const message = idsToAlertMessage(commonwellPatientId, personIds);
       log(`${subject}: ${message}`);
-      captureMessage(subject, {
+      capture.message(subject, {
         extra: { commonwellPatientId, personIds, context: `cw.findOrCreatePerson.strongIds` },
       });
       return undefined;
@@ -64,7 +64,7 @@ export async function findOrCreatePerson({
       const subject = "Found more than one person for patient demographics";
       const message = idsToAlertMessage(commonwellPatientId, personIds);
       log(`${subject}: ${message}`);
-      captureMessage(subject, {
+      capture.message(subject, {
         extra: { commonwellPatientId, personIds, context: `cw.findOrCreatePerson.no.strongIds` },
       });
       return undefined;
@@ -130,7 +130,7 @@ export async function searchPersonIds({
     personalIds.map(id =>
       commonWell.searchPerson(queryMeta, id.key, id.system).catch(err => {
         log(`Failure searching person @ CW by personal ID`, err);
-        captureError(err, { extra: { context: `cw.searchPersonIds` } });
+        capture.error(err, { extra: { context: `cw.searchPersonIds` } });
         throw err;
       })
     )
@@ -163,7 +163,7 @@ export async function searchPersons({
     strongIds.map(id =>
       commonWell.searchPerson(queryMeta, id.key, id.system).catch(err => {
         console.log(`Failed to search for person with strongId: `, err);
-        captureError(err, { extra: { context: `cw.searchPersons` } });
+        capture.error(err, { extra: { context: `cw.searchPersons` } });
         throw err;
       })
     )

--- a/api/app/src/external/commonwell/patient.ts
+++ b/api/app/src/external/commonwell/patient.ts
@@ -9,7 +9,7 @@ import {
 import { StrongId } from "@metriport/commonwell-sdk/lib/models/identifier";
 import { MedicalDataSource } from "..";
 import { Patient, PatientExternalData } from "../../models/medical/patient";
-import { captureMessage } from "../../shared/notifications";
+import { capture } from "../../shared/notifications";
 import { oid } from "../../shared/oid";
 import { Util } from "../../shared/util";
 import { LinkStatus } from "../patient-link";
@@ -131,8 +131,8 @@ export async function update(patient: Patient, facilityId: string): Promise<void
       if (err.response?.status !== 404) throw err;
       const subject = "Got 404 when trying to update person @ CW, trying to find/create it";
       log(`${subject} - CW Person ID ${personId}`);
-      captureMessage(subject, {
-        extra: { cxId: patient.cxId, commonwellPatientId, personId, context: `cw.patient.update` },
+      capture.message(subject, {
+        extra: { commonwellPatientId, personId, context: `cw.patient.update` },
       });
       await findOrCreatePersonAndLink({
         commonWell,

--- a/api/app/src/providers/oauth1.ts
+++ b/api/app/src/providers/oauth1.ts
@@ -10,6 +10,7 @@ import { saveUserToken } from "../command/cx-user/save-user-token";
 import { UserToken } from "../domain/user-token";
 import { Config } from "../shared/config";
 import { ProviderOAuth1Options } from "../shared/constants";
+import { capture } from "../shared/notifications";
 import { Util } from "../shared/util";
 
 const axios = Axios.create();
@@ -164,6 +165,7 @@ export class OAuth1DefaultImpl implements OAuth1 {
     for (const oauthUserAccessToken of userAccessTokens) {
       const userTokenList = await getUserTokenByUAT({ oauthUserAccessToken });
       for (const userToken of userTokenList) {
+        capture.setUserId(userToken.userId);
         // DynamoDB (Webhook and auth)
         const updatedUserToken = userToken.clone();
         updatedUserToken.oauthUserAccessToken = undefined;

--- a/api/app/src/routes/connect.ts
+++ b/api/app/src/routes/connect.ts
@@ -17,6 +17,7 @@ import { processOAuth1 } from "./middlewares/oauth1";
 import { processOAuth2 } from "./middlewares/oauth2";
 import { asyncHandler, getCxIdFromHeaders, getUserIdFromHeaders } from "./util";
 import { PROVIDER_APPLE } from "../shared/constants";
+import { capture } from "../shared/notifications";
 
 const router = Router();
 
@@ -116,6 +117,7 @@ router.get("/:provider", async (req: Request, res: Response) => {
     }
   } catch (err) {
     console.log(`Error on /connect/${req.params.provider}`, err);
+    capture.error(err, { extra: { context: `connect.${req.params.provider}` } });
     return res.redirect(buildConnectErrorRedirectURL(false, state));
   }
 });

--- a/api/app/src/routes/internal.ts
+++ b/api/app/src/routes/internal.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import Router from "express-promise-router";
 import status from "http-status";
 import { accountInit } from "../command/account-init";
-import { asyncHandler, getFromQueryOrFail } from "./util";
+import { asyncHandler, getCxIdFromQueryOrFail } from "./util";
 
 const router = Router();
 
@@ -18,7 +18,7 @@ const router = Router();
 router.post(
   "/init",
   asyncHandler(async (req: Request, res: Response) => {
-    const cxId = getFromQueryOrFail("cxId", req);
+    const cxId = getCxIdFromQueryOrFail(req);
     await accountInit(cxId);
     return res.sendStatus(status.OK);
   })

--- a/api/app/src/routes/medical/organization.ts
+++ b/api/app/src/routes/medical/organization.ts
@@ -11,7 +11,7 @@ import {
   updateOrganization,
 } from "../../command/medical/organization/update-organization";
 import cwCommands from "../../external/commonwell";
-import { captureError } from "../../shared/notifications";
+import { capture } from "../../shared/notifications";
 import { asyncHandler, getCxIdOrFail, getETag, getFromParamsOrFail } from "../util";
 import { dtoFromModel } from "./dtos/organizationDTO";
 import { organizationCreateSchema, organizationUpdateSchema } from "./schemas/organization";
@@ -39,8 +39,8 @@ router.post(
     // Intentionally asynchronous
     cwCommands.organization.create(org).catch(err => {
       console.error(`Failure while creating organization ${org.id} @ CW: `, err);
-      captureError(err, {
-        extra: { cxId, orgId: org.id, context: `cw.org.create` },
+      capture.error(err, {
+        extra: { orgId: org.id, context: `cw.org.create` },
       });
     });
 
@@ -82,8 +82,8 @@ router.put(
       })
       .catch(err => {
         console.error(`Failure while updating/creating organization ${org.id} @ CW: `, err);
-        captureError(err, {
-          extra: { cxId, orgId: org.id, context: `cw.org.update` },
+        capture.error(err, {
+          extra: { orgId: org.id, context: `cw.org.update` },
         });
       });
 

--- a/api/app/src/routes/medical/patient.ts
+++ b/api/app/src/routes/medical/patient.ts
@@ -5,7 +5,7 @@ import { createPatient, PatientCreateCmd } from "../../command/medical/patient/c
 import { getPatientOrFail, getPatients } from "../../command/medical/patient/get-patient";
 import { PatientUpdateCmd, updatePatient } from "../../command/medical/patient/update-patient";
 import cwCommands from "../../external/commonwell";
-import { captureError } from "../../shared/notifications";
+import { capture } from "../../shared/notifications";
 import {
   asyncHandler,
   getCxIdOrFail,
@@ -49,8 +49,8 @@ router.post(
     // Intentionally asynchronous - it takes too long to perform
     cwCommands.patient.create(patient, facilityId).catch(err => {
       console.error(`Failure while creating patient ${patient.id} @ CW: `, err);
-      captureError(err, {
-        extra: { cxId, facilityId, patientId: patient.id, context: `cw.patient.create` },
+      capture.error(err, {
+        extra: { facilityId, patientId: patient.id, context: `cw.patient.create` },
       });
     });
 
@@ -86,8 +86,8 @@ router.put(
     // Intentionally asynchronous - it takes too long to perform
     cwCommands.patient.update(patient, facilityId).catch(err => {
       console.error(`Failed to update patient ${patient.id} @ CW: `, err);
-      captureError(err, {
-        extra: { cxId, facilityId, patientId: patient.id, context: `cw.patient.update` },
+      capture.error(err, {
+        extra: { facilityId, patientId: patient.id, context: `cw.patient.update` },
       });
     });
 

--- a/api/app/src/routes/util.ts
+++ b/api/app/src/routes/util.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
-
 import BadRequestError from "../errors/bad-request";
+import { capture } from "../shared/notifications";
 
 export const asyncHandler =
   (
@@ -54,45 +54,33 @@ export const getFromParamsOrFail = (prop: string, req: Request): string => {
   return value;
 };
 
-export const getCxId = (req: Request): string | undefined => req.cxId;
+export const getCxId = (req: Request): string | undefined => {
+  const cxId = req.cxId;
+  capture.setUserId(cxId);
+  return cxId;
+};
 export const getCxIdOrFail = (req: Request): string => {
   const cxId = getCxId(req);
   if (!cxId) throw new BadRequestError("Missing cxId");
   return cxId;
 };
 
-/** @deprecated use getFromQuery() */
-export const getCxIdFromQuery = (req: Request): string | undefined =>
-  req.query.cxId as string | undefined;
-/** @deprecated use getFromQueryOrFail() */
+export const getCxIdFromQuery = (req: Request): string | undefined => {
+  const cxId = req.query.cxId as string | undefined;
+  cxId && capture.setUserId(cxId);
+  return cxId;
+};
 export const getCxIdFromQueryOrFail = (req: Request): string => {
   const cxId = getCxIdFromQuery(req);
   if (!cxId) throw new BadRequestError("Missing cxId query param");
   return cxId;
 };
 
-/** @deprecated use getFromQuery() */
-export const getFacilityIdFromQuery = (req: Request): string | undefined =>
-  req.query.facilityId as string | undefined;
-/** @deprecated use getFromQueryOrFail() */
-export const getFacilityIdFromQueryOrFail = (req: Request): string => {
-  const facilityId = getFacilityIdFromQuery(req);
-  if (!facilityId) throw new BadRequestError("Missing facilityId query param");
-  return facilityId;
+export const getCxIdFromHeaders = (req: Request): string | undefined => {
+  const cxId = req.header("cxId") as string | undefined;
+  cxId && capture.setUserId(cxId);
+  return cxId;
 };
-
-/** @deprecated use getFromQuery() */
-export const getPatientIdFromQuery = (req: Request): string | undefined =>
-  req.query.patientId as string | undefined;
-/** @deprecated use getFromQueryOrFail() */
-export const getPatientIdFromQueryOrFail = (req: Request): string => {
-  const patientId = getPatientIdFromQuery(req);
-  if (!patientId) throw new BadRequestError("Missing patientId query param");
-  return patientId;
-};
-
-export const getCxIdFromHeaders = (req: Request): string | undefined =>
-  req.header("cxId") as string | undefined;
 
 export const getUserIdFromHeaders = (req: Request): string | undefined =>
   req.header("userId") as string | undefined;

--- a/api/app/src/shared/notifications.ts
+++ b/api/app/src/shared/notifications.ts
@@ -57,30 +57,33 @@ export type CaptureContext = {
   };
 };
 
-/**
- * Captures an exception event and sends it to Sentry.
- *
- * @param error — An Error object.
- * @param captureContext — Additional scope data to apply to exception event.
- * @returns — The generated eventId.
- */
-//eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function captureError(error: any, captureContext?: Partial<CaptureContext>): string {
-  return Sentry.captureException(error, captureContext);
-}
-
 export type SeverityLevel = "fatal" | "error" | "warning" | "log" | "info" | "debug";
 
-/**
- * Captures an exception event and sends it to Sentry.
- *
- * @param message The message to send to Sentry.
- * @param captureContext — Additional scope data to apply to exception event.
- * @returns — The generated eventId.
- */
-export function captureMessage(
-  message: string,
-  captureContext?: Partial<CaptureContext> | SeverityLevel
-): string {
-  return Sentry.captureMessage(message, captureContext);
-}
+export const capture = {
+  setUserId: (id: string): void => {
+    Sentry.setUser({ id });
+  },
+
+  /**
+   * Captures an exception event and sends it to Sentry.
+   *
+   * @param error — An Error object.
+   * @param captureContext — Additional scope data to apply to exception event.
+   * @returns — The generated eventId.
+   */
+  //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  error: (error: any, captureContext?: Partial<CaptureContext>): string => {
+    return Sentry.captureException(error, captureContext);
+  },
+
+  /**
+   * Captures an exception event and sends it to Sentry.
+   *
+   * @param message The message to send to Sentry.
+   * @param captureContext — Additional scope data to apply to exception event.
+   * @returns — The generated eventId.
+   */
+  message: (message: string, captureContext?: Partial<CaptureContext> | SeverityLevel): string => {
+    return Sentry.captureMessage(message, captureContext);
+  },
+};


### PR DESCRIPTION
Ref. metriport/metriport-internal#156

### Dependencies

- Upstream: none
- Downstream: none

### Description

Send `cxId` to Sentry through auth, so we don't have to pass it around when reporting errors/messages.

### Release Plan

- nothing special, asap