### PR TITLE
fix(api): setCommonwellId not updating the DB

### DIFF
--- a/api/app/src/external/commonwell/patient-external-data.ts
+++ b/api/app/src/external/commonwell/patient-external-data.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from "lodash";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
 import { Patient } from "../../models/medical/patient";
 import { PatientDataCommonwell } from "./patient-shared";
@@ -13,14 +14,13 @@ export const setCommonwellId = async ({
   commonwellPatientId: string;
   commonwellPersonId: string | undefined;
 }): Promise<Patient> => {
-  const query = { id: patientId, cxId };
-  const updatedPatient = await getPatientOrFail(query);
+  const updatedPatient = await getPatientOrFail({ id: patientId, cxId });
 
-  const data = updatedPatient.data;
-  data.externalData = {
-    ...data.externalData,
+  const updatedData = cloneDeep(updatedPatient.data);
+  updatedData.externalData = {
+    ...updatedData.externalData,
     COMMONWELL: new PatientDataCommonwell(commonwellPatientId, commonwellPersonId),
   };
 
-  return updatedPatient.update({ data }, { where: { ...query, eTag: updatedPatient.eTag } });
+  return updatedPatient.update({ data: updatedData });
 };

--- a/api/app/src/external/commonwell/patient.ts
+++ b/api/app/src/external/commonwell/patient.ts
@@ -88,6 +88,7 @@ export async function create(patient: Patient, facilityId: string): Promise<void
     capture.error(err, {
       extra: { facilityId, patientId: patient.id, context: `cw.patient.create` },
     });
+    throw err;
   }
 }
 
@@ -97,8 +98,10 @@ export async function update(patient: Patient, facilityId: string): Promise<void
 
     const updateData = await setupUpdate(patient, facilityId);
     if (!updateData) {
-      log(`WARN - Could not find external data on Patient, not updating @ CW`);
-      return;
+      capture.message("Could not find external data on Patient, creating it @ CW", {
+        extra: { patientId: patient.id, context: `cw.patient.update` },
+      });
+      return create(patient, facilityId);
     }
     const { commonWell, queryMeta, commonwellPatient, commonwellPatientId, personId } = updateData;
 
@@ -195,6 +198,7 @@ export async function update(patient: Patient, facilityId: string): Promise<void
     capture.error(err, {
       extra: { facilityId, patientId: patient.id, context: `cw.patient.update` },
     });
+    throw err;
   }
 }
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#156

### Dependencies

- Upstream: none
- Downstream: none

### Description

- setCommonwellId not updating the DB
- create patient @ CW if no CW data found upon update

### Release Plan

- nothing special, asap