### PR TITLE
fix(api): use USA when no country from CW

### DIFF
--- a/api/app/src/routes/medical/dtos/linkDTO.ts
+++ b/api/app/src/routes/medical/dtos/linkDTO.ts
@@ -80,7 +80,7 @@ function personToPatient(person: { id: string } & Person): PatientOnLinkDTO {
       city: address && address.city ? address.city : "",
       state: address && address.state ? address.state : "",
       zip: address && address.zip ? address.zip : "",
-      country: address && address.country ? address.country : "",
+      country: address && address.country ? address.country : "USA",
     },
     contact: {},
   };


### PR DESCRIPTION
Ref. metriport/metriport-internal#504

### Dependencies

- Upstream: none
- Downstream: nont

### Description

Use `USA` when no country from CW.

Context: https://metriport.slack.com/archives/C04DMKE9DME/p1680232608751439

### Release Plan

- asap