### PR TITLE
fix(cw): fix CW SDK building query headers

### DIFF
--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -17852,7 +17852,7 @@
       "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.0.0",
+        "@metriport/commonwell-sdk": "^4.0.1-alpha.0",
         "commander": "^9.5.0",
         "dotenv": "^16.0.3",
         "lodash": "^4.17.21",
@@ -17881,7 +17881,7 @@
       "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.0.0",
+        "@metriport/commonwell-sdk": "^4.0.1-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -17896,7 +17896,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.0.0",
+      "version": "4.0.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "http-status": "^1.6.2",

--- a/packages/packages/commonwell-cert-runner/package.json
+++ b/packages/packages/commonwell-cert-runner/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.0.0",
+    "@metriport/commonwell-sdk": "^4.0.1-alpha.0",
     "commander": "^9.5.0",
     "dotenv": "^16.0.3",
     "lodash": "^4.17.21",

--- a/packages/packages/commonwell-jwt-maker/package.json
+++ b/packages/packages/commonwell-jwt-maker/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.0.0",
+    "@metriport/commonwell-sdk": "^4.0.1-alpha.0",
     "commander": "^9.5.0"
   }
 }

--- a/packages/packages/commonwell-sdk/package.json
+++ b/packages/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.0.0",
+  "version": "4.0.1-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-sdk/src/client/document.ts
+++ b/packages/packages/commonwell-sdk/src/client/document.ts
@@ -4,20 +4,19 @@ import { CommonwellError } from "../common/commonwell-error";
 import { downloadFile } from "../common/fileDownload";
 import { convertPatientIdToSubjectId } from "../common/util";
 import { DocumentQueryResponse, documentQueryResponseSchema } from "../models/document";
-import { buildQueryHeaders, CommonWell, RequestMetadata } from "./commonwell";
+import { CommonWell } from "./commonwell";
 
 export async function query(
   api: AxiosInstance,
-  meta: RequestMetadata,
+  headers: Record<string, string>,
   patientId: string
 ): Promise<DocumentQueryResponse> {
   const subjectId = convertPatientIdToSubjectId(patientId);
   if (!subjectId) {
     throw new Error(`Could not determine subject ID for document query`);
   }
-  const headers = await buildQueryHeaders(meta);
   const url = `${CommonWell.DOCUMENT_QUERY_ENDPOINT}?subject.id=${subjectId}`;
-  const additionalInfo = { meta, patientId };
+  const additionalInfo = { headers, patientId };
   let response: any; //eslint-disable-line @typescript-eslint/no-explicit-any
   try {
     response = await api.get(url, { headers });
@@ -36,11 +35,10 @@ export async function query(
 
 export async function retrieve(
   api: AxiosInstance,
-  meta: RequestMetadata,
+  headers: Record<string, string>,
   inputUrl: string,
   outputStream: stream.Writable
 ): Promise<void> {
-  const headers = await buildQueryHeaders(meta);
   try {
     await downloadFile({
       url: inputUrl,
@@ -50,7 +48,7 @@ export async function retrieve(
     });
   } catch (err) {
     throw new CommonwellError(`Error retrieve document`, err, {
-      meta,
+      headers,
       inputUrl,
       outputStream: outputStream ? "[object]" : outputStream,
     });

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",
-        "@metriport/commonwell-sdk": "^3.1.4-alpha.0",
+        "@metriport/commonwell-sdk": "^4.0.1-alpha.0",
         "axios": "^1.3.2",
         "commander": "^10.0.0",
         "dotenv": "^16.0.3",
@@ -1394,9 +1394,9 @@
       }
     },
     "node_modules/@metriport/commonwell-sdk": {
-      "version": "3.1.4-alpha.0",
-      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-3.1.4-alpha.0.tgz",
-      "integrity": "sha512-becgis4SxVXVM/O3zs6DYsAY7lO8LAk1bc/xYq+x8n7zSZ3l7Z9SQZfmIjoEYlVxNrBetllTrSxNrpah+Bq3og==",
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-zXIbOUv+CRCVMCDMoQxDadBUAB7fXASVwPmBTeDEztLtyWvpfNeYX26xwq1KKnLOJnpLcdqDx+l/h1H4sXXpGw==",
       "dependencies": {
         "http-status": "^1.6.2",
         "jsonwebtoken": "^9.0.0",

--- a/utils/package.json
+++ b/utils/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.301.0",
-    "@metriport/commonwell-sdk": "^3.1.4-alpha.0",
+    "@metriport/commonwell-sdk": "^4.0.1-alpha.0",
     "axios": "^1.3.2",
     "commander": "^10.0.0",
     "dotenv": "^16.0.3",

--- a/utils/src/cw-doc-query.ts
+++ b/utils/src/cw-doc-query.ts
@@ -1,0 +1,39 @@
+import { APIMode, CommonWell, PurposeOfUse } from "@metriport/commonwell-sdk";
+import * as fs from "fs";
+
+/**
+ * Utility to query CW to query documents using Metriport's CW SDK.
+ *
+ * Update the variables below and run `ts-node src/cw-doc-parse`
+ */
+
+const cert = fs.readFileSync("xxx", "utf8");
+const privkey = fs.readFileSync("xxx", "utf8");
+const npi = "xxx";
+const orgName = "xxx";
+const orgId = "xxx";
+const patientId = `xxx`;
+const apiMode = APIMode.production;
+
+async function main() {
+  const api = new CommonWell(cert, privkey, orgName, "urn:oid:" + orgId, apiMode);
+  const base = {
+    purposeOfUse: PurposeOfUse.TREATMENT,
+    role: "ict",
+    subjectId: `${orgName} System User`,
+  };
+  const queryMeta = {
+    subjectId: base.subjectId,
+    role: base.role,
+    purposeOfUse: base.purposeOfUse,
+    npi: npi,
+  };
+
+  console.log(`>>> Querying...`);
+  const docs = await api.queryDocuments(queryMeta, `${patientId}%5E%5E%5Eurn%3aoid%3a${orgId}`);
+  console.log(`>>> Response:`);
+  console.log(JSON.stringify(docs, null, 2));
+  console.log(`>>> Found ${docs.entry?.length} documents.`);
+}
+
+main();


### PR DESCRIPTION
Ref. metriport/metriport-internal#506

### Dependencies

- Upstream: [none](https://github.com/metriport/metriport/pull/192)
- Downstream: none

### Description

Fix CW SDK building query headers.

### Release Plan

- nothing special, asap