### PR TITLE
feat(api): async document query

### DIFF
--- a/api/app/src/command/medical/document/create-or-update.ts
+++ b/api/app/src/command/medical/document/create-or-update.ts
@@ -1,0 +1,64 @@
+import { Transaction } from "sequelize";
+import { v4 as uuidv4 } from "uuid";
+import {
+  DocumentReference,
+  DocumentReferenceCreate,
+} from "../../../domain/medical/document-reference";
+import { MedicalDataSource } from "../../../external";
+import { DocumentReferenceModel } from "../../../models/medical/document-reference";
+import { Patient } from "../../../models/medical/patient";
+
+export async function createOrUpdate(
+  patient: Patient,
+  docs: DocumentReferenceCreate[]
+): Promise<DocumentReference[]> {
+  const documents = await Promise.all(
+    docs.map(async doc => {
+      const sequelize = DocumentReferenceModel.sequelize;
+      if (!sequelize) throw new Error("Missing sequelize");
+      let transaction: Transaction | undefined = await sequelize.transaction();
+      try {
+        const existing = await DocumentReferenceModel.findOne({
+          where: {
+            cxId: patient.cxId,
+            patientId: patient.id,
+            source: doc.source,
+            externalId: doc.externalId,
+          },
+          lock: true,
+          transaction,
+        });
+        if (existing) {
+          return await existing.update(
+            {
+              data: {
+                ...existing.data,
+                ...doc.data,
+              },
+            },
+            { transaction }
+          );
+        } else {
+          return await DocumentReferenceModel.create(
+            {
+              id: uuidv4(),
+              cxId: patient.cxId,
+              patientId: patient.id,
+              source: MedicalDataSource.COMMONWELL,
+              externalId: doc.externalId,
+              data: doc.data,
+            },
+            { transaction }
+          );
+        }
+      } catch (err) {
+        await transaction.rollback();
+        transaction = undefined;
+        throw err;
+      } finally {
+        if (transaction) await transaction.commit();
+      }
+    })
+  );
+  return documents;
+}

--- a/api/app/src/command/medical/document/get-documents.ts
+++ b/api/app/src/command/medical/document/get-documents.ts
@@ -1,0 +1,34 @@
+import { DocumentQueryStatus, DocumentReference } from "../../../domain/medical/document-reference";
+import { DocumentReferenceModel } from "../../../models/medical/document-reference";
+import { Patient } from "../../../models/medical/patient";
+import { getPatientOrFail } from "../patient/get-patient";
+
+export const getDocuments = async ({
+  cxId,
+  patientId,
+}: {
+  cxId: string;
+  patientId: string;
+}): Promise<DocumentReference[]> => {
+  const documents = await DocumentReferenceModel.findAll({
+    where: { cxId, patientId },
+    order: [["created_at", "ASC"]],
+  });
+  return documents;
+};
+
+export const updateDocQueryStatus = async ({
+  patient,
+  status,
+}: {
+  patient: Patient;
+  status: DocumentQueryStatus;
+}): Promise<void> => {
+  const patientModel = await getPatientOrFail({ id: patient.id, cxId: patient.cxId });
+  await patientModel.update({
+    data: {
+      ...patient.data,
+      documentQueryStatus: status,
+    },
+  });
+};

--- a/api/app/src/command/settings/updateSettings.ts
+++ b/api/app/src/command/settings/updateSettings.ts
@@ -1,4 +1,5 @@
 import { nanoid } from "nanoid";
+import { processAsyncError } from "../../errors";
 import WebhookError from "../../errors/webhook";
 import { Settings, WEBHOOK_STATUS_BAD_RESPONSE, WEBHOOK_STATUS_OK } from "../../models/settings";
 import { Util } from "../../shared/util";
@@ -64,7 +65,8 @@ const getWebhookDataForUpdate = (
     webhookStatus: null,
   };
   // if there's a URL, fire a test towards it - intentionally asynchronous
-  webhookData.webhookUrl && testWebhook({ id: settings.id, ...webhookData });
+  webhookData.webhookUrl &&
+    testWebhook({ id: settings.id, ...webhookData }).catch(processAsyncError(`testWebhook`));
   return webhookData;
 };
 

--- a/api/app/src/command/webhook/retry-failed.ts
+++ b/api/app/src/command/webhook/retry-failed.ts
@@ -1,3 +1,4 @@
+import { processAsyncError } from "../../errors";
 import { WebhookRequest } from "../../models/webhook-request";
 import { capture } from "../../shared/notifications";
 import { Util } from "../../shared/util";
@@ -37,5 +38,5 @@ export const retryFailedRequests = async (cxId: string): Promise<void> => {
     }
   };
   // intentionally asynchronous
-  _processRequest();
+  _processRequest().catch(processAsyncError(`retryFailedRequests._processRequest`));
 };

--- a/api/app/src/domain/medical/codeable-concept.ts
+++ b/api/app/src/domain/medical/codeable-concept.ts
@@ -1,0 +1,10 @@
+export type Coding = {
+  system?: string | null;
+  code?: string | null;
+  display?: string | null;
+};
+
+export type CodeableConcept = {
+  coding?: Coding[];
+  text?: string | null;
+};

--- a/api/app/src/domain/medical/document-reference.ts
+++ b/api/app/src/domain/medical/document-reference.ts
@@ -1,0 +1,27 @@
+import { MedicalDataSource } from "../../external";
+import { IBaseModel, IBaseModelCreate } from "../../models/_default";
+import { CodeableConcept } from "./codeable-concept";
+
+export type ExternalDocumentReference = {
+  fileName: string;
+  location: string;
+  description: string | undefined;
+  status: string | undefined;
+  indexed: string | undefined; // ISO-8601
+  mimeType: string | undefined;
+  size: number | undefined; // bytes
+  type: CodeableConcept | undefined;
+};
+
+export const documentQueryStatus = ["processing", "completed"] as const;
+export type DocumentQueryStatus = (typeof documentQueryStatus)[number];
+
+export interface DocumentReferenceCreate extends Omit<IBaseModelCreate, "id"> {
+  cxId: string;
+  patientId: string;
+  source: MedicalDataSource;
+  externalId: string;
+  data: ExternalDocumentReference;
+}
+
+export interface DocumentReference extends IBaseModel, DocumentReferenceCreate {}

--- a/api/app/src/errors/index.ts
+++ b/api/app/src/errors/index.ts
@@ -1,4 +1,13 @@
+import { capture } from "../shared/notifications";
+
 export function getErrorMessage(error: unknown) {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+export function processAsyncError(msg: string) {
+  return (err: unknown) => {
+    console.error(`${msg}: ${getErrorMessage(err)}`);
+    capture.error(err, { extra: { message: msg } });
+  };
 }

--- a/api/app/src/external/commonwell/patient-shared.ts
+++ b/api/app/src/external/commonwell/patient-shared.ts
@@ -17,6 +17,7 @@ import { capture } from "../../shared/notifications";
 import { driversLicenseURIs } from "../../shared/oid";
 import { Util } from "../../shared/util";
 import { makePersonForPatient } from "./patient-conversion";
+
 export class PatientDataCommonwell extends PatientExternalDataEntry {
   constructor(public patientId: string, public personId?: string | undefined) {
     super();

--- a/api/app/src/models/db.ts
+++ b/api/app/src/models/db.ts
@@ -5,6 +5,7 @@ import { Config, getEnvVarOrFail } from "../shared/config";
 import { ConnectedUser } from "./connected-user";
 import { initDDBDev } from "./db-dev";
 import { CustomerSequenceModel } from "./medical/customer-sequence";
+import { DocumentReferenceModel } from "./medical/document-reference";
 import { FacilityModel } from "./medical/facility";
 import { MAPIAccess } from "./medical/mapi-access";
 import { OrganizationModel } from "./medical/organization";
@@ -23,6 +24,7 @@ const models: ModelSetup[] = [
   PatientModel.setup,
   MAPIAccess.setup,
   CustomerSequenceModel.setup,
+  DocumentReferenceModel.setup,
 ];
 
 export type MetriportDB = {

--- a/api/app/src/models/medical/document-reference.ts
+++ b/api/app/src/models/medical/document-reference.ts
@@ -1,0 +1,42 @@
+import { DataTypes, Sequelize } from "sequelize";
+import { ExternalDocumentReference } from "../../domain/medical/document-reference";
+import { MedicalDataSource } from "../../external";
+import { BaseModel, ModelSetup } from "../_default";
+
+export type DocumentReferenceData = ExternalDocumentReference;
+
+export class DocumentReferenceModel extends BaseModel<DocumentReferenceModel> {
+  static NAME = "document_reference";
+  declare cxId: string;
+  declare patientId: string;
+  declare source: MedicalDataSource;
+  declare externalId: string;
+  declare data: DocumentReferenceData;
+
+  static setup: ModelSetup = (sequelize: Sequelize) => {
+    DocumentReferenceModel.init(
+      {
+        ...BaseModel.attributes(),
+        cxId: {
+          type: DataTypes.UUID,
+        },
+        patientId: {
+          type: DataTypes.STRING,
+        },
+        source: {
+          type: DataTypes.STRING,
+        },
+        externalId: {
+          type: DataTypes.STRING,
+        },
+        data: {
+          type: DataTypes.JSONB,
+        },
+      },
+      {
+        ...BaseModel.modelOptions(sequelize),
+        tableName: DocumentReferenceModel.NAME,
+      }
+    );
+  };
+}

--- a/api/app/src/models/medical/patient.ts
+++ b/api/app/src/models/medical/patient.ts
@@ -1,7 +1,8 @@
 import { DataTypes, Sequelize } from "sequelize";
+import { DocumentQueryStatus } from "../../domain/medical/document-reference";
 import { MedicalDataSource } from "../../external";
 import { USState } from "../../shared/geographic-locations";
-import { IBaseModelCreate, IBaseModel, ModelSetup, BaseModel } from "../_default";
+import { BaseModel, IBaseModel, IBaseModelCreate, ModelSetup } from "../_default";
 import { Address } from "./address";
 import { Contact } from "./contact";
 
@@ -56,6 +57,7 @@ export type PatientData = {
   personalIdentifiers: PersonalIdentifier[];
   address: Address;
   contact?: Contact;
+  documentQueryStatus?: DocumentQueryStatus;
   externalData?: PatientExternalData;
 };
 

--- a/api/app/src/routes/medical/dtos/codeableDTO.ts
+++ b/api/app/src/routes/medical/dtos/codeableDTO.ts
@@ -1,0 +1,28 @@
+import { CodeableConcept, Coding } from "../../../domain/medical/codeable-concept";
+
+export type CodingDTO = {
+  system: string | undefined;
+  code: string | undefined;
+  display: string | undefined;
+};
+
+export type CodeableConceptDTO = {
+  coding: CodingDTO[] | undefined;
+  text: string | undefined;
+};
+
+export function toDTO(domain: CodeableConcept | undefined): CodeableConceptDTO | undefined {
+  if (!domain) return undefined;
+  return {
+    coding: domain.coding ? domain.coding.map(codingToDTO) : undefined,
+    text: domain.text ?? undefined,
+  };
+}
+
+export function codingToDTO(domain: Coding): CodingDTO {
+  return {
+    system: domain.system ?? undefined,
+    code: domain.code ?? undefined,
+    display: domain.display ?? undefined,
+  };
+}

--- a/api/app/src/routes/medical/dtos/documentDTO.ts
+++ b/api/app/src/routes/medical/dtos/documentDTO.ts
@@ -1,5 +1,5 @@
-import { DocumentContent } from "@metriport/commonwell-sdk";
-import { DocumentWithLocation } from "../../../external/commonwell/document";
+import { DocumentReference } from "../../../domain/medical/document-reference";
+import { CodeableConceptDTO, toDTO as codeableToDTO } from "./codeableDTO";
 
 export type DocumentReferenceDTO = {
   id: string;
@@ -10,19 +10,21 @@ export type DocumentReferenceDTO = {
   indexed: string | undefined; // ISO-8601
   mimeType: string | undefined;
   size: number | undefined; // bytes
-} & Partial<Pick<DocumentContent, "type">>; // TODO build our own representation
+  type: CodeableConceptDTO | undefined;
+};
 
-export function dtoFromModel(doc: DocumentWithLocation): DocumentReferenceDTO {
-  const { id, description, type, status, location, fileName, indexed, mimeType, size } = doc;
+export function toDTO(doc: DocumentReference): DocumentReferenceDTO {
+  const { id } = doc;
+  const { description, type, status, location, fileName, indexed, mimeType, size } = doc.data;
   return {
     id,
-    description,
+    description: description,
     fileName,
     location,
-    type,
-    status,
-    indexed,
-    mimeType,
-    size,
+    type: codeableToDTO(type),
+    status: status,
+    indexed: indexed,
+    mimeType: mimeType,
+    size: size,
   };
 }

--- a/api/app/src/routes/medical/organization.ts
+++ b/api/app/src/routes/medical/organization.ts
@@ -10,6 +10,7 @@ import {
   OrganizationUpdateCmd,
   updateOrganization,
 } from "../../command/medical/organization/update-organization";
+import { processAsyncError } from "../../errors";
 import cwCommands from "../../external/commonwell";
 import { asyncHandler, getCxIdOrFail, getETag, getFromParamsOrFail } from "../util";
 import { dtoFromModel } from "./dtos/organizationDTO";
@@ -36,7 +37,7 @@ router.post(
 
     // TODO: #393 declarative, event-based integration
     // Intentionally asynchronous
-    cwCommands.organization.create(org);
+    cwCommands.organization.create(org).catch(processAsyncError(`cw.org.create`));
 
     return res.status(status.CREATED).json(dtoFromModel(org));
   })
@@ -67,7 +68,7 @@ router.put(
 
     // TODO: #393 declarative, event-based integration
     // Intentionally asynchronous
-    cwCommands.organization.update(org);
+    cwCommands.organization.update(org).catch(processAsyncError(`cw.org.update`));
 
     return res.status(status.OK).json(dtoFromModel(org));
   })

--- a/api/app/src/routes/medical/patient.ts
+++ b/api/app/src/routes/medical/patient.ts
@@ -4,6 +4,7 @@ import status from "http-status";
 import { createPatient, PatientCreateCmd } from "../../command/medical/patient/create-patient";
 import { getPatientOrFail, getPatients } from "../../command/medical/patient/get-patient";
 import { PatientUpdateCmd, updatePatient } from "../../command/medical/patient/update-patient";
+import { processAsyncError } from "../../errors";
 import cwCommands from "../../external/commonwell";
 import {
   asyncHandler,
@@ -46,7 +47,7 @@ router.post(
 
     // TODO: #393 declarative, event-based integration
     // Intentionally asynchronous - it takes too long to perform
-    cwCommands.patient.create(patient, facilityId);
+    cwCommands.patient.create(patient, facilityId).catch(processAsyncError(`cw.patient.create`));
 
     return res.status(status.CREATED).json(dtoFromModel(patient));
   })
@@ -78,7 +79,7 @@ router.put(
 
     // TODO: #393 declarative, event-based integration
     // Intentionally asynchronous - it takes too long to perform
-    cwCommands.patient.update(patient, facilityId);
+    cwCommands.patient.update(patient, facilityId).catch(processAsyncError(`cw.patient.update`));
 
     return res.status(status.OK).json(dtoFromModel(patient));
   })

--- a/api/app/src/routes/webhook/garmin.ts
+++ b/api/app/src/routes/webhook/garmin.ts
@@ -2,6 +2,7 @@ import { MetriportData } from "@metriport/api/lib/devices/models/metriport-data"
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import { processData } from "../../command/webhook/webhook";
+import { processAsyncError } from "../../errors";
 import { UserData } from "../../mappings/garmin";
 import { garminActivityListSchema, mapToActivity } from "../../mappings/garmin/activity";
 import {
@@ -51,7 +52,7 @@ routes.post(
     }
     // STORE AND SEND TO CUSTOMER
     // Intentionally asynchronous, respond asap, sending to customers is irrelevant to Provider
-    processData(data);
+    processData(data).catch(processAsyncError(`wh.garmin.processData`));
 
     return res.sendStatus(200);
   })

--- a/api/app/src/sequelize/migrations/20230404153200-create-document-reference.ts
+++ b/api/app/src/sequelize/migrations/20230404153200-create-document-reference.ts
@@ -1,0 +1,48 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+import * as shared from "../migrations-shared";
+
+// Use 'Promise.all' when changes are independent of each other
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await shared.createTable(
+      queryInterface,
+      "document_reference",
+      {
+        id: {
+          type: DataTypes.STRING,
+          primaryKey: true,
+        },
+        cxId: {
+          type: DataTypes.UUID,
+          field: "cx_id",
+        },
+        patientId: {
+          type: DataTypes.STRING,
+          field: "patient_id",
+        },
+        source: {
+          type: DataTypes.STRING,
+        },
+        externalId: {
+          type: DataTypes.STRING,
+          field: "external_id",
+        },
+        data: {
+          type: DataTypes.JSONB,
+        },
+      },
+      {
+        transaction,
+        addVersion: true,
+        uniqueKeys: { external_unique: { fields: ["patient_id", "source", "external_id"] } },
+      }
+    );
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.dropTable("document-reference", { transaction });
+  });
+};

--- a/docs/devices-api/more-info/webhooks.mdx
+++ b/docs/devices-api/more-info/webhooks.mdx
@@ -165,8 +165,8 @@ The format follows:
 <ResponseField name="Details">
   <Expandable title="details">
 
-    - `message-id`: this request ID from Metriport, useful for debugging purposes only;
-    - `date-time-in-utc`: the timestamp in datetime format when this message was originally sent
+    - `messageid`: this request ID from Metriport, useful for debugging purposes only;
+    - `when`: the timestamp when this message was originally sent, formatted as [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601)
       (example: `2022-12-24T00:46:05.413Z`)
     - `users`: array of users, where each item represents all of that user's information available
       in this request (more data might be available in subsequent requests)

--- a/docs/medical-api/api-reference/document/list-documents.mdx
+++ b/docs/medical-api/api-reference/document/list-documents.mdx
@@ -4,6 +4,15 @@ description: "Lists all Documents that can be retrieved for a Patient."
 api: "GET /medical/v1/document"
 ---
 
+This endpoint returns the document references associated with a Patient.
+
+Because this might contain a large number of records that have to obtained from HIEs,
+this endpoint works asynchronously:
+1. Upon request, it fires an asynchronous document query with HIEs and immediately returns the existing 
+document references stored at Metriport;
+   - When the asynchronous document query finishes, it stores new/updated document references for future requests;
+1. When requested again, it will return the existing documents and trigger a new document query (step 1).
+
 ## Query Params
 
 <ParamField query="patientId" type="string" required>
@@ -18,6 +27,9 @@ api: "GET /medical/v1/document"
 
 An array of objects describing the Documents that can be retrieved for the Patient.
 
+<ResponseField name="queryStatus" type="string">
+  The status of querying document references across HIEs, either `processing` or `completed`.
+</ResponseField>
 <ResponseField name="documents" type="DocumentReference[]">
   <Expandable title="DocumentReference properties">
     <Snippet file="document-reference-response.mdx" />
@@ -41,6 +53,7 @@ const documents = await metriportClient.listDocuments(
 
 ```json
 {
+  "queryStatus": "processing",
   "documents": [
     {
       "id": "1.2.543.1.34.1.34.134",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -17837,7 +17837,7 @@
     },
     "packages/api": {
       "name": "@metriport/api",
-      "version": "2.5.0-alpha.0",
+      "version": "2.5.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.4",
@@ -17852,7 +17852,7 @@
       "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.0.1",
+        "@metriport/commonwell-sdk": "^4.0.2-alpha.0",
         "axios": "^1.3.4",
         "commander": "^9.5.0",
         "dotenv": "^16.0.3",
@@ -17882,7 +17882,7 @@
       "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.0.1",
+        "@metriport/commonwell-sdk": "^4.0.2-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -17897,7 +17897,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.0.1",
+      "version": "4.0.2-alpha.0",
       "license": "MIT",
       "dependencies": {
         "http-status": "^1.6.2",

--- a/packages/packages/api/package.json
+++ b/packages/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api",
-  "version": "2.5.0-alpha.0",
+  "version": "2.5.1-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/api/src/medical/models/document.ts
+++ b/packages/packages/api/src/medical/models/document.ts
@@ -25,5 +25,6 @@ export const documentReferenceSchema = z.object({
 export type DocumentReference = z.infer<typeof documentReferenceSchema>;
 
 export const documentListSchema = z.object({
+  queryStatus: z.boolean(),
   documents: z.array(documentReferenceSchema),
 });

--- a/packages/packages/commonwell-cert-runner/package.json
+++ b/packages/packages/commonwell-cert-runner/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.0.1",
+    "@metriport/commonwell-sdk": "^4.0.2-alpha.0",
     "axios": "^1.3.4",
     "commander": "^9.5.0",
     "dotenv": "^16.0.3",

--- a/packages/packages/commonwell-jwt-maker/package.json
+++ b/packages/packages/commonwell-jwt-maker/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.0.1",
+    "@metriport/commonwell-sdk": "^4.0.2-alpha.0",
     "commander": "^9.5.0"
   }
 }

--- a/packages/packages/commonwell-sdk/package.json
+++ b/packages/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.0.1",
+  "version": "4.0.2-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-sdk/src/common/fileDownload.ts
+++ b/packages/packages/commonwell-sdk/src/common/fileDownload.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
-import * as httpStatus from "http-status";
 import * as stream from "stream";
 import * as util from "util";
 
@@ -20,16 +19,9 @@ export async function downloadFile({
 }): Promise<boolean> {
   const config: AxiosRequestConfig = {
     responseType: "stream",
-    validateStatus: null,
     headers,
   };
   const response = await (client ?? axios).get(url, config);
   await pipeline(response.data, outputStream);
-  const status = response.status;
-  if (httpStatus[`${status}_CLASS`] === httpStatus.classes.SUCCESSFUL) return true;
-
-  const msg = `Failed to download, status ${status}: ${response.statusText}`;
-  console.log(`${msg}`);
-  console.log({ url, headers, client });
-  throw new Error(msg);
+  return true;
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#515

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/523

### Description

- fix the issue w/ error on download sending error payload to API response
- create table `document_reference`
- decouple document query from listing
- trigger async doc query w/ CW when doc list is requested
- store doc references from from CW on the `document_reference` table
- update SDK to match `/document` payload
- update async function calls to have a default error handler (found out this makes Express break if not treated/processed)
- add `version` to shared migration code
- update docs

### Release Plan

- ⚠️ Contains a DB migration
- nothing on infra
- as soon as possible