### PR TITLE
feat(api): async docs v1

### DIFF
--- a/api/app/src/command/medical/document/document-query.ts
+++ b/api/app/src/command/medical/document/document-query.ts
@@ -1,0 +1,51 @@
+import { DocumentQueryStatus } from "../../../domain/medical/document-reference";
+import { processAsyncError } from "../../../errors";
+import { getDocuments as getDocumentsFromCW } from "../../../external/commonwell/document/document-query";
+import { PatientDataCommonwell } from "../../../external/commonwell/patient-shared";
+import { Patient } from "../../../models/medical/patient";
+import { getPatientOrFail } from "../patient/get-patient";
+
+// TODO: eventually we will have to update this to support multiple HIEs
+export async function queryDocumentsAcrossHIEs({
+  cxId,
+  patientId,
+  facilityId,
+}: {
+  cxId: string;
+  patientId: string;
+  facilityId: string;
+}): Promise<DocumentQueryStatus> {
+  const patient = await getPatientOrFail({ id: patientId, cxId });
+  if (patient.data.documentQueryStatus === "processing") return "processing";
+
+  const externalData = patient.data.externalData?.COMMONWELL;
+  if (!externalData) return "completed";
+
+  const cwData = externalData as PatientDataCommonwell;
+  if (!cwData.patientId) return "completed";
+
+  await updateDocQueryStatus({ patient, status: "processing" });
+
+  // intentionally asynchronous, not waiting for the result
+  getDocumentsFromCW({ patient, facilityId }).catch(
+    processAsyncError(`doc.list.getDocumentsFromCW`)
+  );
+
+  return "processing";
+}
+
+export const updateDocQueryStatus = async ({
+  patient,
+  status,
+}: {
+  patient: Patient;
+  status: DocumentQueryStatus;
+}): Promise<Patient> => {
+  const patientModel = await getPatientOrFail({ id: patient.id, cxId: patient.cxId });
+  return patientModel.update({
+    data: {
+      ...patient.data,
+      documentQueryStatus: status,
+    },
+  });
+};

--- a/api/app/src/command/medical/document/get-documents.ts
+++ b/api/app/src/command/medical/document/get-documents.ts
@@ -23,9 +23,9 @@ export const updateDocQueryStatus = async ({
 }: {
   patient: Patient;
   status: DocumentQueryStatus;
-}): Promise<void> => {
+}): Promise<Patient> => {
   const patientModel = await getPatientOrFail({ id: patient.id, cxId: patient.cxId });
-  await patientModel.update({
+  return patientModel.update({
     data: {
       ...patient.data,
       documentQueryStatus: status,

--- a/api/app/src/command/medical/document/get-documents.ts
+++ b/api/app/src/command/medical/document/get-documents.ts
@@ -1,7 +1,5 @@
-import { DocumentQueryStatus, DocumentReference } from "../../../domain/medical/document-reference";
+import { DocumentReference } from "../../../domain/medical/document-reference";
 import { DocumentReferenceModel } from "../../../models/medical/document-reference";
-import { Patient } from "../../../models/medical/patient";
-import { getPatientOrFail } from "../patient/get-patient";
 
 export const getDocuments = async ({
   cxId,
@@ -15,20 +13,4 @@ export const getDocuments = async ({
     order: [["created_at", "ASC"]],
   });
   return documents;
-};
-
-export const updateDocQueryStatus = async ({
-  patient,
-  status,
-}: {
-  patient: Patient;
-  status: DocumentQueryStatus;
-}): Promise<Patient> => {
-  const patientModel = await getPatientOrFail({ id: patient.id, cxId: patient.cxId });
-  return patientModel.update({
-    data: {
-      ...patient.data,
-      documentQueryStatus: status,
-    },
-  });
 };

--- a/api/app/src/external/commonwell/document/document-download.ts
+++ b/api/app/src/external/commonwell/document/document-download.ts
@@ -1,0 +1,43 @@
+import { CommonwellError } from "@metriport/commonwell-sdk";
+import * as stream from "stream";
+import NotFoundError from "../../../errors/not-found";
+import { capture } from "../../../shared/notifications";
+import { oid } from "../../../shared/oid";
+import { makeCommonWellAPI, organizationQueryMeta } from "../api";
+import { getPatientData } from "../patient-shared";
+
+export async function downloadDocument({
+  cxId,
+  patientId,
+  facilityId,
+  location,
+  stream,
+}: {
+  cxId: string;
+  patientId: string;
+  facilityId: string;
+  location: string;
+  stream: stream.Writable;
+}): Promise<void> {
+  const { organization, facility } = await getPatientData({ id: patientId, cxId }, facilityId);
+  const orgName = organization.data.name;
+  const orgId = organization.id;
+  const facilityNPI = facility.data["npi"] as string; // TODO #414 move to strong type - remove `as string`
+  const commonWell = makeCommonWellAPI(orgName, oid(orgId));
+  const queryMeta = organizationQueryMeta(orgName, { npi: facilityNPI });
+
+  try {
+    await commonWell.retrieveDocument(queryMeta, location, stream);
+  } catch (err) {
+    capture.error(err, {
+      extra: {
+        context: `cw.retrieveDocument`,
+        ...(err instanceof CommonwellError ? err.additionalInfo : undefined),
+      },
+    });
+    if (err instanceof CommonwellError && err.cause?.response?.status === 404) {
+      throw new NotFoundError("Document not found");
+    }
+    throw err;
+  }
+}

--- a/api/app/src/external/commonwell/document/document-query.ts
+++ b/api/app/src/external/commonwell/document/document-query.ts
@@ -1,14 +1,14 @@
 import { CommonwellError, DocumentQueryResponse } from "@metriport/commonwell-sdk";
-import { createOrUpdate } from "../../command/medical/document/create-or-update";
-import { updateDocQueryStatus } from "../../command/medical/document/get-documents";
-import { DocumentReference } from "../../domain/medical/document-reference";
-import { Patient } from "../../models/medical/patient";
-import { capture } from "../../shared/notifications";
-import { oid } from "../../shared/oid";
-import { Util } from "../../shared/util";
-import { makeCommonWellAPI, organizationQueryMeta } from "./api";
-import { getPatientData, PatientDataCommonwell } from "./patient-shared";
-import { DocumentWithLocation, getFileName, toDomain } from "./document/shared";
+import { createOrUpdate } from "../../../command/medical/document/create-or-update";
+import { updateDocQueryStatus } from "../../../command/medical/document/document-query";
+import { DocumentReference } from "../../../domain/medical/document-reference";
+import { Patient } from "../../../models/medical/patient";
+import { capture } from "../../../shared/notifications";
+import { oid } from "../../../shared/oid";
+import { Util } from "../../../shared/util";
+import { makeCommonWellAPI, organizationQueryMeta } from "../api";
+import { getPatientData, PatientDataCommonwell } from "../patient-shared";
+import { DocumentWithLocation, getFileName, toDomain } from "./shared";
 
 export async function getDocuments({
   patient,

--- a/api/app/src/external/commonwell/document/shared.ts
+++ b/api/app/src/external/commonwell/document/shared.ts
@@ -1,0 +1,56 @@
+import { Document, DocumentContent } from "@metriport/commonwell-sdk";
+import mime from "mime-types";
+import { MedicalDataSource } from "../..";
+import { DocumentReferenceCreate } from "../../../domain/medical/document-reference";
+import { Patient } from "../../../models/medical/patient";
+import { makePatientOID } from "../../../shared/oid";
+
+// TODO #340 When we fix tsconfig on CW SDK we can remove the `Required` for `id`
+export type DocumentWithLocation = Required<Pick<Document, "id">> &
+  Omit<DocumentContent, "location"> &
+  Required<Pick<DocumentContent, "location">> & {
+    fileName: string;
+  };
+
+export function toDomain(patient: Patient) {
+  return (doc: DocumentWithLocation): DocumentReferenceCreate => {
+    return {
+      cxId: patient.cxId,
+      patientId: patient.id,
+      source: MedicalDataSource.COMMONWELL,
+      externalId: doc.id,
+      data: {
+        fileName: doc.fileName,
+        location: doc.location,
+        description: doc.description,
+        status: doc.status,
+        indexed: doc.indexed,
+        mimeType: doc.mimeType,
+        size: doc.size,
+        type: doc.type,
+      },
+    };
+  };
+}
+
+export function getFileName(patient: Patient, doc: Document): string {
+  const prefix = "document_" + makePatientOID("", patient.patientNumber).substring(1);
+  const display = doc.content?.type?.coding?.length
+    ? doc.content?.type.coding[0].display
+    : undefined;
+  const suffix = getSuffix(doc.id);
+  const extension = getFileExtension(doc.content?.mimeType);
+  const fileName = `${prefix}_${display ? display + "_" : display}${suffix}${extension}`;
+  return fileName.replace(/\s/g, "-");
+}
+
+function getSuffix(id: string | undefined): string {
+  if (!id) return "";
+  return id.replace("urn:uuid:", "");
+}
+
+function getFileExtension(value: string | undefined): string {
+  if (!value || !mime.contentType(value)) return "";
+  const extension = mime.extension(value);
+  return extension ? `.${extension}` : "";
+}

--- a/api/app/src/routes/medical/document.ts
+++ b/api/app/src/routes/medical/document.ts
@@ -1,14 +1,10 @@
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import status from "http-status";
+import { queryDocumentsAcrossHIEs } from "../../command/medical/document/document-query";
 import { getDocuments } from "../../command/medical/document/get-documents";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
-import { processAsyncError } from "../../errors";
-import {
-  downloadDocument,
-  getDocuments as getDocumentsFromCW,
-} from "../../external/commonwell/document";
-import { PatientDataCommonwell } from "../../external/commonwell/patient-shared";
+import { downloadDocument } from "../../external/commonwell/document/document-download";
 import { asyncHandler, getCxIdOrFail, getFromQuery, getFromQueryOrFail } from "../util";
 import { toDTO } from "./dtos/documentDTO";
 
@@ -29,27 +25,38 @@ router.get(
     const cxId = getCxIdOrFail(req);
     const patientId = getFromQueryOrFail("patientId", req);
     const facilityId = getFromQueryOrFail("facilityId", req);
-
-    const patient = await getPatientOrFail({ id: patientId, cxId });
-    let queryStatus = patient.data.documentQueryStatus;
+    const forceQuery = getFromQuery("force-query", req);
 
     const documents = await getDocuments({ cxId, patientId });
-
-    // TODO: #515 We should only query on certain situations, when patient is created and/or updated.
-    // This is temporary and makes the current solution extensible for that ^.
-    if (queryStatus !== "processing") {
-      getDocumentsFromCW({ patient, facilityId }).catch(processAsyncError(`getDocumentsFromCW`));
-      // Temporary solution
-      // only override the status if we have CW IDs
-      const externalData = patient.data.externalData?.COMMONWELL;
-      if (externalData) {
-        const cwData = externalData as PatientDataCommonwell;
-        if (cwData.patientId) queryStatus = "processing";
-      }
-    }
-
     const documentsDTO = documents.map(toDTO);
+
+    const queryStatus = forceQuery
+      ? await queryDocumentsAcrossHIEs({ cxId, patientId, facilityId })
+      : (await getPatientOrFail({ cxId, id: patientId })).data.documentQueryStatus ?? "completed";
+
     return res.status(status.OK).json({ queryStatus, documents: documentsDTO });
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * GET /document/query
+ *
+ * Triggers a document query for the specified patient across HIEs.
+ *
+ * @param req.query.patientId Patient ID for which to retrieve document metadata.
+ * @param req.query.facilityId The facility providing NPI for the document query.
+ * @return The status of document querying.
+ */
+router.post(
+  "/query",
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getCxIdOrFail(req);
+    const patientId = getFromQueryOrFail("patientId", req);
+    const facilityId = getFromQueryOrFail("facilityId", req);
+
+    const queryStatus = await queryDocumentsAcrossHIEs({ cxId, patientId, facilityId });
+
+    return res.status(status.OK).json({ queryStatus });
   })
 );
 

--- a/docs/medical-api/api-reference/document/list-documents.mdx
+++ b/docs/medical-api/api-reference/document/list-documents.mdx
@@ -4,14 +4,14 @@ description: "Lists all Documents that can be retrieved for a Patient."
 api: "GET /medical/v1/document"
 ---
 
-This endpoint returns the document references associated with a Patient.
+This endpoint returns the document references available at Metriport which are associated with the
+given Patient.
 
-Because this might contain a large number of records that have to obtained from HIEs,
-this endpoint works asynchronously:
-1. Upon request, it fires an asynchronous document query with HIEs and immediately returns the existing 
-document references stored at Metriport;
-   - When the asynchronous document query finishes, it stores new/updated document references for future requests;
-1. When requested again, it will return the existing documents and trigger a new document query (step 1).
+It also returns the status of querying document references across HIEs, indicating whether
+there is an asynchronous query in progress (status `processing`) or not (status `completed`).
+
+To start a new document
+query, see [Start Document Query endpoint](/medical-api/api-reference/document/start-document-query).
 
 ## Query Params
 
@@ -43,10 +43,11 @@ import { MetriportMedicalApi } from "@metriport/api";
 
 const metriportClient = new MetriportMedicalApi("YOUR_API_KEY");
 
-const documents = await metriportClient.listDocuments(
-  "2.16.840.1.113883.3.666.777",
-  "2.16.840.1.113883.3.666.5.2004.4.2005"
-);
+const { documents, queryStatus } = await metriportClient
+  .listDocuments(
+    "2.16.840.1.113883.3.666.777",
+    "2.16.840.1.113883.3.666.5.2004.4.2005"
+  );
 ```
 
 </ResponseExample>

--- a/docs/medical-api/api-reference/document/start-document-query.mdx
+++ b/docs/medical-api/api-reference/document/start-document-query.mdx
@@ -1,0 +1,47 @@
+---
+title: "Start Document Query"
+description: "Triggers a document query for the specified patient across HIEs."
+api: "POST /medical/v1/document/query"
+---
+
+When executed, this endpoint triggers an asynchronous document query with HIEs and immediately returns the status
+of document query, `processing`.
+
+When the asynchronous document query finishes, it stores new/updated document references for future requests and
+update the status of document query to `completed` - acessible through 
+[List Documents endpoint](/medical-api/api-reference/document/list-documents).
+
+## Query Params
+
+<ParamField query="patientId" type="string" required>
+  The ID of the Patient for which to list available Documents.
+</ParamField>
+
+<ParamField query="facilityId" type="string" required>
+  The ID of the Facility where the patient is receiving care.
+</ParamField>
+
+## Response
+
+<ResponseField name="queryStatus" type="string">
+  The status of querying document references across HIEs, either `processing` or `completed`.
+</ResponseField>
+
+<ResponseExample>
+```javascript Metriport SDK
+import { MetriportMedicalApi } from "@metriport/api";
+
+const metriportClient = new MetriportMedicalApi("YOUR_API_KEY");
+
+const status = await api.startDocumentQuery(
+  "2.16.840.1.113883.3.666.5.2004.4.2005",
+  "2.16.840.1.113883.3.666.123",
+);
+```
+</ResponseExample>
+
+```json
+{
+  "queryStatus": "processing"
+}
+```

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -112,6 +112,7 @@
         {
           "group": "Document",
           "pages": [
+            "medical-api/api-reference/document/start-document-query",
             "medical-api/api-reference/document/list-documents",
             "medical-api/api-reference/document/get-document"
           ]

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -17837,7 +17837,7 @@
     },
     "packages/api": {
       "name": "@metriport/api",
-      "version": "2.5.1-alpha.3",
+      "version": "2.6.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.4",

--- a/packages/packages/api/package.json
+++ b/packages/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api",
-  "version": "2.5.1-alpha.3",
+  "version": "2.6.0-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,6 +41,5 @@
   },
   "devDependencies": {
     "ts-essentials": "^9.3.1"
-  },
-  "gitHead": "b8cb8989ca1f22fd433c1555b084c444cf37c643"
+  }
 }

--- a/packages/packages/api/src/index.ts
+++ b/packages/packages/api/src/index.ts
@@ -21,6 +21,14 @@ export {
   personalIdentifierSchema,
 } from "./medical/models/demographics";
 export {
+  DocumentList,
+  documentListSchema,
+  DocumentQueryStatus,
+  documentQueryStatusSchema,
+  DocumentReference,
+  documentReferenceSchema,
+} from "./medical/models/document";
+export {
   Facility,
   FacilityCreate,
   facilityCreateSchema,

--- a/packages/packages/api/src/medical/client/metriport.ts
+++ b/packages/packages/api/src/medical/client/metriport.ts
@@ -1,7 +1,12 @@
 import axios, { AxiosInstance, AxiosStatic } from "axios";
 import { BASE_ADDRESS, BASE_ADDRESS_SANDBOX } from "../../shared";
 import { getETagHeader } from "../models/common/base-update";
-import { documentListSchema, DocumentReference } from "../models/document";
+import {
+  DocumentList,
+  documentListSchema,
+  documentQuerySchema,
+  DocumentQueryStatus,
+} from "../models/document";
 import { Facility, FacilityCreate, facilityListSchema, facilitySchema } from "../models/facility";
 import { MedicalDataSource, PatientLinks, patientLinksSchema } from "../models/link";
 import { Organization, OrganizationCreate, organizationSchema } from "../models/organization";
@@ -294,7 +299,7 @@ export class MetriportMedicalApi {
    * @param facilityId The facility providing the NPI to support this operation.
    * @return The metadata of available documents.
    */
-  async listDocuments(patientId: string, facilityId: string): Promise<DocumentReference[]> {
+  async listDocuments(patientId: string, facilityId: string): Promise<DocumentList> {
     const resp = await this.api.get(`${DOCUMENT_URL}`, {
       params: {
         patientId,
@@ -302,7 +307,25 @@ export class MetriportMedicalApi {
       },
     });
     if (!resp.data) [];
-    return documentListSchema.parse(resp.data).documents;
+    return documentListSchema.parse(resp.data);
+  }
+
+  /**
+   * Start a document query for the given patient across HIEs.
+   *
+   * @param patientId Patient ID for which to retrieve document metadata.
+   * @param facilityId The facility providing the NPI to support this operation.
+   * @return The document query status indicating whether its being executed or not.
+   */
+  async startDocumentQuery(patientId: string, facilityId: string): Promise<DocumentQueryStatus> {
+    const resp = await this.api.post(`${DOCUMENT_URL}/query`, null, {
+      params: {
+        patientId,
+        facilityId,
+      },
+    });
+    if (!resp.data) throw new Error(NO_DATA_MESSAGE);
+    return documentQuerySchema.parse(resp.data).queryStatus;
   }
 
   // TODO #435 review the return type of this function

--- a/packages/packages/api/src/medical/models/document.ts
+++ b/packages/packages/api/src/medical/models/document.ts
@@ -24,7 +24,16 @@ export const documentReferenceSchema = z.object({
 });
 export type DocumentReference = z.infer<typeof documentReferenceSchema>;
 
-export const documentListSchema = z.object({
-  queryStatus: z.boolean(),
-  documents: z.array(documentReferenceSchema),
+export const documentQueryStatusSchema = z.enum(["processing", "completed"]);
+export type DocumentQueryStatus = z.infer<typeof documentQueryStatusSchema>;
+
+export const documentQuerySchema = z.object({
+  queryStatus: documentQueryStatusSchema,
 });
+
+export const documentListSchema = z
+  .object({
+    documents: z.array(documentReferenceSchema),
+  })
+  .merge(documentQuerySchema);
+export type DocumentList = z.infer<typeof documentListSchema>;


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/522

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/527

### Description

- add start doc query endpoint
- update sdk to reflect the API change (⚠️ breaking change)
- update docs
- split document commands in diff files

Note: added two commits so Git recognizes a file renaming/moving, but the diff on the PR shows as deleted/created (`api/app/src/external/commonwell/document.ts`)

### Release Plan

- NPM and references to it already updated for `staging`
- note for `prod` release: update version of package SDK/api on `major`, even though this PR increased it on `minor` (there are breaking changes on the SDK - `listDocuments` function)