### PR TITLE
feat(commonwell-sdk): capture CW-Reference header

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "@metriport/api": "^3.0.0",
-    "@metriport/commonwell-sdk": "^4.0.2",
+    "@metriport/commonwell-sdk": "^4.1.0-alpha.0",
     "@sentry/node": "^7.45.0",
     "@sentry/tracing": "^7.45.0",
     "aws-sdk": "^2.1243.0",

--- a/api/app/src/external/commonwell/document/document-download.ts
+++ b/api/app/src/external/commonwell/document/document-download.ts
@@ -32,6 +32,7 @@ export async function downloadDocument({
     capture.error(err, {
       extra: {
         context: `cw.retrieveDocument`,
+        cwReference: commonWell.lastReferenceHeader,
         ...(err instanceof CommonwellError ? err.additionalInfo : undefined),
       },
     });

--- a/api/app/src/external/commonwell/document/document-query.ts
+++ b/api/app/src/external/commonwell/document/document-query.ts
@@ -71,6 +71,7 @@ async function internalGetDocuments({
     capture.error(err, {
       extra: {
         context: `cw.queryDocuments`,
+        cwReference: commonWell.lastReferenceHeader,
         ...(err instanceof CommonwellError ? err.additionalInfo : undefined),
       },
     });

--- a/api/app/src/external/commonwell/link/shared.ts
+++ b/api/app/src/external/commonwell/link/shared.ts
@@ -5,16 +5,16 @@ import {
   Person,
   RequestMetadata,
 } from "@metriport/commonwell-sdk";
+import { MedicalDataSource } from "../..";
 import {
   Patient,
   PatientData,
   PatientExternalData,
   PatientExternalDataEntry,
 } from "../../../models/medical/patient";
-import { PatientDataCommonwell } from "../patient-shared";
-import { MedicalDataSource } from "../..";
 import { filterTruthy } from "../../../shared/filter-map-utils";
 import { capture } from "../../../shared/notifications";
+import { PatientDataCommonwell } from "../patient-shared";
 
 export const commonwellPersonLinks = (persons: Person[]): Person[] => {
   return persons.flatMap<Person>(filterTruthy);
@@ -77,7 +77,12 @@ export async function autoUpgradeNetworkLinks(
             .catch(err => {
               console.log(`Failed to upgrade link: `, err);
               capture.error(err, {
-                extra: { commonwellPatientId, commonwellPersonId, context: executionContext },
+                extra: {
+                  commonwellPatientId,
+                  commonwellPersonId,
+                  cwReference: commonWell.lastReferenceHeader,
+                  context: executionContext,
+                },
               });
               throw err;
             })

--- a/api/app/src/external/commonwell/mock.ts
+++ b/api/app/src/external/commonwell/mock.ts
@@ -49,6 +49,9 @@ export class CommonWellMock implements CommonWellAPI {
   get oid() {
     return this._oid;
   }
+  get lastReferenceHeader() {
+    return undefined;
+  }
 
   //--------------------------------------------------------------------------------------------
   // Org Management

--- a/api/app/src/external/commonwell/organization.ts
+++ b/api/app/src/external/commonwell/organization.ts
@@ -64,11 +64,11 @@ export async function organizationToCommonwell(
 export const create = async (org: Organization): Promise<void> => {
   const { log, debug } = Util.out(`CW create - M orgId ${org.id}`);
   const cwOrg = await organizationToCommonwell(org);
+  const commonWell = makeCommonWellAPI(
+    Config.getMetriportOrgName(),
+    Config.getMemberManagementOID()
+  );
   try {
-    const commonWell = makeCommonWellAPI(
-      Config.getMetriportOrgName(),
-      Config.getMemberManagementOID()
-    );
     const respCreate = await commonWell.createOrg(metriportQueryMeta, cwOrg);
     debug(`resp respCreate: ${JSON.stringify(respCreate, null, 2)}`);
     const respAddCert = await commonWell.addCertificateToOrg(
@@ -81,7 +81,12 @@ export const create = async (org: Organization): Promise<void> => {
     const msg = `Failure creating Org @ CW`;
     log(msg, error);
     capture.error(error, {
-      extra: { orgId: org.id, context: `cw.org.create`, payload: cwOrg },
+      extra: {
+        orgId: org.id,
+        cwReference: commonWell.lastReferenceHeader,
+        context: `cw.org.create`,
+        payload: cwOrg,
+      },
     });
     throw error;
   }
@@ -90,29 +95,30 @@ export const create = async (org: Organization): Promise<void> => {
 export const update = async (org: Organization): Promise<void> => {
   const { log, debug } = Util.out(`CW update - M orgId ${org.id}`);
   const cwOrg = await organizationToCommonwell(org);
+  const commonWell = makeCommonWellAPI(
+    Config.getMetriportOrgName(),
+    Config.getMemberManagementOID()
+  );
   try {
-    const commonWell = makeCommonWellAPI(
-      Config.getMetriportOrgName(),
-      Config.getMemberManagementOID()
-    );
     const respUpdate = await commonWell.updateOrg(metriportQueryMeta, cwOrg, cwOrg.organizationId);
     debug(`resp respUpdate: ${JSON.stringify(respUpdate, null, 2)}`);
 
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
+    const extra = {
+      orgId: org.id,
+      cwReference: commonWell.lastReferenceHeader,
+      context: `cw.org.update`,
+    };
     // Try to create the org if it doesn't exist
     if (error.response?.status === 404) {
-      capture.message("Got 404 when updating Org @ CW, creating it", {
-        extra: { orgId: org.id, context: `cw.org.update` },
-      });
+      capture.message("Got 404 when updating Org @ CW, creating it", { extra });
       return create(org);
     }
     // General error handling
     const msg = `Failure updating Org @ CW`;
     log(msg, error);
-    capture.error(error, {
-      extra: { orgId: org.id, context: `cw.org.update`, payload: cwOrg },
-    });
+    capture.error(error, { extra: { ...extra, payload: cwOrg } });
     throw error;
   }
 };

--- a/api/app/src/external/commonwell/patient-shared.ts
+++ b/api/app/src/external/commonwell/patient-shared.ts
@@ -66,7 +66,12 @@ export async function findOrCreatePerson({
       const message = idsToAlertMessage(commonwellPatientId, personIds);
       log(`${subject}: ${message}`);
       capture.message(subject, {
-        extra: { commonwellPatientId, personIds, context: `cw.findOrCreatePerson.no.strongIds` },
+        extra: {
+          commonwellPatientId,
+          personIds,
+          cwReference: commonWell.lastReferenceHeader,
+          context: `cw.findOrCreatePerson.no.strongIds`,
+        },
       });
       return undefined;
     }

--- a/docs/medical-api/getting-started/quickstart.mdx
+++ b/docs/medical-api/getting-started/quickstart.mdx
@@ -37,6 +37,7 @@ Let's get into it! 🤘
   account, if you don't have one already.
 </Card>
 
+---
 ## 2. Request API access
 
 Once you've created an account and confirmed your email, you'll be taken to the [dashboard
@@ -48,6 +49,7 @@ home page](https://dash.metriport.com/). From here, take the following steps to 
 
 Once the form is submitted, we will review your request promptly and contact you if we need any further information.
 
+---
 ## 3. Generate an API key
 
 After we approve your access request, take the following steps to get your API key:
@@ -77,6 +79,7 @@ home page](https://dash.metriport.com/). From here, take the following steps to 
 
 </Tip>
 
+---
 ## 4. Register your Organization
 
 <Info>
@@ -111,6 +114,7 @@ See the [Create Organization endpoint](/medical-api/api-reference/organization/c
 - In the Organization section, click `Create`.
 - Fill in the details and submit the form to register your Organization.
 
+---
 ## 5. Create Facilities and Patients
 
 Once your Organization is registered, you can now create `Facilities` and `Patients`. First,
@@ -152,6 +156,7 @@ See the [Create Patient endpoint](/medical-api/api-reference/patient/create-pati
   creating the Patient.
 </Info>
 
+---
 ## 6. Get Patient Medical Documents 🎉🎉🎉
 
 Now, you're able to access your Patients' medical `Documents`. This involves 2 main steps:
@@ -163,13 +168,16 @@ To query for a Patient's available `Documents`, you can either:
 
 ### Query for Documents using the API
 
-See the [List Documents endpoint](/medical-api/api-reference/document/list-documents) in our API reference.
+1. Start an asynchronous [Document Query](/medical-api/api-reference/document/start-document-query) across HIEs.
+1. [List Documents](/medical-api/api-reference/document/list-documents) to get the available document
+references returned from HIEs.
 
 ### Query for Documents using the Dashboard
 
 - On the `Medical API` page, in the Facilities section, click `Patients` for the Facility where the Patient is located.
 - In the desired Patient's row, click `Documents`.
 - You'll see all available Documents in the side panel.
+- To update the list of documents from HIEs, click on `Query Documents`.
 
 <Info>Not all Patients will have available Documents, but they should ~95% of the time.</Info>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       "license": "ISC",
       "dependencies": {
         "@metriport/api": "^3.0.0",
-        "@metriport/commonwell-sdk": "^4.0.2",
+        "@metriport/commonwell-sdk": "^4.1.0-alpha.0",
         "@sentry/node": "^7.45.0",
         "@sentry/tracing": "^7.45.0",
         "aws-sdk": "^2.1243.0",
@@ -4709,9 +4709,9 @@
       }
     },
     "node_modules/@metriport/commonwell-sdk": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-4.0.2.tgz",
-      "integrity": "sha512-gbXVDaJ3utCl2CDB3dyANqap3ymTMlMbEf1c9q7Uxm3mAsQ/SGARfEzaI8cnXT+oyVbS9H/qBTWti4xqL1Dkig==",
+      "version": "4.1.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-4.1.0-alpha.0.tgz",
+      "integrity": "sha512-X/Qn1P2jO9WAm0DjnIq9RmTtpbChhvy6FH//gZZ9ro3odQTo3Ye4ejb5xLHPTRhNeOBUbmsCbFzySDdggzxTeA==",
       "dependencies": {
         "http-status": "^1.6.2",
         "jsonwebtoken": "^9.0.0",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -17852,7 +17852,7 @@
       "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.0.2",
+        "@metriport/commonwell-sdk": "^4.1.0-alpha.0",
         "axios": "^1.3.4",
         "commander": "^9.5.0",
         "dotenv": "^16.0.3",
@@ -17882,7 +17882,7 @@
       "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.0.2",
+        "@metriport/commonwell-sdk": "^4.1.0-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -17897,7 +17897,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.0.2",
+      "version": "4.1.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "http-status": "^1.6.2",

--- a/packages/packages/commonwell-cert-runner/package.json
+++ b/packages/packages/commonwell-cert-runner/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.0.2",
+    "@metriport/commonwell-sdk": "^4.1.0-alpha.0",
     "axios": "^1.3.4",
     "commander": "^9.5.0",
     "dotenv": "^16.0.3",

--- a/packages/packages/commonwell-jwt-maker/package.json
+++ b/packages/packages/commonwell-jwt-maker/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.0.2",
+    "@metriport/commonwell-sdk": "^4.1.0-alpha.0",
     "commander": "^9.5.0"
   }
 }

--- a/packages/packages/commonwell-sdk/package.json
+++ b/packages/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.0.2",
+  "version": "4.1.0-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-sdk/src/client/commonwell-api.ts
+++ b/packages/packages/commonwell-sdk/src/client/commonwell-api.ts
@@ -14,6 +14,7 @@ import {
 import { PatientLink, PatientLinkSearchResp, Person, PersonSearchResp } from "../models/person";
 
 export interface CommonWellAPI {
+  get lastReferenceHeader(): string | undefined;
   createOrg(meta: RequestMetadata, organization: Organization): Promise<Organization>;
   updateOrg(meta: RequestMetadata, organization: Organization, id: string): Promise<Organization>;
   getAllOrgs(

--- a/packages/packages/commonwell-sdk/src/client/commonwell.ts
+++ b/packages/packages/commonwell-sdk/src/client/commonwell.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from "axios";
+import axios, { AxiosInstance, AxiosResponse } from "axios";
 import * as httpStatus from "http-status";
 import { Agent } from "https";
 import * as stream from "stream";
@@ -68,6 +68,7 @@ export class CommonWell implements CommonWellAPI {
   private orgName: string;
   private _oid: string;
   private httpsAgent: Agent;
+  private _lastReferenceHeader: string | undefined;
 
   /**
    * Creates a new instance of the CommonWell API client pertaining to an
@@ -91,12 +92,40 @@ export class CommonWell implements CommonWellAPI {
         apiMode === APIMode.production ? CommonWell.productionUrl : CommonWell.integrationUrl,
       httpsAgent: this.httpsAgent,
     });
+    this.api.interceptors.response.use(
+      this.axiosSuccessfulResponse(this),
+      this.axiosErrorResponse(this)
+    );
     this.orgName = orgName;
     this._oid = oid;
   }
 
   get oid() {
     return this._oid;
+  }
+  /**
+   * Returns the `CW-Reference` header from the last request.
+   */
+  get lastReferenceHeader(): string | undefined {
+    return this._lastReferenceHeader;
+  }
+
+  // Being extra safe with these bc a failure here fails the actual request
+  private postRequest(response: AxiosResponse): void {
+    this._lastReferenceHeader =
+      response && response.headers ? response.headers["cw-reference"] : undefined;
+  }
+  private axiosSuccessfulResponse(_this: CommonWell) {
+    return (response: AxiosResponse): AxiosResponse => {
+      _this && _this.postRequest(response);
+      return response;
+    };
+  }
+  private axiosErrorResponse(_this: CommonWell) {
+    return (response: AxiosResponse): AxiosResponse => {
+      _this && _this.postRequest(response);
+      return response;
+    };
   }
 
   // TODO: #322 handle errors in API calls as per
@@ -718,8 +747,6 @@ export class CommonWell implements CommonWellAPI {
     await this.api.delete(`${CommonWell.ORG_ENDPOINT}/${this.oid}/patient/${id}/`, {
       headers,
     });
-
-    return;
   }
 
   //--------------------------------------------------------------------------------------------


### PR DESCRIPTION
Ref. metriport/metriport-internal#156

### Dependencies

none

### Description

- capture CW-Reference header and make it available on SDK
- add CW-Ref to reports to Sentry
- update MAPI docs' quickstart, including info about async doc query

In addition to the info on async doc query, I'm also suggesting a bit more space between sections of the quickstart, it hard to differentiate the sections when scanning the page, and those lines seem to help w/o messing with larger UI changes (left with new lines, right original version):

<img width="3007" alt="image" src="https://user-images.githubusercontent.com/2132564/230500479-5e6132c9-2b31-4415-8a43-79ff60d241ca.png">

### Release Plan

- nothing special