### PR TITLE
fix(api): update to proper ts version, fix error rethrows

### DIFF
--- a/api/app/src/external/commonwell/patient.ts
+++ b/api/app/src/external/commonwell/patient.ts
@@ -412,7 +412,9 @@ async function getLinkInfo({
   const strongIds = getMatchingStrongIds(person, commonwellPatient);
   const hasLink = Boolean(linkToPatient && linkToPatient.assuranceLevel);
   const isLinkLola3Plus = linkToPatient?.assuranceLevel
-    ? [LOLA.level_3, LOLA.level_4].map(toString).includes(linkToPatient.assuranceLevel)
+    ? [LOLA.level_3, LOLA.level_4]
+        .map(level => level.toString())
+        .includes(linkToPatient.assuranceLevel)
     : false;
   return { hasLink, isLinkLola3Plus, strongIds };
 }

--- a/api/app/src/providers/dexcom.ts
+++ b/api/app/src/providers/dexcom.ts
@@ -111,7 +111,7 @@ export class Dexcom extends Provider implements OAuth2 {
             context: `dexcom.refreshToken`,
           },
         });
-        throw new Error("Error refreshing access token: ");
+        throw new Error("Error refreshing access token", { cause: error });
       }
     }
 

--- a/api/app/src/providers/oauth2.ts
+++ b/api/app/src/providers/oauth2.ts
@@ -138,7 +138,7 @@ export class OAuth2DefaultImpl implements OAuth2 {
         return accessToken.token;
       } catch (error) {
         console.log("Error refreshing access token: ", error);
-        throw new Error("Error refreshing access token: ");
+        throw new Error("Error refreshing access token", { cause: error });
       }
     }
 

--- a/api/app/src/providers/withings.ts
+++ b/api/app/src/providers/withings.ts
@@ -142,7 +142,7 @@ export class Withings extends Provider implements OAuth2 {
         return response.data.body;
       } catch (error) {
         console.log("Error refreshing access token: ", error);
-        throw new Error("Error refreshing access token: ");
+        throw new Error("Error refreshing access token", { cause: error });
       }
     }
 

--- a/api/app/tsconfig.json
+++ b/api/app/tsconfig.json
@@ -13,8 +13,8 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "ES2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["ES2022"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */


### PR DESCRIPTION
refs. metriport/metriport-internal#537


### Dependencies

N/A

### Description

update to proper ts version as per [here](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping) (we were woefully out of date using es2016), fix error rethrows

### Release Plan

nothing special
