### PR TITLE
ci: support GH action's `merge_group` trigger

### DIFF
--- a/.github/workflows/_reusable_deploy.yml
+++ b/.github/workflows/_reusable_deploy.yml
@@ -12,14 +12,16 @@ on:
         required: true
         type: string
         description: "the environment we're deploying to, either 'staging', 'production', or 'sandbox'"
+      cdk_stack:
+        required: true
+        type: string
+        description: "the name of the CDK stack we're deploying"
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
       AWS_SECRET_ACCESS_KEY:
         required: true
       AWS_REGION:
-        required: true
-      CDK_STACK:
         required: true
       INFRA_CONFIG:
         required: true
@@ -34,7 +36,7 @@ jobs:
     # https://serverlessfirst.com/emails/how-to-prevent-concurrent-deployments-of-serverless-stacks-in-github-actions/
     # TODO Consider the solution here: https://github.com/tj-actions/aws-cdk/blob/main/action.yml
     concurrency:
-      group: ${{ format('{0}-{1}', github.job, inputs.deploy_env) }}
+      group: ${{ format('{0}-{1}-{2}', github.job, inputs.cdk_stack, inputs.deploy_env) }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy_env }}
     steps:
@@ -110,7 +112,7 @@ jobs:
         with:
           cdk_action: "diff"
           cdk_version: "2.49.0"
-          cdk_stack: "${{ secrets.CDK_STACK }}"
+          cdk_stack: "${{ inputs.cdk_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -123,7 +125,7 @@ jobs:
         with:
           cdk_action: "deploy --verbose --require-approval never"
           cdk_version: "2.49.0"
-          cdk_stack: "${{ secrets.CDK_STACK }}"
+          cdk_stack: "${{ inputs.cdk_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/_reusable_release.yml
+++ b/.github/workflows/_reusable_release.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # TODO once this is mature, remove '--debug'
         run: |
           pwd
-          npx semantic-release --debug
+          npx semantic-release

--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -11,11 +11,11 @@ jobs:
     with:
       build_env: "staging"
       deploy_env: "staging"
+      cdk_stack: ${{ vars.WIDGET_STACK_NAME_STAGING }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.WIDGET_REGION_STAGING }}
-      CDK_STACK: ${{ secrets.WIDGET_STACK_NAME_STAGING }}
       INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_STAGING }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -24,11 +24,11 @@ jobs:
     uses: ./.github/workflows/_reusable_deploy.yml
     with:
       deploy_env: "staging"
+      cdk_stack: ${{ vars.API_STACK_NAME_STAGING }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.API_REGION_STAGING }}
-      CDK_STACK: ${{ secrets.API_STACK_NAME_STAGING }}
       INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_STAGING }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,20 +5,39 @@ on:
     branches:
       - master
     paths:
-      - "connect-widget/app/**"
-      - "api/app/**"
-      - "api/lambdas/**"
+      - "connect-widget/**"
+      - "api/**"
       - "infra/**"
-      - "package.json"
-      - "package-lock.json"
-      - "commitlint.config.js"
-      - ".releaserc.yaml"
-      - ".github/workflows/deploy-production*"
-      - ".github/workflows/_reusable*"
+      - "package*.json"
   workflow_dispatch: # manually executed by a user
 
 jobs:
+  files-changed:
+    name: detect which files changed
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    # Map a step output to a job output
+    outputs:
+      api: ${{ steps.changes.outputs.api }}
+      widget: ${{ steps.changes.outputs.widget }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@4067d885736b84de7c414f582ac45897079b0a78 # v2
+        id: changes
+        with:
+          filters: |
+            api:
+              - "api/**"
+              - "infra/**"
+              - "package*.json"
+            widget:
+              - "connect-widget/**"
+              - "infra/**"
+              - "package*.json"
+
   widget-build:
+    if: needs.files-changed.outputs.widget == 'true'
+    needs: files-changed
     uses: ./.github/workflows/_reusable_build.yml
     with:
       path: "connect-widget/app"
@@ -29,16 +48,18 @@ jobs:
     with:
       build_env: "production"
       deploy_env: "production"
+      cdk_stack: ${{ vars.WIDGET_STACK_NAME_PRODUCTION }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.WIDGET_REGION_PRODUCTION }}
-      CDK_STACK: ${{ secrets.WIDGET_STACK_NAME_PRODUCTION }}
       INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_PRODUCTION }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
 
   api-build:
+    if: needs.files-changed.outputs.api == 'true'
+    needs: files-changed
     uses: ./.github/workflows/_reusable_build.yml
     with:
       path: "api/app" # there's no "build" for lambdas, so one job for both works
@@ -47,11 +68,11 @@ jobs:
     needs: api-build
     with:
       deploy_env: "production"
+      cdk_stack: ${{ vars.API_STACK_NAME_PRODUCTION }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.API_REGION_PRODUCTION }}
-      CDK_STACK: ${{ secrets.API_STACK_NAME_PRODUCTION }}
       INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_PRODUCTION }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -60,11 +81,11 @@ jobs:
     needs: api-deploy
     with:
       deploy_env: "sandbox"
+      cdk_stack: ${{ vars.API_STACK_NAME_SANDBOX }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.API_REGION_SANDBOX }}
-      CDK_STACK: ${{ secrets.API_STACK_NAME_SANDBOX }}
       INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_SANDBOX }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -72,4 +93,8 @@ jobs:
   release:
     uses: ./.github/workflows/_reusable_release.yml
     needs: [widget-deploy, api-sandbox-deploy]
+    # run even if one of the dependencies didn't
+    # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."
+    # can't use ${{ ! failure() && contains(needs.*.result, 'success') }} because if anything that came before succeeded, even if not a direct dependency, it will run
+    if: ${{ !failure() && (needs.widget-deploy.result == 'success' || needs.api-sandbox-deploy.result == 'success') }}
     secrets: inherit

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,9 +10,11 @@ on:
       - "api/lambdas/**"
       - "infra/**"
       - "package.json"
+      - "package-lock.json"
       - "commitlint.config.js"
       - ".releaserc.yaml"
-      - ".github/workflows/**"
+      - ".github/workflows/deploy-production*"
+      - ".github/workflows/_reusable*"
   workflow_dispatch: # manually executed by a user
 
 jobs:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,20 +5,39 @@ on:
     branches:
       - develop
     paths:
-      - "connect-widget/app/**"
-      - "api/app/**"
-      - "api/lambdas/**"
+      - "connect-widget/**"
+      - "api/**"
       - "infra/**"
-      - "package.json"
-      - "package-lock.json"
-      - "commitlint.config.js"
-      - ".releaserc.yaml"
-      - ".github/workflows/deploy-staging*"
-      - ".github/workflows/_reusable*"
+      - "package*.json"
   workflow_dispatch: # manually executed by a user
 
 jobs:
+  files-changed:
+    name: detect which files changed
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    # Map a step output to a job output
+    outputs:
+      api: ${{ steps.changes.outputs.api }}
+      widget: ${{ steps.changes.outputs.widget }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@4067d885736b84de7c414f582ac45897079b0a78 # v2
+        id: changes
+        with:
+          filters: |
+            api:
+              - "api/**"
+              - "infra/**"
+              - "package*.json"
+            widget:
+              - "connect-widget/**"
+              - "infra/**"
+              - "package*.json"
+
   widget-build:
+    if: needs.files-changed.outputs.widget == 'true'
+    needs: files-changed
     uses: ./.github/workflows/_reusable_build.yml
     with:
       path: "connect-widget/app"
@@ -29,16 +48,18 @@ jobs:
     with:
       build_env: "staging"
       deploy_env: "staging"
+      cdk_stack: ${{ vars.WIDGET_STACK_NAME_STAGING }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.WIDGET_REGION_STAGING }}
-      CDK_STACK: ${{ secrets.WIDGET_STACK_NAME_STAGING }}
       INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_STAGING }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
 
   api-build:
+    if: needs.files-changed.outputs.api == 'true'
+    needs: files-changed
     uses: ./.github/workflows/_reusable_build.yml
     with:
       path: "api/app" # there's no "build" for lambdas, so one job for both works
@@ -47,11 +68,11 @@ jobs:
     needs: api-build
     with:
       deploy_env: "staging"
+      cdk_stack: ${{ vars.API_STACK_NAME_STAGING }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.API_REGION_STAGING }}
-      CDK_STACK: ${{ secrets.API_STACK_NAME_STAGING }}
       INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_STAGING }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -59,4 +80,8 @@ jobs:
   release:
     uses: ./.github/workflows/_reusable_release.yml
     needs: [widget-deploy, api-deploy]
+    # run even if one of the dependencies didn't
+    # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."
+    # can't use ${{ ! failure() && contains(needs.*.result, 'success') }} because if anything that came before succeeded, even if not a direct dependency, it will run
+    if: ${{ !failure() && (needs.widget-deploy.result == 'success' || needs.api-deploy.result == 'success') }}
     secrets: inherit

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -10,9 +10,11 @@ on:
       - "api/lambdas/**"
       - "infra/**"
       - "package.json"
+      - "package-lock.json"
       - "commitlint.config.js"
       - ".releaserc.yaml"
-      - ".github/workflows/**"
+      - ".github/workflows/deploy-staging*"
+      - ".github/workflows/_reusable*"
   workflow_dispatch: # manually executed by a user
 
 jobs:

--- a/.github/workflows/pull-request_api.yml
+++ b/.github/workflows/pull-request_api.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - "api/app/**"
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pull-request_infra.yml
+++ b/.github/workflows/pull-request_infra.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "infra/**"
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pull-request_packages.yml
+++ b/.github/workflows/pull-request_packages.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "packages/**"
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pull-request_utils.yml
+++ b/.github/workflows/pull-request_utils.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "utils/**"
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pull-request_widget.yml
+++ b/.github/workflows/pull-request_widget.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "connect-widget/app/**"
+  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Ref. metriport/metriport-internal#531

### Dependencies

- Upstream:
  - https://github.com/metriport/metriport-internal/pull/539
  - https://github.com/metriport/metriport-internal/pull/540
- Downstream: none

### Description

- support GH action's `merge_group` trigger
- don't deploy when pr only stuff changed

### Release Plan

- [x] update this repo's settings [for develop](https://github.com/metriport/metriport/settings/branch_protection_rules/32510057) and [for master](https://github.com/metriport/metriport/settings/branch_protection_rules/32447900), enabling `Require merge queue`
- [x] create GH variables for stack names
- [ ] merge this
- [ ] test queuing PRs to be merged
