### PR TITLE
fix: prod private zone accessing sandbox's one

### DIFF
--- a/infra/lib/env-config.ts
+++ b/infra/lib/env-config.ts
@@ -13,6 +13,7 @@ export type EnvConfig = {
   secretsStackName: string;
   environmentType: EnvType;
   region: string;
+  sandboxRegion?: string; // Only used for prod
   secretReplicaRegion?: string;
   host: string; // DNS Zone
   domain: string; // Base domain


### PR DESCRIPTION
Ref. metriport/metriport-internal#547

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/548

### Description

Allow `prod`'s private zone accessing sandbox's one, so `post-confirmation` lambda in `prod` can initialize the account in `sandbox` as well.

### Release Plan

- ⚠️ this is pointing to `master`
- [x] update GH's secret with prod's config from internal (base64)
- [x] merge this (new deployment in `production`)
- [ ] merge `master` into `develop`