### PR TITLE
fix: dynamic sandbox vpc name

### DIFF
--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -696,8 +696,8 @@ function createPrivateZone(stack: APIStack, props: APIStackProps): r53.IPrivateH
   // When creating prod's zone, we need to add a reference to the sandbox's vpc because some prod
   // resources need to access sandbox's.
   if (isProd(props.config) && props.config.sandboxRegion) {
-    const sandboxVpc = ec2.Vpc.fromLookup(stack, "APIVpc", {
-      vpcName: "APIVpc",
+    const sandboxVpc = ec2.Vpc.fromLookup(stack, "APIVpcSandbox", {
+      vpcName: props.config.sandboxVpcName,
       region: props.config.sandboxRegion,
     });
     if (sandboxVpc) zone.addVpc(sandboxVpc);

--- a/infra/lib/env-config.ts
+++ b/infra/lib/env-config.ts
@@ -14,6 +14,7 @@ export type EnvConfig = {
   environmentType: EnvType;
   region: string;
   sandboxRegion?: string; // Only used for prod
+  sandboxVpcName?: string; // Only used for prod
   secretReplicaRegion?: string;
   host: string; // DNS Zone
   domain: string; // Base domain


### PR DESCRIPTION
Ref. metriport/metriport-internal#547

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/217
- Downstream: https://github.com/metriport/metriport-internal/pull/548

### Description

dynamic sandbox vpc name

### Release Plan

- ⚠️ this is pointing to `master`
- [x] update GH's secret with prod's config from internal (base64)
- [ ] merge this (new deployment in `production`)
- [ ] merge `master` into `develop`