### PR TITLE
refactor(api): dedup doc ref by master ID + store raw

### DIFF
--- a/api/app/src/command/medical/document/create-or-update.ts
+++ b/api/app/src/command/medical/document/create-or-update.ts
@@ -35,6 +35,7 @@ export async function createOrUpdate(
                 ...existing.data,
                 ...doc.data,
               },
+              raw: doc.raw,
             },
             { transaction }
           );
@@ -47,6 +48,7 @@ export async function createOrUpdate(
               source: MedicalDataSource.COMMONWELL,
               externalId: doc.externalId,
               data: doc.data,
+              raw: doc.raw,
             },
             { transaction }
           );

--- a/api/app/src/domain/base-domain.ts
+++ b/api/app/src/domain/base-domain.ts
@@ -1,0 +1,9 @@
+export interface BaseDomainCreate {
+  id: string;
+}
+
+export interface BaseDomain extends BaseDomainCreate {
+  createdAt: Date;
+  updatedAt: Date;
+  eTag: string;
+}

--- a/api/app/src/domain/medical/document-reference.ts
+++ b/api/app/src/domain/medical/document-reference.ts
@@ -1,5 +1,5 @@
 import { MedicalDataSource } from "../../external";
-import { IBaseModel, IBaseModelCreate } from "../../models/_default";
+import { BaseDomain } from "../base-domain";
 import { CodeableConcept } from "./codeable-concept";
 
 export type ExternalDocumentReference = {
@@ -16,12 +16,13 @@ export type ExternalDocumentReference = {
 export const documentQueryStatus = ["processing", "completed"] as const;
 export type DocumentQueryStatus = (typeof documentQueryStatus)[number];
 
-export interface DocumentReferenceCreate extends Omit<IBaseModelCreate, "id"> {
+export interface DocumentReferenceCreate {
   cxId: string;
   patientId: string;
   source: MedicalDataSource;
   externalId: string;
   data: ExternalDocumentReference;
+  raw?: unknown;
 }
 
-export interface DocumentReference extends IBaseModel, DocumentReferenceCreate {}
+export interface DocumentReference extends BaseDomain, DocumentReferenceCreate {}

--- a/api/app/src/external/commonwell/document/document-query.ts
+++ b/api/app/src/external/commonwell/document/document-query.ts
@@ -78,23 +78,22 @@ async function internalGetDocuments({
   }
 
   const documents: DocumentWithLocation[] = docs.entry
-    ? docs.entry
-        .flatMap(d =>
-          d.id && d.content && d.content.location
-            ? { id: d.id, content: { location: d.content.location, ...d.content } }
-            : []
-        )
-        .map(d => ({
-          id: d.id,
-          fileName: getFileName(patient, d),
-          description: d.content.description,
-          type: d.content.type,
-          status: d.content.status,
-          location: d.content.location,
-          indexed: d.content.indexed,
-          mimeType: d.content.mimeType,
-          size: d.content.size, // bytes
-        }))
+    ? docs.entry.flatMap(d =>
+        d.content?.masterIdentifier?.value && d.content?.location
+          ? {
+              id: d.content.masterIdentifier.value,
+              fileName: getFileName(patient, d),
+              description: d.content.description,
+              type: d.content.type,
+              status: d.content.status,
+              location: d.content.location,
+              indexed: d.content.indexed,
+              mimeType: d.content.mimeType,
+              size: d.content.size, // bytes
+              raw: d,
+            }
+          : []
+      )
     : [];
   return documents;
 }

--- a/api/app/src/external/commonwell/document/shared.ts
+++ b/api/app/src/external/commonwell/document/shared.ts
@@ -10,6 +10,7 @@ export type DocumentWithLocation = Required<Pick<Document, "id">> &
   Omit<DocumentContent, "location"> &
   Required<Pick<DocumentContent, "location">> & {
     fileName: string;
+    raw?: unknown;
   };
 
 export function toDomain(patient: Patient) {
@@ -29,6 +30,7 @@ export function toDomain(patient: Patient) {
         size: doc.size,
         type: doc.type,
       },
+      raw: doc.raw,
     };
   };
 }

--- a/api/app/src/models/_default.ts
+++ b/api/app/src/models/_default.ts
@@ -7,25 +7,16 @@ import {
   Model,
   Sequelize,
 } from "sequelize";
+import { BaseDomain } from "../domain/base-domain";
 import VersionMismatchError from "../errors/version-mismatch";
 import { Util } from "../shared/util";
 
 export type ModelSetup = (sequelize: Sequelize) => void;
 
-export interface IBaseModelCreate {
-  id: string;
-}
-
-export interface IBaseModel extends IBaseModelCreate {
-  createdAt: Date;
-  updatedAt: Date;
-  eTag: string;
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export abstract class BaseModel<T extends Model<any, any>>
   extends Model<InferAttributes<T>, InferCreationAttributes<T>>
-  implements IBaseModel
+  implements BaseDomain
 {
   declare id: string;
   declare createdAt: CreationOptional<Date>;
@@ -74,7 +65,7 @@ export abstract class BaseModel<T extends Model<any, any>>
 }
 
 export function validateVersionForUpdate(
-  entity: Pick<IBaseModel, "id" | "eTag">,
+  entity: Pick<BaseDomain, "id" | "eTag">,
   eTag: string | undefined
 ) {
   if (eTag != null && eTag !== entity.eTag) {

--- a/api/app/src/models/medical/document-reference.ts
+++ b/api/app/src/models/medical/document-reference.ts
@@ -1,17 +1,24 @@
 import { DataTypes, Sequelize } from "sequelize";
-import { ExternalDocumentReference } from "../../domain/medical/document-reference";
+import {
+  DocumentReference,
+  ExternalDocumentReference,
+} from "../../domain/medical/document-reference";
 import { MedicalDataSource } from "../../external";
 import { BaseModel, ModelSetup } from "../_default";
 
 export type DocumentReferenceData = ExternalDocumentReference;
 
-export class DocumentReferenceModel extends BaseModel<DocumentReferenceModel> {
+export class DocumentReferenceModel
+  extends BaseModel<DocumentReferenceModel>
+  implements DocumentReference
+{
   static NAME = "document_reference";
   declare cxId: string;
   declare patientId: string;
   declare source: MedicalDataSource;
   declare externalId: string;
   declare data: DocumentReferenceData;
+  declare raw?: unknown;
 
   static setup: ModelSetup = (sequelize: Sequelize) => {
     DocumentReferenceModel.init(
@@ -30,6 +37,9 @@ export class DocumentReferenceModel extends BaseModel<DocumentReferenceModel> {
           type: DataTypes.STRING,
         },
         data: {
+          type: DataTypes.JSONB,
+        },
+        raw: {
           type: DataTypes.JSONB,
         },
       },

--- a/api/app/src/models/medical/facility.ts
+++ b/api/app/src/models/medical/facility.ts
@@ -1,5 +1,6 @@
 import { CreationOptional, DataTypes, Sequelize } from "sequelize";
-import { IBaseModelCreate, IBaseModel, ModelSetup, BaseModel } from "../_default";
+import { BaseDomain, BaseDomainCreate } from "../../domain/base-domain";
+import { BaseModel, ModelSetup } from "../_default";
 import { Address } from "./address";
 
 export type FacilityData = {
@@ -10,12 +11,12 @@ export type FacilityData = {
   address: Address;
 };
 
-export interface FacilityCreate extends IBaseModelCreate {
+export interface FacilityCreate extends BaseDomainCreate {
   cxId: string;
   facilityNumber: number;
   data: FacilityData;
 }
-export interface Facility extends IBaseModel, FacilityCreate {}
+export interface Facility extends BaseDomain, FacilityCreate {}
 
 export class FacilityModel extends BaseModel<FacilityModel> implements Facility {
   static NAME = "facility";

--- a/api/app/src/models/medical/organization.ts
+++ b/api/app/src/models/medical/organization.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Sequelize } from "sequelize";
-import { IBaseModelCreate, IBaseModel, ModelSetup, BaseModel } from "../_default";
+import { BaseDomain, BaseDomainCreate } from "../../domain/base-domain";
+import { BaseModel, ModelSetup } from "../_default";
 import { Address } from "./address";
 
 export enum OrgType {
@@ -17,13 +18,13 @@ export type OrganizationData = {
   location: Address;
 };
 
-export interface OrganizationCreate extends IBaseModelCreate {
+export interface OrganizationCreate extends BaseDomainCreate {
   cxId: string;
   organizationNumber: number;
   data: OrganizationData;
 }
 
-export interface Organization extends IBaseModel, OrganizationCreate {}
+export interface Organization extends BaseDomain, OrganizationCreate {}
 
 export class OrganizationModel extends BaseModel<OrganizationModel> implements Organization {
   static NAME = "organization";

--- a/api/app/src/models/medical/patient.ts
+++ b/api/app/src/models/medical/patient.ts
@@ -1,8 +1,9 @@
 import { DataTypes, Sequelize } from "sequelize";
+import { BaseDomain, BaseDomainCreate } from "../../domain/base-domain";
 import { DocumentQueryStatus } from "../../domain/medical/document-reference";
 import { MedicalDataSource } from "../../external";
 import { USState } from "../../shared/geographic-locations";
-import { BaseModel, IBaseModel, IBaseModelCreate, ModelSetup } from "../_default";
+import { BaseModel, ModelSetup } from "../_default";
 import { Address } from "./address";
 import { Contact } from "./contact";
 
@@ -61,14 +62,14 @@ export type PatientData = {
   externalData?: PatientExternalData;
 };
 
-export interface PatientCreate extends IBaseModelCreate {
+export interface PatientCreate extends BaseDomainCreate {
   cxId: string;
   facilityIds: string[];
   patientNumber: number;
   data: PatientData;
 }
 
-export interface Patient extends IBaseModel, PatientCreate {}
+export interface Patient extends BaseDomain, PatientCreate {}
 
 export class PatientModel extends BaseModel<PatientModel> implements Patient {
   static NAME = "patient";

--- a/api/app/src/sequelize/migrations/20230404153200-create-document-reference.ts
+++ b/api/app/src/sequelize/migrations/20230404153200-create-document-reference.ts
@@ -43,6 +43,6 @@ export const up: Migration = async ({ context: queryInterface }) => {
 
 export const down: Migration = ({ context: queryInterface }) => {
   return queryInterface.sequelize.transaction(async transaction => {
-    await queryInterface.dropTable("document-reference", { transaction });
+    await queryInterface.dropTable("document_reference", { transaction });
   });
 };

--- a/api/app/src/sequelize/migrations/20230411144500-alter-document-reference-add-raw.ts
+++ b/api/app/src/sequelize/migrations/20230411144500-alter-document-reference-add-raw.ts
@@ -1,0 +1,20 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+
+// Use 'Promise.all' when changes are independent of each other
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.addColumn(
+      "document_reference",
+      "raw",
+      { type: DataTypes.JSONB, allowNull: true },
+      { transaction }
+    );
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.removeColumn("document_reference", "raw", { transaction });
+  });
+};

--- a/packages/packages/commonwell-sdk/src/models/document.ts
+++ b/packages/packages/commonwell-sdk/src/models/document.ts
@@ -10,7 +10,7 @@ import { genderSchema } from "./demographics";
 // https://specification.commonwellalliance.org/services/rest-api-reference#8610-documentreference
 
 // TODO can this be an enum?
-// Bundle, DocumentReference, Organization, Practitioner
+// Bundle, DocumentReference, Organization, Practitioner, OperationOutcome
 const resourceTypeSchema = z.string().optional();
 
 const identifierSchema = z.object({


### PR DESCRIPTION
Ref. metriport/metriport-internal#564

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/567

### Description

- dedup doc ref by master ID
- store raw doc content from CW
- also changed the interfaces bc the domain was importing the model/DB

### Release Plan

- ⚠️ This is pointing to `master` - deploy in `production`
- [ ] merge this
- [ ] get list of patient and facility IDs for each customer:
  - `select distinct cx_id, patient_id from document_reference order by cx_id, patient_id;`
  - `select cx_id, id from facility order by cx_id, id;`
- [ ] backup existing doc ref table
  - `CREATE TABLE document_reference_564_20240411 AS  TABLE document_reference;`
- [ ] remove the document references from prod DB:
  - `delete from document_reference` 
- [ ] execute internal's `oss-query-docs.ts` with those