### PR TITLE
refactor(api): recreate CW doc refs on new query

### DIFF
--- a/api/app/src/command/medical/document/create-or-update.ts
+++ b/api/app/src/command/medical/document/create-or-update.ts
@@ -4,7 +4,6 @@ import {
   DocumentReference,
   DocumentReferenceCreate,
 } from "../../../domain/medical/document-reference";
-import { MedicalDataSource } from "../../../external";
 import { DocumentReferenceModel } from "../../../models/medical/document-reference";
 import { Patient } from "../../../models/medical/patient";
 
@@ -45,7 +44,7 @@ export async function createOrUpdate(
               id: uuidv4(),
               cxId: patient.cxId,
               patientId: patient.id,
-              source: MedicalDataSource.COMMONWELL,
+              source: doc.source,
               externalId: doc.externalId,
               data: doc.data,
               raw: doc.raw,

--- a/api/app/src/domain/base-domain.ts
+++ b/api/app/src/domain/base-domain.ts
@@ -7,3 +7,7 @@ export interface BaseDomain extends BaseDomainCreate {
   updatedAt: Date;
   eTag: string;
 }
+
+export interface BaseDomainSoftDelete extends BaseDomain {
+  deletedAt?: Date;
+}

--- a/api/app/src/domain/medical/document-reference.ts
+++ b/api/app/src/domain/medical/document-reference.ts
@@ -1,5 +1,5 @@
 import { MedicalDataSource } from "../../external";
-import { BaseDomain } from "../base-domain";
+import { BaseDomainSoftDelete } from "../base-domain";
 import { CodeableConcept } from "./codeable-concept";
 
 export type ExternalDocumentReference = {
@@ -25,4 +25,4 @@ export interface DocumentReferenceCreate {
   raw?: unknown;
 }
 
-export interface DocumentReference extends BaseDomain, DocumentReferenceCreate {}
+export interface DocumentReference extends BaseDomainSoftDelete, DocumentReferenceCreate {}

--- a/api/app/src/models/medical/document-reference.ts
+++ b/api/app/src/models/medical/document-reference.ts
@@ -13,6 +13,7 @@ export class DocumentReferenceModel
   implements DocumentReference
 {
   static NAME = "document_reference";
+  declare deletedAt?: Date;
   declare cxId: string;
   declare patientId: string;
   declare source: MedicalDataSource;
@@ -24,6 +25,9 @@ export class DocumentReferenceModel
     DocumentReferenceModel.init(
       {
         ...BaseModel.attributes(),
+        deletedAt: {
+          type: DataTypes.DATE(6),
+        },
         cxId: {
           type: DataTypes.UUID,
         },
@@ -46,6 +50,8 @@ export class DocumentReferenceModel
       {
         ...BaseModel.modelOptions(sequelize),
         tableName: DocumentReferenceModel.NAME,
+        paranoid: true,
+        deletedAt: "deleted_at",
       }
     );
   };

--- a/api/app/src/sequelize/migrations/20230411221500-alter-document-reference-remove-unique.ts
+++ b/api/app/src/sequelize/migrations/20230411221500-alter-document-reference-remove-unique.ts
@@ -1,0 +1,33 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "document_reference";
+const constraintName = "document_reference_patient_id_source_external_id_key";
+
+// Use 'Promise.all' when changes are independent of each other
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.addColumn(
+      tableName,
+      "deleted_at",
+      {
+        type: DataTypes.DATE(6),
+        allowNull: true,
+      },
+      { transaction }
+    );
+    await queryInterface.removeConstraint(tableName, constraintName, { transaction });
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.addConstraint(tableName, {
+      transaction,
+      type: "unique",
+      name: constraintName,
+      fields: ["patient_id", "source", "external_id"],
+    });
+    await queryInterface.removeColumn(tableName, "deleted_at", { transaction });
+  });
+};


### PR DESCRIPTION
Ref. metriport/metriport-internal#564

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/221
- Downstream: none

### Description

Recreate CW doc refs on new query.

### Release Plan

- ⚠️ This is pointing to `master`, new deployment in `production` upon merge
- ⚠️ This contains a DB migration
- [ ] merge this and deploy to `production`
- [ ] trigger another run of internal's `oss-query-docs.ts` for each customer, like we did on the [upstream dependency](https://github.com/metriport/metriport/pull/221)