### PR TITLE
553 Add login to Docker Hub

### DIFF
--- a/.github/workflows/_reusable_build.yml
+++ b/.github/workflows/_reusable_build.yml
@@ -11,50 +11,85 @@ on:
         type: string
         description: "the environment we're building to, either 'staging' or 'production'"
         default: "production"
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
 
 jobs:
   lint-and-build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.path }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Log Environment
+        run: |
+          env
+        shell: bash
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.14"
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 100 # bc of below
+      - name: Log Git Ref
+        run: |
+          echo "Git ref: $(git rev-parse HEAD)"
+        shell: bash
       # check commits' messages to make sure they follow Conventional Commits
       - uses: wagoid/commitlint-github-action@v5
       # Lint and build/compile the code
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "lts/*"
       - name: Install environment
         run: |
           pwd
           npm ci --ignore-scripts
+        working-directory: "./" # from root bc package-lock.json is there
       - name: Run Linter
         run: npm run lint
+        working-directory: ${{ inputs.path }}
       # move to an external file so both this and deploy can use this logic
       - name: Build/compile
         if: ${{ inputs.build_env == 'production' }}
         run: npm run build:cloud
+        working-directory: ${{ inputs.path }}
       - name: Build/compile STAGING
         if: ${{ inputs.build_env == 'staging' }}
         run: npm run build:staging
+        working-directory: ${{ inputs.path }}
 
   test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.path }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Log Environment
+        run: |
+          env
+        shell: bash
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
         with:
-          node-version: "lts/*"
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.14"
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Log Git Ref
+        run: |
+          echo "Git ref: $(git rev-parse HEAD)"
+        shell: bash
       - name: Install environment
         run: |
           pwd
           npm ci --ignore-scripts
+        working-directory: "./" # from root bc package-lock.json is there
       - name: Run Tests
         run: npm run test
+        working-directory: ${{ inputs.path }}

--- a/.github/workflows/_reusable_deploy.yml
+++ b/.github/workflows/_reusable_deploy.yml
@@ -29,6 +29,10 @@ on:
         required: false
       SENTRY_ORG:
         required: false
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
 
 jobs:
   deploy:
@@ -40,16 +44,26 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy_env }}
     steps:
+      - name: Log Environment
+        run: |
+          env
+        shell: bash
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.14"
       # TODO we should reuse the checked out code from the previous step
       # doing this here might introduce minutes between `build` and `deploy`, which
       # gives opportunity for problems (someone merges between `build` and `deploy`)
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "lts/*"
-      - run: env
-        shell: bash
-      - run: |
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Log Git Ref
+        run: |
           echo "Git ref: $(git rev-parse HEAD)"
         shell: bash
 

--- a/.github/workflows/_reusable_release.yml
+++ b/.github/workflows/_reusable_release.yml
@@ -2,6 +2,11 @@ name: Reusable Release script
 
 on:
   workflow_call: # called by other workflows
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
   workflow_dispatch: # manually executed by a user - should be able to remove this once semver is well mature
 
 # From https://thecodinganalyst.github.io/knowledgebase/Using-Semantic-Release-with-Github-Actions/
@@ -13,19 +18,27 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - run: env
+        shell: bash
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.14"
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "lts/*"
-
+          persist-credentials: false # bc PAT? https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+      - run: |
+          echo "Git ref: $(git rev-parse HEAD)"
+        shell: bash
       - name: Install dependencies
         run: npm ci --ignore-scripts
-
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -12,24 +12,12 @@ jobs:
       build_env: "staging"
       deploy_env: "staging"
       cdk_stack: ${{ vars.WIDGET_STACK_NAME_STAGING }}
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.WIDGET_REGION_STAGING }}
-      INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_STAGING }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+    secrets: inherit
+
 
   api-deploy:
     uses: ./.github/workflows/_reusable_deploy.yml
     with:
       deploy_env: "staging"
       cdk_stack: ${{ vars.API_STACK_NAME_STAGING }}
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.API_REGION_STAGING }}
-      INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_STAGING }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-
+    secrets: inherit

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   files-changed:
-    name: detect which files changed
+    name: detect changes
     runs-on: ubuntu-latest
     timeout-minutes: 3
     # Map a step output to a job output

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -21,8 +21,15 @@ jobs:
       api: ${{ steps.changes.outputs.api }}
       widget: ${{ steps.changes.outputs.widget }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@4067d885736b84de7c414f582ac45897079b0a78 # v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Detect Changes
+        uses: dorny/paths-filter@4067d885736b84de7c414f582ac45897079b0a78 # v2
         id: changes
         with:
           base: 'master'
@@ -50,13 +57,7 @@ jobs:
       build_env: "production"
       deploy_env: "production"
       cdk_stack: ${{ vars.WIDGET_STACK_NAME_PRODUCTION }}
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.WIDGET_REGION_PRODUCTION }}
-      INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_PRODUCTION }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+    secrets: inherit
 
   api-build:
     if: needs.files-changed.outputs.api == 'true'
@@ -70,26 +71,14 @@ jobs:
     with:
       deploy_env: "production"
       cdk_stack: ${{ vars.API_STACK_NAME_PRODUCTION }}
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.API_REGION_PRODUCTION }}
-      INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_PRODUCTION }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+    secrets: inherit
   api-sandbox-deploy:
     uses: ./.github/workflows/_reusable_deploy.yml
     needs: api-deploy
     with:
       deploy_env: "sandbox"
       cdk_stack: ${{ vars.API_STACK_NAME_SANDBOX }}
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.API_REGION_SANDBOX }}
-      INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_SANDBOX }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+    secrets: inherit
 
   release:
     uses: ./.github/workflows/_reusable_release.yml

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,8 +21,15 @@ jobs:
       api: ${{ steps.changes.outputs.api }}
       widget: ${{ steps.changes.outputs.widget }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@4067d885736b84de7c414f582ac45897079b0a78 # v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Detect Changes
+        uses: dorny/paths-filter@4067d885736b84de7c414f582ac45897079b0a78 # v2
         id: changes
         with:
           filters: |
@@ -42,6 +49,7 @@ jobs:
     with:
       path: "connect-widget/app"
       build_env: "staging"
+    secrets: inherit
   widget-deploy:
     uses: ./.github/workflows/_reusable_deploy.yml
     needs: widget-build
@@ -49,13 +57,7 @@ jobs:
       build_env: "staging"
       deploy_env: "staging"
       cdk_stack: ${{ vars.WIDGET_STACK_NAME_STAGING }}
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.WIDGET_REGION_STAGING }}
-      INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_STAGING }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+    secrets: inherit
 
   api-build:
     if: needs.files-changed.outputs.api == 'true'
@@ -63,19 +65,14 @@ jobs:
     uses: ./.github/workflows/_reusable_build.yml
     with:
       path: "api/app" # there's no "build" for lambdas, so one job for both works
+    secrets: inherit
   api-deploy:
     uses: ./.github/workflows/_reusable_deploy.yml
     needs: api-build
     with:
       deploy_env: "staging"
       cdk_stack: ${{ vars.API_STACK_NAME_STAGING }}
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.API_REGION_STAGING }}
-      INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_STAGING }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+    secrets: inherit
 
   release:
     uses: ./.github/workflows/_reusable_release.yml

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   files-changed:
-    name: detect which files changed
+    name: detect changes
     runs-on: ubuntu-latest
     timeout-minutes: 3
     # Map a step output to a job output

--- a/.github/workflows/pull-request_api.yml
+++ b/.github/workflows/pull-request_api.yml
@@ -13,3 +13,4 @@ jobs:
     uses: ./.github/workflows/_reusable_build.yml
     with:
       path: "api/app"
+    secrets: inherit

--- a/.github/workflows/pull-request_infra.yml
+++ b/.github/workflows/pull-request_infra.yml
@@ -12,3 +12,4 @@ jobs:
     uses: ./.github/workflows/_reusable_build.yml
     with:
       path: "infra"
+    secrets: inherit

--- a/.github/workflows/pull-request_packages.yml
+++ b/.github/workflows/pull-request_packages.yml
@@ -12,3 +12,4 @@ jobs:
     uses: ./.github/workflows/_reusable_build.yml
     with:
       path: "packages"
+    secrets: inherit

--- a/.github/workflows/pull-request_utils.yml
+++ b/.github/workflows/pull-request_utils.yml
@@ -12,3 +12,4 @@ jobs:
     uses: ./.github/workflows/_reusable_build.yml
     with:
       path: "utils"
+    secrets: inherit

--- a/.github/workflows/pull-request_widget.yml
+++ b/.github/workflows/pull-request_widget.yml
@@ -14,6 +14,7 @@ jobs:
     with:
       path: "connect-widget/app"
       build_env: "production"
+    secrets: inherit
 
   check-pr-staging:
     if: ${{ github.event.pull_request.base.ref != 'master' }}
@@ -21,3 +22,4 @@ jobs:
     with:
       path: "connect-widget/app"
       build_env: "staging"
+    secrets: inherit


### PR DESCRIPTION
Ref. metriport/metriport-internal#553

### Dependencies

https://github.com/metriport/metriport-internal/pull/589

### Description

- Add login to Docker Hub on CI/CD, like what we did with internal
- Match internal's GH workflow structure/logic

### Release Plan

- nothing special, no deploy should be done