### PR TITLE
340 fix deploy staging and production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -82,7 +82,7 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.WIDGET_REGION_PRODUCTION }} # renamed
+      AWS_REGION: ${{ secrets.API_REGION_PRODUCTION }} # renamed
       INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_PRODUCTION }} # renamed
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -60,7 +60,7 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.API_REGION_STAGING }} # renamed
+      AWS_REGION: ${{ secrets.WIDGET_REGION_STAGING }} # renamed
       INFRA_CONFIG: ${{ secrets.INFRA_CONFIG_STAGING }} # renamed
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}


### PR DESCRIPTION
Ref. metriport/metriport-internal#340

### Dependencies

none

### Description

- fix deploy staging and production, it was pointing to the wrong envs; staging didn't fail bc API and Widget use the same, but in prod they are different

### Release Plan

- asap so we can release to prod