### PR TITLE
594 fix deploy-production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -50,6 +50,7 @@ jobs:
     with:
       path: "connect-widget/app"
       build_env: "production"
+    secrets: inherit
   widget-deploy:
     uses: ./.github/workflows/_reusable_deploy.yml
     needs: widget-build
@@ -73,6 +74,7 @@ jobs:
     uses: ./.github/workflows/_reusable_build.yml
     with:
       path: "api/app" # there's no "build" for lambdas, so one job for both works
+    secrets: inherit
   api-deploy:
     uses: ./.github/workflows/_reusable_deploy.yml
     needs: api-build


### PR DESCRIPTION
Ref. metriport/metriport-internal#594

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/233
- Downstream: none

### Description

Add missing `secrets: inherit` to `deploy-production` when calling `reusable_deploy`

### Release Plan

- ⚠️ merging into `master`
- ASAP