### PR TITLE
608 make vo2Max optional on Garmin

### DIFF
--- a/api/app/src/mappings/garmin/user.ts
+++ b/api/app/src/mappings/garmin/user.ts
@@ -42,7 +42,7 @@ export const garminUserMetricsToBody = (gBody: GarminUserMetrics): Biometrics | 
 
 export const garminUserMetricsSchema = z.object({
   calendarDate: garminTypes.date,
-  vo2Max: garminTypes.vo2Max,
+  vo2Max: garminTypes.vo2Max.nullish(),
   // fitnessAge: 44, // we don't have this
 });
 export type GarminUserMetrics = z.infer<typeof garminUserMetricsSchema>;

--- a/api/app/src/routes/webhook/garmin.ts
+++ b/api/app/src/routes/webhook/garmin.ts
@@ -103,9 +103,9 @@ function mapData(body: any): UserData<MetriportData>[] | undefined {
 }
 
 function logRequest(req: Request): void {
-  log(`Headers: ${JSON.stringify(req.headers, undefined, 2)}`);
-  log(`Query: ${JSON.stringify(req.query, undefined, 2)}`);
-  log(`BODY: ${JSON.stringify(req.body, undefined, 2)}`);
+  log(`Headers: ${JSON.stringify(req.headers)}`);
+  log(`Query: ${JSON.stringify(req.query)}`);
+  log(`BODY: ${JSON.stringify(req.body)}`);
 }
 
 export default routes;


### PR DESCRIPTION
Ref. metriport/metriport-internal#608

### Dependencies

none

### Description

Make vo2Max optional on Garmin.

Don't format log as it breaks CW's log

### Release Plan

- [ ] merge/test into `staging`
- [ ] create a new PR to patch this into `production`