### PR TITLE
621 accept undefined for getId

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -24,7 +24,7 @@
     "@medplum/core": "^2.0.14",
     "@medplum/fhirtypes": "^2.0.14",
     "@metriport/api": "^3.1.1",
-    "@metriport/commonwell-sdk": "^4.1.3-alpha.0",
+    "@metriport/commonwell-sdk": "^4.1.3-alpha.1",
     "@sentry/node": "^7.45.0",
     "@sentry/tracing": "^7.45.0",
     "aws-sdk": "^2.1243.0",

--- a/api/app/src/external/commonwell/patient-shared.ts
+++ b/api/app/src/external/commonwell/patient-shared.ts
@@ -70,7 +70,7 @@ export async function findOrCreatePerson({
     if (persons.length > 1) {
       return alertAndReturnMostRecentPerson(
         commonwellPatientId,
-        [persons[0], ...persons], // to match the type requiring at least one element
+        [persons[0], ...persons.slice(1)], // to match the type requiring at least one element
         commonWell.lastReferenceHeader,
         context
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@medplum/core": "^2.0.14",
         "@medplum/fhirtypes": "^2.0.14",
         "@metriport/api": "^3.1.1",
-        "@metriport/commonwell-sdk": "^4.1.3-alpha.0",
+        "@metriport/commonwell-sdk": "^4.1.3-alpha.1",
         "@sentry/node": "^7.45.0",
         "@sentry/tracing": "^7.45.0",
         "aws-sdk": "^2.1243.0",
@@ -4656,9 +4656,9 @@
       }
     },
     "node_modules/@metriport/commonwell-sdk": {
-      "version": "4.1.3-alpha.0",
-      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-4.1.3-alpha.0.tgz",
-      "integrity": "sha512-qAKHZ+piYwz+gi3Eq6Q8oPmwwVKtNGK3ZFei/Z3oQfaIXbWHRiYuXd0PazrvbstAJcLEE0GxlBkmWqetjuaMKQ==",
+      "version": "4.1.3-alpha.1",
+      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-4.1.3-alpha.1.tgz",
+      "integrity": "sha512-pHpID9tt4oa1lY8u/3JnLHUJYt4laNMNzyKlPibFb90WArkIwL/yxT+ke3G9wiri9ysklINgSMbLhTY3N2pNSw==",
       "dependencies": {
         "axios": "^1.3.5",
         "http-status": "^1.6.2",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -19829,7 +19829,7 @@
       "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.1.3-alpha.0",
+        "@metriport/commonwell-sdk": "^4.1.3-alpha.1",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -19878,7 +19878,7 @@
       "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.1.3-alpha.0",
+        "@metriport/commonwell-sdk": "^4.1.3-alpha.1",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -19910,7 +19910,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.1.3-alpha.0",
+      "version": "4.1.3-alpha.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",

--- a/packages/packages/commonwell-cert-runner/package.json
+++ b/packages/packages/commonwell-cert-runner/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.1.3-alpha.0",
+    "@metriport/commonwell-sdk": "^4.1.3-alpha.1",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/packages/commonwell-jwt-maker/package.json
+++ b/packages/packages/commonwell-jwt-maker/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.1.3-alpha.0",
+    "@metriport/commonwell-sdk": "^4.1.3-alpha.1",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/packages/commonwell-sdk/package.json
+++ b/packages/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.1.3-alpha.0",
+  "version": "4.1.3-alpha.1",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-sdk/src/common/util.ts
+++ b/packages/packages/commonwell-sdk/src/common/util.ts
@@ -4,7 +4,8 @@ import { Organization } from "../models/organization";
 import { Patient } from "../models/patient";
 import { Person, PersonSearchResp } from "../models/person";
 
-export function getId(object: Person): string | undefined {
+export function getId(object: Person | undefined): string | undefined {
+  if (!object) return undefined;
   const url = object._links?.self?.href;
   if (!url) return undefined;
   return url.substring(url.lastIndexOf("/") + 1);


### PR DESCRIPTION
Ref. metriport/metriport-internal#621

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/260
- Downstream: none

### Description

- Make CW SDK's `getId` accept undefined
- Fix access to array when checking the most recent person

### Release Plan

- nothing special, asap