### PR TITLE
RELEASE - chatbot channel config per environment

### DIFF
--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -679,7 +679,7 @@ function setupSlackNotifSnsTopic(
   });
 
   AlarmSlackBot.addSlackChannelConfig(stack, {
-    configName: `slack-chatbot-configuration`,
+    configName: `slack-chatbot-configuration-` + config.environmentType,
     workspaceId: config.slack.workspaceId,
     channelId: config.slack.alertsChannelId,
     topics: [slackNotifSnsTopic],


### PR DESCRIPTION
Ref. metriport/metriport-internal#627

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/262
- Downstream: none

### Description

Chatbot channel config per environment

Context: https://metriport.slack.com/archives/C04DBBJSKGB/p1682561953119409?thread_ts=1682559846.204019&cid=C04DBBJSKGB

### Release Plan

- following the upstream release plan
- asap