### PR TITLE
135 reuse slack SNS topic on sandbox

### DIFF
--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -21,6 +21,7 @@ import { Construct } from "constructs";
 import { AlarmSlackBot } from "./alarm-slack-chatbot";
 import { createAPIService } from "./api-service";
 import { EnvConfig } from "./env-config";
+import { EnvType } from "./env-type";
 import { getSecrets } from "./secrets";
 import { addErrorAlarmToLambdaFunc, isProd, isSandbox, mbToBytes } from "./util";
 
@@ -674,18 +675,25 @@ function setupSlackNotifSnsTopic(
 ): { snsTopic: ITopic; alarmAction: SnsAction } | undefined {
   if (!config.slack) return undefined;
 
-  const slackNotifSnsTopic = new sns.Topic(stack, "SlackSnsTopic", {
-    displayName: "Slack SNS Topic",
-  });
+  if (config.environmentType !== EnvType.sandbox) {
+    const slackNotifSnsTopic = new sns.Topic(stack, "SlackSnsTopic", {
+      displayName: "Slack SNS Topic",
+    });
+    AlarmSlackBot.addSlackChannelConfig(stack, {
+      configName: `slack-chatbot-configuration-` + config.environmentType,
+      workspaceId: config.slack.workspaceId,
+      channelId: config.slack.alertsChannelId,
+      topics: [slackNotifSnsTopic],
+    });
+    const alarmAction = new SnsAction(slackNotifSnsTopic);
+    return { snsTopic: slackNotifSnsTopic, alarmAction };
+  }
 
-  AlarmSlackBot.addSlackChannelConfig(stack, {
-    configName: `slack-chatbot-configuration-` + config.environmentType,
-    workspaceId: config.slack.workspaceId,
-    channelId: config.slack.alertsChannelId,
-    topics: [slackNotifSnsTopic],
-  });
-
+  const slackNotifSnsTopic = sns.Topic.fromTopicArn(
+    stack,
+    "SlackSnsTopic",
+    config.slack.snsTopicArn
+  );
   const alarmAction = new SnsAction(slackNotifSnsTopic);
-
   return { snsTopic: slackNotifSnsTopic, alarmAction };
 }

--- a/infra/lib/env-config.ts
+++ b/infra/lib/env-config.ts
@@ -11,7 +11,6 @@ export type ConnectWidgetConfig = {
 export type EnvConfig = {
   stackName: string;
   secretsStackName: string;
-  environmentType: EnvType;
   region: string;
   secretReplicaRegion?: string;
   host: string; // DNS Zone
@@ -64,19 +63,27 @@ export type EnvConfig = {
     CW_GATEWAY_AUTHORIZATION_CLIENT_SECRET: string;
   };
   sentryDSN?: string; // API's Sentry DSN
-  slack?: {
-    SLACK_ALERT_URL?: string;
-    SLACK_NOTIFICATION_URL?: string;
-    workspaceId: string;
-    alertsChannelId: string;
-  };
 } & (
   | {
+      environmentType: EnvType.staging | EnvType.production;
       connectWidget: ConnectWidgetConfig;
       connectWidgetUrl?: never;
+      slack?: SlackBase & {
+        workspaceId: string;
+        alertsChannelId: string;
+      };
     }
   | {
+      environmentType: EnvType.sandbox;
       connectWidget?: never;
       connectWidgetUrl: string;
+      slack?: SlackBase & {
+        snsTopicArn: string;
+      };
     }
 );
+
+type SlackBase = {
+  SLACK_ALERT_URL?: string;
+  SLACK_NOTIFICATION_URL?: string;
+};


### PR DESCRIPTION
Ref. metriport/metriport-internal#135

### Dependencies

https://github.com/metriport/metriport-internal/pull/633

### Description

Reuse `prod`'s slack SNS topic on `sandbox`

### Release Plan

- `develop`
  - nothing special
- `master`
  - update GH secret `INFRA SANDBOX` w/ base64 from internal