### PR TITLE
135 slack notif channel for sandbox

### DIFF
--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -21,7 +21,6 @@ import { Construct } from "constructs";
 import { AlarmSlackBot } from "./alarm-slack-chatbot";
 import { createAPIService } from "./api-service";
 import { EnvConfig } from "./env-config";
-import { EnvType } from "./env-type";
 import { getSecrets } from "./secrets";
 import { addErrorAlarmToLambdaFunc, isProd, isSandbox, mbToBytes } from "./util";
 
@@ -675,25 +674,15 @@ function setupSlackNotifSnsTopic(
 ): { snsTopic: ITopic; alarmAction: SnsAction } | undefined {
   if (!config.slack) return undefined;
 
-  if (config.environmentType !== EnvType.sandbox) {
-    const slackNotifSnsTopic = new sns.Topic(stack, "SlackSnsTopic", {
-      displayName: "Slack SNS Topic",
-    });
-    AlarmSlackBot.addSlackChannelConfig(stack, {
-      configName: `slack-chatbot-configuration-` + config.environmentType,
-      workspaceId: config.slack.workspaceId,
-      channelId: config.slack.alertsChannelId,
-      topics: [slackNotifSnsTopic],
-    });
-    const alarmAction = new SnsAction(slackNotifSnsTopic);
-    return { snsTopic: slackNotifSnsTopic, alarmAction };
-  }
-
-  const slackNotifSnsTopic = sns.Topic.fromTopicArn(
-    stack,
-    "SlackSnsTopic",
-    config.slack.snsTopicArn
-  );
+  const slackNotifSnsTopic = new sns.Topic(stack, "SlackSnsTopic", {
+    displayName: "Slack SNS Topic",
+  });
+  AlarmSlackBot.addSlackChannelConfig(stack, {
+    configName: `slack-chatbot-configuration-` + config.environmentType,
+    workspaceId: config.slack.workspaceId,
+    channelId: config.slack.alertsChannelId,
+    topics: [slackNotifSnsTopic],
+  });
   const alarmAction = new SnsAction(slackNotifSnsTopic);
   return { snsTopic: slackNotifSnsTopic, alarmAction };
 }

--- a/infra/lib/env-config.ts
+++ b/infra/lib/env-config.ts
@@ -63,27 +63,21 @@ export type EnvConfig = {
     CW_GATEWAY_AUTHORIZATION_CLIENT_SECRET: string;
   };
   sentryDSN?: string; // API's Sentry DSN
+  slack?: {
+    SLACK_ALERT_URL?: string;
+    SLACK_NOTIFICATION_URL?: string;
+    workspaceId: string;
+    alertsChannelId: string;
+  };
 } & (
   | {
       environmentType: EnvType.staging | EnvType.production;
       connectWidget: ConnectWidgetConfig;
       connectWidgetUrl?: never;
-      slack?: SlackBase & {
-        workspaceId: string;
-        alertsChannelId: string;
-      };
     }
   | {
       environmentType: EnvType.sandbox;
       connectWidget?: never;
       connectWidgetUrl: string;
-      slack?: SlackBase & {
-        snsTopicArn: string;
-      };
     }
 );
-
-type SlackBase = {
-  SLACK_ALERT_URL?: string;
-  SLACK_NOTIFICATION_URL?: string;
-};


### PR DESCRIPTION
Ref. metriport/metriport-internal#135

### Dependencies

https://github.com/metriport/metriport-internal/pull/637

### Description

Add slack notif channel for sandbox

### Release Plan

- merge/deploy this in staging
- create patch for production
- update GH secrets `INFRA SANDBOX` from base64 of internal
- merge/deploy in prod/staging