### PR TITLE
507 validate IDs as UUID on API requests 

### DIFF
--- a/api/app/src/mappings/fitbit/activity.ts
+++ b/api/app/src/mappings/fitbit/activity.ts
@@ -6,6 +6,7 @@ import convert from "convert-units";
 import { PROVIDER_FITBIT } from "../../shared/constants";
 import { FitbitActivityLogs, HeartRateZone } from "./models/activity-log";
 import { Util } from "../../shared/util";
+import { ISO_DATE } from "../../shared/date";
 
 export const mapToActivity = (fitbitActiveLogs: FitbitActivityLogs, date: string): Activity => {
   const filteredLogs = filterLogsByDate(fitbitActiveLogs, date);
@@ -105,7 +106,7 @@ export const mapToActivity = (fitbitActiveLogs: FitbitActivityLogs, date: string
 
 const filterLogsByDate = (logs: FitbitActivityLogs, date: string): FitbitActivityLogs => {
   const filteredLogs = logs.filter(log => {
-    const originalDate = dayjs(log.originalStartTime).format("YYYY-MM-DD");
+    const originalDate = dayjs(log.originalStartTime).format(ISO_DATE);
 
     return originalDate === date;
   });

--- a/api/app/src/mappings/google/index.ts
+++ b/api/app/src/mappings/google/index.ts
@@ -12,7 +12,7 @@ export const getSamples = (arr: GooglePoint, valueIndex = 0): Sample[] => {
     return {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: hasFpVal[valueIndex].fpVal!,
-      time: dayjs(convert(startTimeNanos).from("ns").to("ms")).format("YYYY-MM-DDTHH:mm:ssZ"),
+      time: dayjs(convert(startTimeNanos).from("ns").to("ms")).toISOString(),
     };
   });
 };

--- a/api/app/src/mappings/withings/activity.ts
+++ b/api/app/src/mappings/withings/activity.ts
@@ -90,8 +90,8 @@ const formatWorkoutLogs = (
     for (const withingsWorkoutLog of withingsWorkoutLogs) {
       const workoutLog: ActivityLog = {
         metadata: metadata,
-        start_time: dayjs.unix(withingsWorkoutLog.startdate).format("YYYY-MM-DDTHH:mm:ssZ"),
-        end_time: dayjs.unix(withingsWorkoutLog.enddate).format("YYYY-MM-DDTHH:mm:ssZ"),
+        start_time: dayjs.unix(withingsWorkoutLog.startdate).toISOString(),
+        end_time: dayjs.unix(withingsWorkoutLog.enddate).toISOString(),
         name: categories[withingsWorkoutLog.category],
       };
 

--- a/api/app/src/mappings/withings/biometrics.ts
+++ b/api/app/src/mappings/withings/biometrics.ts
@@ -4,9 +4,9 @@ import dayjs from "dayjs";
 import { Util } from "../../shared/util";
 
 import { PROVIDER_WITHINGS } from "../../shared/constants";
-import { WithingsHeartRate } from "./models/heart-rate";
-import { WithingsMeasurements, WithingsMeasType } from "./models/measurements";
 import { getMeasurementResults } from "./body";
+import { WithingsHeartRate } from "./models/heart-rate";
+import { WithingsMeasType, WithingsMeasurements } from "./models/measurements";
 
 export const mapToBiometrics = (
   date: string,
@@ -143,7 +143,7 @@ const createDiastolicSamples = (arr: WithingsHeartRate): Sample[] => {
   return arr.reduce((acc: Sample[], item) => {
     if (item.bloodpressure) {
       acc.push({
-        time: dayjs(item.timestamp).format("YYYY-MM-DDTHH:mm:ssZ"),
+        time: dayjs(item.timestamp).toISOString(),
         value: item.bloodpressure.diastole,
       });
     }
@@ -156,7 +156,7 @@ const createSystolicSamples = (arr: WithingsHeartRate): Sample[] => {
   return arr.reduce((acc: Sample[], item) => {
     if (item.bloodpressure) {
       acc.push({
-        time: dayjs(item.timestamp).format("YYYY-MM-DDTHH:mm:ssZ"),
+        time: dayjs(item.timestamp).toISOString(),
         value: item.bloodpressure.systole,
       });
     }
@@ -168,7 +168,7 @@ const createSystolicSamples = (arr: WithingsHeartRate): Sample[] => {
 const createHrSamples = (arr: WithingsHeartRate): Sample[] => {
   return arr.map(item => {
     return {
-      time: dayjs(item.timestamp).format("YYYY-MM-DDTHH:mm:ssZ"),
+      time: dayjs(item.timestamp).toISOString(),
       value: item.heart_rate,
     };
   });

--- a/api/app/src/mappings/withings/body.ts
+++ b/api/app/src/mappings/withings/body.ts
@@ -68,7 +68,7 @@ export const getMeasurementResults = (
     .filter(measure => !measure.is_inconclusive)
     .reduce<ResultsMeasurements>((acc, curr) => {
       const { measures } = curr;
-      const time = dayjs(curr.date * 1000).format("YYYY-MM-DDTHH:mm:ssZ");
+      const time = dayjs(curr.date * 1000).toISOString();
 
       measures.forEach(item => {
         const trueValue = item.value * 10 ** item.unit;

--- a/api/app/src/mappings/withings/sleep.ts
+++ b/api/app/src/mappings/withings/sleep.ts
@@ -17,8 +17,8 @@ export const mapToSleep = (date: string, withingsSleep: WithingsSleep): Sleep =>
   if (withingsSleep.length) {
     const mainSleep = withingsSleep[0];
 
-    sleep.start_time = dayjs.unix(mainSleep.startdate).format("YYYY-MM-DDTHH:mm:ssZ");
-    sleep.end_time = dayjs.unix(mainSleep.enddate).format("YYYY-MM-DDTHH:mm:ssZ");
+    sleep.start_time = dayjs.unix(mainSleep.startdate).toISOString();
+    sleep.end_time = dayjs.unix(mainSleep.enddate).toISOString();
 
     if (mainSleep.data) {
       const {

--- a/api/app/src/routes/connect.ts
+++ b/api/app/src/routes/connect.ts
@@ -12,12 +12,13 @@ import {
   Constants,
   providerOAuth1OptionsSchema,
   providerOAuth2OptionsSchema,
+  PROVIDER_APPLE,
 } from "../shared/constants";
+import { capture } from "../shared/notifications";
 import { processOAuth1 } from "./middlewares/oauth1";
 import { processOAuth2 } from "./middlewares/oauth2";
-import { asyncHandler, getCxIdFromHeaders, getUserIdFromHeaders } from "./util";
-import { PROVIDER_APPLE } from "../shared/constants";
-import { capture } from "../shared/notifications";
+import { getUserIdFrom } from "./schemas/user-id";
+import { asyncHandler, getCxIdFromHeaders } from "./util";
 
 const router = Router();
 
@@ -105,7 +106,7 @@ router.get(
       if (providerOAuth2.success) {
         const provider = providerOAuth2.data;
         const cxId = getCxIdFromHeaders(req);
-        const userId = getUserIdFromHeaders(req);
+        const userId = getUserIdFrom("headers", req).optional();
         await processOAuth2(provider, state, authCode, cxId, userId);
         return res.redirect(`${buildConnectErrorRedirectURL(true, state)}`);
       }
@@ -151,7 +152,7 @@ router.get(
       userId = useToken.userId;
     } else {
       cxId = getCxIdFromHeaders(req);
-      userId = getUserIdFromHeaders(req);
+      userId = getUserIdFrom("headers", req).optional();
     }
 
     if (!cxId || !userId) {
@@ -192,7 +193,7 @@ router.get(
       userId = useToken.userId;
     } else {
       cxId = getCxIdFromHeaders(req);
-      userId = getUserIdFromHeaders(req);
+      userId = getUserIdFrom("headers", req).optional();
     }
 
     if (!cxId || !userId) {

--- a/api/app/src/routes/helpers/provider-route-helper.ts
+++ b/api/app/src/routes/helpers/provider-route-helper.ts
@@ -1,11 +1,12 @@
-import { Request } from "express";
 import { Metadata } from "@metriport/api/lib/devices/models/common/metadata";
+import { Request } from "express";
 
 import { getConnectedUserOrFail } from "../../command/connected-user/get-connected-user";
 import { ConsumerHealthDataType } from "../../providers/provider";
 import { Constants, ProviderOptions } from "../../shared/constants";
-import { getCxIdOrFail, getDateOrFail, getUserIdFromQueryOrFail } from "../util";
 import { capture } from "../../shared/notifications";
+import { getUserIdFrom } from "../schemas/user-id";
+import { getCxIdOrFail, getDateOrFail } from "../util";
 
 // TODO make one of this for each Type so we can avoid the potential type mismatching
 // on the caller's side
@@ -14,7 +15,7 @@ export async function getProviderDataForType<T>(
   type: ConsumerHealthDataType
 ): Promise<T[]> {
   const cxId = getCxIdOrFail(req);
-  const userId = getUserIdFromQueryOrFail(req);
+  const userId = getUserIdFrom("query", req).orFail();
   const date = getDateOrFail(req);
   const connectedUser = await getConnectedUserOrFail({ id: userId, cxId });
   if (!connectedUser.providerMap) return [];

--- a/api/app/src/routes/middlewares/usage.ts
+++ b/api/app/src/routes/middlewares/usage.ts
@@ -1,8 +1,8 @@
 import { NextFunction, Request } from "express";
-import { reportUsage as reportUsageCmd } from "../../command/usage/report-usage";
+import { ApiTypes, reportUsage as reportUsageCmd } from "../../command/usage/report-usage";
 import { Util } from "../../shared/util";
-import { getCxId, getUserId } from "../util";
-import { ApiTypes } from "../../command/usage/report-usage";
+import { getUserIdFrom } from "../schemas/user-id";
+import { getCxId } from "../util";
 
 const log = Util.log("USAGE");
 
@@ -41,7 +41,7 @@ const reportIt = async (req: Request, apiType: ApiTypes): Promise<void> => {
       log(`Skipped, missing cxId`);
       return;
     }
-    const cxUserId = getUserId(req);
+    const cxUserId = getUserIdFrom("query", req).optional();
     if (!cxUserId) {
       log(`Skipped, missing cxUserId (cxId ${cxId})`);
       return;

--- a/api/app/src/routes/schemas/user-id.ts
+++ b/api/app/src/routes/schemas/user-id.ts
@@ -1,0 +1,9 @@
+import { Request } from "express";
+import { Context, GetWithoutParams } from "../util";
+import { getUUIDFrom } from "./uuid";
+
+export const userIdPropName = "userId";
+
+export function getUserIdFrom(context: Context, req: Request): GetWithoutParams {
+  return getUUIDFrom(context, req, userIdPropName);
+}

--- a/api/app/src/routes/schemas/uuid.ts
+++ b/api/app/src/routes/schemas/uuid.ts
@@ -1,0 +1,30 @@
+import { Request } from "express";
+import { z } from "zod";
+import { Context, getFrom, GetWithoutParams } from "../util";
+
+export const uuiSchema = z.string().uuid();
+
+function validateUUID(id: string, propName?: string): string {
+  return uuiSchema.parse(
+    id,
+    propName
+      ? {
+          path: [propName],
+        }
+      : undefined
+  );
+}
+function getUUIDFromOrFail(context: Context, propName: string, req: Request): string {
+  return validateUUID(getFrom(context).orFail(propName, req), propName);
+}
+function getUUIDFromOptional(context: Context, propName: string, req: Request): string | undefined {
+  const id = getFrom(context).optional(propName, req);
+  return id ? validateUUID(id, propName) : undefined;
+}
+
+export function getUUIDFrom(context: Context, req: Request, propName = "id"): GetWithoutParams {
+  return {
+    optional: () => getUUIDFromOptional(context, propName, req),
+    orFail: () => getUUIDFromOrFail(context, propName, req),
+  };
+}

--- a/api/app/src/routes/user.ts
+++ b/api/app/src/routes/user.ts
@@ -12,12 +12,8 @@ import { ConsumerHealthDataType } from "../providers/provider";
 import { Config } from "../shared/config";
 import { Constants, providerOAuth2OptionsSchema, PROVIDER_APPLE } from "../shared/constants";
 import { getProviderDataForType } from "./helpers/provider-route-helper";
-import {
-  asyncHandler,
-  getCxIdOrFail,
-  getUserIdFromQueryOrFail,
-  getUserIdFromParamsOrFail,
-} from "./util";
+import { getUserIdFrom } from "./schemas/user-id";
+import { asyncHandler, getCxIdOrFail } from "./util";
 
 const router = Router();
 
@@ -104,7 +100,7 @@ router.get(
     if (!req.query.userId) {
       return res.sendStatus(status.BAD_REQUEST);
     }
-    const userId = getUserIdFromQueryOrFail(req);
+    const userId = getUserIdFrom("query", req).orFail();
     const cxId = getCxIdOrFail(req);
 
     // check to make sure this user actually exists
@@ -134,7 +130,7 @@ router.get(
 router.delete(
   "/revoke",
   asyncHandler(async (req: Request, res: Response) => {
-    const userId = getUserIdFromQueryOrFail(req);
+    const userId = getUserIdFrom("query", req).orFail();
     const cxId = getCxIdOrFail(req);
     const connectedUser = await getConnectedUserOrFail({ id: userId, cxId });
 
@@ -175,7 +171,7 @@ router.delete(
 router.get(
   "/:userId/connected-providers",
   asyncHandler(async (req: Request, res: Response) => {
-    const userId = getUserIdFromParamsOrFail(req);
+    const userId = getUserIdFrom("params", req).orFail();
     const cxId = getCxIdOrFail(req);
     const connectedUser = await getConnectedUserOrFail({ id: userId, cxId });
 


### PR DESCRIPTION
Ref. https://github.com/metriport/metriport-internal/issues/507

### Dependencies

none

### Description

- validate IDs as UUID on API requests
- use dayjs toISOString() (address [this comment](https://github.com/metriport/metriport/pull/280#discussion_r1181148148))

Before, sending an invalid UUID:

<img width="575" alt="image" src="https://user-images.githubusercontent.com/2132564/235331657-9ceedc8c-be13-4040-8771-16990b320e48.png">

After, sending an invalid UUID:

<img width="474" alt="image" src="https://user-images.githubusercontent.com/2132564/235331684-e70c5a4f-f63d-4065-85c4-d0f9090c52cb.png">

### Release Plan

- nothing special