### PR TITLE
649 update report usage to work with MAPI

### DIFF
--- a/api/app/src/command/usage/report-usage.ts
+++ b/api/app/src/command/usage/report-usage.ts
@@ -10,7 +10,7 @@ export enum ApiTypes {
 
 export type ReportUsageCommand = {
   cxId: string;
-  cxUserId: string;
+  cxUserId: string | undefined;
   apiType: ApiTypes;
 };
 
@@ -21,9 +21,6 @@ export const reportUsage = async ({
 }: ReportUsageCommand): Promise<void> => {
   const url = Config.getUsageUrl();
   if (!url) return;
-
-  const payload = { cxId, cxUserId };
-
-  // TODO consider configuring Axios to not wait for response
-  await axios.post(`${url}/${apiType}`, payload, { timeout: 2_000 });
+  const payload = { cxId, cxUserId, apiType };
+  await axios.post(`${url}`, payload);
 };

--- a/api/app/src/command/usage/report-usage.ts
+++ b/api/app/src/command/usage/report-usage.ts
@@ -1,5 +1,6 @@
 import Axios from "axios";
 import { Config } from "../../shared/config";
+import { capture } from "../../shared/notifications";
 
 const axios = Axios.create();
 
@@ -10,17 +11,18 @@ export enum ApiTypes {
 
 export type ReportUsageCommand = {
   cxId: string;
-  cxUserId: string | undefined;
+  entityId: string;
   apiType: ApiTypes;
 };
 
-export const reportUsage = async ({
-  cxId,
-  cxUserId,
-  apiType,
-}: ReportUsageCommand): Promise<void> => {
+export const reportUsage = ({ cxId, entityId, apiType }: ReportUsageCommand): void => {
   const url = Config.getUsageUrl();
   if (!url) return;
-  const payload = { cxId, cxUserId, apiType };
-  await axios.post(`${url}`, payload);
+  const payload = { cxId, entityId, apiType };
+
+  // intentionally failing silently
+  axios.post(`${url}`, payload).catch(err => {
+    console.log(`Failed to report usage (${payload}): `, err.message);
+    capture.error(err, { extra: payload });
+  });
 };

--- a/api/app/src/external/commonwell/document/document-query.ts
+++ b/api/app/src/external/commonwell/document/document-query.ts
@@ -1,32 +1,32 @@
+import { DocumentReference } from "@medplum/fhirtypes";
 import {
   CommonwellError,
   Document,
-  OperationOutcome,
   documentReferenceResourceType,
+  OperationOutcome,
   operationOutcomeResourceType,
 } from "@metriport/commonwell-sdk";
-import { DocumentReference } from "@medplum/fhirtypes";
-import { PassThrough } from "stream";
 import * as AWS from "aws-sdk";
+import { PassThrough } from "stream";
 import { updateDocQuery } from "../../../command/medical/document/document-query";
-import { Patient } from "../../../models/medical/patient";
-import { Organization } from "../../../models/medical/organization";
+import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
+import { ApiTypes, reportUsage } from "../../../command/usage/report-usage";
+import { processPatientRequest } from "../../../command/webhook/webhook";
 import { Facility } from "../../../models/medical/facility";
+import { Organization } from "../../../models/medical/organization";
+import { Patient } from "../../../models/medical/patient";
+import { toDTO } from "../../../routes/medical/dtos/documentDTO";
+import { Config } from "../../../shared/config";
+import { createS3FileName } from "../../../shared/external";
 import { capture } from "../../../shared/notifications";
 import { oid } from "../../../shared/oid";
 import { Util } from "../../../shared/util";
+import { toFHIR as toFHIRDocRef } from "../../fhir/document";
+import { upsertDocumentToFHIRServer } from "../../fhir/document/save-document-reference";
 import { makeCommonWellAPI, organizationQueryMeta } from "../api";
 import { getPatientData, PatientDataCommonwell } from "../patient-shared";
 import { downloadDocument } from "./document-download";
-import { upsertDocumentToFHIRServer } from "../../fhir/document/save-document-reference";
-import { toFHIR as toFHIRDocRef } from "../../fhir/document";
-import { DocumentWithFilename } from "./shared";
-import { Config } from "../../../shared/config";
-import { createS3FileName } from "../../../shared/external";
-import { getFileName } from "./shared";
-import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
-import { toDTO } from "../../../routes/medical/dtos/documentDTO";
-import { processPatientRequest } from "../../../command/webhook/webhook";
+import { DocumentWithFilename, getFileName } from "./shared";
 
 const s3client = new AWS.S3();
 
@@ -55,6 +55,8 @@ export async function queryDocuments({
       facilityId,
       documents: cwDocuments,
     });
+
+    reportDocQuery(patient);
 
     // send webhook to cx async when docs are done processing
     processPatientRequest(organization.cxId, patient.id, toDTO(FHIRDocRefs));
@@ -263,4 +265,12 @@ async function downloadDocsAndUpsertFHIR({
   );
 
   return docsNewLocation;
+}
+
+function reportDocQuery(patient: Patient): void {
+  reportUsage({
+    cxId: patient.cxId,
+    entityId: patient.id,
+    apiType: ApiTypes.medical,
+  });
 }

--- a/api/app/src/routes/index.ts
+++ b/api/app/src/routes/index.ts
@@ -7,7 +7,7 @@ import { requestLogger } from "./helpers/requestLogger";
 import internal from "./internal";
 import medical from "./medical";
 import { checkMAPIAccess, processAPIKey } from "./middlewares/auth";
-import { reportDeviceUsage, reportMedicalUsage } from "./middlewares/usage";
+import { reportDeviceUsage } from "./middlewares/usage";
 import nutrition from "./nutrition";
 import oauthRoutes from "./oauth-routes";
 import settings from "./settings";
@@ -32,7 +32,7 @@ export default (app: Application) => {
   app.use("/user", processAPIKey, reportDeviceUsage, user);
 
   // medical routes with API key auth
-  app.use("/medical/v1", processAPIKey, checkMAPIAccess, reportMedicalUsage, medical);
+  app.use("/medical/v1", processAPIKey, checkMAPIAccess, medical);
 
   // routes with session token auth
   app.use("/connect", connect);

--- a/api/app/src/routes/middlewares/usage.ts
+++ b/api/app/src/routes/middlewares/usage.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request } from "express";
 import { ApiTypes, reportUsage as reportUsageCmd } from "../../command/usage/report-usage";
+import { capture } from "../../shared/notifications";
 import { Util } from "../../shared/util";
 import { getUserIdFrom } from "../schemas/user-id";
 import { getCxId } from "../util";
@@ -42,13 +43,9 @@ const reportIt = async (req: Request, apiType: ApiTypes): Promise<void> => {
       return;
     }
     const cxUserId = getUserIdFrom("query", req).optional();
-    if (!cxUserId) {
-      log(`Skipped, missing cxUserId (cxId ${cxId})`);
-      return;
-    }
     await reportUsageCmd({ cxId, cxUserId, apiType });
   } catch (err) {
-    console.log(err);
+    capture.error(err, { extra: { apiType } });
     // intentionally failing silently
   }
 };

--- a/api/app/src/routes/util.ts
+++ b/api/app/src/routes/util.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from "express";
+import httpStatus from "http-status";
 import { ApiTypes } from "../command/usage/report-usage";
 import BadRequestError from "../errors/bad-request";
 import { analytics, EventTypes } from "../shared/analytics";
@@ -175,4 +176,8 @@ export function getETag(req: Request): {
   return {
     eTag: eTagHeader ?? eTagPayload,
   };
+}
+
+export function isHttpOK(statusCode: number): boolean {
+  return httpStatus[`${statusCode}_CLASS`] === httpStatus.classes.SUCCESSFUL;
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#649

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/650
- Downstream: none

### Description

- Update report usage to work with MAPI
  - only report MAPI on successful doc query
- Remove `forceQuery` from `GET /document`
- Only report successful requests

### Release Plan

- update OSS GH secret `INFRA_STAGING`
- merge this