### PR TITLE
621 add unspecified id use

### DIFF
--- a/packages/packages/commonwell-sdk/src/models/identifier.ts
+++ b/packages/packages/commonwell-sdk/src/models/identifier.ts
@@ -4,8 +4,14 @@ import { periodSchema } from "./period";
 // Identifies the use for an identifier, if known. This value set defines its own
 // terms in the system http://hl7.org/fhir/identifier-use
 // See: https://specification.commonwellalliance.org/appendix/terminology-bindings#c8-identifier-use-codes
-
-export const identifierUseCodesSchema = z.enum(["usual", "official", "temp", "secondary", "old"]);
+export const identifierUseCodesSchema = z.enum([
+  "usual",
+  "official",
+  "temp",
+  "secondary",
+  "old",
+  "unspecified",
+]);
 
 export type IdentifierUseCodes = z.infer<typeof identifierUseCodesSchema>;
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#621

### Dependencies

none

### Description

Add `unspecified` id use.

Additional context: https://metriport.slack.com/archives/C04DBBJSKGB/p1683332701694779

### Release Plan

- nothing special