### PR TITLE
621 deploy new version to npm

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -24,7 +24,7 @@
     "@medplum/core": "^2.0.14",
     "@medplum/fhirtypes": "^2.0.14",
     "@metriport/api": "^3.1.1",
-    "@metriport/commonwell-sdk": "^4.1.4",
+    "@metriport/commonwell-sdk": "^4.1.5-alpha.1",
     "@sentry/node": "^7.45.0",
     "@sentry/tracing": "^7.45.0",
     "aws-sdk": "^2.1243.0",

--- a/api/app/src/external/fhir/document/index.ts
+++ b/api/app/src/external/fhir/document/index.ts
@@ -1,10 +1,11 @@
+import { DocumentReference, Identifier } from "@medplum/fhirtypes";
 import { MedicalDataSource } from "@metriport/api";
-import { DocumentReference } from "@medplum/fhirtypes";
-import { DocumentWithFilename } from "../../commonwell/document/shared";
+import { DocumentIdentifier } from "@metriport/commonwell-sdk";
+import { MedicalDataSourceOid } from "../..";
 import { Organization } from "../../../models/medical/organization";
 import { Patient } from "../../../models/medical/patient";
+import { DocumentWithFilename } from "../../commonwell/document/shared";
 import { ResourceType } from "../shared";
-import { MedicalDataSourceOid } from "../..";
 
 export const toFHIR = (
   doc: DocumentWithFilename,
@@ -31,13 +32,7 @@ export const toFHIR = (
       system: doc.content?.masterIdentifier?.system,
       value: doc.content?.masterIdentifier?.value,
     },
-    identifier: doc.content?.identifier?.map(id => {
-      return {
-        system: id.system,
-        value: id.value,
-        use: id.use,
-      };
-    }),
+    identifier: doc.content?.identifier?.map(idToFHIR),
     date: doc.content?.indexed,
     status: "current",
     type: doc.content?.type,
@@ -77,3 +72,13 @@ export const toFHIR = (
     context: doc.content?.context,
   };
 };
+
+// TODO once we merge DocumentIdentifier with Identifier on CW SDK, let's move this to
+// an identifier-specific file
+export function idToFHIR(id: DocumentIdentifier): Identifier {
+  return {
+    system: id.system,
+    value: id.value,
+    use: id.use === "unspecified" ? undefined : id.use,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@medplum/core": "^2.0.14",
         "@medplum/fhirtypes": "^2.0.14",
         "@metriport/api": "^3.1.1",
-        "@metriport/commonwell-sdk": "^4.1.4",
+        "@metriport/commonwell-sdk": "^4.1.5-alpha.1",
         "@sentry/node": "^7.45.0",
         "@sentry/tracing": "^7.45.0",
         "aws-sdk": "^2.1243.0",
@@ -4656,9 +4656,9 @@
       }
     },
     "node_modules/@metriport/commonwell-sdk": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-4.1.4.tgz",
-      "integrity": "sha512-C2UmnODp+mfyYruHqk9TFmYNP274vpbGVH3Q4kincf+9xqcOrcH4BaPU9dwP2rWbNPMhuNxS604Q8uSy0jgLKQ==",
+      "version": "4.1.5-alpha.1",
+      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-4.1.5-alpha.1.tgz",
+      "integrity": "sha512-F3HjJKDtEiOI9gmRiZBK+lfHya1aA9wZXwfmT8TlQAARqvLM3OyipvM6w+5CBmsthK2+qEuGcZqfJqkfClIDSw==",
       "dependencies": {
         "axios": "^1.3.5",
         "http-status": "^1.6.2",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -19829,7 +19829,7 @@
       "version": "1.4.6",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.1.3",
+        "@metriport/commonwell-sdk": "^4.1.5-alpha.1",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -19878,7 +19878,7 @@
       "version": "1.4.6",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.1.3",
+        "@metriport/commonwell-sdk": "^4.1.5-alpha.1",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -19910,7 +19910,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.1.4",
+      "version": "4.1.5-alpha.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",

--- a/packages/packages/commonwell-cert-runner/package.json
+++ b/packages/packages/commonwell-cert-runner/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.1.3",
+    "@metriport/commonwell-sdk": "^4.1.5-alpha.1",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/packages/commonwell-jwt-maker/package.json
+++ b/packages/packages/commonwell-jwt-maker/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.1.3",
+    "@metriport/commonwell-sdk": "^4.1.5-alpha.1",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/packages/commonwell-sdk/package.json
+++ b/packages/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.1.4",
+  "version": "4.1.5-alpha.1",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-sdk/src/models/document.ts
+++ b/packages/packages/commonwell-sdk/src/models/document.ts
@@ -13,11 +13,14 @@ import { genderSchema } from "./demographics";
 // Bundle, DocumentReference, Organization, Practitioner, OperationOutcome
 const resourceTypeSchema = z.string().optional();
 
+// TODO we should try to reuse identifierSchema from models/identifier instead
+// TODO try to replace this when we can properly test it
 const identifierSchema = z.object({
   use: identifierUseCodesSchema.optional(),
   system: z.string().optional(),
   value: z.string(),
 });
+export type DocumentIdentifier = z.infer<typeof identifierSchema>;
 
 const codeableConceptSchema = z.object({
   coding: z


### PR DESCRIPTION
Ref. metriport/metriport-internal#621

### Dependencies

https://github.com/metriport/metriport/pull/292

### Description

Deploy CW SDK to NPM and update version at packages and API

### Release Plan

- once merged, replicate this to production