### PR TITLE
docs: clarify return on document url endpoint

### DIFF
--- a/docs/medical-api/api-reference/document/get-document.mdx
+++ b/docs/medical-api/api-reference/document/get-document.mdx
@@ -16,7 +16,11 @@ This endpoint returns a URL which you can use to download the specified document
 
 ## Response
 
-<ResponseField type="string">The presigned URL.</ResponseField>
+An json object containing the URL will be returned.
+
+<ResponseField name="url" type="string">
+  The presigned URL.
+</ResponseField>
 
 <ResponseExample>
 


### PR DESCRIPTION
refs. metriport/metriport#304

### Dependencies

N/A

### Description

clarify return on document url endpoint - was missing the name of the actual object property, so it made it seem like it returned a string

### Release Plan

nothing special