### PR TITLE
664 Add doc info to sentry

### DIFF
--- a/api/app/src/command/settings/updateSettings.ts
+++ b/api/app/src/command/settings/updateSettings.ts
@@ -86,7 +86,7 @@ const testWebhook = async ({ id, webhookUrl, webhookKey }: TestWebhookCommand): 
       await updateWebhookStatus({
         id,
         webhookEnabled: false,
-        webhookStatusDetail: err.underlyingError.message,
+        webhookStatusDetail: err.cause.message,
       });
     } else {
       log(`Unexpected error testing webhook`, err);

--- a/api/app/src/command/webhook/webhook.ts
+++ b/api/app/src/command/webhook/webhook.ts
@@ -94,7 +94,12 @@ export const processRequest = async (
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (err: any) {
     capture.error(err, {
-      extra: { webhookRequestId: webhookRequest.id, webhookUrl, context: `webhook.processRequest` },
+      extra: {
+        webhookRequestId: webhookRequest.id,
+        webhookUrl,
+        context: `webhook.processRequest`,
+        cause: err.cause,
+      },
     });
     try {
       // mark this request as failed on the DB
@@ -114,7 +119,7 @@ export const processRequest = async (
     }
     let webhookStatusDetail;
     if (err instanceof WebhookError) {
-      webhookStatusDetail = err.underlyingError.message;
+      webhookStatusDetail = err.cause.message;
     } else {
       log(`Unexpected error testing webhook`, err);
       webhookStatusDetail = `Internal error: ${err?.message}`;

--- a/api/app/src/errors/metriport-error.ts
+++ b/api/app/src/errors/metriport-error.ts
@@ -2,7 +2,8 @@ import status from "http-status";
 
 export default abstract class MetriportError extends Error {
   status: number = status.INTERNAL_SERVER_ERROR;
-  constructor(message: string) {
+  constructor(message: string, cause?: unknown) {
     super(message);
+    this.cause = cause;
   }
 }

--- a/api/app/src/errors/not-found.ts
+++ b/api/app/src/errors/not-found.ts
@@ -4,8 +4,8 @@ import MetriportError from "./metriport-error";
 const numericStatus = httpStatus.NOT_FOUND;
 
 export default class NotFoundError extends MetriportError {
-  constructor(message = "Could not find the requested resource") {
-    super(message);
+  constructor(message = "Could not find the requested resource", cause?: unknown) {
+    super(message, cause);
     this.status = numericStatus;
     this.name = this.constructor.name;
   }

--- a/api/app/src/errors/webhook.ts
+++ b/api/app/src/errors/webhook.ts
@@ -1,10 +1,12 @@
 import MetriportError from "./metriport-error";
 
+export type ErrorCause = Error & { message: string; status?: number };
+
 export default class WebhookError extends MetriportError {
-  underlyingError: { message: string };
-  constructor(message = "Unexpected error with webhook", underlyingError: { message: string }) {
-    super(message);
+  override cause: ErrorCause;
+  constructor(message = "Unexpected error with webhook", cause: ErrorCause) {
+    super(message, cause);
     this.name = this.constructor.name;
-    this.underlyingError = underlyingError;
+    this.cause = cause;
   }
 }

--- a/api/app/src/external/commonwell/document/document-download.ts
+++ b/api/app/src/external/commonwell/document/document-download.ts
@@ -32,12 +32,14 @@ export async function downloadDocument({
     capture.error(err, {
       extra: {
         context: `cw.retrieveDocument`,
+        patientId,
+        documentLocation: location,
         cwReference: commonWell.lastReferenceHeader,
-        ...(err instanceof CommonwellError ? err.additionalInfo : undefined),
+        err,
       },
     });
     if (err instanceof CommonwellError && err.cause?.response?.status === 404) {
-      throw new NotFoundError("Document not found");
+      throw new NotFoundError("Document not found", err);
     }
     throw err;
   }

--- a/api/app/src/external/commonwell/document/document-query.ts
+++ b/api/app/src/external/commonwell/document/document-query.ts
@@ -11,6 +11,7 @@ import { PassThrough } from "stream";
 import { updateDocQuery } from "../../../command/medical/document/document-query";
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 import { ApiTypes, reportUsage } from "../../../command/usage/report-usage";
+import { processPatientDocumentRequest } from "../../../command/webhook/medical";
 import { Facility } from "../../../models/medical/facility";
 import { Organization } from "../../../models/medical/organization";
 import { Patient } from "../../../models/medical/patient";
@@ -21,13 +22,12 @@ import { capture } from "../../../shared/notifications";
 import { oid } from "../../../shared/oid";
 import { Util } from "../../../shared/util";
 import { toFHIR as toFHIRDocRef } from "../../fhir/document";
+import { getDocumentSandboxPayload } from "../../fhir/document/get-documents";
 import { upsertDocumentToFHIRServer } from "../../fhir/document/save-document-reference";
 import { makeCommonWellAPI, organizationQueryMeta } from "../api";
 import { getPatientData, PatientDataCommonwell } from "../patient-shared";
 import { downloadDocument } from "./document-download";
-import { processPatientDocumentRequest } from "../../../command/webhook/medical";
 import { DocumentWithFilename, getFileName } from "./shared";
-import { getDocumentSandboxPayload } from "../../fhir/document/get-documents";
 
 const s3client = new AWS.S3();
 
@@ -239,6 +239,8 @@ async function downloadDocsAndUpsertFHIR({
         capture.error(error, {
           extra: {
             context: `s3.documentUpload`,
+            patientId: patient.id,
+            documentReference: doc,
           },
         });
         throw error;


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/664

### Dependencies

none

### Description

Add doc info to sentry.

Also has a [cherry-pick](https://github.com/metriport/metriport/pull/298/commits/5ad4b6b4d73b3e09a0e7cfcda3d2ec7be2f08791) from [this PR](https://github.com/metriport/metriport/pull/298) to support `cause` on `MetriportError` - [context](https://metriport.slack.com/archives/C0553DYC95L/p1683554679386879?thread_ts=1683507833.836849&cid=C0553DYC95L).

### Release Plan

- ⚠️ This is pointing to `master`, deployment in `production`
- after merge/deploy, merge `master` into `develop`