### PR TITLE
fix(api): filter out empty strings when splitting names

### DIFF
--- a/api/app/src/models/medical/patient.ts
+++ b/api/app/src/models/medical/patient.ts
@@ -74,7 +74,8 @@ export interface PatientCreate extends BaseDomainCreate {
 }
 
 export function splitName(name: string): string[] {
-  return name.split(/[\s,]+/);
+  // splits by comma delimiter and filters out empty strings
+  return name.split(/[\s,]+/).filter(str => str);
 }
 
 export function joinName(name: string[]): string {


### PR DESCRIPTION
refs. metriport/metriport#327

### Dependencies

N/A

### Description

 filter out empty strings when splitting names

### Release Plan

asap