### PR TITLE
691 add tenant support to Binary on CW proxy

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -26,7 +26,7 @@
     "@medplum/core": "^2.0.18",
     "@medplum/fhirtypes": "^2.0.18",
     "@metriport/api": "^3.1.3",
-    "@metriport/commonwell-sdk": "^4.2.0-alpha.2",
+    "@metriport/commonwell-sdk": "^4.2.0-alpha.4",
     "@sentry/node": "^7.45.0",
     "@sentry/tracing": "^7.45.0",
     "aws-sdk": "^2.1243.0",

--- a/api/app/src/command/medical/document/document-query.ts
+++ b/api/app/src/command/medical/document/document-query.ts
@@ -44,9 +44,10 @@ export async function queryDocumentsAcrossHIEs({
   await updateDocQuery({ patient, status: "processing" });
 
   // intentionally asynchronous, not waiting for the result
-  getDocumentsFromCW({ patient, facilityId, override }).catch(
-    processAsyncError(`doc.list.getDocumentsFromCW`)
-  );
+  getDocumentsFromCW({ patient, facilityId, override }).catch(() => {
+    updateDocQuery({ patient, status: "completed" });
+    processAsyncError(`doc.list.getDocumentsFromCW`);
+  });
 
   return createQueryResponse("processing", patient);
 }

--- a/api/app/src/external/commonwell/__tests__/cw-fhir-proxy.test.ts
+++ b/api/app/src/external/commonwell/__tests__/cw-fhir-proxy.test.ts
@@ -1,0 +1,112 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import NotFoundError from "../../../errors/not-found";
+import { processBinary, processDocReference } from "../cw-fhir-proxy";
+import * as helper from "../cw-fhir-proxy-helpers";
+
+describe("cw-fhir-proxy", () => {
+  // Couldn't get this to work within the timebox
+  // Should also add this import: `import * as lib from "../cw-fhir-proxy";`
+  // describe("process", () => {
+  // let processBinaryMock: jest.SpyInstance;
+  // beforeAll(() => {
+  //   processBinaryMock = jest.spyOn(lib, "processBinary");
+  //   processBinaryMock.mockImplementation(async () => mockResponseProcessBinary);
+  // });
+  // afterAll(() => {
+  //   processBinaryMock.mockRestore();
+  // });
+  // it("calls processBinary when Binary", async () => {
+  //   const res = await process("Binary");
+  //   expect(res).toBeTruthy();
+  //   expect(processBinaryMock).toHaveBeenCalledTimes(1);
+  // });
+  // });
+
+  describe("processDocReference", () => {
+    let mock_getOrgOrFail: jest.SpyInstance;
+    beforeAll(() => {
+      mock_getOrgOrFail = jest.spyOn(helper, "getOrgOrFail");
+    });
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    const makeQuery = (patientParamName: string, patientParamValue: string) =>
+      `?_include=DocumentReference:patient` +
+      `&_include=DocumentReference:subject` +
+      `&_include=DocumentReference:authenticator` +
+      `&_include=DocumentReference:author` +
+      `&_include=DocumentReference:custodian` +
+      `&_include=DocumentReference:encounter` +
+      `&${patientParamName}=${patientParamValue}` +
+      `&status=current`;
+
+    it("throws when gets no query params", async () => {
+      const path = `/DocumentReference`;
+      await expect(processDocReference(path)).rejects.toThrow("Missing query string");
+    });
+
+    it("throws when gets NotFoundError", async () => {
+      const orgId = "2.16.840.1.113883.3.9621.5.106";
+      const patientId = "2.16.840.1.113883.3.9621.5.106.2.102";
+      const path = `/DocumentReference`;
+      const inputPatientParam = "patient.identifier";
+      const inputQuery = makeQuery(inputPatientParam, `urn:oid:${orgId}%7C${patientId}`);
+      mock_getOrgOrFail.mockRejectedValueOnce(new NotFoundError("not found"));
+      await expect(processDocReference(path, inputQuery)).rejects.toThrow("not found");
+    });
+
+    it("returns expected when URL has tenant", async () => {
+      const tenant = "1541456f-6734-42a5-9eb7-ef0d98b10d49";
+      const orgId = "2.16.840.1.113883.3.9621.5.106";
+      const patientId = "2.16.840.1.113883.3.9621.5.106.2.102";
+      const path = `/DocumentReference`;
+      const inputPatientParam = "patient.identifier";
+      const expectedPatientParam = "patient";
+      const inputQuery = makeQuery(inputPatientParam, `urn:oid:${orgId}%7C${patientId}`);
+      const expectedQuery = makeQuery(expectedPatientParam, patientId);
+      mock_getOrgOrFail.mockImplementation(async () => ({ cxId: tenant }));
+      const res = await processDocReference(path, inputQuery);
+      expect(res).toBeTruthy();
+      expect(res.updatedPath).toEqual(path);
+      expect(res.updatedQuery).toEqual(expectedQuery);
+      expect(res.tenant).toEqual(tenant);
+    });
+  });
+
+  describe("processBinary", () => {
+    it("returns expected when URL has tenant", async () => {
+      const tenant = "1541456f-6734-42a5-9eb7-ef0d98b10d49";
+      const expectedPath = "/Binary/007df4f8-ecfd-4709-ac73-24982c981af5";
+      const path = "/" + tenant + expectedPath;
+      const query = "";
+      const res = processBinary(path, query);
+      expect(res).toBeTruthy();
+      expect(res.updatedPath).toEqual(expectedPath);
+      expect(res.updatedQuery).toEqual(query);
+      expect(res.tenant).toEqual(tenant);
+    });
+    it("returns expected with URL does not have tenant", async () => {
+      const tenant = "";
+      const expectedPath = "/Binary/007df4f8-ecfd-4709-ac73-24982c981af5";
+      const path = expectedPath;
+      const query = "";
+      const res = processBinary(path, query);
+      expect(res).toBeTruthy();
+      expect(res.updatedPath).toEqual(expectedPath);
+      expect(res.updatedQuery).toEqual(query);
+      expect(res.tenant).toEqual(tenant);
+    });
+    it("returns expected when URL has query params", async () => {
+      const tenant = "1541456f-6734-42a5-9eb7-ef0d98b10d49";
+      const expectedPath = "/Binary/007df4f8-ecfd-4709-ac73-24982c981af5";
+      const path = "/" + tenant + expectedPath;
+      const query = "?something=else";
+      const res = processBinary(path, query);
+      expect(res).toBeTruthy();
+      expect(res.updatedPath).toEqual(expectedPath);
+      expect(res.updatedQuery).toEqual(query);
+      expect(res.updatedQuery).toEqual(query);
+      expect(res.tenant).toEqual(tenant);
+    });
+  });
+});

--- a/api/app/src/external/commonwell/api.ts
+++ b/api/app/src/external/commonwell/api.ts
@@ -109,7 +109,7 @@ export const certificate = {
 function getCertificateContent(cert: string): string | undefined {
   const regex = /-+BEGIN CERTIFICATE-+([\s\S]+?)-+END CERTIFICATE-+/i;
   const matches = cert.match(regex);
-  if (matches && matches.length > 1) {
+  if (matches && matches[1]) {
     const content = matches[1];
     return content.replace(/\r\n|\n|\r/gm, "");
   }

--- a/api/app/src/external/commonwell/cw-fhir-proxy-helpers.ts
+++ b/api/app/src/external/commonwell/cw-fhir-proxy-helpers.ts
@@ -1,0 +1,10 @@
+import NotFoundError from "../../errors/not-found";
+import { Organization, OrganizationModel } from "../../models/medical/organization";
+
+// Didn't reuse getOrganizationOrFail bc we don't have `cxId` in this context and
+// we want to keep that function requiring `cxId` to avoid cross-tenant data access
+export async function getOrgOrFail(orgId: string): Promise<Organization> {
+  const org = await OrganizationModel.findByPk(orgId);
+  if (!org) throw new NotFoundError(`Could not find organization ${orgId}`);
+  return org;
+}

--- a/api/app/src/external/commonwell/document/document-download.ts
+++ b/api/app/src/external/commonwell/document/document-download.ts
@@ -3,6 +3,7 @@ import * as stream from "stream";
 import NotFoundError from "../../../errors/not-found";
 import { capture } from "../../../shared/notifications";
 import { oid } from "../../../shared/oid";
+import { Util } from "../../../shared/util";
 import { makeCommonWellAPI, organizationQueryMeta } from "../api";
 import { getPatientData } from "../patient-shared";
 
@@ -19,6 +20,8 @@ export async function downloadDocument({
   location: string;
   stream: stream.Writable;
 }): Promise<void> {
+  const { log } = Util.out(`CW downloadDocument - M patient ${patientId}`);
+
   const { organization, facility } = await getPatientData({ id: patientId, cxId }, facilityId);
   const orgName = organization.data.name;
   const orgId = organization.id;
@@ -29,6 +32,7 @@ export async function downloadDocument({
   try {
     await commonWell.retrieveDocument(queryMeta, location, stream);
   } catch (err) {
+    log(`Error retrieving from CW (patientId ${patientId}, location ${location}): `, err);
     capture.error(err, {
       extra: {
         context: `cw.retrieveDocument`,

--- a/api/app/src/external/commonwell/document/document-query.ts
+++ b/api/app/src/external/commonwell/document/document-query.ts
@@ -270,6 +270,7 @@ async function downloadDocsAndUpsertFHIR({
           log(`Doc without location, skipping - docId ${primaryId}, s3FileName ${s3FileName}`);
         }
       } catch (error) {
+        log(`Error downloading from CW and upserting to FHIR (docId ${doc.id}): ${error}`);
         capture.error(error, {
           extra: {
             context: `s3.documentUpload`,

--- a/api/app/src/external/commonwell/document/shared.ts
+++ b/api/app/src/external/commonwell/document/shared.ts
@@ -11,7 +11,7 @@ export type DocumentWithFilename = Document & {
 export function getFileName(patient: Patient, doc: Document): string {
   const prefix = "document_" + makePatientOID("", patient.patientNumber).substring(1);
   const display = doc.content?.type?.coding?.length
-    ? doc.content?.type.coding[0].display
+    ? doc.content?.type.coding[0]?.display
     : undefined;
   const suffix = getSuffix(doc.id);
   const extension = getFileExtension(doc.content?.mimeType);

--- a/api/app/src/external/commonwell/tsconfig.json
+++ b/api/app/src/external/commonwell/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true,
+  },
+  "include": ["./**/*"],
+}

--- a/api/app/src/external/fhir/document/save-document-reference.ts
+++ b/api/app/src/external/fhir/document/save-document-reference.ts
@@ -2,8 +2,14 @@ import { DocumentReference } from "@medplum/fhirtypes";
 import { makeFhirApi } from "../api/api-factory";
 
 export const upsertDocumentToFHIRServer = async (cxId: string, docRef: DocumentReference) => {
-  await makeFhirApi(cxId).updateResource({
-    id: docRef.id,
-    ...docRef,
-  });
+  const fhir = makeFhirApi(cxId);
+  try {
+    await fhir.updateResource({
+      id: docRef.id,
+      ...docRef,
+    });
+  } catch (err) {
+    console.log(`[upsertDocumentToFHIRServer] ` + JSON.stringify(err));
+    throw err;
+  }
 };

--- a/api/app/tsconfig.json
+++ b/api/app/tsconfig.json
@@ -25,5 +25,6 @@
     "rootDir": "./src" /* Specify the root folder within your source files. */,
     "outDir": "./dist" /* Specify an output folder for all emitted files. */
   },
-  "include": ["./src"]
+  "include": ["./src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@medplum/core": "^2.0.18",
         "@medplum/fhirtypes": "^2.0.18",
         "@metriport/api": "^3.1.3",
-        "@metriport/commonwell-sdk": "^4.2.0-alpha.2",
+        "@metriport/commonwell-sdk": "^4.2.0-alpha.4",
         "@sentry/node": "^7.45.0",
         "@sentry/tracing": "^7.45.0",
         "aws-sdk": "^2.1243.0",
@@ -4659,9 +4659,9 @@
       }
     },
     "node_modules/@metriport/commonwell-sdk": {
-      "version": "4.2.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-4.2.0-alpha.2.tgz",
-      "integrity": "sha512-zzAXQ5DUzNcIOYbMV3NQ/5g9SvxTqBuy4lFo9wNWtAlzsNMqKu/eEXCH1BJXbVd68ZchJ1nhRFiZLwZXYQEHIQ==",
+      "version": "4.2.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-4.2.0-alpha.4.tgz",
+      "integrity": "sha512-dT0uVEh1GjME7fp6nHWBRphshR9R7GicexZdtPjJb8zIqYjmYgP5HbosDeOXknmBWjUr3pGONq2Wq9NJ645aJw==",
       "dependencies": {
         "axios": "^1.3.5",
         "http-status": "^1.6.2",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -19826,10 +19826,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.4.7-alpha.5",
+      "version": "1.4.7-alpha.7",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.2.0-alpha.2",
+        "@metriport/commonwell-sdk": "^4.2.0-alpha.4",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -19878,7 +19878,7 @@
       "version": "1.4.6",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.2.0-alpha.2",
+        "@metriport/commonwell-sdk": "^4.2.0-alpha.4",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -19910,7 +19910,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.2.0-alpha.2",
+      "version": "4.2.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",

--- a/packages/packages/commonwell-cert-runner/package.json
+++ b/packages/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.4.7-alpha.5",
+  "version": "1.4.7-alpha.7",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.2.0-alpha.2",
+    "@metriport/commonwell-sdk": "^4.2.0-alpha.4",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/packages/commonwell-jwt-maker/package.json
+++ b/packages/packages/commonwell-jwt-maker/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.2.0-alpha.2",
+    "@metriport/commonwell-sdk": "^4.2.0-alpha.4",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/packages/commonwell-sdk/package.json
+++ b/packages/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.2.0-alpha.2",
+  "version": "4.2.0-alpha.4",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",


### PR DESCRIPTION
Ref. metriport/metriport-internal#691

### Dependencies

https://github.com/metriport/metriport/pull/331

### Description

- Add tenant support to Binary on CW proxy
- Add logs when error while processing doc refs/binaries
- Add unit tests for CW FHIR proxy
- Add stricter `tsconfig` for specific path to make safer access to arrays

### Release Plan

- nothing special, asap