### PR TITLE
686 add patient consolidated endpoint

### DIFF
--- a/api/app/src/command/medical/patient/consolidate-data.ts
+++ b/api/app/src/command/medical/patient/consolidate-data.ts
@@ -1,5 +1,5 @@
 import { OperationOutcomeError } from "@medplum/core";
-import { Bundle, BundleEntry } from "@medplum/fhirtypes";
+import { Bundle, BundleEntry, OperationOutcomeIssue, Resource } from "@medplum/fhirtypes";
 import { makeFhirApi } from "../../../external/fhir/api/api-factory";
 import { capture } from "../../../shared/notifications";
 import { Util } from "../../../shared/util";
@@ -13,9 +13,9 @@ export async function getConsolidatedPatientData({
   cxId: string;
   patientId: string;
   resources?: ResourceTypeForConsolidation[];
-}): Promise<Bundle> {
+}): Promise<Bundle<Resource>> {
   const { log } = Util.out(`[getConsolidatedPatientData - cxId ${cxId}, patientId ${patientId}]`);
-  const fhir = makeFhirApi("cxId");
+  const fhir = makeFhirApi(cxId);
 
   // Just validate that the patient exists
   await getPatientOrFail({ id: patientId, cxId });
@@ -23,52 +23,117 @@ export async function getConsolidatedPatientData({
   const resourcesToUse = resources ?? resourceTypeForConsolidation;
   log(`Getting consolidated data with resources: `, resourcesToUse);
 
+  const errorsToReport: Record<string, string> = {};
   const settled = await Promise.allSettled(
     resourcesToUse.map(async resource =>
       fhir.search(resource, `patient=${patientId}`).catch(err => {
         if (err instanceof OperationOutcomeError && err.outcome.id === "not-found") throw err;
-        log(`Failed to get ${resource} for patient ${patientId} with error: ${err}`);
-        capture.error(err, {
-          extra: { context: `getConsolidatedPatientData`, resource, patientId },
-        });
+        if (err instanceof OperationOutcomeError) errorsToReport[resource] = getMessage(err);
+        else errorsToReport[resource] = err.message;
         throw err;
       })
     )
   );
 
-  const success: BundleEntry[] = settled
-    .flatMap(s => (s.status === "fulfilled" ? s : []))
-    .map(s => s.value);
+  const success: BundleEntry[] = settled.flatMap(s =>
+    s.status === "fulfilled" && s.value.entry ? s.value.entry : []
+  );
+  const successCount = success.length;
 
-  return { resourceType: "Bundle", entry: success };
+  if (Object.keys(errorsToReport).length > 0) {
+    log(
+      `Failed to get some resources for patient ${patientId} (${successCount} succeeded): ${JSON.stringify(
+        errorsToReport
+      )}`
+    );
+    capture.error(new Error(`Failed to get some resources for patient`), {
+      extra: {
+        context: `getConsolidatedPatientData`,
+        patientId,
+        errorsToReport,
+        succeeded: successCount,
+      },
+    });
+  }
+
+  return { resourceType: "Bundle", total: successCount, type: "searchset", entry: success };
+}
+
+function getMessage(err: OperationOutcomeError): string {
+  return err.outcome.issue ? err.outcome.issue.map(issueToString).join(",") : "";
+}
+
+function issueToString(issue: OperationOutcomeIssue): string {
+  return (
+    issue.details?.text ??
+    (issue.diagnostics ? issue.diagnostics.slice(0, 100) + "..." : null) ??
+    JSON.stringify(issue)
+  );
 }
 
 export const resourceTypeForConsolidation = [
+  "Account",
   "AllergyIntolerance",
+  "Appointment",
+  "AppointmentResponse",
+  "AuditEvent",
+  "Basic",
+  "BodyStructure",
   "CarePlan",
+  "CareTeam",
+  "ChargeItem",
   "Claim",
+  "ClaimResponse",
+  "ClinicalImpression",
+  "Communication",
+  "CommunicationRequest",
+  "Composition",
   "Condition",
   "Consent",
   "Contract",
   "Coverage",
+  "CoverageEligibilityRequest",
+  "CoverageEligibilityResponse",
   "DetectedIssue",
+  "Device",
+  "DeviceRequest",
+  "DeviceUseStatement",
+  "DiagnosticReport",
+  "DocumentManifest",
   "DocumentReference",
-  "EpisodeOfCare",
   "Encounter",
+  "EnrollmentRequest",
+  "EpisodeOfCare",
+  "ExplanationOfBenefit",
   "FamilyMemberHistory",
+  "Flag",
+  "Goal",
+  "GuidanceResponse",
+  "ImagingStudy",
+  "Immunization",
+  "ImmunizationEvaluation",
+  "ImmunizationRecommendation",
   "Invoice",
+  "List",
   "MeasureReport",
   "Media",
   "MedicationAdministration",
   "MedicationDispense",
   "MedicationRequest",
   "MedicationStatement",
+  "MolecularSequence",
+  "NutritionOrder",
   "Observation",
+  "Person",
   "Procedure",
+  "Provenance",
   "QuestionnaireResponse",
   "RelatedPerson",
+  "RequestGroup",
+  "ResearchSubject",
   "RiskAssessment",
   "ServiceRequest",
+  "Specimen",
 ] as const;
 
 export type ResourceTypeForConsolidation = (typeof resourceTypeForConsolidation)[number];

--- a/api/app/src/command/medical/patient/consolidate-data.ts
+++ b/api/app/src/command/medical/patient/consolidate-data.ts
@@ -1,0 +1,74 @@
+import { OperationOutcomeError } from "@medplum/core";
+import { Bundle, BundleEntry } from "@medplum/fhirtypes";
+import { makeFhirApi } from "../../../external/fhir/api/api-factory";
+import { capture } from "../../../shared/notifications";
+import { Util } from "../../../shared/util";
+import { getPatientOrFail } from "./get-patient";
+
+export async function getConsolidatedPatientData({
+  cxId,
+  patientId,
+  resources,
+}: {
+  cxId: string;
+  patientId: string;
+  resources?: ResourceTypeForConsolidation[];
+}): Promise<Bundle> {
+  const { log } = Util.out(`[getConsolidatedPatientData - cxId ${cxId}, patientId ${patientId}]`);
+  const fhir = makeFhirApi("cxId");
+
+  // Just validate that the patient exists
+  await getPatientOrFail({ id: patientId, cxId });
+
+  const resourcesToUse = resources ?? resourceTypeForConsolidation;
+  log(`Getting consolidated data with resources: `, resourcesToUse);
+
+  const settled = await Promise.allSettled(
+    resourcesToUse.map(async resource =>
+      fhir.search(resource, `patient=${patientId}`).catch(err => {
+        if (err instanceof OperationOutcomeError && err.outcome.id === "not-found") throw err;
+        log(`Failed to get ${resource} for patient ${patientId} with error: ${err}`);
+        capture.error(err, {
+          extra: { context: `getConsolidatedPatientData`, resource, patientId },
+        });
+        throw err;
+      })
+    )
+  );
+
+  const success: BundleEntry[] = settled
+    .flatMap(s => (s.status === "fulfilled" ? s : []))
+    .map(s => s.value);
+
+  return { resourceType: "Bundle", entry: success };
+}
+
+export const resourceTypeForConsolidation = [
+  "AllergyIntolerance",
+  "CarePlan",
+  "Claim",
+  "Condition",
+  "Consent",
+  "Contract",
+  "Coverage",
+  "DetectedIssue",
+  "DocumentReference",
+  "EpisodeOfCare",
+  "Encounter",
+  "FamilyMemberHistory",
+  "Invoice",
+  "MeasureReport",
+  "Media",
+  "MedicationAdministration",
+  "MedicationDispense",
+  "MedicationRequest",
+  "MedicationStatement",
+  "Observation",
+  "Procedure",
+  "QuestionnaireResponse",
+  "RelatedPerson",
+  "RiskAssessment",
+  "ServiceRequest",
+] as const;
+
+export type ResourceTypeForConsolidation = (typeof resourceTypeForConsolidation)[number];

--- a/api/app/src/default-error-handler.ts
+++ b/api/app/src/default-error-handler.ts
@@ -47,7 +47,8 @@ export const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
     return res.contentType("json").status(httpStatus.BAD_REQUEST).send(zodResponseBody(err));
   }
   if (err instanceof OperationOutcomeError) {
-    const status = httpStatus.INTERNAL_SERVER_ERROR;
+    const status =
+      err.outcome.id === "not-found" ? httpStatus.NOT_FOUND : httpStatus.INTERNAL_SERVER_ERROR;
     if (req.path.includes("fhir/R4")) {
       return res.contentType("json").status(status).send(err.outcome);
     } else {
@@ -58,7 +59,9 @@ export const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
           httpResponseBody({
             status,
             title: err.name,
-            detail: err.outcome.issue?.map(i => i.diagnostics ?? i.details ?? i.code).join("; "),
+            detail: err.outcome.issue
+              ?.map(i => i.diagnostics ?? i.details?.text ?? i.code)
+              .join("; "),
             name: httpStatus[status],
           })
         );

--- a/api/app/src/external/commonwell/cw-fhir-proxy.ts
+++ b/api/app/src/external/commonwell/cw-fhir-proxy.ts
@@ -77,7 +77,8 @@ export async function proxyReqPathResolver(req: Request) {
 
   const { updatedPath, updatedQuery, tenant } = await process(path, queryString);
 
-  const updatedURL = `/fhir/${tenant}` + updatedPath + (updatedQuery ? "?" + updatedQuery : "");
+  const updatedURL =
+    `/fhir` + (tenant ? `/${tenant}` : "") + updatedPath + (updatedQuery ? "?" + updatedQuery : "");
   console.log(`UPDATED URL: `, updatedURL);
   return updatedURL;
 }

--- a/api/app/src/routes/medical/patient.ts
+++ b/api/app/src/routes/medical/patient.ts
@@ -1,18 +1,25 @@
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import status from "http-status";
+import { z } from "zod";
+import { areDocumentsProcessing } from "../../command/medical/document/document-status";
+import {
+  getConsolidatedPatientData,
+  resourceTypeForConsolidation,
+} from "../../command/medical/patient/consolidate-data";
 import { createPatient, PatientCreateCmd } from "../../command/medical/patient/create-patient";
-import { getPatientOrFail, getPatients } from "../../command/medical/patient/get-patient";
 import { deletePatient } from "../../command/medical/patient/delete-patient";
+import { getPatientOrFail, getPatients } from "../../command/medical/patient/get-patient";
 import { PatientUpdateCmd, updatePatient } from "../../command/medical/patient/update-patient";
 import { processAsyncError } from "../../errors";
+import cwCommands from "../../external/commonwell";
 import { toFHIR } from "../../external/fhir/patient";
 import { upsertPatientToFHIRServer } from "../../external/fhir/patient/upsert-patient";
-import cwCommands from "../../external/commonwell";
 import {
   asyncHandler,
   getCxIdOrFail,
   getETag,
+  getFrom,
   getFromParamsOrFail,
   getFromQueryOrFail,
 } from "../util";
@@ -23,7 +30,6 @@ import {
   schemaCreateToPatient,
   schemaUpdateToPatient,
 } from "./schemas/patient";
-import { areDocumentsProcessing } from "../../command/medical/document/document-status";
 
 const router = Router();
 
@@ -108,7 +114,7 @@ router.put(
  * Returns a patient corresponding to the specified facility at the customer's organization.
  *
  * @param   req.cxId      The customer ID.
- * @param   req.param.id  The ID of the patient to be returned is associated with.
+ * @param   req.param.id  The ID of the patient to be returned.
  * @return  The customer's patients associated with the given facility.
  */
 router.get(
@@ -169,6 +175,34 @@ router.get(
 
     const patientsData = patients.map(dtoFromModel);
     return res.status(status.OK).json({ patients: patientsData });
+  })
+);
+
+const resourceSchema = z.enum(resourceTypeForConsolidation).array();
+
+/** ---------------------------------------------------------------------------
+ * GET /patient/:id/consolidated
+ *
+ * Returns a patient's consolidated data.
+ *
+ * @param req.cxId The customer ID.
+ * @param req.param.id The ID of the patient whose data is to be returned.
+ * @param req.query.resources Optional comma-separated list of resources to be returned.
+ * @return The customer's patients associated with the given facility.
+ */
+router.get(
+  "/:id/consolidated",
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getCxIdOrFail(req);
+    const patientId = getFrom("params").orFail("id", req);
+    const resourcesRaw = getFrom("query").optional("resources", req);
+    const resources = resourcesRaw
+      ? resourceSchema.parse(resourcesRaw.split(",").map(r => r.trim()))
+      : undefined;
+
+    const data = await getConsolidatedPatientData({ cxId, patientId, resources });
+
+    return res.json(data);
   })
 );
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#686

Ref: #_[ticket-number]_

### Dependencies

- Upstream: _[this PR points to another PR or depends on its release]_
- Downstream: _[PRs that depend on this one, either point to this or can only be released after this one is released]_

### Description

- add patient consolidated endpoint
- adjust defaultHandler for FHIR related errors
- small tweak on `cw-fhir-proxy` when tenant missing

#### Outstanding:
-  update docs

### Release Plan

- WIP