### PR TITLE
698 external IDs limit to 64chars

### DIFF
--- a/api/app/src/external/index.ts
+++ b/api/app/src/external/index.ts
@@ -2,6 +2,8 @@ export enum MedicalDataSource {
   COMMONWELL = "COMMONWELL",
 }
 
+export const HL7OID = "2.16.840.1.113883";
+
 export const MedicalDataSourceOid: Record<MedicalDataSource, string> = {
   [MedicalDataSource.COMMONWELL]: "2.16.840.1.113883.3.3330",
 };

--- a/api/app/src/routes/medical/dtos/documentDTO.ts
+++ b/api/app/src/routes/medical/dtos/documentDTO.ts
@@ -1,7 +1,7 @@
 import { DocumentReference } from "@medplum/fhirtypes";
-import base64url from "base64url";
-import { CodeableConceptDTO, toDTO as codeableToDTO } from "./codeableDTO";
+import { decodeExternalId } from "../../../shared/external";
 import { capture } from "../../../shared/notifications";
+import { CodeableConceptDTO, toDTO as codeableToDTO } from "./codeableDTO";
 
 export type DocumentReferenceDTO = {
   id: string;
@@ -19,7 +19,7 @@ export function toDTO(docs: DocumentReference[] | undefined): DocumentReferenceD
   if (docs) {
     return docs.flatMap(doc => {
       if (doc && doc.id && doc.content) {
-        const decodedId = base64url.decode(doc.id);
+        const decodedId = decodeExternalId(doc.id);
         const hasAttachment = doc.content[0];
 
         if (doc.content.length > 1) {

--- a/api/app/src/shared/__tests__/external.test.ts
+++ b/api/app/src/shared/__tests__/external.test.ts
@@ -1,0 +1,39 @@
+import { decodeExternalId, encodeExternalId } from "../external";
+
+describe("mapi external", () => {
+  describe("encode and decode external IDs", () => {
+    const MAX_FHIR_ID_LENGTH = 64;
+
+    const idsToTest = [
+      // https://metriport.slack.com/archives/C04DBBJSKGB/p1684107884991659?thread_ts=1684105959.041439&cid=C04DBBJSKGB
+      "2.16.840.1.113883.3.107.100.1.3.252.1.00805946.896751",
+      // https://metriport.slack.com/archives/C04DBBJSKGB/p1684109280912069?thread_ts=1684105959.041439&cid=C04DBBJSKGB
+      "2.16.840.1.113883.3.107^100",
+      // UUID v4
+      "C5CD8A63-352F-4BCF-9ECA-92D7937CCFE5",
+      // with non-hl7 prefix
+      "-M-B61C405F-EAF8-486B-8DD2-F9F32F684F09",
+    ];
+
+    describe("encode and decode", () => {
+      for (const decoded of idsToTest) {
+        it(`encode/decode ID ${decoded}`, async () => {
+          const encoded = encodeExternalId(decoded);
+          expect(encoded).toBeTruthy();
+          const res = decodeExternalId(encoded);
+          expect(res).toEqual(decoded);
+        });
+      }
+    });
+
+    describe("encode within length limit", () => {
+      for (const decoded of idsToTest) {
+        it(`encode within limit ID ${decoded}`, async () => {
+          const encoded = encodeExternalId(decoded);
+          expect(encoded).toBeTruthy();
+          expect(encoded.length).toBeLessThanOrEqual(MAX_FHIR_ID_LENGTH);
+        });
+      }
+    });
+  });
+});

--- a/api/app/src/shared/external.ts
+++ b/api/app/src/shared/external.ts
@@ -1,5 +1,6 @@
 import { Document } from "@metriport/commonwell-sdk";
 import base64url from "base64url";
+import { HL7OID } from "../external";
 
 export const createS3FileName = (cxId: string, fileName: string): string => {
   return `${cxId}-${fileName}`;
@@ -7,5 +8,21 @@ export const createS3FileName = (cxId: string, fileName: string): string => {
 
 export const getDocumentPrimaryId = (document: Document): string => {
   const id = document.content?.masterIdentifier?.value || document.id;
-  return base64url.encode(id);
+  return encodeExternalId(id);
 };
+
+const NON_HL7_SUFFIX = "-M-";
+
+export function encodeExternalId(decodedId: string): string {
+  const hasHl7Prefix = decodedId.includes(HL7OID);
+  const idToEncode = hasHl7Prefix ? decodedId.replace(HL7OID, "") : NON_HL7_SUFFIX + decodedId;
+  return base64url.encode(idToEncode);
+}
+export function decodeExternalId(encodedId: string): string {
+  const decoded = base64url.decode(encodedId);
+  if (decoded.startsWith(NON_HL7_SUFFIX)) {
+    const res = decoded.replace(NON_HL7_SUFFIX, "");
+    return res;
+  }
+  return HL7OID + base64url.decode(encodedId);
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#698

### Dependencies

none

### Description

(doc) external IDs limit to 64chars

context: https://metriport.slack.com/archives/C04DBBJSKGB/p1684106893571899?thread_ts=1684105959.041439&cid=C04DBBJSKGB

### Release Plan

- ⚠️ This is pointing to `master`, deploying in `production`
- re-populate Delfina's data ([here](https://metriport.slack.com/archives/C04DBBJSKGB/p1684105959041439))
  - it should re-download doc and re-inserts them on the FHIR DB
  - the ones that failed should work now
- just back merge into `develop` once this is merged