### PR TITLE
698 try FHIR id before upload S3

### DIFF
--- a/api/app/src/errors/metriport-error.ts
+++ b/api/app/src/errors/metriport-error.ts
@@ -1,8 +1,8 @@
 import status from "http-status";
 
-export default abstract class MetriportError extends Error {
+export default class MetriportError extends Error {
   status: number = status.INTERNAL_SERVER_ERROR;
-  constructor(message: string, cause?: unknown) {
+  constructor(message: string, cause?: unknown, readonly additionalInfo?: Record<string, string>) {
     super(message);
     this.cause = cause;
   }

--- a/api/app/src/external/fhir/document/index.ts
+++ b/api/app/src/external/fhir/document/index.ts
@@ -6,17 +6,15 @@ import { Organization } from "../../../models/medical/organization";
 import { Patient } from "../../../models/medical/patient";
 import { DocumentWithFilename } from "../../commonwell/document/shared";
 import { ResourceType } from "../shared";
-import { getDocumentPrimaryId } from "../../../shared/external";
 
 export const toFHIR = (
+  docId: string,
   doc: DocumentWithFilename,
   organization: Organization,
   patient: Patient
 ): DocumentReference => {
-  const primaryId = getDocumentPrimaryId(doc);
-
   return {
-    id: primaryId,
+    id: docId,
     resourceType: ResourceType.DocumentReference,
     contained: [
       {

--- a/api/app/src/external/fhir/shared/index.ts
+++ b/api/app/src/external/fhir/shared/index.ts
@@ -3,3 +3,5 @@ export enum ResourceType {
   Patient = "Patient",
   DocumentReference = "DocumentReference",
 }
+
+export const MAX_FHIR_DOC_ID_LENGTH = 64;

--- a/api/app/src/shared/__tests__/external.test.ts
+++ b/api/app/src/shared/__tests__/external.test.ts
@@ -9,6 +9,7 @@ describe("mapi external", () => {
       "2.16.840.1.113883.3.107.100.1.3.252.1.00805946.896751",
       // https://metriport.slack.com/archives/C04DBBJSKGB/p1684109280912069?thread_ts=1684105959.041439&cid=C04DBBJSKGB
       "2.16.840.1.113883.3.107^100",
+      "1.2.840.114350.1.13.325.2.7.8.688883.379834396",
       // UUID v4
       "C5CD8A63-352F-4BCF-9ECA-92D7937CCFE5",
       // with non-hl7 prefix

--- a/api/app/src/shared/external.ts
+++ b/api/app/src/shared/external.ts
@@ -11,18 +11,17 @@ export const getDocumentPrimaryId = (document: Document): string => {
   return encodeExternalId(id);
 };
 
-const NON_HL7_SUFFIX = "-M-";
+const HL7_SUFFIX = ".";
 
 export function encodeExternalId(decodedId: string): string {
   const hasHl7Prefix = decodedId.includes(HL7OID);
-  const idToEncode = hasHl7Prefix ? decodedId.replace(HL7OID, "") : NON_HL7_SUFFIX + decodedId;
+  const idToEncode = hasHl7Prefix ? decodedId.replace(HL7OID, "") : decodedId;
   return base64url.encode(idToEncode);
 }
 export function decodeExternalId(encodedId: string): string {
   const decoded = base64url.decode(encodedId);
-  if (decoded.startsWith(NON_HL7_SUFFIX)) {
-    const res = decoded.replace(NON_HL7_SUFFIX, "");
-    return res;
+  if (decoded.startsWith(HL7_SUFFIX)) {
+    return HL7OID + decoded;
   }
-  return HL7OID + base64url.decode(encodedId);
+  return decoded;
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#698

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/335
- Downstream: none

### Description

try FHIR id before upload S3

### Release Plan

- ⚠️ This is pointing to `master`, deploying in `production`
- re-populate Delfina's data ([here](https://metriport.slack.com/archives/C04DBBJSKGB/p1684105959041439))
  - it should re-download doc and re-inserts them on the FHIR DB
  - the ones that failed should work now
- just back merge into `develop` once this is merged