### PR TITLE
696 increase max DB connections to 300

### DIFF
--- a/api/app/docker-compose.dev.yml
+++ b/api/app/docker-compose.dev.yml
@@ -57,7 +57,7 @@ services:
   postgres:
     image: postgres:14.4-alpine
     restart: always
-    command: -c 'max_connections=200'
+    command: -c 'max_connections=350'
     environment:
       # You can set the value of environment variables
       # in your docker-compose.yml file

--- a/api/app/src/models/db.ts
+++ b/api/app/src/models/db.ts
@@ -58,7 +58,7 @@ const initDB = async (): Promise<void> => {
     port: dbCreds.port,
     dialect: dbCreds.engine,
     pool: {
-      max: 50,
+      max: 300,
       min: 20,
       acquire: 30000,
       idle: 10000,


### PR DESCRIPTION
Ref. metriport/metriport-internal#696

### Description

Increase max DB connections to 300

Context: https://metriport.slack.com/archives/C04DMKE9DME/p1684174050171709?thread_ts=1684171454.512509&cid=C04DMKE9DME

### Release Plan

- ⚠️ This is pointing to `master`, deploying in `production`
- back merge into `develop` once this is merged