### PR TITLE
698 add extra logs to doc query/download

### DIFF
--- a/api/app/src/command/medical/admin-populate-fhir.ts
+++ b/api/app/src/command/medical/admin-populate-fhir.ts
@@ -36,8 +36,8 @@ export async function populateFhirServer({
   log("Creating organization on FHIR server: ", orgOnDB.id);
   await fhirApi.updateResource(orgToFhir);
 
-  log("Creating patients on FHIR server...");
   const patientsOnDB = await getPatients({ cxId });
+  log(`Creating ${patientsOnDB.length} patients on FHIR server...`);
   const res = await Promise.allSettled(
     patientsOnDB.map(async patient => {
       try {
@@ -51,7 +51,7 @@ export async function populateFhirServer({
     })
   );
 
-  log("Triggering document queries...");
+  log(`Triggering document queries for ${patientsOnDB.length} patients...`);
   patientsOnDB.forEach(patient => {
     if (patient.facilityIds.length < 1) return;
     queryDocumentsAcrossHIEs({

--- a/api/app/src/command/medical/document/document-query.ts
+++ b/api/app/src/command/medical/document/document-query.ts
@@ -32,8 +32,12 @@ export async function queryDocumentsAcrossHIEs({
   override?: boolean;
 }): Promise<DocumentQueryResp> {
   const patient = await getPatientOrFail({ id: patientId, cxId });
-  if (patient.data.documentQueryStatus === "processing")
+  if (patient.data.documentQueryStatus === "processing") {
+    console.log(
+      `[queryDocumentsAcrossHIEs] Patient ${patientId} documentQueryStatus is already 'processing', skipping...`
+    );
     return createQueryResponse("processing", patient);
+  }
 
   const externalData = patient.data.externalData?.COMMONWELL;
   if (!externalData) return createQueryResponse("completed");

--- a/api/app/src/external/commonwell/document/document-query.ts
+++ b/api/app/src/external/commonwell/document/document-query.ts
@@ -64,6 +64,7 @@ export async function queryDocuments({
         toDTO(getDocumentSandboxPayload(patient.id))
       );
     } else {
+      log(`Querying for documents of patient ${patient.id}...`);
       const cwDocuments = await internalGetDocuments({ patient, organization, facility });
       log(`Found ${cwDocuments.length} documents`);
 
@@ -112,7 +113,10 @@ async function internalGetDocuments({
   const { log } = Util.out(`CW internalGetDocuments - M patient ${patient.id}`);
 
   const externalData = patient.data.externalData?.COMMONWELL;
-  if (!externalData) return [];
+  if (!externalData) {
+    log(`No external data found for patient ${patient.id}, not querying for docs`);
+    return [];
+  }
   const cwData = externalData as PatientDataCommonwell;
 
   const orgName = organization.data.name;


### PR DESCRIPTION
Ref. metriport/metriport-internal#698

### Dependencies

none

### Description

Add extra logs to doc query/download

Context: https://metriport.slack.com/archives/C04DBBJSKGB/p1684255094506319?thread_ts=1684251060.218089&cid=C04DBBJSKGB

### Release Plan

- ⚠️ This is pointing to `master`, deploying in `production`
- merge `master` into `develop` once this has been merged