### PR TITLE
PATCH 686 paginate fhir on consolidated endpoint

### DIFF
--- a/api/app/src/command/medical/__tests__/consolidate-data.test.ts
+++ b/api/app/src/command/medical/__tests__/consolidate-data.test.ts
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { Observation } from "@medplum/fhirtypes";
+import { v4 as uuidv4 } from "uuid";
+import { HapiFhirClient } from "../../../external/fhir/api/api-hapi";
+import { makePatient } from "../../../models/medical/__tests__/patient";
+import { getConsolidatedPatientData } from "../patient/consolidate-data";
+import * as getPatient from "../patient/get-patient";
+
+let getPatientOrFailMock: jest.SpyInstance;
+let fhir_searchResourcePages: jest.SpyInstance;
+beforeEach(() => {
+  jest.restoreAllMocks();
+  getPatientOrFailMock = jest.spyOn(getPatient, "getPatientOrFail");
+  fhir_searchResourcePages = jest.spyOn(HapiFhirClient.prototype, "searchResourcePages");
+});
+
+describe("getConsolidatedPatientData", () => {
+  const cxId = uuidv4();
+  const patientId = uuidv4();
+
+  it("paginates appropriately", async () => {
+    getPatientOrFailMock.mockReturnValueOnce(makePatient({ id: patientId }));
+
+    const returnedResource: Observation = {
+      resourceType: "Observation",
+      id: "1",
+      status: "final",
+      code: {
+        coding: [
+          {
+            system: "http://loinc.org",
+            code: "12345",
+            display: "Test",
+          },
+        ],
+      },
+    };
+    const generator = (async function* generateResources() {
+      yield [returnedResource];
+      yield [returnedResource];
+    })();
+    fhir_searchResourcePages.mockReturnValue(generator);
+
+    const resp = await getConsolidatedPatientData({ cxId, patientId, resources: ["Observation"] });
+
+    expect(resp).toBeTruthy();
+    expect(resp.resourceType).toEqual(`Bundle`);
+    expect(resp.total).toEqual(2);
+    expect(resp.entry).toEqual(expect.arrayContaining([{ resource: returnedResource }]));
+    expect(getPatientOrFailMock).toHaveBeenCalledTimes(1);
+    expect(fhir_searchResourcePages).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Ref. metriport/metriport-internal#686

### Description

Paginate fhir on consolidated endpoint

### Release Plan

- ⚠️ This is pointing to `master`, deploy in `production`