### PR TITLE
[Docs][Hotfix] Fix quotes wrapping

### DIFF
--- a/docs/medical-api/fhir/resources/clinicalimpression.mdx
+++ b/docs/medical-api/fhir/resources/clinicalimpression.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ClinicalImpression"
-description: "A record of a clinical assessment performed to determine what problem(s) may affect the patient and before planning the treatments or management strategies that are best to manage a patient's condition. Assessments are often 1:1 with a clinical consultation / encounter,  but this varies greatly depending on the clinical workflow. This resource is called "ClinicalImpression" rather than "ClinicalAssessment" to avoid confusion with the recording of assessment tools such as Apgar score."
+description: 'A record of a clinical assessment performed to determine what problem(s) may affect the patient and before planning the treatments or management strategies that are best to manage a patient's condition. Assessments are often 1:1 with a clinical consultation / encounter,  but this varies greatly depending on the clinical workflow. This resource is called "ClinicalImpression" rather than "ClinicalAssessment" to avoid confusion with the recording of assessment tools such as Apgar score.'
 ---
 
 ## Properties

--- a/docs/medical-api/fhir/resources/clinicalimpression.mdx
+++ b/docs/medical-api/fhir/resources/clinicalimpression.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ClinicalImpression"
-description: 'A record of a clinical assessment performed to determine what problem(s) may affect the patient and before planning the treatments or management strategies that are best to manage a patient's condition. Assessments are often 1:1 with a clinical consultation / encounter,  but this varies greatly depending on the clinical workflow. This resource is called "ClinicalImpression" rather than "ClinicalAssessment" to avoid confusion with the recording of assessment tools such as Apgar score.'
+description: A record of a clinical assessment performed to determine what problem(s) may affect the patient and before planning the treatments or management strategies that are best to manage a patient's condition. Assessments are often 1:1 with a clinical consultation / encounter,  but this varies greatly depending on the clinical workflow. This resource is called "ClinicalImpression" rather than "ClinicalAssessment" to avoid confusion with the recording of assessment tools such as Apgar score.
 ---
 
 ## Properties


### PR DESCRIPTION
# Summary

The error that prevented the docs from updating was caused by the use of quotations (`"` and `'`) inside the page's description property while being wrapped in quotations.