### PR TITLE
706 move to ALB and update infra

### DIFF
--- a/infra/lib/api-service.ts
+++ b/infra/lib/api-service.ts
@@ -37,7 +37,7 @@ export function createAPIService(
   loadBalancerAddress: string;
 } {
   // Create a new Amazon Elastic Container Service (ECS) cluster
-  const cluster = new ecs.Cluster(stack, "APICluster", { vpc });
+  const cluster = new ecs.Cluster(stack, "APICluster", { vpc, containerInsights: true });
 
   // Create a Docker image and upload it to the Amazon Elastic Container Registry (ECR)
   const dockerImage = new ecr_assets.DockerImageAsset(stack, "APIImage", {

--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -114,8 +114,8 @@ export class APIStack extends Stack {
       clusterIdentifier: dbClusterName,
       storageEncrypted: true,
     });
-    const minDBCap = this.isProd(props) ? 2 : 1;
-    const maxDBCap = this.isProd(props) ? 8 : 2;
+    const minDBCap = this.isProd(props) ? 2 : 0.5;
+    const maxDBCap = this.isProd(props) ? 16 : 2;
     Aspects.of(dbCluster).add({
       visit(node) {
         if (node instanceof rds.CfnDBCluster) {


### PR DESCRIPTION
Ref. metriport/metriport-internal#706

### Dependencies

none

### Description

Update FHIR Converter infra
- LB from LB to ALB
- scaling thresholds
- double CPU in prod
- enable container insights

Update API infra
- DB min/max caps prod/staging
- enable container insights

### Release Plan

- nothing special