### PR TITLE
feat(api): add doc ref id to fhir res, improve timestamp for doc refs…

### DIFF
--- a/api/app/src/command/medical/document/document-redownload.ts
+++ b/api/app/src/command/medical/document/document-redownload.ts
@@ -17,7 +17,7 @@ import { downloadDocsAndUpsertFHIR } from "../../../external/commonwell/document
 import { hasCommonwellContent, isCommonwellContent } from "../../../external/commonwell/extension";
 import { makeFhirApi } from "../../../external/fhir/api/api-factory";
 import { downloadedFromHIEs } from "../../../external/fhir/shared";
-import { isMetriportContent } from "../../../external/fhir/shared/extension";
+import { isMetriportContent } from "../../../external/fhir/shared/extensions/extension";
 import { decodeExternalId } from "../../../shared/external";
 import { capture } from "../../../shared/notifications";
 import { Util } from "../../../shared/util";

--- a/api/app/src/external/commonwell/document/document-query.ts
+++ b/api/app/src/external/commonwell/document/document-query.ts
@@ -173,11 +173,10 @@ export async function internalGetDocuments({
   log(`Document query got ${docs.length} documents${docs.length ? ", processing" : ""}...`);
   const documents: Document[] = docs.flatMap(d => {
     if (d.content.size === 0) {
-      log(`Document is of size 0, skipping - doc id ${d.id}`);
+      log(`Document is of size 0, this may result in a 404 error - doc id ${d.id}`);
       capture.message("Document is of size 0", {
         extra: d.content,
       });
-      return [];
     }
 
     if (d.content && d.content.masterIdentifier?.value && d.content.location) {
@@ -327,7 +326,7 @@ export async function downloadDocsAndUpsertFHIR({
 
             let getS3InfoAndContents: () => Promise<{
               s3Location: string;
-              fileContents: Promise<string>;
+              fileContents: Promise<{ contents: string; size: number }>;
             }>;
 
             if (!fileExists || override) {
@@ -367,12 +366,14 @@ export async function downloadDocsAndUpsertFHIR({
             }
 
             const { s3Location, fileContents } = await getS3InfoAndContents();
+            const file = await fileContents;
 
             const docWithFile: CWDocumentWithMetriportData = {
               ...doc,
               metriport: {
                 fileName: s3FileName,
                 location: s3Location,
+                fileSize: file.size,
               },
             };
 
@@ -382,16 +383,15 @@ export async function downloadDocsAndUpsertFHIR({
               doc.content?.mimeType === "text/xml"
             ) {
               try {
-                const fileString = await fileContents;
                 // note that on purpose, this bundle will not contain the corresponding doc ref
-                const fhirBundle = await convertCDAToFHIR(patient.id, fileString);
+                const fhirBundle = await convertCDAToFHIR(patient.id, fhirDocId, file.contents);
                 if (fhirBundle) await postFHIRBundle(patient.cxId, fhirBundle);
               } catch (error) {
                 reportFHIRError({ patientId: patient.id, doc, error, log });
               }
             }
-
             const FHIRDocRef = toFHIRDocRef(fhirDocId, docWithFile, organization, patient);
+            // update the stored doc ref based on the actual file content size
             await upsertDocumentToFHIRServer(organization.cxId, FHIRDocRef);
 
             return FHIRDocRef;
@@ -399,12 +399,17 @@ export async function downloadDocsAndUpsertFHIR({
             log(`Doc without location, skipping - docId ${fhirDocId}, s3FileName ${s3FileName}`);
           }
         } catch (error) {
-          log(`Error downloading from CW and upserting to FHIR (docId ${doc.id}): ${error}`);
+          const isZeroLength = doc.content.size === 0;
+          const zeroLengthDetailsStr = isZeroLength ? "zero length document" : "";
+          log(
+            `Error downloading ${zeroLengthDetailsStr} from CW and upserting to FHIR (docId ${doc.id}): ${error}`
+          );
           capture.error(error, {
             extra: {
               context: `s3.documentUpload`,
               patientId: patient.id,
               documentReference: doc,
+              isZeroLength,
             },
           });
           throw error;

--- a/api/app/src/external/commonwell/document/document-query.ts
+++ b/api/app/src/external/commonwell/document/document-query.ts
@@ -391,7 +391,6 @@ export async function downloadDocsAndUpsertFHIR({
               }
             }
             const FHIRDocRef = toFHIRDocRef(fhirDocId, docWithFile, organization, patient);
-            // update the stored doc ref based on the actual file content size
             await upsertDocumentToFHIRServer(organization.cxId, FHIRDocRef);
 
             return FHIRDocRef;

--- a/api/app/src/external/commonwell/document/shared.ts
+++ b/api/app/src/external/commonwell/document/shared.ts
@@ -7,6 +7,7 @@ export type CWDocumentWithMetriportData = Document & {
   metriport: {
     fileName: string;
     location: string;
+    fileSize: number;
   };
 };
 

--- a/api/app/src/external/commonwell/extension.ts
+++ b/api/app/src/external/commonwell/extension.ts
@@ -1,6 +1,9 @@
 import { DocumentReference, DocumentReferenceContent, Extension } from "@medplum/fhirtypes";
 import { MedicalDataSource } from "@metriport/api";
-import { dataSourceExtensionDefaults, MetriportExtension } from "../fhir/shared/extension";
+import {
+  dataSourceExtensionDefaults,
+  MetriportExtension,
+} from "../fhir/shared/extensions/extension";
 
 export const cwExtension: MetriportExtension = {
   ...dataSourceExtensionDefaults,

--- a/api/app/src/external/fhir/document/index.ts
+++ b/api/app/src/external/fhir/document/index.ts
@@ -6,7 +6,32 @@ import { Patient } from "../../../models/medical/patient";
 import { CWDocumentWithMetriportData } from "../../commonwell/document/shared";
 import { cwExtension } from "../../commonwell/extension";
 import { ResourceType } from "../shared";
-import { metriportExtension } from "../shared/extension";
+import { metriportExtension } from "../shared/extensions/extension";
+import dayjs from "dayjs";
+import isToday from "dayjs/plugin/isToday";
+dayjs.extend(isToday);
+
+// HIEs probably don't have records before the year 1800 :)
+const earliestPossibleYear = 1800;
+
+function getBestDateFromCWDocRef(doc: CWDocumentWithMetriportData): string {
+  const date = dayjs(doc.content?.indexed);
+
+  // if the timestamp from CW for the indexed date is from today, this usually
+  // means that the timestamp is auto-generated, and there may be a more accurate
+  // timestamp in the doc ref.
+  if (date.isToday() && doc.content?.context?.period?.start) {
+    const newDate = dayjs(doc.content.context.period.start);
+
+    // this check is necessary to prevent using weird dates... seen stuff like
+    // this before:  "period": { "start": "0001-01-01T00:00:00Z" }
+    if (newDate.year() >= earliestPossibleYear) {
+      return newDate.toISOString();
+    }
+  }
+
+  return date.toISOString();
+}
 
 export const toFHIR = (
   docId: string,
@@ -16,7 +41,7 @@ export const toFHIR = (
 ): DocumentReference => {
   const baseAttachment = {
     contentType: doc.content?.mimeType,
-    size: doc.content?.size,
+    size: doc.metriport.fileSize, // can't trust the file size from CW, use what we actually saved
     creation: doc.content?.indexed,
   };
   const metriportContent: DocumentReferenceContent = {
@@ -58,7 +83,7 @@ export const toFHIR = (
       value: doc.content?.masterIdentifier?.value,
     },
     identifier: doc.content?.identifier?.map(idToFHIR),
-    date: doc.content?.indexed,
+    date: getBestDateFromCWDocRef(doc),
     status: "current",
     type: doc.content?.type,
     subject: {

--- a/api/app/src/external/fhir/shared/extensions/base-extension.ts
+++ b/api/app/src/external/fhir/shared/extensions/base-extension.ts
@@ -1,0 +1,1 @@
+export const BASE_EXTENSION_URL = "https://public.metriport.com/fhir/StructureDefinition";

--- a/api/app/src/external/fhir/shared/extensions/doc-id-extension.ts
+++ b/api/app/src/external/fhir/shared/extensions/doc-id-extension.ts
@@ -1,0 +1,16 @@
+import { Extension } from "@medplum/fhirtypes";
+import { BASE_EXTENSION_URL } from "./base-extension";
+
+// TODO #712: create this extension
+const DOC_ID_EXTENSION_URL = `${BASE_EXTENSION_URL}/doc-id-extension.json`;
+
+export type DocIdExtension = Required<Pick<Extension, "url">> & {
+  valueString: string;
+};
+
+export function buildDocIdFHIRExtension(docId: string): DocIdExtension {
+  return {
+    url: DOC_ID_EXTENSION_URL,
+    valueString: docId,
+  };
+}

--- a/api/app/src/external/fhir/shared/extensions/extension.ts
+++ b/api/app/src/external/fhir/shared/extensions/extension.ts
@@ -1,16 +1,17 @@
 import { Coding, DocumentReferenceContent, Extension } from "@medplum/fhirtypes";
+import { METRIPORT } from "../../../../shared/constants";
+import { isCommonwellContent } from "../../../commonwell/extension";
+import { BASE_EXTENSION_URL } from "./base-extension";
 import { DeepRequired } from "ts-essentials";
-import { METRIPORT } from "../../../shared/constants";
-import { isCommonwellContent } from "../../commonwell/extension";
-
-const DATA_SOURCE_EXTENSION_URL =
-  "https://public.metriport.com/fhir/StructureDefinition/data-source.json";
 
 // URL is required: https://www.hl7.org/fhir/R4/extensibility.html#Extension.url
 export type MetriportExtension = Omit<Extension, "url" | "valueCoding"> &
   Required<Pick<Extension, "url">> & {
     valueCoding: Omit<Coding, "system" | "code"> & DeepRequired<Pick<Coding, "system" | "code">>;
   };
+
+// TODO #712: create this extension
+const DATA_SOURCE_EXTENSION_URL = `${BASE_EXTENSION_URL}/data-source.json`;
 
 export const dataSourceExtensionDefaults = {
   url: DATA_SOURCE_EXTENSION_URL,

--- a/api/app/src/external/fhir/shared/extensions/extension.ts
+++ b/api/app/src/external/fhir/shared/extensions/extension.ts
@@ -4,14 +4,14 @@ import { isCommonwellContent } from "../../../commonwell/extension";
 import { BASE_EXTENSION_URL } from "./base-extension";
 import { DeepRequired } from "ts-essentials";
 
+// TODO #712: create this extension
+const DATA_SOURCE_EXTENSION_URL = `${BASE_EXTENSION_URL}/data-source.json`;
+
 // URL is required: https://www.hl7.org/fhir/R4/extensibility.html#Extension.url
 export type MetriportExtension = Omit<Extension, "url" | "valueCoding"> &
   Required<Pick<Extension, "url">> & {
     valueCoding: Omit<Coding, "system" | "code"> & DeepRequired<Pick<Coding, "system" | "code">>;
   };
-
-// TODO #712: create this extension
-const DATA_SOURCE_EXTENSION_URL = `${BASE_EXTENSION_URL}/data-source.json`;
 
 export const dataSourceExtensionDefaults = {
   url: DATA_SOURCE_EXTENSION_URL,

--- a/api/app/src/routes/medical/document.ts
+++ b/api/app/src/routes/medical/document.ts
@@ -19,10 +19,18 @@ const router = Router();
 /** ---------------------------------------------------------------------------
  * GET /document
  *
- * Queries for all available document metadata for the specified patient across HIEs.
+ * Lists all Documents that can be retrieved for a Patient.
  *
- * @param req.query.patientId Patient ID for which to retrieve document metadata.
- * @return The metadata of available documents.
+ *
+ * It also returns the status of querying document references across HIEs,
+ * indicating whether there is an asynchronous query in progress (status processing)
+ * or not (status completed).
+ *
+ * If the query is in progress, you will also receive the total number of documents
+ * to be queried as well as the ones that have already been completed.
+ *
+ * @param req.query.patientId Patient ID for which to list documents.
+ * @return The available documents, including query status and progress - as applicable.
  */
 router.get(
   "/",

--- a/api/app/src/shared/util.ts
+++ b/api/app/src/shared/util.ts
@@ -114,12 +114,17 @@ export class Util {
   static oneOf = <T>(...values: T[]): NonNullable<T> | undefined =>
     values.find(v => v != null) ?? undefined;
 
-  static async streamToString(stream: Stream): Promise<string> {
+  static async streamToString(stream: Stream): Promise<{ contents: string; size: number }> {
     const chunks: Buffer[] = [];
+    let size = 0;
     return new Promise((resolve, reject) => {
-      stream.on("data", chunk => chunks.push(Buffer.from(chunk)));
+      stream.on("data", chunk => {
+        const chunkBuffer = Buffer.from(chunk);
+        chunks.push(chunkBuffer);
+        size += chunkBuffer.length;
+      });
       stream.on("error", err => reject(err));
-      stream.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+      stream.on("end", () => resolve({ contents: Buffer.concat(chunks).toString("utf8"), size }));
     });
   }
 }


### PR DESCRIPTION
refs. metriport/metriport#383


### Dependencies

N/A

### Description

- add doc ref id to fhir resources
- improve timestamp for doc refs from CW
- download all docs regardless of supposed size in metadata
- calculate document size properly when creating doc refs

### Release Plan

asap