### PR TITLE
706 log NODE_OPTIONS on FHIR converter

### DIFF
--- a/fhir-converter/src/index.js
+++ b/fhir-converter/src/index.js
@@ -11,5 +11,6 @@ var port = process.env.PORT || 8080;
 
 var server = app.listen(port, function () {
   var host = server.address().address;
+  console.log(`NODE_OPTIONS=${process.env.NODE_OPTIONS}`);
   console.log("FHIR Converter listening at http://%s:%s", host, port);
 });


### PR DESCRIPTION
Ref. metriport/metriport-internal#706

### Dependencies

none

### Description

Log NODE_OPTIONS on FHIR converter so we can know what's the actual setup we have in `prod` - couldn't get the env var even logging into the ECS task.

### Release Plan

- nothing special, asap