### PR TITLE
build: adj lambda timeout to match LBs, 15min

### DIFF
--- a/api/lambdas/sqs-to-fhir/index.js
+++ b/api/lambdas/sqs-to-fhir/index.js
@@ -20,7 +20,7 @@ const metricsNamespace = getEnvOrFail("METRICS_NAMESPACE");
 const envType = getEnvOrFail("ENV_TYPE");
 const sentryDsn = getEnv("SENTRY_DSN");
 const maxTimeoutRetries = Number(getEnvOrFail("MAX_TIMEOUT_RETRIES"));
-const delayWhenRetryingSeconds = Number(getEnvOrFail("DELAY_WHEN_RETRY"));
+const delayWhenRetryingSeconds = Number(getEnvOrFail("DELAY_WHEN_RETRY_SECONDS"));
 const sourceQueueURL = getEnvOrFail("QUEUE_URL");
 const dlqURL = getEnvOrFail("DLQ_URL");
 const fhirServerUrl = getEnvOrFail("FHIR_SERVER_URL");
@@ -175,6 +175,7 @@ function isTimeout(err) {
     err.code === "ECONNRESET" ||
     err.code === "ESOCKETTIMEDOUT" ||
     err.response?.status === 502 ||
+    err.response?.status === 503 ||
     err.response?.status === 504
   );
 }

--- a/infra/lib/api-stack/fhir-server-connector.ts
+++ b/infra/lib/api-stack/fhir-server-connector.ts
@@ -7,7 +7,7 @@ import { Queue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
 import { EnvType } from "../env-type";
 import { getConfig, METRICS_NAMESPACE } from "../shared/config";
-import { createLambda as defaultCreateLambda } from "../shared/lambda";
+import { createLambda as defaultCreateLambda, MAXIMUM_LAMBDA_TIMEOUT } from "../shared/lambda";
 import { createQueue as defaultCreateQueue, provideAccessToQueue } from "../shared/sqs";
 import { isProd } from "../shared/util";
 
@@ -16,7 +16,7 @@ function settings() {
   const prod = isProd(config);
   // How long can the lambda run for, max is 900 seconds (15 minutes)
   // It SHOULD be slightly less than the ALB timeout of the FHIR server
-  const lambdaTimeout = Duration.minutes(15).minus(Duration.seconds(5));
+  const lambdaTimeout = MAXIMUM_LAMBDA_TIMEOUT.minus(Duration.seconds(5));
   return {
     connectorName: "FHIRServer",
     lambdaMemory: 512,

--- a/infra/lib/fhir-converter-service.ts
+++ b/infra/lib/fhir-converter-service.ts
@@ -24,6 +24,8 @@ export function settings() {
     memoryLimitMiB: prod ? 8192 : 4096,
     taskCountMin: prod ? 2 : 1,
     taskCountMax: prod ? 30 : 10,
+    // How long this service can run for
+    maxExecutionTimeout: Duration.minutes(15),
   };
 }
 
@@ -38,7 +40,7 @@ export function createFHIRConverterService(
   vpc: ec2.IVpc,
   alarmAction: SnsAction | undefined
 ): { service: FargateService; address: string } {
-  const { cpu, memoryLimitMiB, taskCountMin, taskCountMax } = settings();
+  const { cpu, memoryLimitMiB, taskCountMin, taskCountMax, maxExecutionTimeout } = settings();
 
   // Create a new Amazon Elastic Container Service (ECS) cluster
   const cluster = new ecs.Cluster(stack, "FHIRConverterCluster", { vpc, containerInsights: true });
@@ -69,6 +71,7 @@ export function createFHIRConverterService(
       },
       healthCheckGracePeriod: Duration.seconds(60),
       publicLoadBalancer: false,
+      idleTimeout: maxExecutionTimeout,
     }
   );
   const serverAddress = fargateService.loadBalancer.loadBalancerDnsName;

--- a/infra/lib/fhir-converter-service.ts
+++ b/infra/lib/fhir-converter-service.ts
@@ -10,6 +10,7 @@ import { Construct } from "constructs";
 import { EnvConfig } from "./env-config";
 import { getConfig } from "./shared/config";
 import { vCPU } from "./shared/fargate";
+import { MAXIMUM_LAMBDA_TIMEOUT } from "./shared/lambda";
 import { isProd } from "./shared/util";
 
 export function settings() {
@@ -25,7 +26,7 @@ export function settings() {
     taskCountMin: prod ? 2 : 1,
     taskCountMax: prod ? 30 : 10,
     // How long this service can run for
-    maxExecutionTimeout: Duration.minutes(15),
+    maxExecutionTimeout: MAXIMUM_LAMBDA_TIMEOUT,
   };
 }
 

--- a/infra/lib/shared/lambda.ts
+++ b/infra/lib/shared/lambda.ts
@@ -14,7 +14,8 @@ import { Construct } from "constructs";
 import { getConfig, METRICS_NAMESPACE } from "./config";
 import { addErrorAlarmToLambdaFunc } from "./util";
 
-export const DEFAULT_LAMBDA_TIMEOUT_SECONDS = 10;
+export const DEFAULT_LAMBDA_TIMEOUT = Duration.seconds(30);
+export const MAXIMUM_LAMBDA_TIMEOUT = Duration.minutes(15);
 const pathToLambdas = "../api/lambdas";
 
 export const buildEventRule = (scope: Construct, id: string, scheduleExpression: string): Rule =>
@@ -64,7 +65,7 @@ export function createLambda(props: LambdaProps): Lambda {
      * queue's VisibilityTimeout so the message is not processed more than once.
      * See: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
      */
-    timeout: props.timeout ?? Duration.seconds(DEFAULT_LAMBDA_TIMEOUT_SECONDS), // max 900
+    timeout: props.timeout ?? DEFAULT_LAMBDA_TIMEOUT,
     memorySize: props.memory,
     reservedConcurrentExecutions: props.reservedConcurrentExecutions,
     role: props.role ?? undefined,

--- a/infra/lib/shared/sqs.ts
+++ b/infra/lib/shared/sqs.ts
@@ -3,7 +3,7 @@ import { IVpc } from "aws-cdk-lib/aws-ec2";
 import { IGrantable } from "aws-cdk-lib/aws-iam";
 import { IQueue, Queue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs/lib/construct";
-import { createRetryLambda, DEFAULT_LAMBDA_TIMEOUT_SECONDS } from "./lambda";
+import { createRetryLambda, DEFAULT_LAMBDA_TIMEOUT } from "./lambda";
 
 /**
  * ...set the source queue's visibility timeout to at least six times the timeout that
@@ -84,7 +84,9 @@ function createStandardQueue(props: StandardQueueProps): Queue {
     receiveMessageWaitTime: props.receiveMessageWaitTime ?? Duration.seconds(0),
     visibilityTimeout:
       props.visibilityTimeout ??
-      Duration.seconds(DEFAULT_LAMBDA_TIMEOUT_SECONDS * DEFAULT_VISIBILITY_TIMEOUT_MULTIPLIER + 1),
+      Duration.seconds(
+        DEFAULT_LAMBDA_TIMEOUT.toSeconds() * DEFAULT_VISIBILITY_TIMEOUT_MULTIPLIER + 1
+      ),
     deadLetterQueue: props.dlq
       ? {
           maxReceiveCount:
@@ -109,7 +111,9 @@ function createFifoQueue(props: FifoQueueProps): Queue {
     receiveMessageWaitTime: props.receiveMessageWaitTime ?? Duration.seconds(0),
     visibilityTimeout:
       props.visibilityTimeout ??
-      Duration.seconds(DEFAULT_LAMBDA_TIMEOUT_SECONDS * DEFAULT_VISIBILITY_TIMEOUT_MULTIPLIER + 1),
+      Duration.seconds(
+        DEFAULT_LAMBDA_TIMEOUT.toSeconds() * DEFAULT_VISIBILITY_TIMEOUT_MULTIPLIER + 1
+      ),
     contentBasedDeduplication: props.contentBasedDeduplication ?? false, // if false, expects MessageDeduplicationId on message
     deadLetterQueue: props.dlq
       ? {


### PR DESCRIPTION
Ref. metriport/metriport-internal#738

### Dependencies

- Upstream: https://github.com/metriport/fhir-server/pull/26
- Downstream: none

### Description

- adj lambda timeout to match LBs, 15min
- adj converter lambda to diff concurrencies in prod/staging
- include 503 on error codes to check on lambdas

### Release Plan

- alongside dependencies