### PR TITLE
fix(api): fix doc ref date filter to not return null

### DIFF
--- a/api/app/src/routes/medical/document.ts
+++ b/api/app/src/routes/medical/document.ts
@@ -46,7 +46,7 @@ router.get(
     const dateTo = parseISODate(getFrom("query").optional("dateTo", req));
 
     const documents = await getDocuments({ cxId, patientId });
-    const documentsDTO = toDTO(documents).map(doc => {
+    const documentsDTO = toDTO(documents).flatMap(doc => {
       if (!doc.indexed) return doc;
       if (
         (!dateFrom || dayjs(dateFrom).isBefore(doc.indexed)) &&
@@ -54,6 +54,7 @@ router.get(
       ) {
         return doc;
       }
+      return [];
     });
 
     const patient = await getPatientOrFail({ cxId, id: patientId });


### PR DESCRIPTION
refs. metriport/metriport-internal#731

### Dependencies

N/A

### Description

fix doc ref date filter to not return null

### Release Plan

asap
⚠️ this is pointing to master
