### PR TITLE
706 add alarm to DLQ

### DIFF
--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -24,10 +24,10 @@ import * as fhirConverterConnector from "./api-stack/fhir-converter-connector";
 import * as fhirServerConnector from "./api-stack/fhir-server-connector";
 import { EnvConfig } from "./env-config";
 import { createFHIRConverterService } from "./fhir-converter-service";
-import { createLambda } from "./shared/lambda";
+import { addErrorAlarmToLambdaFunc, createLambda } from "./shared/lambda";
 import { getSecrets } from "./shared/secrets";
 import { provideAccessToQueue } from "./shared/sqs";
-import { addErrorAlarmToLambdaFunc, isProd, isSandbox, mbToBytes } from "./shared/util";
+import { isProd, isSandbox, mbToBytes } from "./shared/util";
 
 interface APIStackProps extends StackProps {
   config: EnvConfig;
@@ -179,7 +179,11 @@ export class APIStack extends Stack {
       queue: fhirConverterQueue,
       dlq: fhirConverterDLQ,
       bucket: fhirConverterBucket,
-    } = fhirConverterConnector.createQueueAndBucket({ stack: this, vpc: this.vpc });
+    } = fhirConverterConnector.createQueueAndBucket({
+      stack: this,
+      vpc: this.vpc,
+      alarmSnsAction: slackNotification?.alarmAction,
+    });
 
     const fhirServerQueue = fhirServerConnector.createConnector({
       envType: props.config.environmentType,

--- a/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/infra/lib/api-stack/fhir-converter-connector.ts
@@ -41,7 +41,15 @@ function settings() {
   };
 }
 
-export function createQueueAndBucket({ stack, vpc }: { stack: Construct; vpc: IVpc }): {
+export function createQueueAndBucket({
+  stack,
+  vpc,
+  alarmSnsAction,
+}: {
+  stack: Construct;
+  vpc: IVpc;
+  alarmSnsAction?: SnsAction;
+}): {
   queue: Queue;
   dlq: DeadLetterQueue;
   bucket: s3.Bucket;
@@ -57,6 +65,7 @@ export function createQueueAndBucket({ stack, vpc }: { stack: Construct; vpc: IV
     fifo: false,
     visibilityTimeout,
     maxReceiveCount,
+    alarmSnsAction,
   });
 
   const dlq = queue.deadLetterQueue;

--- a/infra/lib/api-stack/fhir-server-connector.ts
+++ b/infra/lib/api-stack/fhir-server-connector.ts
@@ -76,6 +76,7 @@ export function createConnector({
     fifo: false,
     visibilityTimeout,
     maxReceiveCount,
+    alarmSnsAction,
   });
 
   const dlq = queue.deadLetterQueue;

--- a/infra/lib/connect-widget-stack.ts
+++ b/infra/lib/connect-widget-stack.ts
@@ -10,7 +10,7 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import { ConnectWidgetConfig, EnvConfig } from "./env-config";
-import { addErrorAlarmToLambdaFunc } from "./shared/util";
+import { addErrorAlarmToLambdaFunc } from "./shared/lambda";
 
 interface ConnectWidgetStackProps extends StackProps {
   config: Omit<EnvConfig, "connectWidget" | "connectWidgetUrl"> & {

--- a/infra/lib/shared/lambda.ts
+++ b/infra/lib/shared/lambda.ts
@@ -6,13 +6,13 @@ import { ISubnet, IVpc } from "aws-cdk-lib/aws-ec2";
 import { Rule, Schedule } from "aws-cdk-lib/aws-events";
 import * as iam from "aws-cdk-lib/aws-iam";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Function as Lambda, Runtime } from "aws-cdk-lib/aws-lambda";
 import * as lambda_node from "aws-cdk-lib/aws-lambda-nodejs";
 import { FilterPattern } from "aws-cdk-lib/aws-logs";
 import { Queue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
 import { getConfig, METRICS_NAMESPACE } from "./config";
-import { addErrorAlarmToLambdaFunc } from "./util";
 
 export const DEFAULT_LAMBDA_TIMEOUT = Duration.seconds(30);
 export const MAXIMUM_LAMBDA_TIMEOUT = Duration.minutes(15);
@@ -195,3 +195,23 @@ export function createRetryLambda(props: RetryLambdaProps): Lambda {
 
 //   return lambdaFn;
 // };
+
+export function addErrorAlarmToLambdaFunc(
+  construct: Construct,
+  lambdaFunc: lambda.SingletonFunction | lambda_node.NodejsFunction,
+  alarmName: string,
+  alarmAction?: SnsAction
+) {
+  const errMetric = lambdaFunc.metricErrors({
+    period: Duration.minutes(1),
+  });
+  // 👇 create an Alarm directly on the Metric
+  const alarm = errMetric.createAlarm(construct, alarmName, {
+    threshold: 1,
+    evaluationPeriods: 1,
+    alarmDescription:
+      "Alarm if the SUM of Lambda invocations is greater than or equal to the  threshold (1) for 1 evaluation period",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  });
+  alarmAction && alarm.addAlarmAction(alarmAction);
+}

--- a/infra/lib/shared/util.ts
+++ b/infra/lib/shared/util.ts
@@ -1,9 +1,3 @@
-import { Duration } from "aws-cdk-lib";
-import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
-import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
-import * as lambda from "aws-cdk-lib/aws-lambda";
-import * as lambda_node from "aws-cdk-lib/aws-lambda-nodejs";
-import { Construct } from "constructs";
 import { EnvConfig } from "../env-config";
 import { EnvType } from "../env-type";
 
@@ -15,26 +9,6 @@ export function isProd(config: EnvConfig): boolean {
 }
 export function isSandbox(config: EnvConfig): boolean {
   return config.environmentType === EnvType.sandbox;
-}
-
-export function addErrorAlarmToLambdaFunc(
-  construct: Construct,
-  lambdaFunc: lambda.SingletonFunction | lambda_node.NodejsFunction,
-  alarmName: string,
-  alarmAction?: SnsAction
-) {
-  const errMetric = lambdaFunc.metricErrors({
-    period: Duration.minutes(1),
-  });
-  // 👇 create an Alarm directly on the Metric
-  const alarm = errMetric.createAlarm(construct, alarmName, {
-    threshold: 1,
-    evaluationPeriods: 1,
-    alarmDescription:
-      "Alarm if the SUM of Lambda invocations is greater than or equal to the  threshold (1) for 1 evaluation period",
-    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-  });
-  alarmAction && alarm.addAlarmAction(alarmAction);
 }
 
 export function mbToBytes(mb: number): number {


### PR DESCRIPTION
Ref. metriport/metriport-internal#706

### Dependencies

none

### Description

- Add alarm to DLQ
- Moved `addErrorAlarmToLambdaFunc` to the lambda shared file

### Release Plan

- nothing special