### PR TITLE
738 add missing request on FHIR bundle

### DIFF
--- a/api/lambdas/sqs-to-converter/index.js
+++ b/api/lambdas/sqs-to-converter/index.js
@@ -147,6 +147,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
         await reportMemoryUsage();
         addExtensionToConversion(conversionResult, documentExtension);
         removePatientFromConversion(conversionResult);
+        addMissingRequests(conversionResult);
 
         await reportMemoryUsage();
         await sendConversionResult(cxId, s3FileName, conversionResult, jobStartedAt, log);
@@ -202,6 +203,17 @@ function removePatientFromConversion(conversion) {
   const entries = conversion.fhirResource?.entry ?? [];
   const pos = entries.findIndex(e => e.resource?.resourceType === "Patient");
   if (pos >= 0) conversion.fhirResource.entry.splice(pos, 1);
+}
+
+function addMissingRequests(conversion) {
+  conversion.fhirResource.entry.forEach(e => {
+    if (!e.request) {
+      e.request = {
+        method: "PUT",
+        url: `${e.resource.resourceType}/${e.resource.id}}`,
+      };
+    }
+  });
 }
 
 // Being more generic with errors, not strictly timeouts

--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -784,7 +784,7 @@ export class APIStack extends Stack {
 
     const writeIOPsMetric = dbCluster.metricVolumeWriteIOPs();
     const wIOPSAlarm = writeIOPsMetric.createAlarm(this, `${dbClusterName}VolumeWriteIOPsAlarm`, {
-      threshold: 5000, // IOPs per second
+      threshold: 10000, // IOPs per second
       evaluationPeriods: 1,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });


### PR DESCRIPTION
Ref. metriport/metriport-internal#738

### Dependencies

none

### Description

- add missing request on FHIR bundle after converting from CDA to FHIR
- increase IOPS alarm from 5,000 to 10,000 IOPS

### Release Plan

- ⚠️ This is pointing to `master`