### PR TITLE
build: add FHIR load test package

### DIFF
--- a/api/app/src/routes/util.ts
+++ b/api/app/src/routes/util.ts
@@ -3,6 +3,7 @@ import httpStatus from "http-status";
 import { ApiTypes } from "../command/usage/report-usage";
 import BadRequestError from "../errors/bad-request";
 import { analytics, EventTypes } from "../shared/analytics";
+import { Config } from "../shared/config";
 import { capture } from "../shared/notifications";
 
 export const asyncHandler =
@@ -19,7 +20,7 @@ export const asyncHandler =
       analyzeRoute(req);
       await f(req, res, next);
     } catch (err) {
-      console.error(err);
+      Config.isCloudEnv() && console.error(err);
       next(err);
     }
   };

--- a/fhir-test/.env.example
+++ b/fhir-test/.env.example
@@ -1,0 +1,8 @@
+REGION=us-east-1
+
+MEDPLUM_USER=user@domain.com
+MEDPLUM_PASSWORD=password
+MEDPLUM_URL=https://domain.com
+
+HAPI_URL=https://domain.com
+HAPI_TENANT_ID=some-id

--- a/fhir-test/.gitignore
+++ b/fhir-test/.gitignore
@@ -1,0 +1,4 @@
+.env
+node_modules
+src/fhir/batch/**/*
+test-run-report*

--- a/fhir-test/README.md
+++ b/fhir-test/README.md
@@ -1,0 +1,55 @@
+# FHIR Test
+
+Tests to validate two base implementations of FHIR servers:
+
+- [HAPI FHIR JPA Server](https://github.com/hapifhir/hapi-fhir-jpaserver-starter)
+- [Medplum](https://github.com/medplum/medplum)
+
+It's based on [Artillery](https://www.artillery.io/) and publishes metrics on [AWS Cloudwatch](https://aws.amazon.com/cloudwatch/).
+
+### Getting Started
+
+Install Artillery globally, if not installed already:
+
+```shell
+$ npm i artillery -g
+```
+
+Install dependencies:
+
+```shell
+$ npm i
+```
+
+Set environment variables or store them on a `.env` file (see `.env.example`).
+
+The tests included here are load tests, meaning they'll execute hundreds/thousands of requests to the chosen server.
+
+Batch tests will execute a tens/lower hundred tests, because of the nature of the batch inserting a lot of data.
+
+Run desired test (this one runs load testing for HAPI, loading env vars from a `.env` file):
+
+```shell
+$ artillery run --dotenv .env src/healthcheck-medplum.yml
+```
+
+To run batch tests, first store FHIR Bundles in JSON format under the `src/fhir/batch` - tests will pick a file for
+each request randomly.
+
+To see detailed information about requests/responses, set an env var:
+
+```shell
+$ DEBUG=http:response artillery run --dotenv .env src/healthcheck-medplum.yml
+```
+
+To store the result of the tests on a file:
+
+```shell
+$ artillery run --dotenv .env --output test-run-report.json src/healthcheck-medplum.yml
+```
+
+And to generate a report in HTML:
+
+```shell
+$ artillery report test-run-report.json
+```

--- a/fhir-test/package-lock.json
+++ b/fhir-test/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "fhir-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fhir-test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@faker-js/faker": "^8.0.2"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.2.tgz",
+      "integrity": "sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
+      }
+    }
+  }
+}

--- a/fhir-test/package.json
+++ b/fhir-test/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fhir-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@faker-js/faker": "^8.0.2"
+  }
+}

--- a/fhir-test/src/example.js
+++ b/fhir-test/src/example.js
@@ -1,0 +1,23 @@
+const functionFromProcessor = async (userContext, events, done) => {
+  userContext.vars.requestBodyFromProcessor = "something";
+  // continue with executing the scenario:
+  return done();
+};
+
+// https://www.artillery.io/docs/guides/guides/http-reference#beforerequest-hooks
+function setJSONBody(requestParams, context, ee, next) {
+  // ...
+  return next(); // MUST be called for the scenario to continue
+}
+
+// https://www.artillery.io/docs/guides/guides/http-reference#afterresponse-hooks
+function logHeaders(requestParams, response, context, ee, next) {
+  console.log(response.headers);
+  return next(); // MUST be called for the scenario to continue
+}
+
+module.exports = {
+  functionFromProcessor,
+  setJSONBody,
+  logHeaders,
+};

--- a/fhir-test/src/example.yml
+++ b/fhir-test/src/example.yml
@@ -1,0 +1,57 @@
+config:
+  target: "https://yourserver.com"
+  # https://www.artillery.io/docs/guides/guides/test-script-reference#environments---config-profiles
+  # environments:
+  #   staging:
+  #     target: "http://staging.yourserver.com"
+  http:
+    # Responses have to be sent within 60 seconds, or an `ETIMEDOUT` error gets raised.
+    timeout: 60
+  plugins:
+    publish-metrics:
+      # https://www.artillery.io/docs/guides/plugins/plugin-publish-metrics#cloudwatch
+      - type: cloudwatch
+        region: us-east-1
+  phases:
+    - duration: 1
+      arrivalRate: 1
+      name: Warm up
+    - duration: 60
+      arrivalRate: 10
+      rampTo: 50
+      name: Ramp up load
+  variables:
+    auth: "Bearer ....."
+  processor: "./example.js"
+
+before:
+  flow:
+    - log: "Get auth token"
+    - post:
+        url: "/auth/login"
+        json:
+          email: "admin@domain.com"
+          password: "password"
+        capture:
+          - json: $.code
+            as: token
+
+scenarios:
+  - name: "Example"
+    beforeScenario: functionFromProcessor
+    flow:
+      - log: "Got variable {{ requestBodyFromProcessor }}"
+
+      - post:
+          url: "/fhir/R4/"
+          headers:
+            Authorization: "Bearer {{ token }}"
+          json: "{{ requestBodyFromProcessor }}"
+          capture:
+            - json: "$.id"
+              as: "patientId"
+
+      - get:
+          url: "/fhir/R4/Patient/{{ patientId }}"
+          beforeRequest: "setJSONBody"
+          afterResponse: "logHeaders"

--- a/fhir-test/src/fhir/fhir-batch-hapi.yml
+++ b/fhir-test/src/fhir/fhir-batch-hapi.yml
@@ -1,0 +1,34 @@
+config:
+  target: "{{ $processEnvironment.HAPI_URL }}"
+  http:
+    timeout: 120
+  plugins:
+    # https://www.artillery.io/docs/guides/plugins/plugin-publish-metrics
+    publish-metrics:
+      - type: cloudwatch
+        region: "{{ $processEnvironment.REGION }}"
+  phases:
+    # two users, one every 3 seconds
+    - duration: 6
+      arrivalCount: 2
+      name: Warm up
+    # - duration: 60
+    #   arrivalRate: 10
+    #   rampTo: 50
+    # name: Ramp up load
+  variables:
+    tenantId: "{{ $processEnvironment.HAPI_TENANT_ID }}"
+  processor: "./fhir-batch.js"
+
+scenarios:
+  - name: "FHIR Batch HAPI"
+    beforeScenario: generatePostBody
+    flow:
+      - log: "Posting batch {{ requestFile }}"
+      - post:
+          url: "/fhir/{{tenantId}}/"
+          headers:
+          json: "{{ requestBody }}"
+
+      # - get:
+      #     url: '/fhir/{{tenantId}}/Patient/31329'

--- a/fhir-test/src/fhir/fhir-batch-medplum.yml
+++ b/fhir-test/src/fhir/fhir-batch-medplum.yml
@@ -1,0 +1,58 @@
+config:
+  target: "{{ $processEnvironment.MEDPLUM_URL }}"
+  http:
+    timeout: 120
+  plugins:
+    # https://www.artillery.io/docs/guides/plugins/plugin-publish-metrics
+    publish-metrics:
+      - type: cloudwatch
+        region: "{{ $processEnvironment.REGION }}"
+  phases:
+    # two users, one every 3 seconds
+    - duration: 6
+      arrivalCount: 2
+      name: Warm up
+    # - duration: 60
+    #   arrivalRate: 10
+    #   rampTo: 50
+    # name: Ramp up load
+  variables:
+    codeChallenge: "{{ $randomString() }}"
+  processor: "./fhir-batch.js"
+
+before:
+  flow:
+    - log: "Get auth token"
+    - post:
+        url: "/auth/login"
+        json:
+          email: "{{ $processEnvironment.MEDPLUM_USER }}"
+          password: "{{ $processEnvironment.MEDPLUM_PASSWORD }}"
+          codeChallengeMethod: "plain"
+          codeChallenge: "{{ codeChallenge }}"
+        capture:
+          - json: $.code
+            as: code
+    - post:
+        url: "/oauth2/token"
+        form:
+          grant_type: "authorization_code"
+          code: "{{ code }}"
+          code_verifier: "{{ codeChallenge }}"
+        capture:
+          - json: $.access_token
+            as: token
+
+scenarios:
+  - name: "FHIR Batch Medplum"
+    beforeScenario: generatePostBody
+    flow:
+      - log: "Posting batch {{ requestFile }}"
+      - post:
+          url: "/fhir/R4/"
+          headers:
+            Authorization: "Bearer {{ token }}"
+          json: "{{ requestBody }}"
+
+      # - get:
+      #     url: '/fhir/R4/Patient/31329'

--- a/fhir-test/src/fhir/fhir-batch.js
+++ b/fhir-test/src/fhir/fhir-batch.js
@@ -1,0 +1,26 @@
+// Based on: https://github.com/artilleryio/artillery/issues/791#issuecomment-578592350
+const fs = require("fs");
+const { faker } = require("@faker-js/faker");
+
+const path = `${__dirname}/batch`;
+
+/**
+ * Generates post body
+ */
+const generatePostBody = async (userContext, events, done) => {
+  try {
+    const files = fs.readdirSync(path);
+    const chosenFile = faker.helpers.arrayElement(files);
+    // add variables to virtual user's context:
+    const fileContents = fs.readFileSync(path + "/" + chosenFile, "utf8");
+    userContext.vars.requestBody = JSON.parse(fileContents);
+    userContext.vars.requestFile = chosenFile;
+    // continue with executing the scenario:
+    return done();
+  } catch (err) {
+    console.log(`Error occurred in function generatePostBody. Detail: ${err}`);
+    throw err;
+  }
+};
+
+module.exports.generatePostBody = generatePostBody;

--- a/fhir-test/src/fhir/fhir-crud-hapi.yml
+++ b/fhir-test/src/fhir/fhir-crud-hapi.yml
@@ -1,0 +1,58 @@
+config:
+  target: "{{ $processEnvironment.HAPI_URL }}"
+  http:
+    timeout: 60
+  plugins:
+    # https://www.artillery.io/docs/guides/plugins/plugin-publish-metrics
+    publish-metrics:
+      - type: cloudwatch
+        region: "{{ $processEnvironment.REGION }}"
+    # https://www.artillery.io/docs/guides/plugins/plugin-metrics-by-endpoint
+    metrics-by-endpoint:
+      # Group metrics by request name rather than URL:
+      useOnlyRequestNames: true
+  phases:
+    - duration: 10
+      arrivalRate: 2
+      name: Warm up
+    - duration: 60
+      arrivalRate: 10
+      rampTo: 50
+      name: Ramp up load
+    - duration: 120
+      arrivalRate: 20
+      rampTo: 100
+      name: Ramp up load
+  variables:
+    tenantId: "{{ $processEnvironment.HAPI_TENANT_ID }}"
+
+scenarios:
+  - name: "FHIR CRUD HAPI"
+    flow:
+      - loop:
+          - post:
+              url: "/fhir/{{tenantId}}/Patient"
+              headers:
+              json:
+                resourceType: Patient
+                name:
+                  - family: "{{ $randomString() }}"
+              capture:
+                - json: "$.id"
+                  as: "patientId"
+                - json: "$.name[0].family"
+                  as: "familyName"
+              name: "Create Patient"
+          - get:
+              url: "/fhir/{{tenantId}}/Patient/{{ patientId }}"
+              headers:
+              name: "Get Patient by ID"
+          - get:
+              url: "/fhir/{{tenantId}}/Patient?name={{ familyName }}"
+              headers:
+              name: "Get Patient by name"
+          - delete:
+              url: "/fhir/{{tenantId}}/Patient/{{ patientId }}"
+              headers:
+              name: "Delete Patient"
+        count: 2

--- a/fhir-test/src/fhir/fhir-crud-medplum.yml
+++ b/fhir-test/src/fhir/fhir-crud-medplum.yml
@@ -1,0 +1,87 @@
+config:
+  target: "{{ $processEnvironment.MEDPLUM_URL }}"
+  http:
+    timeout: 60
+  plugins:
+    # https://www.artillery.io/docs/guides/plugins/plugin-publish-metrics
+    publish-metrics:
+      - type: cloudwatch
+        region: "{{ $processEnvironment.REGION }}"
+    # https://www.artillery.io/docs/guides/plugins/plugin-metrics-by-endpoint
+    metrics-by-endpoint:
+      # Group metrics by request name rather than URL:
+      useOnlyRequestNames: true
+  phases:
+    - duration: 10
+      arrivalRate: 2
+      name: Warm up
+    - duration: 60
+      arrivalRate: 10
+      rampTo: 50
+      name: Ramp up load
+    - duration: 120
+      arrivalRate: 20
+      rampTo: 100
+      name: Ramp up load
+  variables:
+    codeChallenge: "{{ $randomString() }}"
+
+before:
+  flow:
+    - log: "Get auth token"
+    - post:
+        url: "/auth/login"
+        json:
+          email: "{{ $processEnvironment.MEDPLUM_USER }}"
+          password: "{{ $processEnvironment.MEDPLUM_PASSWORD }}"
+          codeChallengeMethod: "plain"
+          codeChallenge: "{{ codeChallenge }}"
+        capture:
+          - json: $.code
+            as: code
+        name: "Login"
+    - post:
+        url: "/oauth2/token"
+        form:
+          grant_type: "authorization_code"
+          code: "{{ code }}"
+          code_verifier: "{{ codeChallenge }}"
+        capture:
+          - json: $.access_token
+            as: token
+        name: "Get OAuth token"
+
+scenarios:
+  - name: "FHIR CRUD Medplum"
+    flow:
+      - loop:
+          - post:
+              url: "/fhir/R4/Patient"
+              headers:
+                Authorization: "Bearer {{ token }}"
+              json:
+                resourceType: Patient
+                name:
+                  - family: "{{ $randomString() }}"
+              capture:
+                - json: "$.id"
+                  as: "patientId"
+                - json: "$.name[0].family"
+                  as: "familyName"
+              name: "Create Patient"
+          - get:
+              url: "/fhir/R4/Patient/{{ patientId }}"
+              headers:
+                Authorization: "Bearer {{ token }}"
+              name: "Get Patient by ID"
+          - get:
+              url: "/fhir/R4/Patient?name={{ familyName }}"
+              headers:
+                Authorization: "Bearer {{ token }}"
+              name: "Get Patient by name"
+          - delete:
+              url: "/fhir/R4/Patient/{{ patientId }}"
+              headers:
+                Authorization: "Bearer {{ token }}"
+              name: "Delete Patient"
+        count: 2

--- a/fhir-test/src/healthcheck-hapi.yml
+++ b/fhir-test/src/healthcheck-hapi.yml
@@ -1,0 +1,23 @@
+config:
+  target: "{{ $processEnvironment.HAPI_URL }}"
+  plugins:
+    publish-metrics:
+      # https://www.artillery.io/docs/guides/plugins/plugin-publish-metrics#cloudwatch
+      - type: cloudwatch
+        region: "{{ $processEnvironment.REGION }}"
+  phases:
+    - duration: 10
+      arrivalRate: 10
+      name: Warm up
+    - duration: 60
+      arrivalRate: 50
+      rampTo: 200
+      name: Ramp up load
+
+scenarios:
+  - name: 'Healthcheck HAPI'
+    flow:
+      - loop:
+          - get:
+              url: '/'
+        count: 10

--- a/fhir-test/src/healthcheck-medplum.yml
+++ b/fhir-test/src/healthcheck-medplum.yml
@@ -1,0 +1,23 @@
+config:
+  target: "{{ $processEnvironment.MEDPLUM_URL }}"
+  plugins:
+    publish-metrics:
+      # https://www.artillery.io/docs/guides/plugins/plugin-publish-metrics#cloudwatch
+      - type: cloudwatch
+        region: "{{ $processEnvironment.REGION }}"
+  phases:
+    - duration: 10
+      arrivalRate: 10
+      name: Warm up
+    - duration: 60
+      arrivalRate: 50
+      rampTo: 200
+      name: Ramp up load
+
+scenarios:
+  - name: 'Healthcheck Medplum'
+    flow:
+      - loop:
+          - get:
+              url: '/healthcheck'
+        count: 10


### PR DESCRIPTION
Ref. metriport/metriport-internal#746

### Dependencies

none

### Description

Introduces FHIR load test with Artillery.

This does not closes #746, it sets the base for the remaining tests.

### Release Plan

- it will lead to a deploy bc of a small change on `api/app/src/routes/util.ts` (log only)