### PR TITLE
fix(api): provider map token check

### DIFF
--- a/api/app/src/command/connected-user/get-connected-user.ts
+++ b/api/app/src/command/connected-user/get-connected-user.ts
@@ -34,10 +34,14 @@ export const getProviderDataFromConnectUserOrFail = (
   provider: ProviderOptions
 ) => {
   if (!connectedUser.providerMap) throw new NotFoundError("Could not find provider map");
-  const providerData = connectedUser.providerMap[provider];
-  if (!providerData) throw new NotFoundError("Provider map has no data");
 
-  return providerData;
+  if (connectedUser.providerMap[provider]?.token) {
+    const providerData = connectedUser.providerMap[provider];
+    if (!providerData) throw new NotFoundError("Provider map has no data");
+    return providerData;
+  } else {
+    throw new NotFoundError(`Could not find connect token for ${provider}`);
+  }
 };
 
 export const getConnectedUsers = async ({

--- a/api/app/src/command/connected-user/get-connected-user.ts
+++ b/api/app/src/command/connected-user/get-connected-user.ts
@@ -29,19 +29,16 @@ export const getConnectedUserOrFail = async ({
   return connectedUser;
 };
 
-export const getProviderDataFromConnectUserOrFail = (
+export const getProviderTokenFromConnectedUserOrFail = (
   connectedUser: ConnectedUser,
   provider: ProviderOptions
 ) => {
   if (!connectedUser.providerMap) throw new NotFoundError("Could not find provider map");
 
-  if (connectedUser.providerMap[provider]?.token) {
-    const providerData = connectedUser.providerMap[provider];
-    if (!providerData) throw new NotFoundError("Provider map has no data");
-    return providerData;
-  } else {
-    throw new NotFoundError(`Could not find connect token for ${provider}`);
-  }
+  const token = connectedUser.providerMap[provider]?.token;
+  if (token) return token;
+
+  throw new NotFoundError(`Could not find connect token for ${provider}`);
 };
 
 export const getConnectedUsers = async ({

--- a/api/app/src/providers/cronometer.ts
+++ b/api/app/src/providers/cronometer.ts
@@ -8,7 +8,7 @@ import { Config } from "../shared/config";
 import { PROVIDER_CRONOMETER } from "../shared/constants";
 import { OAuth2, OAuth2DefaultImpl } from "./oauth2";
 import Provider, { ConsumerHealthDataType } from "./provider";
-import { getProviderDataFromConnectUserOrFail } from "../command/connected-user/get-connected-user";
+import { getProviderTokenFromConnectedUserOrFail } from "../command/connected-user/get-connected-user";
 
 const axios = Axios.create();
 
@@ -52,9 +52,7 @@ export class Cronometer extends Provider implements OAuth2 {
   }
 
   private getAccessToken(connectedUser: ConnectedUser): string {
-    const providerData = getProviderDataFromConnectUserOrFail(connectedUser, PROVIDER_CRONOMETER);
-
-    return providerData.token;
+    return getProviderTokenFromConnectedUserOrFail(connectedUser, PROVIDER_CRONOMETER);
   }
 
   async revokeProviderAccess(connectedUser: ConnectedUser) {

--- a/api/app/src/providers/dexcom.ts
+++ b/api/app/src/providers/dexcom.ts
@@ -8,7 +8,7 @@ import Provider, { ConsumerHealthDataType } from "./provider";
 import { Config } from "../shared/config";
 import { ConnectedUser } from "../models/connected-user";
 import { updateProviderData } from "../command/connected-user/save-connected-user";
-import { getProviderDataFromConnectUserOrFail } from "../command/connected-user/get-connected-user";
+import { getProviderTokenFromConnectedUserOrFail } from "../command/connected-user/get-connected-user";
 import { mapToBiometrics } from "../mappings/dexcom/biometrics";
 import { mapToNutrition } from "../mappings/dexcom/nutrition";
 import { dexcomEvgsResp } from "../mappings/dexcom/models/evgs";
@@ -56,9 +56,7 @@ export class Dexcom extends Provider implements OAuth2 {
   }
 
   private async getAccessToken(connectedUser: ConnectedUser): Promise<string> {
-    const providerData = getProviderDataFromConnectUserOrFail(connectedUser, PROVIDER_DEXCOM);
-
-    const token = providerData.token;
+    const token = getProviderTokenFromConnectedUserOrFail(connectedUser, PROVIDER_DEXCOM);
 
     const refreshedToken = await this.checkRefreshToken(token, connectedUser);
 

--- a/api/app/src/providers/oauth2.ts
+++ b/api/app/src/providers/oauth2.ts
@@ -5,7 +5,7 @@ import { updateProviderData } from "../command/connected-user/save-connected-use
 import { ConnectedUser } from "../models/connected-user";
 import { Config } from "../shared/config";
 import { ProviderOAuth2Options } from "../shared/constants";
-import { getProviderDataFromConnectUserOrFail } from "../command/connected-user/get-connected-user";
+import { getProviderTokenFromConnectedUserOrFail } from "../command/connected-user/get-connected-user";
 
 export const oauthUserTokenResponse = z.object({
   oauth_token: z.string(),
@@ -147,9 +147,7 @@ export class OAuth2DefaultImpl implements OAuth2 {
   }
 
   async getAccessToken(connectedUser: ConnectedUser): Promise<string> {
-    const providerData = getProviderDataFromConnectUserOrFail(connectedUser, this.providerName);
-
-    const token = providerData.token;
+    const token = getProviderTokenFromConnectedUserOrFail(connectedUser, this.providerName);
 
     const refreshedToken = await this.checkRefreshToken(token, connectedUser);
 
@@ -167,8 +165,6 @@ export class OAuth2DefaultImpl implements OAuth2 {
   }
 
   async revokeLocal(connectedUser: ConnectedUser): Promise<string> {
-    const providerData = getProviderDataFromConnectUserOrFail(connectedUser, this.providerName);
-
     await updateProviderData({
       id: connectedUser.id,
       cxId: connectedUser.cxId,
@@ -176,7 +172,7 @@ export class OAuth2DefaultImpl implements OAuth2 {
       providerItem: undefined,
     });
 
-    return providerData.token;
+    return getProviderTokenFromConnectedUserOrFail(connectedUser, this.providerName);
   }
 
   async fetchProviderData<T>(


### PR DESCRIPTION
refs. metriport/metriport#421

Ref: #_[ticket-number]_

### Description

Modified getProviderDataFromConnectUserOrFail() to include a check for the existence of a token attribute in a providerMap[provider] entry. 

The second part of the issue will be raised separately. 

