### PR TITLE
feat(widget): docs link for no token

### DIFF
--- a/connect-widget/app/src/pages/connect/components/connect-providers.tsx
+++ b/connect-widget/app/src/pages/connect/components/connect-providers.tsx
@@ -2,7 +2,7 @@ import { Flex, Heading } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
-import { getApi } from "../../../shared/api";
+import { getApi, isDemo } from "../../../shared/api";
 import Constants from "../../../shared/constants";
 import { getProviders } from "../../../shared/localStorage/providers";
 import { capture } from "../../../shared/notifications";
@@ -32,8 +32,6 @@ const ConnectProviders = () => {
   }, []);
 
   const searchProviders = searchParams.get(Constants.PROVIDERS_PARAM);
-  const token = searchParams.get(Constants.TOKEN_PARAM);
-  const isDemo = token === "demo";
   const isApple = searchParams.get(Constants.APPLE_PARAM);
   const providers = getProviders(searchProviders, isDemo, isApple);
 
@@ -46,6 +44,7 @@ const ConnectProviders = () => {
       </Flex>
       <Providers
         providers={providers}
+        isDemo={isDemo}
         connectedProviders={connectedProviders}
         setConnectedProviders={setConnectedProviders}
       />

--- a/connect-widget/app/src/pages/connect/components/error-dialog.tsx
+++ b/connect-widget/app/src/pages/connect/components/error-dialog.tsx
@@ -17,16 +17,57 @@ export interface ErrorDialogProps {
   show: boolean;
   title?: string;
   message?: string;
+  link?: string;
+  linkText?: string;
+  remainingText?: string;
   onClose?: () => void;
 }
 
-const ErrorDialog = ({ show, title, message, onClose: closed }: ErrorDialogProps) => {
+const parseMessage = (msg: string) => {
+  console.log(msg);
+  const regex = /(.+?)\s*\[(.+?)\]\((.+?)\)\s*(.+)/;
+  const match = msg.match(regex);
+
+  if (match) {
+    const msg = match[1].trim();
+    const linkText = match[2].trim();
+    const link = match[3].trim();
+    const remainingText = match[4].trim();
+    return { msg, linkText, link, remainingText };
+  }
+  return null;
+};
+
+const ErrorDialog = ({
+  show,
+  title,
+  message,
+  link,
+  linkText,
+  remainingText,
+  onClose: closed,
+}: ErrorDialogProps) => {
   const { isOpen, onClose } = useDisclosure({ isOpen: show });
   const closeButtonRef = useRef(null);
-  const [{ actualTitle, actualMsg }, setActual] = useState({
-    actualTitle: title,
-    actualMsg: message,
-  });
+
+  if (message) {
+    const parsedMsg = parseMessage(message);
+    if (parsedMsg) {
+      message = parsedMsg?.msg;
+      link = parsedMsg?.link;
+      linkText = parsedMsg?.linkText;
+      remainingText = parsedMsg?.remainingText;
+    }
+  }
+
+  const [{ actualTitle, actualMsg, actualLink, actualLinkText, actualRemainingText }, setActual] =
+    useState({
+      actualTitle: title,
+      actualMsg: message,
+      actualLink: link,
+      actualLinkText: linkText,
+      actualRemainingText: remainingText,
+    });
 
   useEffect(() => {
     isOpen && capture.message("Error dialog displayed", { extra: { show, title, message } });
@@ -36,6 +77,9 @@ const ErrorDialog = ({ show, title, message, onClose: closed }: ErrorDialogProps
     setActual({
       actualTitle: title ?? "Ooops...",
       actualMsg: message ?? DEFAULT_ERROR_MESSAGE,
+      actualLink: link ?? undefined,
+      actualLinkText: linkText ?? undefined,
+      actualRemainingText: remainingText ?? "",
     });
   }, [title, message]);
 
@@ -51,7 +95,16 @@ const ErrorDialog = ({ show, title, message, onClose: closed }: ErrorDialogProps
           <AlertDialogHeader fontSize="lg" fontWeight="bold">
             {actualTitle}
           </AlertDialogHeader>
-          <AlertDialogBody>{actualMsg}</AlertDialogBody>
+          {actualLink && (
+            <AlertDialogBody>
+              {actualMsg}{" "}
+              <a href={actualLink}>
+                <u>{actualLinkText}</u>
+              </a>{" "}
+              {actualRemainingText}
+            </AlertDialogBody>
+          )}
+          {!actualLink && <AlertDialogBody>{actualMsg}</AlertDialogBody>}
           <AlertDialogFooter>
             <Button ref={closeButtonRef} onClick={close} ml={3}>
               OK

--- a/connect-widget/app/src/pages/connect/components/error-dialog.tsx
+++ b/connect-widget/app/src/pages/connect/components/error-dialog.tsx
@@ -18,70 +18,30 @@ export interface ErrorDialogProps {
   title?: string;
   message?: string;
   link?: string;
-  linkText?: string;
-  remainingText?: string;
   onClose?: () => void;
 }
 
-const parseMessage = (msg: string) => {
-  console.log(msg);
-  const regex = /(.+?)\s*\[(.+?)\]\((.+?)\)\s*(.+)/;
-  const match = msg.match(regex);
-
-  if (match) {
-    const msg = match[1].trim();
-    const linkText = match[2].trim();
-    const link = match[3].trim();
-    const remainingText = match[4].trim();
-    return { msg, linkText, link, remainingText };
-  }
-  return null;
-};
-
-const ErrorDialog = ({
-  show,
-  title,
-  message,
-  link,
-  linkText,
-  remainingText,
-  onClose: closed,
-}: ErrorDialogProps) => {
+const ErrorDialog = ({ show, title, message, link, onClose: closed }: ErrorDialogProps) => {
   const { isOpen, onClose } = useDisclosure({ isOpen: show });
   const closeButtonRef = useRef(null);
 
-  if (message) {
-    const parsedMsg = parseMessage(message);
-    if (parsedMsg) {
-      message = parsedMsg?.msg;
-      link = parsedMsg?.link;
-      linkText = parsedMsg?.linkText;
-      remainingText = parsedMsg?.remainingText;
-    }
-  }
-
-  const [{ actualTitle, actualMsg, actualLink, actualLinkText, actualRemainingText }, setActual] =
-    useState({
-      actualTitle: title,
-      actualMsg: message,
-      actualLink: link,
-      actualLinkText: linkText,
-      actualRemainingText: remainingText,
-    });
+  const [{ actualTitle, actualMsg, actualLink }, setActual] = useState({
+    actualTitle: title,
+    actualMsg: message,
+    actualLink: link,
+  });
 
   useEffect(() => {
-    isOpen && capture.message("Error dialog displayed", { extra: { show, title, message } });
+    isOpen && capture.message("Error dialog displayed", { extra: { show, title, message, link } });
   }, [isOpen]);
 
   useEffect(() => {
     setActual({
       actualTitle: title ?? "Ooops...",
       actualMsg: message ?? DEFAULT_ERROR_MESSAGE,
-      actualLink: link ?? undefined,
-      actualLinkText: linkText ?? undefined,
-      actualRemainingText: remainingText ?? "",
+      actualLink: link ?? "",
     });
-  }, [title, message]);
+  }, [title, message, link]);
 
   const close = () => {
     onClose();
@@ -95,17 +55,13 @@ const ErrorDialog = ({
           <AlertDialogHeader fontSize="lg" fontWeight="bold">
             {actualTitle}
           </AlertDialogHeader>
-          {actualLink && (
-            <AlertDialogBody>
-              {actualMsg}{" "}
-              <a href={actualLink}>
-                <u>{actualLinkText}</u>
-              </a>{" "}
-              {actualRemainingText}
-            </AlertDialogBody>
-          )}
-          {!actualLink && <AlertDialogBody>{actualMsg}</AlertDialogBody>}
+          <AlertDialogBody>{actualMsg}</AlertDialogBody>
           <AlertDialogFooter>
+            {actualLink && (
+              <a href={actualLink} target="_blank" onClick={close}>
+                <u>See Docs</u>
+              </a>
+            )}
             <Button ref={closeButtonRef} onClick={close} ml={3}>
               OK
             </Button>

--- a/connect-widget/app/src/pages/connect/components/error-dialog.tsx
+++ b/connect-widget/app/src/pages/connect/components/error-dialog.tsx
@@ -59,7 +59,7 @@ const ErrorDialog = ({ show, title, message, link, onClose: closed }: ErrorDialo
           <AlertDialogFooter>
             {actualLink && (
               <a href={actualLink} target="_blank" onClick={close}>
-                <u>See Docs</u>
+                <u>See Documentation</u>
               </a>
             )}
             <Button ref={closeButtonRef} onClick={close} ml={3}>

--- a/connect-widget/app/src/pages/connect/components/error-dialog.tsx
+++ b/connect-widget/app/src/pages/connect/components/error-dialog.tsx
@@ -59,7 +59,7 @@ const ErrorDialog = ({ show, title, message, link, onClose: closed }: ErrorDialo
           <AlertDialogFooter>
             {actualLink && (
               <a href={actualLink} target="_blank" onClick={close}>
-                <u>See Documentation</u>
+                <u>Documentation</u>
               </a>
             )}
             <Button ref={closeButtonRef} onClick={close} ml={3}>

--- a/connect-widget/app/src/pages/connect/components/providers.tsx
+++ b/connect-widget/app/src/pages/connect/components/providers.tsx
@@ -11,6 +11,7 @@ import Constants from "../../../shared/constants";
 
 type ProvidersProps = {
   providers: DefaultProvider[];
+  isDemo: boolean;
   connectedProviders: string[];
   setConnectedProviders: Dispatch<SetStateAction<string[]>>;
 };
@@ -21,11 +22,16 @@ declare global {
   }
 }
 
-const Providers = ({ providers, connectedProviders, setConnectedProviders }: ProvidersProps) => {
+const Providers = ({
+  providers,
+  isDemo,
+  connectedProviders,
+  setConnectedProviders,
+}: ProvidersProps) => {
   const [isLoading, setIsLoading] = useState<{ [id: string]: boolean }>({});
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [searchParams] = useSearchParams();
-  const token = searchParams.get(Constants.TOKEN_PARAM);
+  const token = isDemo ? false : searchParams.get(Constants.TOKEN_PARAM);
 
   const customEventHandler = useCallback(
     //eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/connect-widget/app/src/pages/connect/components/providers.tsx
+++ b/connect-widget/app/src/pages/connect/components/providers.tsx
@@ -31,7 +31,7 @@ const Providers = ({
   const [isLoading, setIsLoading] = useState<{ [id: string]: boolean }>({});
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [searchParams] = useSearchParams();
-  const token = isDemo ? false : searchParams.get(Constants.TOKEN_PARAM);
+  const token = isDemo ? "" : searchParams.get(Constants.TOKEN_PARAM);
 
   const customEventHandler = useCallback(
     //eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/connect-widget/app/src/pages/connect/index.tsx
+++ b/connect-widget/app/src/pages/connect/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
-import { setupApi } from "../../shared/api";
+import { setupApi, isDemo } from "../../shared/api";
 import WidgetContainer from "../../shared/components/WidgetContainer";
 import Constants from "../../shared/constants";
 import { acceptAgreement, setAgreementState } from "../../shared/localStorage/agreement";
@@ -16,10 +16,11 @@ const ConnectPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [searchParams] = useSearchParams();
   const [isError, setIsError] = useState(null);
+  const [errorLink, setErrorLink] = useState(undefined);
+  const [errorTitle, setErrorTitle] = useState(undefined);
 
   const colorMode = searchParams.get(Constants.COLOR_MODE_PARAM);
-  const token = searchParams.get(Constants.TOKEN_PARAM);
-  const isDemo = token === "demo";
+  // const token = searchParams.get(Constants.TOKEN_PARAM);
 
   useEffect(() => {
     try {
@@ -29,6 +30,8 @@ const ConnectPage = () => {
       //eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
       setIsError(err.message);
+      setErrorLink(err.link);
+      setErrorTitle(err.title);
       capture.error(err, { extra: { context: `connect.setup` } });
     }
     setIsLoading(false);
@@ -44,7 +47,15 @@ const ConnectPage = () => {
         ) : (
           <Agreement onAcceptAgreement={() => acceptAgreement(setAgreement, isDemo)} />
         )}
-        {isError && <ErrorDialog message={isError} show onClose={() => setIsError(null)} />}
+        {isError && (
+          <ErrorDialog
+            message={isError}
+            link={errorLink}
+            title={errorTitle}
+            show
+            onClose={() => setIsError(null)}
+          />
+        )}
       </>
     </WidgetContainer>
   );

--- a/connect-widget/app/src/pages/connect/index.tsx
+++ b/connect-widget/app/src/pages/connect/index.tsx
@@ -11,16 +11,19 @@ import Agreement from "./components/agreement";
 import ConnectProviders from "./components/connect-providers";
 import ErrorDialog from "./components/error-dialog";
 
+type DisplayError = {
+  message: string;
+  link: string;
+  title: string;
+};
+
 const ConnectPage = () => {
   const [agreement, setAgreement] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [searchParams] = useSearchParams();
-  const [isError, setIsError] = useState(null);
-  const [errorLink, setErrorLink] = useState(undefined);
-  const [errorTitle, setErrorTitle] = useState(undefined);
+  const [error, setError] = useState<DisplayError | null>(null);
 
   const colorMode = searchParams.get(Constants.COLOR_MODE_PARAM);
-  // const token = searchParams.get(Constants.TOKEN_PARAM);
 
   useEffect(() => {
     try {
@@ -29,9 +32,7 @@ const ConnectPage = () => {
       setAgreementState(setAgreement);
       //eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
-      setIsError(err.message);
-      setErrorLink(err.link);
-      setErrorTitle(err.title);
+      setError(err);
       capture.error(err, { extra: { context: `connect.setup` } });
     }
     setIsLoading(false);
@@ -47,13 +48,13 @@ const ConnectPage = () => {
         ) : (
           <Agreement onAcceptAgreement={() => acceptAgreement(setAgreement, isDemo)} />
         )}
-        {isError && (
+        {error && (
           <ErrorDialog
-            message={isError}
-            link={errorLink}
-            title={errorTitle}
+            message={error.message}
+            link={error.link}
+            title={error.title}
             show
-            onClose={() => setIsError(null)}
+            onClose={() => setError(null)}
           />
         )}
       </>

--- a/connect-widget/app/src/shared/api.ts
+++ b/connect-widget/app/src/shared/api.ts
@@ -35,11 +35,11 @@ export function handleToken(token: string | null): void {
   if (!token) {
     isDemo = true;
   } else if (isDemoToken(token)) {
-    //tell the user widget in demo mode && disable connect buttons
+    // tell the user widget in demo mode && disable connect buttons
     isDemo = true;
     throw new DemoTokenError();
   } else {
-    // Invalid vs valid token logic will go here
+    // invalid vs valid token logic will go here
     isDemo = false;
   }
 }

--- a/connect-widget/app/src/shared/api.ts
+++ b/connect-widget/app/src/shared/api.ts
@@ -26,7 +26,7 @@ export function getApiToken(searchParams: URLSearchParams): string {
   const apiToken = searchParams.get(Constants.TOKEN_PARAM);
   if (!apiToken) {
     throw new Error(
-      `Missing query param ${Constants.TOKEN_PARAM}! To learn more, go to the [Connect Widget](https://docs.metriport.com/devices-api/getting-started/connect-widget#token) overview in our documentation.`
+      `Missing ${Constants.TOKEN_PARAM} query param! To learn more, go to the [Connect Widget](https://docs.metriport.com/devices-api/getting-started/connect-widget#token) overview in our documentation.`
     );
   }
   return apiToken;

--- a/connect-widget/app/src/shared/api.ts
+++ b/connect-widget/app/src/shared/api.ts
@@ -1,7 +1,8 @@
 import axios from "axios";
 import { URLSearchParams } from "url";
 import Constants from "./constants";
-import { getEnvVarOrFail, isLocalEnv, isSandbox } from "./util";
+import { NoTokenError, DemoTokenError } from "./token-errors";
+import { getEnvVarOrFail, isLocalEnv, isSandbox, isDemoToken } from "./util";
 
 function buildBaseURL(searchParams: URLSearchParams): string {
   if (isLocalEnv()) {
@@ -14,7 +15,7 @@ function buildBaseURL(searchParams: URLSearchParams): string {
 
 const api = axios.create();
 let apiInitialized = false;
-export let isDemo = false;
+export let isDemo = true;
 
 export const getApi = () => {
   if (!apiInitialized) throw new Error(`API not initialized`);
@@ -25,24 +26,39 @@ export const getApi = () => {
 export function getApiToken(searchParams: URLSearchParams): string {
   const apiToken = searchParams.get(Constants.TOKEN_PARAM);
   if (!apiToken) {
-    throw new Error(
-      `Missing ${Constants.TOKEN_PARAM} query param! To learn more, go to the [Connect Widget](https://docs.metriport.com/devices-api/getting-started/connect-widget#token) overview in our documentation.`
+    throw new NoTokenError(
+      `Missing '${Constants.TOKEN_PARAM}' query parameter! To learn more, go to the Connect Widget overview in our documentation.`
     );
   }
   return apiToken;
+}
+
+export function handleToken(token: string | null): void {
+  if (!token) {
+    isDemo = true;
+  } else if (isDemoToken(token)) {
+    //tell the user widget in demo mode && disable connect buttons
+    isDemo = true;
+    throw new DemoTokenError(
+      "The Connect Widget is running in demo mode! You will not be able to connect providers unless you acquire a valid connect token. See Create Connect Token documentation for reference."
+    );
+  } else {
+    // Invalid vs valid token logic will go here
+    isDemo = false;
+  }
 }
 
 // get the session token in query params, and set in the API headers
 export function setupApi(searchParams: URLSearchParams) {
   api.defaults.baseURL = buildBaseURL(searchParams);
   const apiToken = getApiToken(searchParams);
-  if (apiToken === Constants.DEMO_TOKEN) isDemo = true;
+  handleToken(apiToken);
   if (isLocalEnv()) {
     // insert the API token right into the headers, as we're bypassing
     // API Gateway in local envs
-    api.defaults.headers.common["api-token"] = getApiToken(searchParams);
+    api.defaults.headers.common["api-token"] = apiToken;
   } else {
-    api.defaults.params = { state: getApiToken(searchParams) };
+    api.defaults.params = { state: apiToken };
   }
   apiInitialized = true;
 }

--- a/connect-widget/app/src/shared/api.ts
+++ b/connect-widget/app/src/shared/api.ts
@@ -26,7 +26,7 @@ export function getApiToken(searchParams: URLSearchParams): string {
   const apiToken = searchParams.get(Constants.TOKEN_PARAM);
   if (!apiToken) {
     throw new Error(
-      `Missing query param ${Constants.TOKEN_PARAM}! To learn more go to the Connect Widget overview in our documentation.`
+      `Missing query param ${Constants.TOKEN_PARAM}! To learn more, go to the [Connect Widget](https://docs.metriport.com/devices-api/getting-started/connect-widget#token) overview in our documentation.`
     );
   }
   return apiToken;

--- a/connect-widget/app/src/shared/api.ts
+++ b/connect-widget/app/src/shared/api.ts
@@ -26,9 +26,7 @@ export const getApi = () => {
 export function getApiToken(searchParams: URLSearchParams): string {
   const apiToken = searchParams.get(Constants.TOKEN_PARAM);
   if (!apiToken) {
-    throw new NoTokenError(
-      `Missing '${Constants.TOKEN_PARAM}' query parameter! To learn more, go to the Connect Widget overview in our documentation.`
-    );
+    throw new NoTokenError();
   }
   return apiToken;
 }
@@ -39,9 +37,7 @@ export function handleToken(token: string | null): void {
   } else if (isDemoToken(token)) {
     //tell the user widget in demo mode && disable connect buttons
     isDemo = true;
-    throw new DemoTokenError(
-      "The Connect Widget is running in demo mode! You will not be able to connect providers unless you acquire a valid connect token. See Create Connect Token documentation for reference."
-    );
+    throw new DemoTokenError();
   } else {
     // Invalid vs valid token logic will go here
     isDemo = false;

--- a/connect-widget/app/src/shared/components/WidgetContainer.tsx
+++ b/connect-widget/app/src/shared/components/WidgetContainer.tsx
@@ -9,6 +9,7 @@ import {
 } from "@chakra-ui/react";
 import { useEffect, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
+import { isDemo } from "../api";
 
 import Constants from "../../shared/constants";
 import { getCustomColor } from "../localStorage/custom-color";
@@ -21,8 +22,6 @@ const WidgetContainer = ({ children }: WidgetContainerProps) => {
   const [searchParams] = useSearchParams();
 
   const color = searchParams.get(Constants.CUSTOM_COLOR_PARAM);
-  const token = searchParams.get(Constants.TOKEN_PARAM);
-  const isDemo = token === "demo";
 
   const customColor = getCustomColor(color, isDemo);
 

--- a/connect-widget/app/src/shared/token-errors.ts
+++ b/connect-widget/app/src/shared/token-errors.ts
@@ -1,0 +1,44 @@
+export class NoTokenError extends Error {
+  title: string;
+  link: string;
+  icon?: string;
+
+  constructor(message: string, link?: string, icon?: string) {
+    super(message);
+    this.link = link
+      ? link
+      : "https://docs.metriport.com/devices-api/getting-started/connect-widget#token";
+    this.title = "Missing Connect Token";
+    this.icon = icon;
+  }
+}
+
+export class DemoTokenError extends Error {
+  title: string;
+  link: string;
+  icon?: string;
+
+  constructor(message: string, link?: string, icon?: string) {
+    super(message);
+    this.link = link
+      ? link
+      : "https://docs.metriport.com/devices-api/api-reference/user/create-connect-token";
+    this.title = "Demo Mode";
+    this.icon = icon;
+  }
+}
+
+export class InvalidTokenError extends Error {
+  title: string;
+  link: string;
+  icon?: string;
+
+  constructor(message: string, link?: string, icon?: string) {
+    super(message);
+    this.link = link
+      ? link
+      : "https://docs.metriport.com/devices-api/api-reference/user/create-connect-token";
+    this.title = "Invalid Connect Token";
+    this.icon = icon;
+  }
+}

--- a/connect-widget/app/src/shared/token-errors.ts
+++ b/connect-widget/app/src/shared/token-errors.ts
@@ -3,8 +3,12 @@ export class NoTokenError extends Error {
   link: string;
   icon?: string;
 
-  constructor(message: string, link?: string, icon?: string) {
-    super(message);
+  constructor(message?: string, link?: string, icon?: string) {
+    super(
+      message
+        ? message
+        : `Missing 'token' query parameter! To learn more, go to the Connect Widget overview in our documentation.`
+    );
     this.link = link
       ? link
       : "https://docs.metriport.com/devices-api/getting-started/connect-widget#token";
@@ -18,8 +22,12 @@ export class DemoTokenError extends Error {
   link: string;
   icon?: string;
 
-  constructor(message: string, link?: string, icon?: string) {
-    super(message);
+  constructor(message?: string, link?: string, icon?: string) {
+    super(
+      message
+        ? message
+        : "The Connect Widget is running in demo mode! You will not be able to connect providers unless you acquire a valid connect token. See Create Connect Token documentation for reference."
+    );
     this.link = link
       ? link
       : "https://docs.metriport.com/devices-api/api-reference/user/create-connect-token";
@@ -33,8 +41,12 @@ export class InvalidTokenError extends Error {
   link: string;
   icon?: string;
 
-  constructor(message: string, link?: string, icon?: string) {
-    super(message);
+  constructor(message?: string, link?: string, icon?: string) {
+    super(
+      message
+        ? message
+        : "Your Connect Token is invalid. See Create Connect Token documentation for reference."
+    );
     this.link = link
       ? link
       : "https://docs.metriport.com/devices-api/api-reference/user/create-connect-token";

--- a/connect-widget/app/src/shared/util.ts
+++ b/connect-widget/app/src/shared/util.ts
@@ -51,4 +51,8 @@ export function getEnvVarOrFail(varName: string): string {
   return value;
 }
 
+export function isDemoToken(token: string | null): boolean {
+  return token === Constants.DEMO_TOKEN;
+}
+
 export const sleep = (timeInMs: number) => new Promise(resolve => setTimeout(resolve, timeInMs));


### PR DESCRIPTION
refs. metriport/metriport#429

Ref: #_[ticket-number]_

### Description

- Created three custom Error classes for the different token situations: no token, demo token, invalid token.
- Error dialog is now displaying the error title, message, and a link (see the image for reference https://imgur.com/a/Z3cyVmk).
- Added isDemoToken function to the util.
- Removed ```token === "demo"``` from everywhere. Also, isDemo is centralized in the api.ts and is exported to all the other files that used it.
- I thought that no token and demo token should both result in the 'demo' behavior, i.e. the Connect buttons become disabled. The error messages and docs links are still unique to each case.
- Cleaned up setupApi to avoid using getApiToken multiple times.

Side note:
The invalid token case will be handled in the next PR on a separate issue, granted this PR goes through!

