### PR TITLE
feat(widget): demo token message

### DIFF
--- a/connect-widget/app/src/pages/connect/components/connect-providers.tsx
+++ b/connect-widget/app/src/pages/connect/components/connect-providers.tsx
@@ -46,6 +46,7 @@ const ConnectProviders = () => {
       </Flex>
       <Providers
         providers={providers}
+        isDemo={isDemo}
         connectedProviders={connectedProviders}
         setConnectedProviders={setConnectedProviders}
       />

--- a/connect-widget/app/src/pages/connect/components/error-dialog.tsx
+++ b/connect-widget/app/src/pages/connect/components/error-dialog.tsx
@@ -17,16 +17,57 @@ export interface ErrorDialogProps {
   show: boolean;
   title?: string;
   message?: string;
+  link?: string;
+  linkText?: string;
+  remainingText?: string;
   onClose?: () => void;
 }
 
-const ErrorDialog = ({ show, title, message, onClose: closed }: ErrorDialogProps) => {
+const parseMessage = (msg: string) => {
+  console.log(msg);
+  const regex = /(.+?)\s*\[(.+?)\]\((.+?)\)\s*(.+)/;
+  const match = msg.match(regex);
+
+  if (match) {
+    const msg = match[1].trim();
+    const linkText = match[2].trim();
+    const link = match[3].trim();
+    const remainingText = match[4].trim();
+    return { msg, linkText, link, remainingText };
+  }
+  return null;
+};
+
+const ErrorDialog = ({
+  show,
+  title,
+  message,
+  link,
+  linkText,
+  remainingText,
+  onClose: closed,
+}: ErrorDialogProps) => {
   const { isOpen, onClose } = useDisclosure({ isOpen: show });
   const closeButtonRef = useRef(null);
-  const [{ actualTitle, actualMsg }, setActual] = useState({
-    actualTitle: title,
-    actualMsg: message,
-  });
+
+  if (message) {
+    const parsedMsg = parseMessage(message);
+    if (parsedMsg) {
+      message = parsedMsg?.msg;
+      link = parsedMsg?.link;
+      linkText = parsedMsg?.linkText;
+      remainingText = parsedMsg?.remainingText;
+    }
+  }
+
+  const [{ actualTitle, actualMsg, actualLink, actualLinkText, actualRemainingText }, setActual] =
+    useState({
+      actualTitle: title,
+      actualMsg: message,
+      actualLink: link,
+      actualLinkText: linkText,
+      actualRemainingText: remainingText,
+    });
 
   useEffect(() => {
     isOpen && capture.message("Error dialog displayed", { extra: { show, title, message } });
@@ -36,6 +77,9 @@ const ErrorDialog = ({ show, title, message, onClose: closed }: ErrorDialogProps
     setActual({
       actualTitle: title ?? "Ooops...",
       actualMsg: message ?? DEFAULT_ERROR_MESSAGE,
+      actualLink: link ?? undefined,
+      actualLinkText: linkText ?? undefined,
+      actualRemainingText: remainingText ?? "",
     });
   }, [title, message]);
 
@@ -51,7 +95,16 @@ const ErrorDialog = ({ show, title, message, onClose: closed }: ErrorDialogProps
           <AlertDialogHeader fontSize="lg" fontWeight="bold">
             {actualTitle}
           </AlertDialogHeader>
-          <AlertDialogBody>{actualMsg}</AlertDialogBody>
+          {actualLink && (
+            <AlertDialogBody>
+              {actualMsg}{" "}
+              <a href={actualLink}>
+                <u>{actualLinkText}</u>
+              </a>{" "}
+              {actualRemainingText}
+            </AlertDialogBody>
+          )}
+          {!actualLink && <AlertDialogBody>{actualMsg}</AlertDialogBody>}
           <AlertDialogFooter>
             <Button ref={closeButtonRef} onClick={close} ml={3}>
               OK

--- a/connect-widget/app/src/pages/connect/components/providers.tsx
+++ b/connect-widget/app/src/pages/connect/components/providers.tsx
@@ -11,6 +11,7 @@ import Constants from "../../../shared/constants";
 
 type ProvidersProps = {
   providers: DefaultProvider[];
+  isDemo: boolean;
   connectedProviders: string[];
   setConnectedProviders: Dispatch<SetStateAction<string[]>>;
 };
@@ -21,11 +22,17 @@ declare global {
   }
 }
 
-const Providers = ({ providers, connectedProviders, setConnectedProviders }: ProvidersProps) => {
+const Providers = ({
+  providers,
+  isDemo,
+  connectedProviders,
+  setConnectedProviders,
+}: ProvidersProps) => {
   const [isLoading, setIsLoading] = useState<{ [id: string]: boolean }>({});
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [searchParams] = useSearchParams();
-  const token = searchParams.get(Constants.TOKEN_PARAM);
+
+  const token = isDemo ? false : searchParams.get(Constants.TOKEN_PARAM);
 
   const customEventHandler = useCallback(
     //eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/connect-widget/app/src/shared/api.ts
+++ b/connect-widget/app/src/shared/api.ts
@@ -28,6 +28,10 @@ export function getApiToken(searchParams: URLSearchParams): string {
     throw new Error(
       `Missing query param ${Constants.TOKEN_PARAM}! To learn more, go to the [Connect Widget](https://docs.metriport.com/devices-api/getting-started/connect-widget#token) overview in our documentation.`
     );
+  } else if (apiToken === "demo") {
+    throw new Error(
+      `The Connect Widget is running in demo mode! You will not be able to connect providers, unless you acquire a valid connect token. See [Create Connect Token](https://docs.metriport.com/devices-api/api-reference/user/create-connect-token) documentation for reference.`
+    );
   }
   return apiToken;
 }

--- a/connect-widget/app/src/shared/api.ts
+++ b/connect-widget/app/src/shared/api.ts
@@ -26,7 +26,7 @@ export function getApiToken(searchParams: URLSearchParams): string {
   const apiToken = searchParams.get(Constants.TOKEN_PARAM);
   if (!apiToken) {
     throw new Error(
-      `Missing query param ${Constants.TOKEN_PARAM}! To learn more go to the Connect Widget overview in our documentation.`
+      `Missing query param ${Constants.TOKEN_PARAM}! To learn more, go to the [Connect Widget](https://docs.metriport.com/devices-api/getting-started/connect-widget#token) overview in our documentation.`
     );
   }
   return apiToken;


### PR DESCRIPTION
Ref: #_[ticket-number]_

###Dependencies

- Upstream: https://github.com/metriport/metriport/pull/444

### Description
The message for the demo token looks like this: 
https://imgur.com/a/rMaSEAx

I am now passing isDemo down the ReactDOM tree, setting the token to be false, which disables the connect buttons. 
