### PR TITLE
FIX sandbox user count send message along status

### DIFF
--- a/api/app/src/routes/user.ts
+++ b/api/app/src/routes/user.ts
@@ -59,7 +59,7 @@ router.post(
       // limit the amount of users that can be created in sandbox mode
       const numConnectedUsers = await ConnectedUser.count({ where: { cxId } });
       if (numConnectedUsers >= Config.SANDBOX_USER_LIMIT) {
-        return res.sendStatus(status.BAD_REQUEST).json({
+        return res.status(status.BAD_REQUEST).json({
           message: `Cannot connect more than ${Config.SANDBOX_USER_LIMIT} users in Sandbox mode!`,
         });
       }

--- a/fhir-test/.gitignore
+++ b/fhir-test/.gitignore
@@ -1,4 +1,5 @@
 .env
 node_modules
-src/fhir/batch/**/*
+src/fhir/batch/load/**/*
 test-run-report*
+report*


### PR DESCRIPTION
Ref.
- https://metriport.slack.com/archives/C0553DYC95L/p1686159871151379
- https://metriport-inc.sentry.io/issues/4234608505/events/2b9b664c82524cbf9ea8d388749aa3ec/

### Description

`sendStatus` sends the status and "closes" the connection, use `status` when we want to also send a body.

### Release Plan

- asap