### PR TITLE
fix(api): sandbox user count send message along status

### DIFF
--- a/api/app/src/routes/user.ts
+++ b/api/app/src/routes/user.ts
@@ -59,7 +59,7 @@ router.post(
       // limit the amount of users that can be created in sandbox mode
       const numConnectedUsers = await ConnectedUser.count({ where: { cxId } });
       if (numConnectedUsers >= Config.SANDBOX_USER_LIMIT) {
-        return res.sendStatus(status.BAD_REQUEST).json({
+        return res.status(status.BAD_REQUEST).json({
           message: `Cannot connect more than ${Config.SANDBOX_USER_LIMIT} users in Sandbox mode!`,
         });
       }

--- a/fhir-test/.gitignore
+++ b/fhir-test/.gitignore
@@ -1,4 +1,5 @@
 .env
 node_modules
-src/fhir/batch/**/*
+src/fhir/batch/load/**/*
 test-run-report*
+report*


### PR DESCRIPTION
### Dependencies

https://github.com/metriport/metriport/pull/457

### Description

Fixes the response to `POST /user` when customer reaches the limit of users on sandbox.

### Release Plan

- ⚠️ Merging to `master`, deploy to `production`
- nothing fancy, just a deploy on OSS API