### PR TITLE
fix(widget): token verification fix

### DIFF
--- a/connect-widget/app/src/shared/api.ts
+++ b/connect-widget/app/src/shared/api.ts
@@ -46,9 +46,9 @@ export function handleToken(token: string): void {
   isDemo = false;
 }
 
-function isTokenValid() {
+async function isTokenValid() {
   try {
-    getApi().get("/connect/redirect", {
+    await getApi().get("/connect/redirect", {
       params: { provider: "fitbit" }, // all we're trying to do here is confirm the token is valid. Doesn't matter which provider to use.
     });
   } catch (err) {


### PR DESCRIPTION
refs. metriport/metriport#428

Ref: #_[ticket-number]_

### Description

The api wasn't making the request to check the token validity. isTokenValid() needed to be async.