### PR TITLE
fix: report metrics array population (put/push)

### DIFF
--- a/api/lambdas/sqs-to-fhir/index.js
+++ b/api/lambdas/sqs-to-fhir/index.js
@@ -368,8 +368,8 @@ async function reportMetrics(metrics) {
   });
   try {
     const MetricData = [durationMetric("Download", download), durationMetric("Upsert", upsert)];
-    job && MetricData.put(durationMetric("Job duration", job, "FHIR Conversion Flow"));
-    errorCount && MetricData.put(countMetric("FHIR Upsert Errors", errorCount));
+    job && MetricData.push(durationMetric("Job duration", job, "FHIR Conversion Flow"));
+    errorCount && MetricData.push(countMetric("FHIR Upsert Errors", errorCount));
     await cloudWatch
       .putMetricData({
         MetricData,


### PR DESCRIPTION
Ref. metriport/metriport-internal#760

### Dependencies

none

### Description

Fix report metrics array population (put/push) on FHIR server lambda

### Release Plan

- already deployed, merge to master asap to prevent an eventual patch there missing this