### PR TITLE
785 remove metriport prefix

### DIFF
--- a/api/lambdas/sqs-to-fhir/index.js
+++ b/api/lambdas/sqs-to-fhir/index.js
@@ -44,6 +44,7 @@ const cloudWatch = new AWS.CloudWatch({ apiVersion: "2010-08-01", region });
 const ossApi = axios.create();
 const docProgressURL = `${apiURL}/doc-conversion-status`;
 const placeholderReplaceRegex = new RegExp("66666666-6666-6666-6666-666666666666", "g");
+const metriportPrefixRegex = new RegExp("Metriport/identifiers/Metriport/", "g");
 
 /* Example of a single message/record in event's `Records` array:
 {
@@ -248,6 +249,7 @@ function replaceIds(payload) {
     const regex = new RegExp(stringToReplace.old, "g");
     fhirBundleStr = fhirBundleStr.replace(regex, stringToReplace.new);
   }
+  fhirBundleStr = fhirBundleStr.replace(metriportPrefixRegex, "");
   return fhirBundleStr;
 }
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#785

### Dependencies

none

### Description

FHIR server lambda: remove metriport prefix

### Release Plan

- asap, code already on lambda console, need this to deploy along next release