### PR TITLE
PATCH RELEASE move request to entry

### DIFF
--- a/api/lambdas/sqs-to-converter/index.js
+++ b/api/lambdas/sqs-to-converter/index.js
@@ -129,6 +129,14 @@ function postProcessSidechainFHIRBundle(fhirBundle, extension) {
         // change the fullUrl in the resource to match what our converter would generate
         bundleEntry.fullUrl = `urn:uuid:${idToUse}`;
 
+        // add missing request
+        if (!bundleEntry.request) {
+          bundleEntry.request = {
+            method: "PUT",
+            url: `${bundleEntry.resource.resourceType}/${bundleEntry.resource.id}}`,
+          };
+        }
+
         // add doc id extension
         if (!bundleEntry.resource.extension) bundleEntry.resource.extension = [];
         bundleEntry.resource.extension.push(extension);
@@ -298,8 +306,8 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
         } else {
           addExtensionToConversion(conversionResult, documentExtension);
           removePatientFromConversion(conversionResult);
+          addMissingRequests(conversionResult);
         }
-        addMissingRequests(conversionResult);
         metrics.postProcess = {
           duration: Date.now() - postProcessStart,
           timestamp: new Date().toISOString(),


### PR DESCRIPTION
Ref. metriport/metriport-internal#785

### Description

- move request to entry
- check entry before using it

### Release Plan

- This is pointing to `master`, deploy in `production`
- Update `develop` after this is merged