### PR TITLE
feat(api): standardized_type for data source

### DIFF
--- a/api/app/src/mappings/fitbit/body.ts
+++ b/api/app/src/mappings/fitbit/body.ts
@@ -5,7 +5,7 @@ import { PROVIDER_FITBIT } from "../../shared/constants";
 import { FitbitUser } from "./models/user";
 import { FitbitWeight } from "./models/weight";
 
-const METRIC = "en_US";
+const DECIMAL_PLACES = 2;
 
 export const mapToBody = (
   date: string,
@@ -23,18 +23,22 @@ export const mapToBody = (
 
   if (fitbitUser) {
     if (fitbitUser.user.height) {
-      if (fitbitUser.user.heightUnit === METRIC) {
-        body.height_cm = convert(fitbitUser.user.height).from("in").to("cm");
+      if (fitbitUser.user.heightUnit === "en_US") {
+        body.height_cm = parseFloat(fitbitUser.user.height.toFixed(DECIMAL_PLACES));
       } else {
-        body.height_cm = fitbitUser.user.height;
+        body.height_cm = parseFloat(
+          convert(fitbitUser.user.height).from("in").to("cm").toFixed(DECIMAL_PLACES)
+        );
       }
     }
 
     if (fitbitUser.user.weight) {
-      if (fitbitUser.user.weightUnit === METRIC) {
-        body.weight_kg = convert(fitbitUser.user.weight).from("lb").to("kg");
+      if (fitbitUser.user.weightUnit === "METRIC") {
+        body.weight_kg = parseFloat(fitbitUser.user.weight.toFixed(DECIMAL_PLACES));
       } else {
-        body.weight_kg = fitbitUser.user.weight;
+        body.weight_kg = parseFloat(
+          convert(fitbitUser.user.weight).from("lb").to("kg").toFixed(DECIMAL_PLACES)
+        );
       }
     }
   }
@@ -47,6 +51,7 @@ export const mapToBody = (
         value: weight.weight,
         data_source: {
           name: weight.source,
+          standardized_type: checkSource(weight.source),
         },
       };
     });
@@ -54,3 +59,7 @@ export const mapToBody = (
 
   return body;
 };
+
+function checkSource(weight: string) {
+  return weight === "API" ? "MANUALLY_ENTERED" : "DEVICE";
+}

--- a/api/app/src/mappings/fitbit/models/weight.ts
+++ b/api/app/src/mappings/fitbit/models/weight.ts
@@ -4,7 +4,7 @@ export const weightSchema = z.array(
   z.object({
     bmi: z.number().optional(),
     date: z.string().optional(),
-    fat: z.string().optional(),
+    fat: z.number().optional(),
     logId: z.number().optional(),
     source: z.string(),
     time: z.string(),

--- a/api/app/src/mappings/withings/body.ts
+++ b/api/app/src/mappings/withings/body.ts
@@ -44,6 +44,7 @@ export const mapToBody = (
         const defaultWeight = {
           time: dayjs(weight.time).toISOString(),
           value: Number(weight.value.toFixed(2)),
+          data_source: {},
         };
 
         if (weight.dataSourceId && devices && devices.length) {
@@ -53,6 +54,7 @@ export const mapToBody = (
             ...defaultWeight,
             ...(device && {
               data_source: {
+                standardized_type: "DEVICE",
                 name: device.model,
                 type: device.type,
                 id: device.deviceid,
@@ -61,6 +63,7 @@ export const mapToBody = (
           };
         }
 
+        defaultWeight["data_source"] = { standardized_type: "MANUALLY ENTERED" };
         return defaultWeight;
       });
     }

--- a/packages/packages/api/src/devices/models/common/source-info.ts
+++ b/packages/packages/api/src/devices/models/common/source-info.ts
@@ -1,5 +1,6 @@
 export interface SourceInfo {
+  standardized_type?: string;
   id?: string;
-  name: string;
+  name?: string;
   type?: string;
 }


### PR DESCRIPTION
refs. metriport/metriport#541


### Description

- Added a `standardized_type` attribute to the `data_source` for weight returns for Fitbit and Withings. 
- Fixed the faulty logic for unit conversion for Fitbit
- Truncated the weight and height returns to 2 decimal places