### PR TITLE
fix(api): garmin now sends metriport id

### DIFF
--- a/api/app/src/command/webhook/garmin.ts
+++ b/api/app/src/command/webhook/garmin.ts
@@ -112,7 +112,6 @@ export const processData = async <T extends MetriportData>(data: UserData<T>[]):
                   userId,
                   [type]: data,
                 });
-                console.log("user push", users);
               }
             }
             const payload: WebhookDataPayloadWithoutMessageId = { users };

--- a/docs/devices-api/more-info/webhooks.mdx
+++ b/docs/devices-api/more-info/webhooks.mdx
@@ -29,7 +29,7 @@ The format follows:
   },
   "users": [
     {
-      "userId": "<user-id-1>",
+      "id": "951faef1-5cfd-464a-81f7-31f76edf309e",
       "sleep": [
         {
           "metadata": {
@@ -92,7 +92,7 @@ The format follows:
       ]
     },
     {
-      "userId": "<user-id-2>",
+      "id": "3a3a7677-25bb-4f1b-bf3c-6e0ff46ce905",
       ...
     }
   ]

--- a/docs/devices-api/more-info/webhooks.mdx
+++ b/docs/devices-api/more-info/webhooks.mdx
@@ -29,7 +29,7 @@ The format follows:
   },
   "users": [
     {
-      "id": "951faef1-5cfd-464a-81f7-31f76edf309e",
+      "userId": "951faef1-5cfd-464a-81f7-31f76edf309e",
       "sleep": [
         {
           "metadata": {
@@ -92,7 +92,7 @@ The format follows:
       ]
     },
     {
-      "id": "3a3a7677-25bb-4f1b-bf3c-6e0ff46ce905",
+      "userId": "3a3a7677-25bb-4f1b-bf3c-6e0ff46ce905",
       ...
     }
   ]


### PR DESCRIPTION
refs. metriport/metriport#542

### Description

- Garmin now sends Metriport ID instead of cxUserId. The field name has been updated to match the change.
- Webhook docs section updated correspondingly.
