### PR TITLE
785 add retries to FHIR server and converter lambdas

### DIFF
--- a/api/lambdas/sqs-to-converter/index.js
+++ b/api/lambdas/sqs-to-converter/index.js
@@ -37,6 +37,8 @@ const sidechainFHIRConverterKeysSecretName = isSidechainConnector()
   : undefined;
 const baseReplaceUrl = "https://public.metriport.com";
 const sourceUrl = "https://api.metriport.com/cda/to/fhir";
+const MAX_SIDE_CHAIN_ATTEMPTS = 5;
+const MAX_API_NOTIFICATION_ATTEMPTS = 5;
 
 // Keep this as early on the file as possible
 Sentry.init({
@@ -186,6 +188,35 @@ function postProcessSidechainFHIRBundle(conversionResult, extension, patientId) 
   return;
 }
 
+async function postToSidechainConverter(payload, patientId, log) {
+  const sidechainUrl = `${sidechainFHIRConverterUrl}/${patientId}`;
+  let attempt = 0;
+  while (attempt++ < MAX_SIDE_CHAIN_ATTEMPTS) {
+    const apiKey = await getSidechainConverterAPIKey();
+    log(`(${attempt}) Calling sidechain converter on url ${sidechainUrl}`);
+    try {
+      const res = await fhirConverter.post(sidechainUrl, payload, {
+        headers: {
+          "Content-Type": "application/xml",
+          Accept: "application/json",
+          "x-api-key": apiKey,
+        },
+      });
+      return res;
+    } catch (error) {
+      if ([401, 429].includes(error.response?.status)) {
+        const msg = "Sidechain quota error, trying again";
+        const extra = { url: sidechainUrl, statusCode: error.response?.status, attempt, error };
+        log(msg, extra);
+        captureMessage(msg, { extra, level: "info" });
+      } else {
+        throw error;
+      }
+    }
+  }
+  throw new Error(`Too many errors from sidechain converter`);
+}
+
 /* Example of a single message/record in event's `Records` array:
 {
     "messageId": "2EBA03BC-D6D1-452B-BFC3-B1DD39F32947",
@@ -203,7 +234,7 @@ function postProcessSidechainFHIRBundle(conversionResult, extension, patientId) 
       cxId: {
         stringValue: '7006E0FB-33C8-42F4-B675-A3FD05717446',
         stringListValues: [],
-        binaryListValues: [], 
+        binaryListValues: [],
         dataType: 'String'
       }
     },
@@ -240,19 +271,19 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
       const attrib = message.messageAttributes;
       const cxId = attrib.cxId?.stringValue;
       const patientId = attrib.patientId?.stringValue;
-      const jobStartedAt = attrib.startedAt?.stringValue;
       const jobId = attrib.jobId?.stringValue;
+      const jobStartedAt = attrib.startedAt?.stringValue;
       if (!cxId) throw new Error(`Missing cxId`);
       if (!patientId) throw new Error(`Missing patientId`);
-      const log = _log(`${i}, cxId ${cxId}, patient ${patientId}, jobId ${jobId}`);
+      const log = _log(`${i}, patient ${patientId}, job ${jobId}`);
 
       try {
         const bodyAsJson = JSON.parse(message.body);
         const s3BucketName = bodyAsJson.s3BucketName;
-        const s3FileName = bodyAsJson.s3FileName;
-        const documentExtension = bodyAsJson.documentExtension;
         if (!s3BucketName) throw new Error(`Missing s3BucketName`);
+        const s3FileName = bodyAsJson.s3FileName;
         if (!s3FileName) throw new Error(`Missing s3FileName`);
+        const documentExtension = bodyAsJson.documentExtension;
         if (!documentExtension) throw new Error(`Missing documentExtension`);
 
         const metrics = { cxId, patientId };
@@ -260,7 +291,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
         await reportMemoryUsage();
         log(`Getting contents from bucket ${s3BucketName}, key ${s3FileName}`);
         const downloadStart = Date.now();
-        const payload = await downloadFileContents(s3BucketName, s3FileName);
+        const payloadRaw = await downloadFileContents(s3BucketName, s3FileName);
         metrics.download = {
           duration: Date.now() - downloadStart,
           timestamp: new Date().toISOString(),
@@ -268,18 +299,10 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
 
         await reportMemoryUsage();
         const conversionStart = Date.now();
-        let res = {};
+        let conversionResult = {};
         if (isSidechainConnector()) {
-          const sidechainUrl = `${sidechainFHIRConverterUrl}/${patientId}`;
-          const apiKey = await getSidechainConverterAPIKey();
-          log(`Calling sidechain converter on url ${sidechainUrl}`);
-          res = await fhirConverter.post(sidechainUrl, payload, {
-            headers: {
-              "Content-Type": "application/xml",
-              Accept: "application/json",
-              "x-api-key": apiKey,
-            },
-          });
+          const res = await postToSidechainConverter(payloadRaw, patientId, log);
+          conversionResult = { fhirResource: res.data };
         } else {
           const converterUrl = attrib.serverUrl?.stringValue;
           if (!converterUrl) throw new Error(`Missing converterUrl`);
@@ -287,12 +310,12 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
           const invalidAccess = attrib.invalidAccess?.stringValue;
           const params = { patientId, fileName: s3FileName, unusedSegments, invalidAccess };
           log(`Calling converter on url ${converterUrl} with params ${JSON.stringify(params)}`);
-          res = await fhirConverter.post(converterUrl, payload, {
+          const res = await fhirConverter.post(converterUrl, payloadRaw, {
             params,
             headers: { "Content-Type": "text/plain" },
           });
+          conversionResult = res.data;
         }
-        const conversionResult = isSidechainConnector() ? { fhirResource: res.data } : res.data;
         metrics.conversion = {
           duration: Date.now() - conversionStart,
           timestamp: new Date().toISOString(),
@@ -350,15 +373,8 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
           });
           await sendToDLQ(message);
 
-          if (cxId && patientId && isSidechainConnector()) {
-            await ossApi.post(docProgressURL, null, {
-              params: {
-                cxId,
-                patientId,
-                status: "failed",
-                jobId,
-              },
-            });
+          if (isSidechainConnector()) {
+            await notifyApi({ cxId, patientId, status: "failed", jobId }, log);
           }
         }
       }
@@ -400,6 +416,24 @@ function addMissingRequests(conversion) {
       };
     }
   });
+}
+
+async function notifyApi(params, log) {
+  if (params.cxId && params.patientId) {
+    let attempt = 0;
+    while (attempt++ < MAX_API_NOTIFICATION_ATTEMPTS) {
+      try {
+        log(`(${attempt}) Notifying API w/ ${JSON.stringify(params)}`);
+        await ossApi.post(docProgressURL, null, { params });
+      } catch (error) {
+        const msg = "Error notifying API, trying again";
+        const extra = { url: docProgressURL, statusCode: error.response?.status, attempt, error };
+        log(msg, extra);
+        captureMessage(msg, { extra, level: "info" });
+      }
+    }
+    throw new Error(`Too many errors from API`);
+  }
 }
 
 // Being more generic with errors, not strictly timeouts

--- a/api/lambdas/sqs-to-fhir/index.js
+++ b/api/lambdas/sqs-to-fhir/index.js
@@ -246,8 +246,9 @@ async function notifyApi(params, log) {
     let attempt = 0;
     while (attempt++ < MAX_API_NOTIFICATION_ATTEMPTS) {
       try {
-        log(`(${attempt}) Notifying API w/ ${JSON.stringify(params)}`);
+        log(`(${attempt}) Notifying API on ${docProgressURL} w/ ${JSON.stringify(params)}`);
         await ossApi.post(docProgressURL, null, { params });
+        return;
       } catch (error) {
         const msg = "Error notifying API, trying again";
         const extra = { url: docProgressURL, statusCode: error.response?.status, attempt, error };

--- a/api/lambdas/sqs-to-fhir/index.js
+++ b/api/lambdas/sqs-to-fhir/index.js
@@ -27,6 +27,7 @@ const delayWhenRetryingSeconds = Number(getEnvOrFail("DELAY_WHEN_RETRY_SECONDS")
 const sourceQueueURL = getEnvOrFail("QUEUE_URL");
 const dlqURL = getEnvOrFail("DLQ_URL");
 const fhirServerUrl = getEnvOrFail("FHIR_SERVER_URL");
+const MAX_API_NOTIFICATION_ATTEMPTS = 5;
 
 // Keep this as early on the file as possible
 Sentry.init({
@@ -97,25 +98,25 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
     for (const [i, message] of records.entries()) {
       // Process one record from the SQS message
       console.log(`Record ${i}, messageId: ${message.messageId}`);
-      try {
-        if (!message.messageAttributes) throw new Error(`Missing message attributes`);
-        if (!message.body) throw new Error(`Missing message body`);
-        const attrib = message.messageAttributes;
-        const cxId = attrib.cxId?.stringValue;
-        const jobId = attrib.jobId?.stringValue;
-        const patientId = attrib.patientId?.stringValue;
-        if (!cxId) throw new Error(`Missing cxId`);
-        if (!patientId) throw new Error(`Missing patientId`);
-        const jobStartedAt = attrib.startedAt?.stringValue;
-        const log = _log(`${i}, cxId ${cxId}, patientId ${patientId}, jobId ${jobId}`);
+      if (!message.messageAttributes) throw new Error(`Missing message attributes`);
+      if (!message.body) throw new Error(`Missing message body`);
+      const attrib = message.messageAttributes;
+      const cxId = attrib.cxId?.stringValue;
+      const patientId = attrib.patientId?.stringValue;
+      const jobId = attrib.jobId?.stringValue;
+      const jobStartedAt = attrib.startedAt?.stringValue;
+      if (!cxId) throw new Error(`Missing cxId`);
+      if (!patientId) throw new Error(`Missing patientId`);
+      const log = _log(`${i}, patient ${patientId}, job ${jobId}`);
 
+      try {
         const bodyAsJson = JSON.parse(message.body);
         const s3BucketName = bodyAsJson.s3BucketName;
-        const s3FileName = bodyAsJson.s3FileName;
         if (!s3BucketName) throw new Error(`Missing s3BucketName`);
+        const s3FileName = bodyAsJson.s3FileName;
         if (!s3FileName) throw new Error(`Missing s3FileName`);
 
-        const metrics = { cxId };
+        const metrics = { cxId, patientId };
 
         await reportMemoryUsage();
         log(`Getting contents from bucket ${s3BucketName}, key ${s3FileName}`);
@@ -125,6 +126,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
           duration: Date.now() - downloadStart,
           timestamp: new Date().toISOString(),
         };
+
         await reportMemoryUsage();
         log(`Converting payload to JSON, length ${payloadRaw.length}`);
         let payload;
@@ -133,13 +135,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
           log(`IDs replaced, length: ${idsReplaced.length}`);
           const placeholderUpdated = idsReplaced.replace(placeholderReplaceRegex, patientId);
           payload = JSON.parse(placeholderUpdated);
-          log(
-            `Payload to FHIR (length ${placeholderUpdated.length}): ${JSON.stringify(
-              payload,
-              null,
-              2
-            )}`
-          );
+          log(`Payload to FHIR (length ${placeholderUpdated.length}): ${JSON.stringify(payload)}`);
         } else {
           payload = JSON.parse(payloadRaw).fhirResource;
         }
@@ -185,14 +181,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
         await reportMemoryUsage();
         await reportMetrics(metrics);
 
-        await ossApi.post(docProgressURL, null, {
-          params: {
-            cxId,
-            patientId,
-            status: "success",
-            jobId,
-          },
-        });
+        await notifyApi({ cxId, patientId, status: "success", jobId }, log);
       } catch (err) {
         // If it timed-out let's just reenqueue for future processing - NOTE: the destination MUST be idempotent!
         const count = message.attributes?.ApproximateReceiveCount;
@@ -202,7 +191,6 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
             extra: { message, context: lambdaName, retryCount: count },
           });
           await reEnqueue(message);
-          uuid4();
         } else {
           console.log(
             `Error processing message: ${JSON.stringify(message)}; \n${err}: ${JSON.stringify(err)}`
@@ -212,20 +200,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(async event => {
           });
           await sendToDLQ(message);
 
-          const cxId = message.messageAttributes?.cxId?.stringValue;
-          const patientId = message.messageAttributes?.patientId?.stringValue;
-          const jobId = message.messageAttributes?.jobId?.stringValue;
-
-          if (cxId && patientId && jobId) {
-            await ossApi.post(docProgressURL, null, {
-              params: {
-                cxId,
-                patientId,
-                status: "failed",
-                jobId,
-              },
-            });
-          }
+          await notifyApi({ cxId, patientId, status: "failed", jobId }, log);
         }
       }
     }
@@ -264,6 +239,24 @@ function replaceIds(payload) {
   fhirBundleStr = fhirBundleStr.replace(metriportPrefixRegex, "");
 
   return fhirBundleStr;
+}
+
+async function notifyApi(params, log) {
+  if (params.cxId && params.patientId) {
+    let attempt = 0;
+    while (attempt++ < MAX_API_NOTIFICATION_ATTEMPTS) {
+      try {
+        log(`(${attempt}) Notifying API w/ ${JSON.stringify(params)}`);
+        await ossApi.post(docProgressURL, null, { params });
+      } catch (error) {
+        const msg = "Error notifying API, trying again";
+        const extra = { url: docProgressURL, statusCode: error.response?.status, attempt, error };
+        log(msg, extra);
+        captureMessage(msg, { extra, level: "info" });
+      }
+    }
+    throw new Error(`Too many errors from API`);
+  }
 }
 
 // Being more generic with errors, not strictly timeouts


### PR DESCRIPTION
Ref. metriport/metriport-internal#785

### Dependencies

none

### Description

Add retries to FHIR server and converter lambdas.

Some changes are just to keep both the `sqs-to-fhir` and `sqs-to-converter` as similar as possible to make it easier to share code once we have https://github.com/metriport/metriport-internal/issues/715 done

### Release Plan

- test on staging