### PR TITLE
fix(api): no providers no error ;)

### DIFF
--- a/api/app/src/routes/user.ts
+++ b/api/app/src/routes/user.ts
@@ -241,15 +241,13 @@ router.get(
     const userId = getUserIdFrom("params", req).orFail();
     const cxId = getCxIdOrFail(req);
     const connectedUser = await getConnectedUserOrFail({ id: userId, cxId });
-
+    let connectedProviders: string[] = [];
     if (connectedUser.providerMap) {
-      const connectedProviders = Object.keys(connectedUser.providerMap).map(key => {
+      connectedProviders = Object.keys(connectedUser.providerMap).map(key => {
         return key;
       });
-      return res.status(status.OK).json({ connectedProviders });
-    } else {
-      throw new BadRequestError(`User ${userId} has no provider map`);
     }
+    return res.status(status.OK).json({ connectedProviders });
   })
 );
 


### PR DESCRIPTION
refs. metriport/metriport#802

### Description

- If a user hasn't connected any providers, using the `/user/:userId/connected-providers` returns an empty array, instead of erroring out.