### PR TITLE
785 add get doc query status

### DIFF
--- a/api/app/package.json
+++ b/api/app/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/client-cloudwatch": "^3.338.0",
     "@medplum/core": "^2.0.18",
     "@medplum/fhirtypes": "^2.0.18",
-    "@metriport/api": "^4.1.9",
+    "@metriport/api": "^4.1.10-alpha.0",
     "@metriport/commonwell-sdk": "^4.3.2",
     "@sentry/node": "^7.45.0",
     "@sentry/tracing": "^7.45.0",

--- a/api/app/src/domain/medical/document-reference.ts
+++ b/api/app/src/domain/medical/document-reference.ts
@@ -12,17 +12,6 @@ export type Progress = {
 };
 
 export type DocumentQueryProgress = {
-  /**
-   * @deprecated
-   */
-  queryStatus?: DocumentQueryStatus;
-  /**
-   * @deprecated
-   */
-  queryProgress?: {
-    total?: number;
-    completed?: number;
-  };
   download?: Progress;
   convert?: Progress;
 };

--- a/api/app/src/external/fhir/document/get-documents.ts
+++ b/api/app/src/external/fhir/document/get-documents.ts
@@ -1,4 +1,5 @@
 import { DocumentReference } from "@medplum/fhirtypes";
+import { capture } from "../../../shared/notifications";
 import { makeFhirApi } from "../api/api-factory";
 
 export const getDocuments = async ({
@@ -10,8 +11,15 @@ export const getDocuments = async ({
 }): Promise<DocumentReference[] | undefined> => {
   const api = makeFhirApi(cxId);
   const docs: DocumentReference[] = [];
-  for await (const page of api.searchResourcePages("DocumentReference", `patient=${patientId}`)) {
-    docs.push(...page);
+  try {
+    for await (const page of api.searchResourcePages("DocumentReference", `patient=${patientId}`)) {
+      docs.push(...page);
+    }
+  } catch (error) {
+    const msg = `Error getting documents for patient ${patientId} from FHIR server`;
+    console.log(msg, error);
+    capture.message(msg, { extra: { patientId, error }, level: "error" });
+    throw error;
   }
   return docs;
 };

--- a/api/app/src/routes/medical/__tests__/document.test.e2e.ts
+++ b/api/app/src/routes/medical/__tests__/document.test.e2e.ts
@@ -63,8 +63,6 @@ describe("Integration Document routes", () => {
         expect(res.status).toBe(200);
         expect(res.data).toBeTruthy();
         expect(res.data).toEqual({
-          queryStatus: expectedStatus,
-          queryProgress: expectedProgress,
           documents: [],
         });
       } catch (error) {

--- a/api/app/src/routes/medical/document.ts
+++ b/api/app/src/routes/medical/document.ts
@@ -42,6 +42,9 @@ router.get(
     const dateFrom = parseISODate(getFrom("query").optional("dateFrom", req));
     const dateTo = parseISODate(getFrom("query").optional("dateTo", req));
 
+    // Confirm the CX can access this patient
+    await getPatientOrFail({ cxId, id: patientId });
+
     const documents = await getDocuments({ cxId, patientId });
     const documentsDTO = toDTO(documents).flatMap(doc => {
       if (!doc.indexed) return doc;
@@ -54,10 +57,7 @@ router.get(
       return [];
     });
 
-    const patient = await getPatientOrFail({ cxId, id: patientId });
-
     return res.status(OK).json({
-      ...patient.data.documentQueryProgress,
       documents: documentsDTO,
     });
   })

--- a/docs/medical-api/api-reference/document/get-document-query.mdx
+++ b/docs/medical-api/api-reference/document/get-document-query.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Get Document Query status"
+title: "Get Document Query Status"
 description: "Returns the document query status for the specified patient."
 api: "GET /medical/v1/document/query"
 ---

--- a/docs/medical-api/api-reference/document/get-document-query.mdx
+++ b/docs/medical-api/api-reference/document/get-document-query.mdx
@@ -1,0 +1,55 @@
+---
+title: "Get Document Query status"
+description: "Returns the document query status for the specified patient."
+api: "GET /medical/v1/document/query"
+---
+
+Returns the document query status for the specified patient. Can be used in to check the progress
+when the final status of the document query is taking longer than expected.
+
+See more on [Start Document Query](/medical-api/api-reference/document/start-document-query).
+
+<Tip>
+  To get updates about the document query progress, including download and conversion status,
+  check out our [webhooks guide](/medical-api/more-info/webhooks).
+</Tip>
+
+## Query Params
+
+<ParamField query="patientId" type="string" required>
+  The ID of the Patient for which to return the status of document querying across HIEs.
+</ParamField>
+
+## Response
+
+<Snippet file="document-progress.mdx" />
+
+```json
+{
+  "download": {
+    "status": "completed",
+    "total": 100,
+    "successful": 95,
+    "errors": 5
+  },
+  "convert": {
+    "status": "processing",
+    "total": 20,
+    "successful": 15,
+    "errors": 1
+  }
+}
+````
+
+<ResponseExample>
+```javascript Metriport SDK
+import { MetriportMedicalApi } from "@metriport/api";
+
+const metriportClient = new MetriportMedicalApi("YOUR_API_KEY");
+
+const status = await api.getDocumentQuery(
+  "2.16.840.1.113883.3.666.5.2004.4.2005"
+);
+
+````
+</ResponseExample>

--- a/docs/medical-api/api-reference/document/get-document-query.mdx
+++ b/docs/medical-api/api-reference/document/get-document-query.mdx
@@ -47,7 +47,7 @@ import { MetriportMedicalApi } from "@metriport/api";
 
 const metriportClient = new MetriportMedicalApi("YOUR_API_KEY");
 
-const status = await api.getDocumentQuery(
+const status = await api.getDocumentQueryStatus(
   "2.16.840.1.113883.3.666.5.2004.4.2005"
 );
 

--- a/docs/medical-api/api-reference/document/list-documents.mdx
+++ b/docs/medical-api/api-reference/document/list-documents.mdx
@@ -7,11 +7,6 @@ api: "GET /medical/v1/document"
 This endpoint returns the document references available at Metriport which are associated with the
 given Patient.
 
-It also returns the status of querying document references across HIEs, indicating whether
-there is an asynchronous query in progress (status `processing`) or not (status `completed`).
-
-If the query is in progress, you will also receive the total number of documents to be queried as well as the ones that have already been completed.
-
 To start a new document
 query, see [Start Document Query endpoint](/medical-api/api-reference/document/start-document-query).
 

--- a/docs/medical-api/api-reference/document/list-documents.mdx
+++ b/docs/medical-api/api-reference/document/list-documents.mdx
@@ -8,7 +8,7 @@ This endpoint returns the document references available at Metriport which are a
 given Patient.
 
 To start a new document
-query, see [Start Document Query endpoint](/medical-api/api-reference/document/start-document-query).
+query, see the [Start Document Query endpoint](/medical-api/api-reference/document/start-document-query).
 
 ## Query Params
 
@@ -39,22 +39,6 @@ An array of objects describing the Documents that can be retrieved for the Patie
     <Snippet file="document-reference-response.mdx" />
   </Expandable>
 </ResponseField>
-<Snippet file="document-progress.mdx" />
-
-<ResponseExample>
-
-```javascript Metriport SDK
-import { MetriportMedicalApi } from "@metriport/api";
-
-const metriportClient = new MetriportMedicalApi("YOUR_API_KEY");
-
-const { documents, queryStatus } = await metriportClient.listDocuments(
-  "2.16.840.1.113883.3.666.777",
-  "2.16.840.1.113883.3.666.5.2004.4.2005"
-);
-```
-
-</ResponseExample>
 
 ```json
 {
@@ -79,18 +63,21 @@ const { documents, queryStatus } = await metriportClient.listDocuments(
         "text": "Diagnoses"
       }
     }
-  ],
-  "download": {
-    "status": "completed",
-    "total": 100,
-    "successful": 95,
-    "errors": 5
-  },
-  "convert": {
-    "status": "processing",
-    "total": 20,
-    "successful": 15,
-    "errors": 1
-  }
+  ]
 }
 ```
+
+<ResponseExample>
+
+```javascript Metriport SDK
+import { MetriportMedicalApi } from "@metriport/api";
+
+const metriportClient = new MetriportMedicalApi("YOUR_API_KEY");
+
+const documents = await metriportClient.listDocuments(
+  "2.16.840.1.113883.3.666.777",
+  "2.16.840.1.113883.3.666.5.2004.4.2005"
+);
+```
+
+</ResponseExample>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -119,6 +119,7 @@
           "group": "Document",
           "pages": [
             "medical-api/api-reference/document/start-document-query",
+            "medical-api/api-reference/document/get-document-query",
             "medical-api/api-reference/document/list-documents",
             "medical-api/api-reference/document/get-document"
           ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@aws-sdk/client-cloudwatch": "^3.338.0",
         "@medplum/core": "^2.0.18",
         "@medplum/fhirtypes": "^2.0.18",
-        "@metriport/api": "^4.1.9",
+        "@metriport/api": "^4.1.10-alpha.0",
         "@metriport/commonwell-sdk": "^4.3.2",
         "@sentry/node": "^7.45.0",
         "@sentry/tracing": "^7.45.0",
@@ -6370,9 +6370,9 @@
       "integrity": "sha512-BAZndyiQ6XDXexRTd2lAMg8UgQYzI9rOGRD0WZ+FbmUvivQNTCivOJJDwZlu8F1TOa9NWvlvSNi1ADb8GFgKTg=="
     },
     "node_modules/@metriport/api": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@metriport/api/-/api-4.1.9.tgz",
-      "integrity": "sha512-kjHkyUxsi7XzHvOiRcuTxWcvn4Q7LlzIzFQuUtj4Y/p1DIrSNdGO2s6gFPYok0dkcRHwTYOyuikyXNOPIQ+qXg==",
+      "version": "4.1.10-alpha.0",
+      "resolved": "https://registry.npmjs.org/@metriport/api/-/api-4.1.10-alpha.0.tgz",
+      "integrity": "sha512-QbjPV5EvHOXA1millLAGSOvS8KojY26buYZ8l/4PZp5v7WlUn9PokK4Y4xdwOdFoTkMSVDgrrkV9qy2ALulfgw==",
       "dependencies": {
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -19794,7 +19794,7 @@
     },
     "packages/api": {
       "name": "@metriport/api",
-      "version": "4.1.9",
+      "version": "4.1.10-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.4",
@@ -19827,10 +19827,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.4.12",
+      "version": "1.4.20",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.3.3",
+        "@metriport/commonwell-sdk": "^4.3.4-alpha.1",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -19876,10 +19876,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.4.11",
+      "version": "1.1.19",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.3.3",
+        "@metriport/commonwell-sdk": "^4.3.4-alpha.1",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -19911,7 +19911,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.3.3",
+      "version": "4.3.4-alpha.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",
@@ -19963,7 +19963,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "0.2.9",
+      "version": "0.2.10-alpha.1",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"

--- a/packages/packages/api/package.json
+++ b/packages/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api",
-  "version": "4.1.9",
+  "version": "4.1.10-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/api/src/index.ts
+++ b/packages/packages/api/src/index.ts
@@ -26,8 +26,6 @@ export {
 export {
   DocumentList,
   documentListSchema,
-  DocumentQueryProgress,
-  documentQueryProgress,
   DocumentQuery,
   documentQuerySchema,
   DocumentQueryStatus,

--- a/packages/packages/api/src/medical/client/metriport.ts
+++ b/packages/packages/api/src/medical/client/metriport.ts
@@ -7,10 +7,10 @@ import {
 } from "../../shared";
 import { getETagHeader } from "../models/common/base-update";
 import {
-  DocumentList,
   documentListSchema,
   DocumentQuery,
   documentQuerySchema,
+  DocumentReference,
 } from "../models/document";
 import { Facility, FacilityCreate, facilityListSchema, facilitySchema } from "../models/facility";
 import { MedicalDataSource, PatientLinks, patientLinksSchema } from "../models/link";
@@ -324,15 +324,15 @@ export class MetriportMedicalApi {
    * @param facilityId The facility providing the NPI to support this operation.
    * @return The list of available document references.
    */
-  async listDocuments(patientId: string, facilityId: string): Promise<DocumentList> {
+  async listDocuments(patientId: string, facilityId: string): Promise<DocumentReference[]> {
     const resp = await this.api.get(`${DOCUMENT_URL}`, {
       params: {
         patientId,
         facilityId,
       },
     });
-    if (!resp.data) return { documents: [] };
-    return documentListSchema.parse(resp.data);
+    if (!resp.data) return [];
+    return documentListSchema.parse(resp.data).documents;
   }
 
   /**

--- a/packages/packages/api/src/medical/client/metriport.ts
+++ b/packages/packages/api/src/medical/client/metriport.ts
@@ -359,7 +359,7 @@ export class MetriportMedicalApi {
    * @param patientId Patient ID for which to retrieve document query status.
    * @return The document query progress & status indicating whether its being executed or not.
    */
-  async getDocumentQuery(patientId: string): Promise<DocumentQuery> {
+  async getDocumentQueryStatus(patientId: string): Promise<DocumentQuery> {
     const resp = await this.api.get(`${DOCUMENT_URL}/query`, {
       params: { patientId },
     });

--- a/packages/packages/api/src/medical/client/metriport.ts
+++ b/packages/packages/api/src/medical/client/metriport.ts
@@ -354,6 +354,20 @@ export class MetriportMedicalApi {
   }
 
   /**
+   * Returns the document query status for the specified patient.
+   *
+   * @param patientId Patient ID for which to retrieve document query status.
+   * @return The document query progress & status indicating whether its being executed or not.
+   */
+  async getDocumentQuery(patientId: string): Promise<DocumentQuery> {
+    const resp = await this.api.get(`${DOCUMENT_URL}/query`, {
+      params: { patientId },
+    });
+    if (!resp.data) throw new Error(NO_DATA_MESSAGE);
+    return documentQuerySchema.parse(resp.data);
+  }
+
+  /**
    * Returns a URL that can be used to download the document.
    *
    * @param req.query.fileName The file name of the document in s3.

--- a/packages/packages/api/src/medical/client/metriport.ts
+++ b/packages/packages/api/src/medical/client/metriport.ts
@@ -322,7 +322,7 @@ export class MetriportMedicalApi {
    *
    * @param patientId Patient ID for which to retrieve document metadata.
    * @param facilityId The facility providing the NPI to support this operation.
-   * @return The metadata of available documents.
+   * @return The list of available document references.
    */
   async listDocuments(patientId: string, facilityId: string): Promise<DocumentList> {
     const resp = await this.api.get(`${DOCUMENT_URL}`, {
@@ -331,7 +331,7 @@ export class MetriportMedicalApi {
         facilityId,
       },
     });
-    if (!resp.data) [];
+    if (!resp.data) return { documents: [] };
     return documentListSchema.parse(resp.data);
   }
 

--- a/packages/packages/api/src/medical/models/document.ts
+++ b/packages/packages/api/src/medical/models/document.ts
@@ -58,9 +58,7 @@ export const documentQuerySchema = z.object({
 
 export type DocumentQuery = z.infer<typeof documentQuerySchema>;
 
-export const documentListSchema = z
-  .object({
-    documents: z.array(documentReferenceSchema),
-  })
-  .merge(documentQuerySchema);
+export const documentListSchema = z.object({
+  documents: z.array(documentReferenceSchema),
+});
 export type DocumentList = z.infer<typeof documentListSchema>;

--- a/packages/packages/api/src/medical/models/document.ts
+++ b/packages/packages/api/src/medical/models/document.ts
@@ -29,13 +29,6 @@ export type DocumentReference = z.infer<typeof documentReferenceSchema>;
 export const documentQueryStatusSchema = z.enum(["processing", "completed", "failed"]);
 export type DocumentQueryStatus = z.infer<typeof documentQueryStatusSchema>;
 
-export const documentQueryProgress = z.object({
-  total: z.number(),
-  completed: z.number(),
-});
-
-export type DocumentQueryProgress = z.infer<typeof documentQueryProgress>;
-
 export const progressSchema = z.object({
   status: documentQueryStatusSchema,
   total: z.number().optional(),
@@ -44,14 +37,6 @@ export const progressSchema = z.object({
 });
 
 export const documentQuerySchema = z.object({
-  /**
-   * @deprecated
-   */
-  queryStatus: documentQueryStatusSchema.optional(),
-  /**
-   * @deprecated
-   */
-  queryProgress: documentQueryProgress.optional(),
   download: progressSchema.optional(),
   convert: progressSchema.optional(),
 });

--- a/packages/packages/commonwell-cert-runner/package.json
+++ b/packages/packages/commonwell-cert-runner/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.3.4-alpha.0",
+    "@metriport/commonwell-sdk": "^4.3.4-alpha.1",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/packages/commonwell-cert-runner/package.json
+++ b/packages/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.4.12",
+  "version": "1.4.20",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.3.3",
+    "@metriport/commonwell-sdk": "^4.3.4-alpha.0",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/packages/commonwell-jwt-maker/package.json
+++ b/packages/packages/commonwell-jwt-maker/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.3.4-alpha.0",
+    "@metriport/commonwell-sdk": "^4.3.4-alpha.1",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/packages/commonwell-jwt-maker/package.json
+++ b/packages/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.4.11",
+  "version": "1.1.19",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -40,7 +40,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.3.3",
+    "@metriport/commonwell-sdk": "^4.3.4-alpha.0",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/packages/commonwell-sdk/package.json
+++ b/packages/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.3.4-alpha.0",
+  "version": "4.3.4-alpha.1",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/commonwell-sdk/package.json
+++ b/packages/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.3.3",
+  "version": "4.3.4-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/react-native-sdk/package.json
+++ b/packages/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "0.2.9",
+  "version": "0.2.10-alpha.0",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/packages/react-native-sdk/package.json
+++ b/packages/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "0.2.10-alpha.0",
+  "version": "0.2.10-alpha.1",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",
         "@medplum/core": "^2.0.14",
         "@medplum/fhirtypes": "^2.0.14",
-        "@metriport/api": "^4.0.0",
+        "@metriport/api": "^4.1.5-alpha.4",
         "aws-sdk": "2.1243",
         "axios": "^1.3.2",
         "commander": "^10.0.0",
@@ -1131,9 +1131,9 @@
       "integrity": "sha512-o2ClyLx/oWnw0ReMy/laCD0L0l5avU6on4N0v4C3ftEq1vAlqgBqAUuPcoYXz5R0IHhPl93thYw74byyusDSdg=="
     },
     "node_modules/@metriport/api": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@metriport/api/-/api-4.0.0.tgz",
-      "integrity": "sha512-9WDb+vhnHOXkcbfCWGZBJD3pdPbEhAWdx5uPXgKIDuVHfK6pE9iS5WUGVzXsZvTHamxNMjVnDdoi1ieSH+M9ng==",
+      "version": "4.1.5-alpha.4",
+      "resolved": "https://registry.npmjs.org/@metriport/api/-/api-4.1.5-alpha.4.tgz",
+      "integrity": "sha512-8AMzW5KgC0lPlfaviVmqbHWyw68R5Lx/ucFB9izIIzZdn1/xUGWANRqhev14RAKJjjLxYlUI4hew523cyS802g==",
       "dependencies": {
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",
         "@medplum/core": "^2.0.14",
         "@medplum/fhirtypes": "^2.0.14",
-        "@metriport/api": "^4.1.5-alpha.4",
+        "@metriport/api": "^4.1.5-alpha.5",
         "aws-sdk": "2.1243",
         "axios": "^1.3.2",
         "commander": "^10.0.0",
@@ -1131,9 +1131,9 @@
       "integrity": "sha512-o2ClyLx/oWnw0ReMy/laCD0L0l5avU6on4N0v4C3ftEq1vAlqgBqAUuPcoYXz5R0IHhPl93thYw74byyusDSdg=="
     },
     "node_modules/@metriport/api": {
-      "version": "4.1.5-alpha.4",
-      "resolved": "https://registry.npmjs.org/@metriport/api/-/api-4.1.5-alpha.4.tgz",
-      "integrity": "sha512-8AMzW5KgC0lPlfaviVmqbHWyw68R5Lx/ucFB9izIIzZdn1/xUGWANRqhev14RAKJjjLxYlUI4hew523cyS802g==",
+      "version": "4.1.5-alpha.5",
+      "resolved": "https://registry.npmjs.org/@metriport/api/-/api-4.1.5-alpha.5.tgz",
+      "integrity": "sha512-3vAnc0xd582qW6UOSLZ5OU6loWPIs84Vl8M+rM7nSb7seChYW0s4klcM6XOcLspOfNusuyMDRZZtq2y10WQ+tw==",
       "dependencies": {
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",

--- a/utils/package.json
+++ b/utils/package.json
@@ -21,7 +21,7 @@
     "@aws-sdk/client-cognito-identity-provider": "^3.301.0",
     "@medplum/core": "^2.0.14",
     "@medplum/fhirtypes": "^2.0.14",
-    "@metriport/api": "^4.1.5-alpha.4",
+    "@metriport/api": "^4.1.5-alpha.5",
     "aws-sdk": "2.1243",
     "axios": "^1.3.2",
     "commander": "^10.0.0",

--- a/utils/package.json
+++ b/utils/package.json
@@ -21,7 +21,7 @@
     "@aws-sdk/client-cognito-identity-provider": "^3.301.0",
     "@medplum/core": "^2.0.14",
     "@medplum/fhirtypes": "^2.0.14",
-    "@metriport/api": "^4.0.0",
+    "@metriport/api": "^4.1.5-alpha.4",
     "aws-sdk": "2.1243",
     "axios": "^1.3.2",
     "commander": "^10.0.0",

--- a/utils/src/test-sdk.ts
+++ b/utils/src/test-sdk.ts
@@ -11,7 +11,7 @@ async function main() {
   const api = new MetriportMedicalApi(apiKey, { baseAddress: apiAddress });
 
   console.log(`Getting doc query status...`);
-  const res = await api.getDocumentQuery(patientId);
+  const res = await api.getDocumentQueryStatus(patientId);
   console.log(`Doc query status: ${JSON.stringify(res, null, 2)}`);
 
   console.log(`Done`);

--- a/utils/src/test-sdk.ts
+++ b/utils/src/test-sdk.ts
@@ -1,0 +1,31 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// Keep dotenv import and config before everything else
+import { MetriportMedicalApi } from "@metriport/api";
+
+async function main() {
+  const apiKey = getEnvVarOrFail("API_KEY");
+  const apiAddress = getEnvVarOrFail("API_ADRESS");
+  const patientId = getEnvVarOrFail("PATIENT_ID");
+
+  const api = new MetriportMedicalApi(apiKey, { baseAddress: apiAddress });
+
+  console.log(`Getting doc query status...`);
+  const res = await api.getDocumentQuery(patientId);
+  console.log(`Doc query status: ${JSON.stringify(res, null, 2)}`);
+
+  console.log(`Done`);
+}
+
+function getEnvVar(varName: string): string | undefined {
+  return process.env[varName];
+}
+function getEnvVarOrFail(varName: string): string {
+  const value = getEnvVar(varName);
+  if (!value || value.trim().length < 1) {
+    throw new Error(`Missing ${varName} env var`);
+  }
+  return value;
+}
+
+main();


### PR DESCRIPTION
Ref. metriport/metriport-internal#785

### Dependencies

- upstream: none
- downstream: https://github.com/metriport/metriport-internal/pull/818

### Description

Add get doc query status

Context: https://metriport.slack.com/archives/C04DMKE9DME/p1687217944864849

### Release Plan

- NPM alpha version already deployed
   - Need to be updated for prod