### PR TITLE
fix(widget): documentation button instead of anchor

### DIFF
--- a/connect-widget/app/src/pages/connect/components/error-dialog.tsx
+++ b/connect-widget/app/src/pages/connect/components/error-dialog.tsx
@@ -58,9 +58,22 @@ const ErrorDialog = ({ show, title, message, link, onClose: closed }: ErrorDialo
           <AlertDialogBody>{actualMsg}</AlertDialogBody>
           <AlertDialogFooter>
             {actualLink && (
-              <a href={actualLink} target="_blank" onClick={close}>
-                <u>Documentation</u>
-              </a>
+              <Button
+                as="a"
+                href={actualLink}
+                target="_blank"
+                onClick={close}
+                ml={3}
+                css={{
+                  background: "#B8B8B8 !important",
+                  "&:hover": {
+                    backgroundColor: `#CCC !important`,
+                    opacity: "0.8 !important",
+                  },
+                }}
+              >
+                Documentation
+              </Button>
             )}
             <Button ref={closeButtonRef} onClick={close} ml={3}>
               OK


### PR DESCRIPTION
refs. metriport/metriport#533

### Description

- Documentation link is now a button instead of an anchor
- The button colour is always grey and becomes light grey on hover (see images: https://imgur.com/a/4wZoRcK)