### PR TITLE
feat(widget): removed demo token notification

### DIFF
--- a/connect-widget/app/src/pages/connect/index.tsx
+++ b/connect-widget/app/src/pages/connect/index.tsx
@@ -37,8 +37,8 @@ const ConnectPage = () => {
       } catch (err: any) {
         if (err.message !== DemoTokenError.DEFAULT_MSG) {
           setError(err);
+          capture.error(err, { extra: { context: `connect.setup` } });
         }
-        capture.error(err, { extra: { context: `connect.setup` } });
       }
       setIsLoading(false);
     }

--- a/connect-widget/app/src/pages/connect/index.tsx
+++ b/connect-widget/app/src/pages/connect/index.tsx
@@ -11,6 +11,7 @@ import AgreementFooter from "./components/agreement-footer";
 import ConnectProviders from "./components/connect-providers";
 import ErrorDialog from "./components/error-dialog";
 import { Box } from "@chakra-ui/react";
+import { DemoTokenError } from "../../shared/token-errors";
 
 type DisplayError = {
   message: string;
@@ -34,7 +35,9 @@ const ConnectPage = () => {
         setAgreementState(setAgreement);
         //eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (err: any) {
-        setError(err);
+        if (err.message !== DemoTokenError.DEFAULT_MSG) {
+          setError(err);
+        }
         capture.error(err, { extra: { context: `connect.setup` } });
       }
       setIsLoading(false);

--- a/connect-widget/app/src/shared/api.ts
+++ b/connect-widget/app/src/shared/api.ts
@@ -35,7 +35,7 @@ export function getApiToken(searchParams: URLSearchParams): string {
 
 export async function handleToken(token: string): Promise<void> {
   if (isDemoToken(token)) {
-    // tell the user the widget is in demo mode && disable connect buttons
+    // disable connect buttons
     throw new DemoTokenError();
   }
   const tokenValid = await isTokenValid();

--- a/connect-widget/app/src/shared/token-errors.ts
+++ b/connect-widget/app/src/shared/token-errors.ts
@@ -23,13 +23,11 @@ export class DemoTokenError extends Error {
   link: string;
   icon?: string;
   static DEFAULT_TITLE = "Demo Mode";
+  static DEFAULT_MSG =
+    "The Connect Widget is running in demo mode! You will not be able to connect providers unless you acquire a valid connect token. See Create Connect Token documentation for reference.";
 
   constructor(message?: string, link?: string, icon?: string) {
-    super(
-      message
-        ? message
-        : "The Connect Widget is running in demo mode! You will not be able to connect providers unless you acquire a valid connect token. See Create Connect Token documentation for reference."
-    );
+    super(message ? message : DemoTokenError.DEFAULT_MSG);
     this.link = link
       ? link
       : "https://docs.metriport.com/devices-api/api-reference/user/create-connect-token";


### PR DESCRIPTION
refs. metriport/metriport#615

### Description

- Removed the demo token notification, but kept the sentry reporting. This error is being ignored on Sentry, so we can still see if any new issues arise.
