### PR TITLE
715 use existing buckets if present

### DIFF
--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -198,8 +198,16 @@ export class APIStack extends Stack {
       alarmSnsAction: slackNotification?.alarmAction,
     });
 
+    const existingSandboxSeedDataBucket = props.config.sandboxSeedDataBucketName
+      ? s3.Bucket.fromBucketName(
+          this,
+          "APISandboxSeedDataBucket",
+          props.config.sandboxSeedDataBucketName
+        )
+      : undefined;
     const sandboxSeedDataBucket = props.config.sandboxSeedDataBucketName
-      ? new s3.Bucket(this, "APISandboxSeedDataBucket", {
+      ? existingSandboxSeedDataBucket ??
+        new s3.Bucket(this, "APISandboxSeedDataBucket", {
           bucketName: props.config.sandboxSeedDataBucketName,
           publicReadAccess: false,
           encryption: s3.BucketEncryption.S3_MANAGED,

--- a/infra/lib/api-stack/fhir-server-connector.ts
+++ b/infra/lib/api-stack/fhir-server-connector.ts
@@ -47,7 +47,7 @@ export function createConnector({
   envType: EnvType;
   stack: Construct;
   vpc: IVpc;
-  fhirConverterBucket: s3.Bucket;
+  fhirConverterBucket: s3.IBucket;
   alarmSnsAction?: SnsAction;
 }): Queue | undefined {
   const config = getConfig();


### PR DESCRIPTION
Ref. metriport/metriport-internal#715

### Dependencies

none

### Description

Use existing buckets if present. Had to do this so I can branch/deploy `develop` into `staging` again to get `staging` on the current state and afterwards can can merge/deploy the lambda refactoring as we'll do in `production`. Trying to validate the deployment as close to prod as possible. 

### Release Plan

asap