### PR TITLE
fix(widget): fixed colorMode and button text color

### DIFF
--- a/connect-widget/app/src/pages/connect/index.tsx
+++ b/connect-widget/app/src/pages/connect/index.tsx
@@ -30,9 +30,9 @@ const ConnectPage = () => {
   useEffect(() => {
     async function setupConnectPage() {
       try {
-        await setupApi(searchParams);
         storeColorMode(colorMode);
         setAgreementState(setAgreement);
+        await setupApi(searchParams);
         //eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (err: any) {
         if (err.message !== DemoTokenError.DEFAULT_MSG) {

--- a/connect-widget/app/src/shared/api.ts
+++ b/connect-widget/app/src/shared/api.ts
@@ -61,7 +61,7 @@ async function isTokenValid() {
 }
 
 // get the session token in query params, and set in the API headers
-export async function setupApi(searchParams: URLSearchParams) {
+export async function setupApi(searchParams: URLSearchParams): Promise<void> {
   api.defaults.baseURL = buildBaseURL(searchParams);
   const apiToken = getApiToken(searchParams);
   if (isLocalEnv()) {

--- a/connect-widget/app/src/shared/components/WidgetContainer.tsx
+++ b/connect-widget/app/src/shared/components/WidgetContainer.tsx
@@ -36,7 +36,6 @@ const WidgetContainer = ({ children }: WidgetContainerProps) => {
     components: {
       Button: {
         baseStyle: {
-          color: "white",
           backgroundColor: decidePrimaryColor,
           _hover: {
             backgroundColor: `${customColor ? customColor : Constants.HOVER_COLOR} !important`,
@@ -51,6 +50,9 @@ const WidgetContainer = ({ children }: WidgetContainerProps) => {
             _hover: {
               backgroundColor: decideHollowColor,
             },
+          },
+          solid: {
+            color: "white",
           },
         },
       },


### PR DESCRIPTION
refs. metriport/metriport#624

### Description

- Fixed the colorMode query parameter - it is now able to set the color theme again
- Fixed the text color inside widget's buttons

### Screenshots
<img width="744" alt="Screenshot 2023-07-01 at 11 43 12 AM" src="https://github.com/metriport/metriport/assets/90670087/6fdb4438-3e86-4551-a3f6-2cc14e3c3b26">
<img width="770" alt="Screenshot 2023-07-01 at 11 43 03 AM" src="https://github.com/metriport/metriport/assets/90670087/281c5c5c-682f-4504-ae7f-d867abb2c639">

