### PR TITLE
693 do not multiline stringify

### DIFF
--- a/api/app/src/external/commonwell/document/document-query.ts
+++ b/api/app/src/external/commonwell/document/document-query.ts
@@ -200,7 +200,7 @@ export async function internalGetDocuments({
     if (d.content.size === 0) {
       log(`Document is of size 0, this may result in a 404 error - doc id ${d.id}`);
       capture.message("Document is of size 0", {
-        extra: { document: JSON.stringify(d, null, 2) },
+        extra: { document: d },
       });
     }
 

--- a/api/app/src/routes/webhook/apple.ts
+++ b/api/app/src/routes/webhook/apple.ts
@@ -22,7 +22,7 @@ routes.post(
     const payload = JSON.parse(req.body.data);
 
     // TEMP LOGS FOR DEBUGGING
-    console.log(metriportUserId, JSON.stringify(payload, null, 2));
+    console.log(metriportUserId, JSON.stringify(payload));
 
     const key = Object.keys(payload)[0];
 

--- a/api/app/src/routes/webhook/withings.ts
+++ b/api/app/src/routes/webhook/withings.ts
@@ -13,7 +13,7 @@ const routes = Router();
 routes.post(
   "/",
   asyncHandler(async (req: Request, res: Response) => {
-    console.log("withings lambda payload:", JSON.stringify(req.body, null, 2));
+    console.log("withings lambda payload:", JSON.stringify(req.body));
     processData(req.body);
     return res.sendStatus(200);
   })

--- a/api/lambdas/src/withings.ts
+++ b/api/lambdas/src/withings.ts
@@ -54,11 +54,7 @@ const lookup = async (address: string): Promise<string[]> => {
     exec(`dig +short TXT ${address}`, (error: any, stdout: string, stderr: any) => {
       if (error || stderr) {
         reject(
-          `DNS lookup failed. error: ${JSON.stringify(error, null, 2)}, stderr: ${JSON.stringify(
-            stderr,
-            null,
-            2
-          )}`
+          `DNS lookup failed. error: ${JSON.stringify(error)}, stderr: ${JSON.stringify(stderr)}`
         );
       }
       resolve(stdout.split(" ").map((s: string) => s.replace(/[^0-9.]/g, "")));


### PR DESCRIPTION
Ref. metriport/metriport-internal#693

### Dependencies

none

### Description

Do not multiline stringify, as it adds too much noise on logs. Also, CW already formats JSON-like logs when we open a log entry.

The ticket's scope is to fix the issue so we can multiline JSON w/o messing with CW logs, but in the meanwhile lets avoid those.

### Release Plan

- nothing special