### PR TITLE
fix(mapi): fixed the document type for sandbox patients

### DIFF
--- a/api/app/src/external/commonwell/document/document-query-sandbox.ts
+++ b/api/app/src/external/commonwell/document/document-query-sandbox.ts
@@ -161,7 +161,7 @@ function addSandboxFields(docRef: DocumentReference): DocumentReference {
       docRef.status = "superseded";
     }
 
-    if (fileExt === "xml") {
+    if (fileExt === ".xml") {
       docRef.description = "C-CDA R2.1 Patient Record";
       docRef.type = {
         coding: [
@@ -172,7 +172,7 @@ function addSandboxFields(docRef: DocumentReference): DocumentReference {
           },
         ],
       };
-    } else if (fileExt === "pdf") {
+    } else if (fileExt === ".pdf") {
       (docRef.description = "Physical Examination"),
         (docRef.type = {
           coding: [
@@ -181,7 +181,7 @@ function addSandboxFields(docRef: DocumentReference): DocumentReference {
             },
           ],
         });
-    } else if (fileExt === "tif" || fileExt === "tiff") {
+    } else if (fileExt === ".tif" || fileExt === ".tiff") {
       (docRef.description = "Pathology Report"),
         (docRef.type = {
           coding: [


### PR DESCRIPTION
refs. metriport/metriport#646

### Description

- Fixed a mistake that resulted in all of the sandbox documents being described as photographs

### Screenshots 

<img width="1436" alt="Screenshot 2023-07-06 at 5 03 41 PM" src="https://github.com/metriport/metriport/assets/90670087/71552a3e-e50f-4e17-970f-1047bd5e8fc9">
