### PR TITLE
237 symlink configs + update CICD accordingly

### DIFF
--- a/.github/workflows/_deploy_cdk.yml
+++ b/.github/workflows/_deploy_cdk.yml
@@ -40,6 +40,8 @@ on:
         required: true
       DOCKERHUB_TOKEN:
         required: true
+      SERVICE_PAT:
+        required: true
 
 jobs:
   deploy:
@@ -64,52 +66,56 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "18.14"
-      # TODO we should reuse the checked out code from the previous step
-      # doing this here might introduce minutes between `build` and `deploy`, which
-      # gives opportunity for problems (someone merges between `build` and `deploy`)
+
+      # checkout the actual repo
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          path: metriport
+      # checkout the internal repo to get configs
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: metriport/metriport-internal
+          ref: ${{ inputs.deploy_env == 'production' && 'master' || 'develop' }}
+          token: ${{ secrets.SERVICE_PAT }} # secret token from user 'metriport-service'
+          path: metriport-internal
+          sparse-checkout: |
+            config-oss/api-infra
+
       - name: Log Git Ref
         run: |
           echo "Git ref: $(git rev-parse HEAD)"
         shell: bash
 
-      # SET CONFIG FILES
-      - name: Infra set config file
-        run: |
-          echo "Env ${{ inputs.deploy_env }}"
-          echo "${{ inputs.INFRA_CONFIG }}" | base64 -d > ${{ inputs.deploy_env }}.ts
-          ls -la
-        working-directory: "packages/infra/config"
-
       # INSTALL DEPENDENCIES
       - name: Install dependencies
         run: npm ci --ignore-scripts
-        working-directory: "./"
+        working-directory: "metriport/"
       - name: Lambdas build shared layer
         run: npm run prep-deploy
-        working-directory: "packages/lambdas/"
+        working-directory: "metriport/packages/lambdas/"
       - name: Lambdas install dependencies
         run: npm ci --ignore-scripts
-        working-directory: "packages/lambdas/"
+        working-directory: "metriport/packages/lambdas/"
 
       # BUILD
       - name: Infra build/compile
         run: npm run build:cloud
-        working-directory: "packages/infra"
+        working-directory: "metriport/packages/infra"
       - name: Lambdas build/compile
         run: npm run build:cloud
-        working-directory: "packages/lambdas"
+        working-directory: "metriport/packages/lambdas"
 
       # TESTS
       - name: Infra test
         run: npm run test
-        working-directory: "packages/infra"
+        working-directory: "metriport/packages/infra"
       - name: Lambdas test
         run: npm run test
-        working-directory: "packages/lambdas"
-
-      # SENTRY
+        working-directory: "metriport/packages/lambdas"
+        
+        # SENTRY
       - name: Create Sentry release
         uses: getsentry/action-release@v1
         env:
@@ -124,7 +130,7 @@ jobs:
           version: ${{ github.sha }}
           ignore_missing: true
           ignore_empty: true
-          sourcemaps: packages/lambdas/dist
+          sourcemaps: metriport/packages/lambdas/dist
           projects: lambdas-oss
 
       # CDK DIFF
@@ -136,6 +142,7 @@ jobs:
           cdk_stack: "${{ inputs.cdk_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
+          INPUT_PATH: "metriport/packages/infra"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
@@ -149,6 +156,7 @@ jobs:
           cdk_stack: "${{ inputs.cdk_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
+          INPUT_PATH: "metriport/packages/infra"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/_deploy_cdk.yml
+++ b/.github/workflows/_deploy_cdk.yml
@@ -77,8 +77,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: metriport/metriport-internal
-          # ref: ${{ inputs.deploy_env == 'production' && 'master' || 'develop' }}
-          ref: "237-one-repo-to-rule-em-all"
+          ref: ${{ inputs.deploy_env == 'production' && 'master' || 'develop' }}
           token: ${{ secrets.SERVICE_PAT }} # secret token from user 'metriport-service'
           path: metriport-internal
           sparse-checkout: |

--- a/.github/workflows/_deploy_cdk.yml
+++ b/.github/workflows/_deploy_cdk.yml
@@ -77,7 +77,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: metriport/metriport-internal
-          ref: ${{ inputs.deploy_env == 'production' && 'master' || 'develop' }}
+          # ref: ${{ inputs.deploy_env == 'production' && 'master' || 'develop' }}
+          ref: "237-one-repo-to-rule-em-all"
           token: ${{ secrets.SERVICE_PAT }} # secret token from user 'metriport-service'
           path: metriport-internal
           sparse-checkout: |

--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -45,6 +45,7 @@ jobs:
       AWS_REGION: ${{ vars.API_REGION_STAGING }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_STAGING }}
     secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -104,6 +104,7 @@ jobs:
       AWS_REGION: ${{ vars.API_REGION_PRODUCTION }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_PRODUCTION }}
     secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -120,6 +121,7 @@ jobs:
       AWS_REGION: ${{ vars.API_REGION_SANDBOX  }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_SANDBOX  }}
     secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -136,6 +138,7 @@ jobs:
       AWS_REGION: ${{ vars.WIDGET_REGION_PRODUCTION }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_PRODUCTION }}
     secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -86,6 +86,7 @@ jobs:
       AWS_REGION: ${{ vars.API_REGION_STAGING }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_STAGING }}
     secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -102,6 +103,7 @@ jobs:
       AWS_REGION: ${{ vars.WIDGET_REGION_STAGING }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_STAGING }}
     secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -176,10 +176,12 @@ To setup this repository for local development, issue this command on the root f
 
 ```shell
 $ npm install # only needs to be run once
+$ npm run build # packages depend on each other, so its best to build/compile them all
 ```
 
 Useful commands:
 
+- `npm run test`: it executes the `test` script on all workspaces;
 - `npm run typecheck`: it will run `typecheck` on all workspaces, which checks for typescript compilation/syntax issues;
 - `npm run lint-fix`: it will run `lint-fix` on all workspaces, which checks for linting issues and automatically fixes the issues it can;
 - `npm run prettier-fix`: it will run `prettier-fix` on all workspaces, which checks for formatting issues and automatically fixes the issues it can;

--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -3,7 +3,7 @@ import * as cdk from "aws-cdk-lib";
 import "source-map-support/register";
 import { APIStack } from "../lib/api-stack";
 import { ConnectWidgetStack } from "../lib/connect-widget-stack";
-import { EnvConfig } from "../lib/env-config";
+import { EnvConfig } from "../config/env-config";
 import { SecretsStack } from "../lib/secrets-stack";
 import { initConfig } from "../lib/shared/config";
 import { getEnvVar } from "../lib/shared/util";

--- a/packages/infra/cdk.json
+++ b/packages/infra/cdk.json
@@ -1,5 +1,6 @@
 {
-  "app": "npx ts-node --prefer-ts-exts bin/infrastructure.ts",
+  "app": "node dist/bin/infrastructure.js",
+  "build": "npm run build",
   "watch": {
     "include": [
       "**"

--- a/packages/infra/config/.gitignore
+++ b/packages/infra/config/.gitignore
@@ -1,3 +1,0 @@
-production.ts
-staging.ts
-sandbox.ts

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -1,4 +1,4 @@
-import { EnvType } from "./env-type";
+import { EnvType } from "../lib/env-type";
 
 export type ConnectWidgetConfig = {
   stackName: string;

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -1,4 +1,4 @@
-import { EnvConfig } from "../lib/env-config";
+import { EnvConfig } from "./env-config";
 import { EnvType } from "../lib/env-type";
 
 export const config: EnvConfig = {

--- a/packages/infra/config/production.ts
+++ b/packages/infra/config/production.ts
@@ -1,0 +1,1 @@
+../../../../metriport-internal/config-oss/api-infra/production.ts

--- a/packages/infra/config/sandbox.ts
+++ b/packages/infra/config/sandbox.ts
@@ -1,0 +1,1 @@
+../../../../metriport-internal/config-oss/api-infra/sandbox.ts

--- a/packages/infra/config/staging.ts
+++ b/packages/infra/config/staging.ts
@@ -1,0 +1,1 @@
+../../../../metriport-internal/config-oss/api-infra/staging.ts

--- a/packages/infra/lib/api-service.ts
+++ b/packages/infra/lib/api-service.ts
@@ -12,7 +12,7 @@ import * as r53 from "aws-cdk-lib/aws-route53";
 import * as r53_targets from "aws-cdk-lib/aws-route53-targets";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
-import { EnvConfig } from "./env-config";
+import { EnvConfig } from "../config/env-config";
 import { DnsZones } from "./shared/dns";
 import { Secrets } from "./shared/secrets";
 import { isProd } from "./shared/util";

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -24,7 +24,7 @@ import { createDocQueryChecker } from "./api-stack/doc-query-checker";
 import * as fhirConverterConnector from "./api-stack/fhir-converter-connector";
 import * as fhirServerConnector from "./api-stack/fhir-server-connector";
 import * as sidechainFHIRConverterConnector from "./api-stack/sidechain-fhir-converter-connector";
-import { EnvConfig } from "./env-config";
+import { EnvConfig } from "../config/env-config";
 import { createFHIRConverterService } from "./fhir-converter-service";
 import { addErrorAlarmToLambdaFunc, createLambda } from "./shared/lambda";
 import { getSecrets } from "./shared/secrets";

--- a/packages/infra/lib/api-stack/doc-query-checker.ts
+++ b/packages/infra/lib/api-stack/doc-query-checker.ts
@@ -3,7 +3,7 @@ import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import { IVpc } from "aws-cdk-lib/aws-ec2";
 import { ILayerVersion, Function as Lambda, Runtime } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
-import { EnvConfig } from "../env-config";
+import { EnvConfig } from "../../config/env-config";
 import { getConfig } from "../shared/config";
 import { createScheduledLambda } from "../shared/lambda-scheduled";
 

--- a/packages/infra/lib/connect-widget-stack.ts
+++ b/packages/infra/lib/connect-widget-stack.ts
@@ -8,7 +8,7 @@ import * as route53 from "aws-cdk-lib/aws-route53";
 import * as targets from "aws-cdk-lib/aws-route53-targets";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
-import { ConnectWidgetConfig, EnvConfig } from "./env-config";
+import { ConnectWidgetConfig, EnvConfig } from "../config/env-config";
 import { addErrorAlarmToLambdaFunc } from "./shared/lambda";
 
 interface ConnectWidgetStackProps extends StackProps {

--- a/packages/infra/lib/fhir-converter-service.ts
+++ b/packages/infra/lib/fhir-converter-service.ts
@@ -7,7 +7,7 @@ import * as ecs from "aws-cdk-lib/aws-ecs";
 import { FargateService } from "aws-cdk-lib/aws-ecs";
 import * as ecs_patterns from "aws-cdk-lib/aws-ecs-patterns";
 import { Construct } from "constructs";
-import { EnvConfig } from "./env-config";
+import { EnvConfig } from "../config/env-config";
 import { getConfig } from "./shared/config";
 import { vCPU } from "./shared/fargate";
 import { MAXIMUM_LAMBDA_TIMEOUT } from "./shared/lambda";

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -1,7 +1,7 @@
 import { CfnOutput, Stack, StackProps } from "aws-cdk-lib";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
-import { EnvConfig } from "./env-config";
+import { EnvConfig } from "../config/env-config";
 
 interface SecretStackProps extends StackProps {
   config: EnvConfig;

--- a/packages/infra/lib/shared/config.ts
+++ b/packages/infra/lib/shared/config.ts
@@ -23,7 +23,7 @@ export async function initConfig(node: Node): Promise<EnvConfig> {
       `Context variable missing on CDK command. Pass in as "-c env=XXX". Valid values are: ${validVals}`
     );
   }
-  const configPath = `../../config/${env}.ts`;
+  const configPath = `../../config/${env}`;
   const configModule = await import(configPath);
   if (!configModule || !configModule.default) {
     throw new Error(`Ensure config is defined, could not fine file ${configPath}`);

--- a/packages/infra/lib/shared/config.ts
+++ b/packages/infra/lib/shared/config.ts
@@ -1,6 +1,6 @@
 import { Node } from "constructs";
 import "source-map-support/register";
-import { EnvConfig } from "../env-config";
+import { EnvConfig } from "../../config/env-config";
 import { EnvType } from "../env-type";
 
 export const METRICS_NAMESPACE = "Metriport";

--- a/packages/infra/lib/shared/secrets.ts
+++ b/packages/infra/lib/shared/secrets.ts
@@ -1,7 +1,7 @@
 import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
-import { EnvConfig } from "../env-config";
+import { EnvConfig } from "../../config/env-config";
 
 export type Secrets = { [key: string]: ecs.Secret };
 

--- a/packages/infra/lib/shared/util.ts
+++ b/packages/infra/lib/shared/util.ts
@@ -1,4 +1,4 @@
-import { EnvConfig } from "../env-config";
+import { EnvConfig } from "../../config/env-config";
 import { EnvType } from "../env-type";
 
 export function isStaging(config: EnvConfig): boolean {

--- a/packages/infra/tsconfig.json
+++ b/packages/infra/tsconfig.json
@@ -13,7 +13,10 @@
     "noUncheckedIndexedAccess": true,
     // END - From @tsconfig/strictest
 
-    "noEmit": true
+    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
+    "rootDir": "./" /* Specify the root folder within your source files. */,
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    "preserveSymlinks": true
   },
   "include": ["bin", "lib", "config"],
   "exclude": [

--- a/packages/infra/tsconfig.json
+++ b/packages/infra/tsconfig.json
@@ -13,11 +13,9 @@
     "noUncheckedIndexedAccess": true,
     // END - From @tsconfig/strictest
 
-    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
-    "rootDir": "./" /* Specify the root folder within your source files. */,
-    "outDir": "./dist" /* Specify an output folder for all emitted files. */
+    "noEmit": true
   },
-  "include": ["./bin", "./lib"],
+  "include": ["bin", "lib", "config"],
   "exclude": [
     "cdk.out",
     "dist",


### PR DESCRIPTION
Ref. metriport/metriport-internal#237

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/878
- Downstream: none

### Description

- Symlink configs, pointing to relative `metriport-internal` repo
- Update CI/CD accordingly

With this PR we don't need to update GH actions with the contents of config files from the internal repo, those are symlinks to the actual files.

The only consideration is that we need the respective environment's configs merged on internal before we can merge the respective OSS repo. Example:
- we're working on OSS and need to update the configs
- update those on internal (can edit them on OSS b/c of symlink, but have to commit on internal)
- once all is done, open a PR on each repo (OSS and internal)
- merge internal first (this gets the updated config to internal's `develop`)
- merge OSS (the updated CICD will checkout both projects' `develop`, allowing OSS to have access to internal/config)

This flow works well when the changes on internal are upstream to OSS. When they are downstream (e.g., the Dashboard requires an API change on OSS AND we have changes in config), we might need to create two PRs on internal, one with config changes being upstream to OSS and one with Dash changes being downstream to OSS.

### Release Plan

- remove secrets per env, as we merge this to the respective environment:
   - [x] `INFRA_CONFIG_STAGING`
   - `INFRA_CONFIG_SANDBOX`
   - `INFRA_CONFIG_PRODUCTION`
- [x] merge the upstream dependency
- [ ] merge this