### PR TITLE
feat(api): update docs to fix appdelegate in swift

### DIFF
--- a/docs/devices-api/more-info/react-native.mdx
+++ b/docs/devices-api/more-info/react-native.mdx
@@ -23,7 +23,7 @@ cd ios
 pod install
 ```
 
-You will also need to add this inside of your `AppDelegate` file:
+If you are using `Objective-C` for your `AppDelegate` file you will need to set it up as follows:
 
 ```objc
 #import "AppDelegate.h"

--- a/docs/devices-api/more-info/react-native.mdx
+++ b/docs/devices-api/more-info/react-native.mdx
@@ -27,11 +27,11 @@ If you are using `Objective-C` for your `AppDelegate` file you will need to set 
 
 ```objc
 #import "AppDelegate.h"
-#import "MetriportConfiguration.h" <- add this line
+#import "MetriportConfiguration.h" // add this line
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
-   [MetriportConfiguration checkBackgroundUpdates]; <- add this line
+   [MetriportConfiguration checkBackgroundUpdates]; // add this line
 
    // your code
 }
@@ -42,13 +42,13 @@ If you are using `Swift` for your `AppDelegate` file you will need to set it up 
 ```swift
 import Foundation
 import UIKit
-import MetriportSDK <--- add this line
+import MetriportSDK // add this line
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 var window: UIWindow?
 var bridge: RCTBridge!
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    MetriportClient.checkBackgroundUpdates() <---- add this line
+    MetriportClient.checkBackgroundUpdates() // add this line
 
     // your code
   }

--- a/docs/devices-api/more-info/react-native.mdx
+++ b/docs/devices-api/more-info/react-native.mdx
@@ -37,6 +37,24 @@ You will also need to add this inside of your `AppDelegate` file:
 }
 ```
 
+If you are using `Swift` for your `AppDelegate` file you will need to set it up as follows:
+
+```swift
+import Foundation
+import UIKit
+import MetriportSDK <--- add this line
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+var window: UIWindow?
+var bridge: RCTBridge!
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    MetriportClient.checkBackgroundUpdates() <---- add this line
+
+    // your code
+  }
+}
+```
+
 ## Usage
 
 To use our SDK go to the root of your project and add:


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ref: 799

### Dependencies

None

### Description

Update docs to explain how to set up react native with swift template instead of obj-c

### Release Plan

- [ ] ASAP
