### PR TITLE
fix(widget): installation name change from cra default

### DIFF
--- a/packages/connect-widget/public/manifest.json
+++ b/packages/connect-widget/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Connect Widget",
+  "name": "Metriport Connect Widget",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
refs. metriport/metriport-internal#881

### Description

- For Widget's installation popup, the name was changed from "Create React App Sample" to "Metriport Connect Widget" 