### PR TITLE
fix(dapi): user's timezone converted to utc for weight logs and heart rate data

### DIFF
--- a/packages/api/src/mappings/fitbit/body.ts
+++ b/packages/api/src/mappings/fitbit/body.ts
@@ -1,10 +1,15 @@
 import { Body, SourceType } from "@metriport/api-sdk";
 import convert from "convert-units";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
 import { PROVIDER_FITBIT } from "../../shared/constants";
 import { US_LOCALE } from "./constants";
 import { FitbitUser } from "./models/user";
 import { FitbitWeight } from "./models/weight";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const STONES_TO_LB = 14;
 const DECIMAL_PLACES = 2;
@@ -41,7 +46,10 @@ export const mapToBody = (
 
   if (fitbitWeight && fitbitWeight.length > 0) {
     body.weight_samples_kg = fitbitWeight.map(weight => {
-      const dateTime = date + "T" + weight.time;
+      let dateTime = date + "T" + weight.time;
+      dateTime = fitbitUser?.user.timezone
+        ? dayjs.tz(dateTime, fitbitUser?.user.timezone).utc().format()
+        : dateTime;
       return {
         time: dayjs(dateTime).toISOString(),
         value: convertStonesToKg(weight.weight),

--- a/packages/api/src/mappings/fitbit/body.ts
+++ b/packages/api/src/mappings/fitbit/body.ts
@@ -16,7 +16,7 @@ const DECIMAL_PLACES = 2;
 
 export const mapToBody = (
   date: string,
-  fitbitUser?: FitbitUser,
+  fitbitUser: FitbitUser,
   fitbitWeight?: FitbitWeight
 ): Body => {
   const metadata = {
@@ -28,27 +28,25 @@ export const mapToBody = (
     metadata: metadata,
   };
 
-  if (fitbitUser) {
-    if (fitbitUser.user.height) {
-      if (fitbitUser.user.heightUnit === US_LOCALE) {
-        body.height_cm = parseFloat(fitbitUser.user.height.toFixed(DECIMAL_PLACES));
-      } else {
-        body.height_cm = parseFloat(
-          convert(fitbitUser.user.height).from("in").to("cm").toFixed(DECIMAL_PLACES)
-        );
-      }
+  if (fitbitUser.user.height) {
+    if (fitbitUser.user.heightUnit === US_LOCALE) {
+      body.height_cm = parseFloat(fitbitUser.user.height.toFixed(DECIMAL_PLACES));
+    } else {
+      body.height_cm = parseFloat(
+        convert(fitbitUser.user.height).from("in").to("cm").toFixed(DECIMAL_PLACES)
+      );
     }
+  }
 
-    if (fitbitUser.user.weight) {
-      body.weight_kg = convertStonesToKg(fitbitUser.user.weight);
-    }
+  if (fitbitUser.user.weight) {
+    body.weight_kg = convertStonesToKg(fitbitUser.user.weight);
   }
 
   if (fitbitWeight && fitbitWeight.length > 0) {
     body.weight_samples_kg = fitbitWeight.map(weight => {
       let dateTime = date + "T" + weight.time;
-      dateTime = fitbitUser?.user.timezone
-        ? dayjs.tz(dateTime, fitbitUser?.user.timezone).utc().format()
+      dateTime = fitbitUser.user.timezone
+        ? dayjs.tz(dateTime, fitbitUser.user.timezone).utc().format()
         : dateTime;
       return {
         time: dayjs(dateTime).toISOString(),

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -143,7 +143,7 @@ export class Fitbit extends Provider implements OAuth2 {
 
   async fetchHeartRateData(accessToken: string, date: string): Promise<FitbitHeartRate> {
     return this.oauth.fetchProviderData<FitbitHeartRate>(
-      `${Fitbit.URL}/${Fitbit.API_PATH}/activities/heart/date/${date}/1d.json`,
+      `${Fitbit.URL}/${Fitbit.API_PATH}/activities/heart/date/${date}/1d.json?timezone=UTC`,
       accessToken,
       async resp => {
         return fitbitHeartRateResp.parse(resp.data["activities-heart"][0]);

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -271,8 +271,9 @@ export class Fitbit extends Provider implements OAuth2 {
     const user = resUser.status === "fulfilled" ? resUser.value : undefined;
     const weight = resWeight.status === "fulfilled" ? resWeight.value : undefined;
 
-    if (!user && !weight) {
-      throw new Error("All Requests failed");
+    if (!user) {
+      if (!weight) throw new Error("All Requests failed");
+      throw new Error("User Request failed");
     }
 
     return mapToBody(date, user, weight);


### PR DESCRIPTION
refs. metriport/metriport#678

### Description

- Weight logs are now taking user's timezone into account and convert all entries to UTC. 
- Heart rate data uses the timezone=UTC query parameter as well

### Side Note

- I cross referenced all of the endpoints that we call in [this file](https://github.com/metriport/metriport/blob/b939a32e70d8fe9e45abefd92b4aa3d78b6be777/packages/api/src/providers/fitbit.ts) to Fitbit documentation, and **only** the heart rate data endpoint uses the timezone query parameter. 