### PR TITLE
feat(dapi): added secrets access to the fitbit lambdas

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -754,10 +754,6 @@ export class APIStack extends Stack {
       secret.grantRead(fitbitSubscriberVerificationLambda);
     }
 
-    // Grant lambdas access to the api server
-    server.service.connections.allowFrom(fitbitAuthLambda, Port.allTcp());
-    server.service.connections.allowFrom(fitbitSubscriberVerificationLambda, Port.allTcp());
-
     const fitbitResource = baseResource.addResource("fitbit");
     fitbitResource.addMethod("POST", new apig.LambdaIntegration(fitbitAuthLambda));
     fitbitResource.addMethod("GET", new apig.LambdaIntegration(fitbitSubscriberVerificationLambda));


### PR DESCRIPTION
refs. metriport/metriport#363

### Description

- Granted the fitbit lambdas access to the secrets

### Release Plan

- [ ] _[action 1]_ Release this PR
- [ ] _[action 2]_ Make sure the fitbit-related secrets are properly set on the AWS side
- [ ] _[action 3]_ Go to dev.fitbit.com and verify subscriber URLs 
