### PR TITLE
704 wait for API deployment to finish on CICD

### DIFF
--- a/packages/scripts/restart-api.sh
+++ b/packages/scripts/restart-api.sh
@@ -29,3 +29,7 @@ aws ecs update-service \
   --service "$ECS_SERVICE" \
   --force-new-deployment
 
+# Wait for the service to be stable
+aws ecs wait services-stable \
+  --cluster "$ECS_CLUSTER" \
+  --service "$ECS_SERVICE"


### PR DESCRIPTION
Ref. metriport/metriport-internal#704

### Dependencies

none

### Description

Currently, the script that deploys the API creates a new image on ECR and triggers a restart on ECS, but it doesn't wait for the service to finish restarting (redeploying).

This should fix it. Tested local while there was a deploy in progress and it waited.

### Release Plan

- nothing special
- asap