### PR TITLE
704 remove facility and patient number columns

### DIFF
--- a/packages/api/src/sequelize/migrations/2023-07-27_00_alter-facility-remove-facilityNumber.ts
+++ b/packages/api/src/sequelize/migrations/2023-07-27_00_alter-facility-remove-facilityNumber.ts
@@ -1,0 +1,23 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "facility";
+const columnName = "facility_number";
+
+// Use 'Promise.all' when changes are independent of each other
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.removeColumn(tableName, columnName, { transaction });
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.addColumn(
+      tableName,
+      columnName,
+      { type: DataTypes.INTEGER },
+      { transaction }
+    );
+  });
+};

--- a/packages/api/src/sequelize/migrations/2023-07-27_01_alter-patient-remove-patientNumber.ts
+++ b/packages/api/src/sequelize/migrations/2023-07-27_01_alter-patient-remove-patientNumber.ts
@@ -1,0 +1,23 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "facility";
+const columnName = "facility_number";
+
+// Use 'Promise.all' when changes are independent of each other
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.removeColumn(tableName, columnName, { transaction });
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.addColumn(
+      tableName,
+      columnName,
+      { type: DataTypes.INTEGER },
+      { transaction }
+    );
+  });
+};


### PR DESCRIPTION
Ref. metriport/metriport-internal#704

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/681
- Downstream: none

### Description

Remove facility and patient number columns from the DB. They are not being used on code.

### Release Plan

- ⚠️ Contains a DB migration
- Planning to merge this no earlier than August 31
- Also remove backup tables:
   ```sql
   drop table "customer_sequence_704_20230720";
   drop table "SequelizeMeta_704_20230720";
   ```