### PR TITLE
fix: revert sequelize .save() to .update()

### DIFF
--- a/packages/api/src/command/connected-user/save-connected-user.ts
+++ b/packages/api/src/command/connected-user/save-connected-user.ts
@@ -19,5 +19,6 @@ export const updateProviderData = async ({
     ? { ...connectedUser.providerMap, ...newItem }
     : { ...newItem };
   connectedUser.providerMap = newProviderMap;
-  return connectedUser.save();
+  await ConnectedUser.update({ providerMap: newProviderMap }, { where: { id, cxId } });
+  return getConnectedUserOrFail({ id, cxId });
 };


### PR DESCRIPTION
Ref. metriport/metriport-internal#695

### Dependencies

none

### Description

Alter `updateProviderData()` to not use Sequelize's `.save()`, it gave us `OptimisticLockError`.

Context: https://metriport.slack.com/archives/C04GEQ1GH9D/p1690041960129549

### Release Plan

- ⚠️ This is pointing to `master`, deploying in `production`.
- asap