### PR TITLE
PATCH RELEASE 907 fix converter env var

### DIFF
--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -140,7 +140,7 @@ export function createLambda({
       MAX_TIMEOUT_RETRIES: String(maxTimeoutRetries),
       DELAY_WHEN_RETRY_SECONDS: delayWhenRetrying.toSeconds().toString(),
       ...(config.lambdasSentryDSN ? { SENTRY_DSN: config.lambdasSentryDSN } : {}),
-      API_URL: apiServiceDnsAddress,
+      API_URL: `http://${apiServiceDnsAddress}`,
       QUEUE_URL: sourceQueue.queueUrl,
       DLQ_URL: dlq.queueUrl,
       CONVERSION_RESULT_QUEUE_URL: conversionResultQueueUrl,

--- a/packages/infra/lib/api-stack/sidechain-fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/sidechain-fhir-converter-connector.ts
@@ -134,7 +134,7 @@ export function createLambda({
       MAX_TIMEOUT_RETRIES: String(maxTimeoutRetries),
       DELAY_WHEN_RETRY_SECONDS: delayWhenRetrying.toSeconds().toString(),
       ...(config.lambdasSentryDSN ? { SENTRY_DSN: config.lambdasSentryDSN } : {}),
-      API_URL: apiServiceDnsAddress,
+      API_URL: `http://${apiServiceDnsAddress}`,
       QUEUE_URL: sourceQueue.queueUrl,
       DLQ_URL: dlq.queueUrl,
       CONVERSION_RESULT_QUEUE_URL: destinationQueue.queueUrl,


### PR DESCRIPTION
Ref. metriport/metriport-internal#907

### Dependencies

none

### Description

Fix FHIR converter env var, it was getting the internal address w/o the protocol, and Axios is converting it to `http://localhost/...`

### Release Plan

- asap
- merge this
- merge `master` into `develop`