### PR TITLE
feat(widget): added success and failure redirect urls to widget localStorage for provider connections

### DIFF
--- a/docs/devices-api/getting-started/connect-widget.mdx
+++ b/docs/devices-api/getting-started/connect-widget.mdx
@@ -414,12 +414,12 @@ For a comprehensive list of available colors [visit here](https://www.w3schools.
 After users successfully connect a provider, they can be redirected to a URL of your choosing.<br/>
 
 ```typescript
-`https://connect.metriport.com/?token=${connectToken}&redirectUrl=https://my-app.com/good-news`;
+`https://connect.metriport.com/?token=${connectToken}&redirectUrl=https%3A%2F%2Fmy-app.com%2Fgood-news`;
 ```
 
 <Tip>
   For optimal results, we advise that you encode your URLs before including them in query
-  parameters. ie. redirectUrl=https://my-app.com/?query=my%20achievements
+  parameters. ie. redirectUrl=https%3A%2F%2Fmy-app.com%2Fgood-news
 </Tip>
 
 ### failRedirectUrl
@@ -427,7 +427,7 @@ After users successfully connect a provider, they can be redirected to a URL of 
 After a failed attempt to connect a provider, your users can be redirected to another URL of your choosing. This is similar to [redirectUrl](#redirecturl) above.<br/>
 
 ```typescript
-`https://connect.metriport.com/?token=${connectToken}&failRedirectUrl=https://my-app.com/less-good-news`;
+`https://connect.metriport.com/?token=${connectToken}&failRedirectUrl=https%3A%2F%2Fmy-app.com%2Fless-good-news`;
 ```
 
 ### providers

--- a/docs/devices-api/getting-started/connect-widget.mdx
+++ b/docs/devices-api/getting-started/connect-widget.mdx
@@ -417,6 +417,11 @@ After users successfully connect a provider, they can be redirected to a URL of 
 `https://connect.metriport.com/?token=${connectToken}&redirectUrl=https://my-app.com/good-news`;
 ```
 
+<Tip>
+  For optimal results, we advise that you encode your URLs before including them in query
+  parameters. ie. redirectUrl=https://my-app.com/?query=my%20achievements
+</Tip>
+
 ### failRedirectUrl
 
 After a failed attempt to connect a provider, your users can be redirected to another URL of your choosing. This is similar to [redirectUrl](#redirecturl) above.<br/>

--- a/docs/devices-api/getting-started/connect-widget.mdx
+++ b/docs/devices-api/getting-started/connect-widget.mdx
@@ -409,6 +409,22 @@ For a comprehensive list of available colors [visit here](https://www.w3schools.
   src="https://connect.metriport.com/?token=demo&customColor=orange"
 ></iframe>
 
+### redirectUrl
+
+After users successfully connect a provider, they can be redirected to a URL of your choosing.<br/>
+
+```typescript
+`https://connect.metriport.com/?token=${connectToken}&redirectUrl=https://my-app.com/good-news`;
+```
+
+### failRedirectUrl
+
+After a failed attempt to connect a provider, your users can be redirected to another URL of your choosing. This is similar to [redirectUrl](#redirecturl) above.<br/>
+
+```typescript
+`https://connect.metriport.com/?token=${connectToken}&failRedirectUrl=https://my-app.com/less-good-news`;
+```
+
 ### providers
 
 You can choose the providers you wish to display to your users. It must be a comma separated lowercased list of providers.

--- a/packages/connect-widget/src/pages/connect/index.tsx
+++ b/packages/connect-widget/src/pages/connect/index.tsx
@@ -1,17 +1,18 @@
+import { Box } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { setupApi, isDemo } from "../../shared/api";
+import { isDemo, setupApi } from "../../shared/api";
 import WidgetContainer from "../../shared/components/WidgetContainer";
 import Constants from "../../shared/constants";
 import { acceptAgreement, setAgreementState } from "../../shared/localStorage/agreement";
 import { storeColorMode } from "../../shared/localStorage/color-mode";
+import { storeFailRedirectUrl, storeRedirectUrl } from "../../shared/localStorage/redirect-url";
 import { capture } from "../../shared/notifications";
+import { DemoTokenError } from "../../shared/token-errors";
 import Agreement from "./components/agreement";
 import AgreementFooter from "./components/agreement-footer";
 import ConnectProviders from "./components/connect-providers";
 import ErrorDialog from "./components/error-dialog";
-import { Box } from "@chakra-ui/react";
-import { DemoTokenError } from "../../shared/token-errors";
 
 type DisplayError = {
   message: string;
@@ -26,11 +27,15 @@ const ConnectPage = () => {
   const [error, setError] = useState<DisplayError | null>(null);
 
   const colorMode = searchParams.get(Constants.COLOR_MODE_PARAM);
+  const redirectUrl = searchParams.get(Constants.SUCCESS_REDIRECT_URL_PARAM);
+  const failRedirectUrl = searchParams.get(Constants.FAILURE_REDIRECT_URL_PARAM);
 
   useEffect(() => {
     async function setupConnectPage() {
       try {
         storeColorMode(colorMode);
+        storeRedirectUrl(redirectUrl);
+        storeFailRedirectUrl(failRedirectUrl);
         setAgreementState(setAgreement);
         await setupApi(searchParams);
         //eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/connect-widget/src/pages/error/index.tsx
+++ b/packages/connect-widget/src/pages/error/index.tsx
@@ -5,12 +5,20 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 
 import WidgetContainer from "../../shared/components/WidgetContainer";
 import { capture } from "../../shared/notifications";
-import { redirectToMain } from "../../shared/util";
+import { redirectToCustomUrl, redirectToMain } from "../../shared/util";
+import Constants from "../../shared/constants";
 
 export default function Error() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const handleClick = () => redirectToMain(navigate, searchParams);
+  const handleClick = () => {
+    const redirectUrl = localStorage.getItem(Constants.FAILURE_REDIRECT_URL_PARAM);
+    if (redirectUrl) {
+      redirectToCustomUrl(redirectUrl);
+      return;
+    }
+    redirectToMain(navigate, searchParams);
+  };
   useEffect(() => {
     capture.message("errorPage.loaded", { extra: { searchParams } });
   }, []);

--- a/packages/connect-widget/src/pages/success/index.tsx
+++ b/packages/connect-widget/src/pages/success/index.tsx
@@ -3,14 +3,20 @@ import { Container, Flex, Heading, Text, Card, IconButton } from "@chakra-ui/rea
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import WidgetContainer from "../../shared/components/WidgetContainer";
-import { redirectToMain } from "../../shared/util";
+import { redirectToCustomUrl, redirectToMain } from "../../shared/util";
 import Analytics from "../../shared/analytics";
+import Constants from "../../shared/constants";
 
 export default function Success() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const handleClick = () => {
     Analytics.emit(Analytics.events.connectSuccess);
+    const redirectUrl = localStorage.getItem(Constants.SUCCESS_REDIRECT_URL_PARAM);
+    if (redirectUrl) {
+      redirectToCustomUrl(redirectUrl);
+      return;
+    }
     redirectToMain(navigate, searchParams);
   };
 

--- a/packages/connect-widget/src/shared/constants.ts
+++ b/packages/connect-widget/src/shared/constants.ts
@@ -6,6 +6,8 @@ export default class Constants {
   static readonly CLOUD_ENV = "production"; // NODE_ENV is production when not local
   static readonly COLOR_MODE_PARAM = "colorMode";
   static readonly CUSTOM_COLOR_PARAM = "customColor";
+  static readonly SUCCESS_REDIRECT_URL_PARAM = "redirectUrl";
+  static readonly FAILURE_REDIRECT_URL_PARAM = "failRedirectUrl";
   static readonly PROVIDERS_PARAM = "providers";
   static readonly APPLE_PARAM = "apple";
   static readonly BREAKPOINTS = {

--- a/packages/connect-widget/src/shared/localStorage/redirect-url.ts
+++ b/packages/connect-widget/src/shared/localStorage/redirect-url.ts
@@ -2,12 +2,12 @@ import Constants from "../constants";
 
 export const storeRedirectUrl = (url: string | null) => {
   if (url && localStorage) {
-    localStorage.setItem(Constants.SUCCESS_REDIRECT_URL_PARAM, url);
+    localStorage.setItem(Constants.SUCCESS_REDIRECT_URL_PARAM, decodeURI(url));
   }
 };
 
 export const storeFailRedirectUrl = (url: string | null) => {
   if (url && localStorage) {
-    localStorage.setItem(Constants.FAILURE_REDIRECT_URL_PARAM, url);
+    localStorage.setItem(Constants.FAILURE_REDIRECT_URL_PARAM, decodeURI(url));
   }
 };

--- a/packages/connect-widget/src/shared/localStorage/redirect-url.ts
+++ b/packages/connect-widget/src/shared/localStorage/redirect-url.ts
@@ -1,0 +1,13 @@
+import Constants from "../constants";
+
+export const storeRedirectUrl = (url: string | null) => {
+  if (url && localStorage) {
+    localStorage.setItem(Constants.SUCCESS_REDIRECT_URL_PARAM, url);
+  }
+};
+
+export const storeFailRedirectUrl = (url: string | null) => {
+  if (url && localStorage) {
+    localStorage.setItem(Constants.FAILURE_REDIRECT_URL_PARAM, url);
+  }
+};

--- a/packages/connect-widget/src/shared/util.ts
+++ b/packages/connect-widget/src/shared/util.ts
@@ -17,6 +17,15 @@ export function redirectToMain(navigate: NavigateFunction, searchParams: URLSear
   }
 }
 
+// redirects to the custom redirect url
+export function redirectToCustomUrl(url: string) {
+  try {
+    window.location.href = url;
+  } catch (err) {
+    capture.error(err, { extra: { context: `redirectToCustomUrl` } });
+  }
+}
+
 /**
  * Checks to see if the app is running in a local development environment.
  *

--- a/packages/connect-widget/src/shared/util.ts
+++ b/packages/connect-widget/src/shared/util.ts
@@ -22,7 +22,7 @@ export function redirectToCustomUrl(url: string) {
   try {
     window.location.href = url;
   } catch (err) {
-    capture.error(err, { extra: { context: `redirectToCustomUrl` } });
+    capture.error(err, { extra: { context: `redirectToCustomUrl`, url } });
   }
 }
 


### PR DESCRIPTION
refs. metriport/metriport#711

### Description

- Added the query parameters `redirectUrl` and `failRedirectUrl` to the Widget, allowing the CX to redirect their users to their custom urls based on success/failure during provider connection in the widget.

### Screenshot
<img width="1153" alt="Screenshot 2023-07-27 at 12 28 20 PM" src="https://github.com/metriport/metriport/assets/90670087/26677f94-33a2-44fa-8fbb-0c7d4836ad09">

