### PR TITLE
fix(dapi): fixed the issue of multiple metriport users connecting the same fitbit account

### DIFF
--- a/packages/api/src/command/connected-user/get-connected-user.ts
+++ b/packages/api/src/command/connected-user/get-connected-user.ts
@@ -95,7 +95,7 @@ export const getConnectedUsersByTokenOrFail = async (
     },
   });
 
-  if (!connectedUsers)
+  if (!connectedUsers.length)
     throw new NotFoundError(`Could not find connected users with str matching token`);
 
   return connectedUsers;

--- a/packages/api/src/command/connected-user/get-connected-user.ts
+++ b/packages/api/src/command/connected-user/get-connected-user.ts
@@ -63,6 +63,7 @@ export const getConnectedUsers = async ({
   });
 };
 
+// TODO 749: This function should be removed in this issue: https://github.com/metriport/metriport/issues/749
 export const getConnectedUserByTokenOrFail = async (
   provider: string,
   str: string
@@ -86,6 +87,7 @@ export const getConnectedUserByTokenOrFail = async (
   return connectedUser;
 };
 
+// TODO 749: See if this function can be improved for token matching within the scope of this issue: https://github.com/metriport/metriport/issues/749
 export const getConnectedUsersByTokenOrFail = async (
   provider: string,
   token: string

--- a/packages/api/src/command/connected-user/get-connected-user.ts
+++ b/packages/api/src/command/connected-user/get-connected-user.ts
@@ -77,3 +77,26 @@ export const getConnectedUserByTokenOrFail = async (
 
   return connectedUser;
 };
+
+export const getConnectedUsersByTokenOrFail = async (
+  provider: string,
+  str: string
+): Promise<ConnectedUser[]> => {
+  const connectedUser = await ConnectedUser.findAll({
+    where: {
+      providerMap: {
+        [provider]: {
+          token: {
+            // TODO: Find more optimal solution
+            [Op.like]: "%" + str + "%",
+          },
+        },
+      },
+    },
+  });
+
+  if (!connectedUser)
+    throw new NotFoundError(`Could not find connected users with str matching token`);
+
+  return connectedUser;
+};

--- a/packages/api/src/command/connected-user/get-connected-user.ts
+++ b/packages/api/src/command/connected-user/get-connected-user.ts
@@ -80,23 +80,23 @@ export const getConnectedUserByTokenOrFail = async (
 
 export const getConnectedUsersByTokenOrFail = async (
   provider: string,
-  str: string
+  token: string
 ): Promise<ConnectedUser[]> => {
-  const connectedUser = await ConnectedUser.findAll({
+  const connectedUsers = await ConnectedUser.findAll({
     where: {
       providerMap: {
         [provider]: {
           token: {
             // TODO: Find more optimal solution
-            [Op.like]: "%" + str + "%",
+            [Op.like]: "%" + token + "%",
           },
         },
       },
     },
   });
 
-  if (!connectedUser)
+  if (!connectedUsers)
     throw new NotFoundError(`Could not find connected users with str matching token`);
 
-  return connectedUser;
+  return connectedUsers;
 };

--- a/packages/api/src/command/connected-user/get-connected-user.ts
+++ b/packages/api/src/command/connected-user/get-connected-user.ts
@@ -41,6 +41,14 @@ export const getProviderTokenFromConnectedUserOrFail = (
   throw new NotFoundError(`Could not find connect token for ${provider}`);
 };
 
+export const getAllConnectedUsers = async (cxId?: string): Promise<ConnectedUser[]> => {
+  return ConnectedUser.findAll({
+    where: {
+      ...(cxId ? { cxId } : undefined),
+    },
+  });
+};
+
 export const getConnectedUsers = async ({
   ids,
   cxId,

--- a/packages/api/src/mappings/fitbit/index.ts
+++ b/packages/api/src/mappings/fitbit/index.ts
@@ -12,3 +12,15 @@ export const fitbitWebhookNotificationSchema = z.array(
 );
 
 export type FitbitWebhook = z.infer<typeof fitbitWebhookNotificationSchema>;
+
+export const fitbitWebhookSubscriptionSchema = z.array(
+  z.object({
+    collectionType: z.enum(fitbitCollectionTypes),
+    ownerId: z.string(),
+    ownerType: z.string(),
+    subscriberId: z.string(),
+    subscriptionId: z.string(),
+  })
+);
+
+export type FitbitWebhookSubscriptions = z.infer<typeof fitbitWebhookSubscriptionSchema>;

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -506,7 +506,7 @@ export class Fitbit extends Provider implements OAuth2 {
         resp.data
       );
     } catch (error) {
-      console.log(`createSubscription for Fitbit failed. Cause: ${error}`);
+      console.log(`createSubscription for Fitbit failed. Url: ${url}, Cause: ${error}`);
       capture.error(error, {
         extra: { context: `fitbit.createSubscription`, url },
       });

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -1,7 +1,17 @@
-import { Activity, Biometrics, Body, Nutrition, Sleep, User } from "@metriport/api-sdk";
+import {
+  Activity,
+  Biometrics,
+  Body,
+  Nutrition,
+  ProviderSource,
+  Sleep,
+  User,
+} from "@metriport/api-sdk";
 
 import axios from "axios";
 import status from "http-status";
+import { getConnectedUsersByTokenOrFail } from "../command/connected-user/get-connected-user";
+import { sendProviderDisconnected } from "../command/webhook/devices";
 import { mapToActivity } from "../mappings/fitbit/activity";
 import { mapToBiometrics } from "../mappings/fitbit/biometrics";
 import { mapToBody } from "../mappings/fitbit/body";
@@ -348,7 +358,7 @@ export class Fitbit extends Provider implements OAuth2 {
     );
   }
 
-  async postAuth(token: string) {
+  async postAuth(token: string, userId: string) {
     const accessToken = JSON.parse(token).access_token;
     const fitbitUserId = JSON.parse(token).user_id;
     const scopes = JSON.parse(token).scope;
@@ -362,17 +372,75 @@ export class Fitbit extends Provider implements OAuth2 {
 
     const subscriptionId = fitbitUserId;
     const activeSubscriptions = await this.checkExistingSubscriptions(accessToken);
+    await this.revokeTokenFromExistingUser(userId, fitbitUserId, activeSubscriptions, accessToken);
+
     // TODO #652: Implement userRevokedAccess
 
-    // Creates new WH subscriptions based on the user's selected scopes, if those subscriptions don't already exist for this Fitbit user
+    // Creates new WH subscriptions based on the user's selected scopes
     await Promise.all(
       Object.entries(subscriptionTypes).map(async ([key, subscriptionType]) => {
-        if (scopes.includes(key) && !activeSubscriptions.includes(subscriptionType)) {
+        if (scopes.includes(key)) {
           const subscriptionUrl = `${Fitbit.URL}/${Fitbit.API_PATH}/${subscriptionType}/apiSubscriptions/${subscriptionId}-${subscriptionType}.json`;
           this.createSubscription(subscriptionUrl, accessToken);
         }
       })
     );
+  }
+
+  // Finds existing users connected to this Fitbit account, revokes their tokens and sends WH updates about the disconnections
+  async revokeTokenFromExistingUser(
+    userId: string,
+    fitbitUserId: string,
+    activeSubscriptions: string[],
+    accessToken: string
+  ) {
+    try {
+      if (activeSubscriptions.length > 0) {
+        const connectedUsers = await getConnectedUsersByTokenOrFail(
+          ProviderSource.fitbit,
+          fitbitUserId
+        );
+        await Promise.all(
+          Object.values(connectedUsers).map(async user => {
+            if (user.dataValues.id !== userId) {
+              await this.oauth.revokeLocal(user);
+              await sendProviderDisconnected(user, [ProviderSource.fitbit]);
+            }
+          })
+        );
+        await this.deleteSubscriptions(activeSubscriptions, fitbitUserId, accessToken);
+      }
+    } catch (err) {
+      console.log("Failed to revoke the token of a Fitbit user.", err);
+      capture.error("Failed to revoke the token of a Fitbit user.", {
+        extra: { context: "fitbit.revokeTokenFromExistingUse" },
+      });
+    }
+  }
+
+  // Deletes all WH subscriptions for a user
+  async deleteSubscriptions(
+    activeSubscriptions: string[],
+    fitbitUserId: string,
+    accessToken: string
+  ): Promise<void> {
+    try {
+      await Promise.all(
+        activeSubscriptions.map(async subscriptionType => {
+          const url = `${Fitbit.URL}/${Fitbit.API_PATH}/${subscriptionType}/apiSubscriptions/${fitbitUserId}-${subscriptionType}.json`;
+          await axios.delete(url, {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          });
+        })
+      );
+    } catch (err) {
+      console.log("Failed to delete existing Fitbit WH subscriptions", err);
+      capture.error("Failed to delete existing Fitbit WH subscriptions", {
+        extra: { context: "fitbit.revokeTokenFromExistingUse" },
+      });
+    }
   }
 
   // Fetches existing subscriptions for the Fitbit user, and returns an array of subscribed collectionTypes

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -428,6 +428,9 @@ export class Fitbit extends Provider implements OAuth2 {
       capture.error(err, {
         extra: { context: "fitbit.revokeTokenFromExistingUsers", err, user: currentUser },
       });
+      throw new Error(
+        `Failed to revoke Fitbit token and delete subscriptions for another user. User: ${currentUser}, Error: ${err}.`
+      );
     }
   }
 

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -1,6 +1,7 @@
 import { Activity, Biometrics, Body, Nutrition, Sleep, User } from "@metriport/api-sdk";
 
 import axios from "axios";
+import status from "http-status";
 import { mapToActivity } from "../mappings/fitbit/activity";
 import { mapToBiometrics } from "../mappings/fitbit/biometrics";
 import { mapToBody } from "../mappings/fitbit/body";
@@ -347,9 +348,9 @@ export class Fitbit extends Provider implements OAuth2 {
     );
   }
 
-  async postAuth(token: string, userId?: string) {
+  async postAuth(token: string) {
     const accessToken = JSON.parse(token).access_token;
-
+    const fitbitUserId = JSON.parse(token).user_id;
     const scopes = JSON.parse(token).scope;
 
     const subscriptionTypes: Record<FitbitScopes, FitbitCollectionTypesWithoutUserRevokedAccess> = {
@@ -359,13 +360,14 @@ export class Fitbit extends Provider implements OAuth2 {
       [FitbitScopes.weight]: "body",
     };
 
-    const subscriptionId = userId;
-
+    const subscriptionId = fitbitUserId;
+    const activeSubscriptions = await this.checkExistingSubscriptions(accessToken);
     // TODO #652: Implement userRevokedAccess
 
+    // Creates new WH subscriptions based on the user's selected scopes, if those subscriptions don't already exist for this Fitbit user
     await Promise.all(
       Object.entries(subscriptionTypes).map(async ([key, subscriptionType]) => {
-        if (scopes.includes(key)) {
+        if (scopes.includes(key) && !activeSubscriptions.includes(subscriptionType)) {
           const subscriptionUrl = `${Fitbit.URL}/${Fitbit.API_PATH}/${subscriptionType}/apiSubscriptions/${subscriptionId}-${subscriptionType}.json`;
           this.createSubscription(subscriptionUrl, accessToken);
         }
@@ -373,7 +375,26 @@ export class Fitbit extends Provider implements OAuth2 {
     );
   }
 
-  // Creates a subscription for all or one specific collectionType
+  // Fetches existing subscriptions for the Fitbit user, and returns an array of subscribed collectionTypes
+  async checkExistingSubscriptions(accessToken: string): Promise<string[]> {
+    const url = `${Fitbit.URL}/${Fitbit.API_PATH}/apiSubscriptions.json`;
+    const resp = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    const subscriptions: string[] = [];
+    if (resp.status === status.OK) {
+      if (resp.data.apiSubscriptions) {
+        resp.data.apiSubscriptions.forEach((sub: { collectionType: string }) => {
+          subscriptions.push(sub.collectionType);
+        });
+      }
+    }
+    return subscriptions;
+  }
+
+  // Creates a WH subscription for the collectionTypes specified in the url
   async createSubscription(url: string, accessToken: string): Promise<void> {
     try {
       const resp = await axios.post(url, null, {
@@ -383,14 +404,18 @@ export class Fitbit extends Provider implements OAuth2 {
           "Content-Length": 0,
         },
       });
-      console.log("Fitbit WH subscription created successfully.", resp.data);
+      console.log(
+        "Fitbit WH subscription created successfully with status:",
+        resp.status,
+        "and data:",
+        resp.data
+      );
     } catch (error) {
-      console.log("createSubscription for Fitbit failed.");
+      console.log("createSubscription for Fitbit failed");
       capture.error(error, {
         extra: { context: `fitbit.createSubscription`, url },
       });
-
-      throw new Error(`WH subscription failed Fitbit`, { cause: error });
+      throw new Error("Failed WH subscription for Fitbit", { cause: error });
     }
   }
 }

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -457,6 +457,7 @@ export class Fitbit extends Provider implements OAuth2 {
       capture.error("Failed to delete existing Fitbit WH subscriptions", {
         extra: { context: "fitbit.deleteSubscriptions" },
       });
+      throw new Error("Failed to delete active WH subscriptions for Fitbit", { cause: err });
     }
   }
 
@@ -481,6 +482,7 @@ export class Fitbit extends Provider implements OAuth2 {
     } catch (err) {
       console.log(`Failed to fetch active subscriptions. Url: ${url}, Error: ${err}.`);
       capture.error(err, { extra: { context: `fitbit.getActiveSubscriptions`, url, err } });
+      throw new Error("Failed to get active WH subscriptions for Fitbit", { cause: err });
     }
   }
 
@@ -510,7 +512,7 @@ export class Fitbit extends Provider implements OAuth2 {
       capture.error(error, {
         extra: { context: `fitbit.createSubscription`, url },
       });
-      throw new Error("Failed WH subscription for Fitbit", { cause: error });
+      throw new Error("Failed to create a WH subscription for Fitbit", { cause: error });
     }
   }
 }

--- a/packages/api/src/providers/oauth2.ts
+++ b/packages/api/src/providers/oauth2.ts
@@ -16,7 +16,7 @@ export interface OAuth2 {
   getAuthUri(state: string): Promise<string>;
   revokeProviderAccess(connectedUser: ConnectedUser): Promise<void>;
   getTokenFromAuthCode(code: string): Promise<string>;
-  postAuth?(token: string): Promise<void>;
+  postAuth?(token: string, userId?: string): Promise<void>;
   getAccessToken(connectedUser: ConnectedUser): Promise<string>;
 }
 

--- a/packages/api/src/providers/oauth2.ts
+++ b/packages/api/src/providers/oauth2.ts
@@ -16,7 +16,7 @@ export interface OAuth2 {
   getAuthUri(state: string): Promise<string>;
   revokeProviderAccess(connectedUser: ConnectedUser): Promise<void>;
   getTokenFromAuthCode(code: string): Promise<string>;
-  postAuth?(token: string, userId?: string): Promise<void>;
+  postAuth?(token: string): Promise<void>;
   getAccessToken(connectedUser: ConnectedUser): Promise<string>;
 }
 

--- a/packages/api/src/providers/oauth2.ts
+++ b/packages/api/src/providers/oauth2.ts
@@ -16,7 +16,7 @@ export interface OAuth2 {
   getAuthUri(state: string): Promise<string>;
   revokeProviderAccess(connectedUser: ConnectedUser): Promise<void>;
   getTokenFromAuthCode(code: string): Promise<string>;
-  postAuth?(token: string, userId?: string): Promise<void>;
+  postAuth?(token: string, user?: ConnectedUser): Promise<void>;
   getAccessToken(connectedUser: ConnectedUser): Promise<string>;
 }
 

--- a/packages/api/src/routes/devices/internal-user.ts
+++ b/packages/api/src/routes/devices/internal-user.ts
@@ -1,13 +1,16 @@
+import { ProviderSource } from "@metriport/api-sdk";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import status from "http-status";
-import { asyncHandler } from "../util";
-import { getConnectedUserOrFail } from "../../command/connected-user/get-connected-user";
-import { Constants, providerOAuth2OptionsSchema } from "../../shared/constants";
+import {
+  getAllConnectedUsers,
+  getConnectedUserOrFail,
+} from "../../command/connected-user/get-connected-user";
 import { updateProviderData } from "../../command/connected-user/save-connected-user";
 import { sendProviderDisconnected } from "../../command/webhook/devices";
+import { Constants, providerOAuth2OptionsSchema } from "../../shared/constants";
 import { getUUIDFrom } from "../schemas/uuid";
-import { ConnectedUser } from "../../models/connected-user";
+import { asyncHandler } from "../util";
 
 const router = Router();
 
@@ -26,14 +29,6 @@ router.post(
   "/refresh-tokens",
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").optional();
-    // move this to a command if we need to use it elsewhere
-    const getAllConnectedUsers = async (cxId?: string): Promise<ConnectedUser[]> => {
-      return ConnectedUser.findAll({
-        where: {
-          ...(cxId ? { cxId } : undefined),
-        },
-      });
-    };
     const connectedUsers = await getAllConnectedUsers(cxId);
     let disconnectCount = 0;
     for (const connectedUser of connectedUsers) {
@@ -68,6 +63,52 @@ router.post(
     return res.status(status.OK).json({
       usersProcessed: connectedUsers.length,
       usersWithDisconnectedProviders: disconnectCount,
+    });
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * POST /internal/user/resubscribe-fitbit-webhooks
+ *
+ * Finds all existing users that are connected to Fitbit and recreates their webhook subscriptions.
+ *
+ * @param req.query.cxId - (Optional) the customer/account's ID.
+ * @return Count of users processed and count of users with disconnected providers.
+ */
+router.post(
+  "/resubscribe-fitbit-webhooks",
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").optional();
+    const connectedUsers = await getAllConnectedUsers(cxId);
+
+    let usersAffected = 0;
+    for (const connectedUser of connectedUsers) {
+      const providers = connectedUser.providerMap ? Object.keys(connectedUser.providerMap) : [];
+      for (const providerStr of providers) {
+        if (providerStr === ProviderSource.fitbit) {
+          const providerOAuth2Type = providerOAuth2OptionsSchema.safeParse(providerStr);
+          if (providerOAuth2Type.success) {
+            try {
+              const fitbitToken = connectedUser.providerMap?.fitbit?.token;
+              if (fitbitToken) {
+                await Constants.PROVIDER_OAUTH2_MAP[ProviderSource.fitbit].postAuth?.(
+                  fitbitToken,
+                  connectedUser
+                );
+                usersAffected++;
+              }
+            } catch (err) {
+              console.log(
+                `Failed to add webhook subscriptions through the internal user route. User: ${connectedUser}, Provider: ${providerStr}, Error: ${err}.`
+              );
+            }
+          }
+        }
+      }
+    }
+    return res.status(status.OK).json({
+      usersProcessed: connectedUsers.length,
+      usersAffected,
     });
   })
 );

--- a/packages/api/src/routes/devices/internal-user.ts
+++ b/packages/api/src/routes/devices/internal-user.ts
@@ -82,6 +82,10 @@ router.post(
     const connectedUsers = await getAllConnectedUsers(cxId);
 
     let usersAffected = 0;
+    const errorsCaught: { count: number; errors: unknown[] } = {
+      count: 0,
+      errors: [],
+    };
     for (const connectedUser of connectedUsers) {
       const providers = connectedUser.providerMap ? Object.keys(connectedUser.providerMap) : [];
       for (const providerStr of providers) {
@@ -98,6 +102,8 @@ router.post(
                 usersAffected++;
               }
             } catch (err) {
+              errorsCaught.count++;
+              errorsCaught.errors.push(err);
               console.log(
                 `Failed to add webhook subscriptions through the internal user route. User: ${connectedUser}, Provider: ${providerStr}, Error: ${err}.`
               );
@@ -109,6 +115,7 @@ router.post(
     return res.status(status.OK).json({
       usersProcessed: connectedUsers.length,
       usersAffected,
+      errorsCaught,
     });
   })
 );

--- a/packages/api/src/routes/middlewares/oauth2.ts
+++ b/packages/api/src/routes/middlewares/oauth2.ts
@@ -35,7 +35,7 @@ export const processOAuth2 = async (
     },
   });
 
-  Constants.PROVIDER_OAUTH2_MAP[provider].postAuth?.(token);
+  Constants.PROVIDER_OAUTH2_MAP[provider].postAuth?.(token, userId);
 
   return connectedUser;
 };

--- a/packages/api/src/routes/middlewares/oauth2.ts
+++ b/packages/api/src/routes/middlewares/oauth2.ts
@@ -35,7 +35,7 @@ export const processOAuth2 = async (
     },
   });
 
-  Constants.PROVIDER_OAUTH2_MAP[provider].postAuth?.(token, userId);
+  Constants.PROVIDER_OAUTH2_MAP[provider].postAuth?.(token);
 
   return connectedUser;
 };

--- a/packages/api/src/routes/middlewares/oauth2.ts
+++ b/packages/api/src/routes/middlewares/oauth2.ts
@@ -35,7 +35,7 @@ export const processOAuth2 = async (
     },
   });
 
-  Constants.PROVIDER_OAUTH2_MAP[provider].postAuth?.(token, userId);
+  Constants.PROVIDER_OAUTH2_MAP[provider].postAuth?.(token, connectedUser);
 
   return connectedUser;
 };


### PR DESCRIPTION
refs. metriport/metriport#735
### Description

- Before we create new WH subscriptions, we now check if they already exist for the Fitbit user
- If other users found to be connected to this Fitbit User, we revoke their tokens and delete their WH subscriptions. Then we re-create the subscriptions based on the new connected user's scopes.
- WH subscription IDs are now built from the Fitbit user ID, instead of the Metriport user ID. 

### Release Plan
- Merge this
- Hit this route on prod: `internal/user/resubscribe-fitbit-webhooks`