### PR TITLE
PATCH RELEASE 2023 08 06

### DIFF
--- a/packages/api/src/command/connected-user/get-connected-user.ts
+++ b/packages/api/src/command/connected-user/get-connected-user.ts
@@ -95,7 +95,7 @@ export const getConnectedUsersByTokenOrFail = async (
     },
   });
 
-  if (!connectedUsers)
+  if (!connectedUsers.length)
     throw new NotFoundError(`Could not find connected users with str matching token`);
 
   return connectedUsers;

--- a/packages/api/src/command/connected-user/get-connected-user.ts
+++ b/packages/api/src/command/connected-user/get-connected-user.ts
@@ -63,6 +63,7 @@ export const getConnectedUsers = async ({
   });
 };
 
+// TODO 749: This function should be removed in this issue: https://github.com/metriport/metriport/issues/749
 export const getConnectedUserByTokenOrFail = async (
   provider: string,
   str: string
@@ -86,6 +87,7 @@ export const getConnectedUserByTokenOrFail = async (
   return connectedUser;
 };
 
+// TODO 749: See if this function can be improved for token matching within the scope of this issue: https://github.com/metriport/metriport/issues/749
 export const getConnectedUsersByTokenOrFail = async (
   provider: string,
   token: string

--- a/packages/api/src/command/connected-user/get-connected-user.ts
+++ b/packages/api/src/command/connected-user/get-connected-user.ts
@@ -77,3 +77,26 @@ export const getConnectedUserByTokenOrFail = async (
 
   return connectedUser;
 };
+
+export const getConnectedUsersByTokenOrFail = async (
+  provider: string,
+  str: string
+): Promise<ConnectedUser[]> => {
+  const connectedUser = await ConnectedUser.findAll({
+    where: {
+      providerMap: {
+        [provider]: {
+          token: {
+            // TODO: Find more optimal solution
+            [Op.like]: "%" + str + "%",
+          },
+        },
+      },
+    },
+  });
+
+  if (!connectedUser)
+    throw new NotFoundError(`Could not find connected users with str matching token`);
+
+  return connectedUser;
+};

--- a/packages/api/src/command/connected-user/get-connected-user.ts
+++ b/packages/api/src/command/connected-user/get-connected-user.ts
@@ -80,23 +80,23 @@ export const getConnectedUserByTokenOrFail = async (
 
 export const getConnectedUsersByTokenOrFail = async (
   provider: string,
-  str: string
+  token: string
 ): Promise<ConnectedUser[]> => {
-  const connectedUser = await ConnectedUser.findAll({
+  const connectedUsers = await ConnectedUser.findAll({
     where: {
       providerMap: {
         [provider]: {
           token: {
             // TODO: Find more optimal solution
-            [Op.like]: "%" + str + "%",
+            [Op.like]: "%" + token + "%",
           },
         },
       },
     },
   });
 
-  if (!connectedUser)
+  if (!connectedUsers)
     throw new NotFoundError(`Could not find connected users with str matching token`);
 
-  return connectedUser;
+  return connectedUsers;
 };

--- a/packages/api/src/command/connected-user/get-connected-user.ts
+++ b/packages/api/src/command/connected-user/get-connected-user.ts
@@ -41,6 +41,14 @@ export const getProviderTokenFromConnectedUserOrFail = (
   throw new NotFoundError(`Could not find connect token for ${provider}`);
 };
 
+export const getAllConnectedUsers = async (cxId?: string): Promise<ConnectedUser[]> => {
+  return ConnectedUser.findAll({
+    where: {
+      ...(cxId ? { cxId } : undefined),
+    },
+  });
+};
+
 export const getConnectedUsers = async ({
   ids,
   cxId,

--- a/packages/api/src/mappings/fitbit/index.ts
+++ b/packages/api/src/mappings/fitbit/index.ts
@@ -12,3 +12,15 @@ export const fitbitWebhookNotificationSchema = z.array(
 );
 
 export type FitbitWebhook = z.infer<typeof fitbitWebhookNotificationSchema>;
+
+export const fitbitWebhookSubscriptionSchema = z.array(
+  z.object({
+    collectionType: z.enum(fitbitCollectionTypes),
+    ownerId: z.string(),
+    ownerType: z.string(),
+    subscriberId: z.string(),
+    subscriptionId: z.string(),
+  })
+);
+
+export type FitbitWebhookSubscriptions = z.infer<typeof fitbitWebhookSubscriptionSchema>;

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -427,6 +427,9 @@ export class Fitbit extends Provider implements OAuth2 {
       capture.error(err, {
         extra: { context: "fitbit.revokeTokenFromExistingUsers", err, user: currentUser },
       });
+      throw new Error(
+        `Failed to revoke Fitbit token and delete subscriptions for another user. User: ${currentUser}, Error: ${err}.`
+      );
     }
   }
 

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -505,7 +505,7 @@ export class Fitbit extends Provider implements OAuth2 {
         resp.data
       );
     } catch (error) {
-      console.log(`createSubscription for Fitbit failed. Cause: ${error}`);
+      console.log(`createSubscription for Fitbit failed. Url: ${url}, Cause: ${error}`);
       capture.error(error, {
         extra: { context: `fitbit.createSubscription`, url },
       });

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -456,6 +456,7 @@ export class Fitbit extends Provider implements OAuth2 {
       capture.error("Failed to delete existing Fitbit WH subscriptions", {
         extra: { context: "fitbit.deleteSubscriptions" },
       });
+      throw new Error("Failed to delete active WH subscriptions for Fitbit", { cause: err });
     }
   }
 
@@ -480,6 +481,7 @@ export class Fitbit extends Provider implements OAuth2 {
     } catch (err) {
       console.log(`Failed to fetch active subscriptions. Url: ${url}, Error: ${err}.`);
       capture.error(err, { extra: { context: `fitbit.getActiveSubscriptions`, url, err } });
+      throw new Error("Failed to get active WH subscriptions for Fitbit", { cause: err });
     }
   }
 
@@ -509,7 +511,7 @@ export class Fitbit extends Provider implements OAuth2 {
       capture.error(error, {
         extra: { context: `fitbit.createSubscription`, url },
       });
-      throw new Error("Failed WH subscription for Fitbit", { cause: error });
+      throw new Error("Failed to create a WH subscription for Fitbit", { cause: error });
     }
   }
 }

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -50,6 +50,7 @@ import { PROVIDER_FITBIT } from "../shared/constants";
 import { capture } from "../shared/notifications";
 import { OAuth2, OAuth2DefaultImpl } from "./oauth2";
 import Provider, { ConsumerHealthDataType } from "./provider";
+import { FitbitWebhookSubscriptions, fitbitWebhookSubscriptionSchema } from "../mappings/fitbit";
 
 export class Fitbit extends Provider implements OAuth2 {
   static URL = "https://api.fitbit.com";
@@ -360,7 +361,7 @@ export class Fitbit extends Provider implements OAuth2 {
     );
   }
 
-  async postAuth(token: string, userId: string) {
+  async postAuth(token: string, user: ConnectedUser): Promise<void> {
     const { access_token: accessToken, user_id: fitbitUserId, scope: scopes } = JSON.parse(token);
 
     const subscriptionTypes: Record<FitbitScopes, FitbitCollectionTypesWithoutUserRevokedAccess> = {
@@ -370,9 +371,9 @@ export class Fitbit extends Provider implements OAuth2 {
       [FitbitScopes.weight]: "body",
     };
 
-    const subscriptionId = fitbitUserId;
-    const activeSubscriptions = await this.getSubscriptionCollectionTypes(accessToken);
-    await this.revokeTokenFromExistingUsers(userId, fitbitUserId, activeSubscriptions, accessToken);
+    const activeSubscriptions = await this.getActiveSubscriptions(accessToken);
+    if (activeSubscriptions)
+      await this.revokeTokenFromOtherUsers(user, fitbitUserId, activeSubscriptions, accessToken);
 
     // TODO #652: Implement userRevokedAccess
 
@@ -380,7 +381,8 @@ export class Fitbit extends Provider implements OAuth2 {
     await Promise.all(
       Object.entries(subscriptionTypes).map(async ([key, subscriptionType]) => {
         if (scopes.includes(key)) {
-          const subscriptionUrl = `${Fitbit.URL}/${Fitbit.API_PATH}/${subscriptionType}/apiSubscriptions/${subscriptionId}-${subscriptionType}.json`;
+          const subscriptionId = `${fitbitUserId}-${subscriptionType}`;
+          const subscriptionUrl = `${Fitbit.URL}/${Fitbit.API_PATH}/${subscriptionType}/apiSubscriptions/${subscriptionId}.json`;
           this.createSubscription(subscriptionUrl, accessToken);
         }
       })
@@ -388,21 +390,25 @@ export class Fitbit extends Provider implements OAuth2 {
   }
 
   // Finds existing users connected to this Fitbit account, revokes their tokens and sends WH updates about the disconnections
-  async revokeTokenFromExistingUsers(
-    userId: string,
+  async revokeTokenFromOtherUsers(
+    currentUser: ConnectedUser,
     fitbitUserId: string,
-    activeSubscriptions: string[],
+    activeSubscriptions: FitbitWebhookSubscriptions,
     accessToken: string
-  ) {
+  ): Promise<void> {
     try {
       if (activeSubscriptions.length > 0) {
         const connectedUsers = await getConnectedUsersByTokenOrFail(
           ProviderSource.fitbit,
           fitbitUserId
         );
+
         await Promise.all(
           connectedUsers.map(async user => {
-            if (user.dataValues.id !== userId) {
+            if (
+              user.dataValues.id !== currentUser.dataValues.id &&
+              user.dataValues.cxId === currentUser.dataValues.cxId
+            ) {
               await this.oauth.revokeLocal(user);
               user = await getConnectedUserOrFail({
                 id: user.id,
@@ -412,12 +418,14 @@ export class Fitbit extends Provider implements OAuth2 {
             }
           })
         );
-        await this.deleteSubscriptions(activeSubscriptions, fitbitUserId, accessToken);
+        await this.deleteSubscriptions(activeSubscriptions, accessToken);
       }
     } catch (err) {
-      console.log("Failed to revoke the token of a Fitbit user.", err);
-      capture.error("Failed to revoke the token of a Fitbit user.", {
-        extra: { context: "fitbit.revokeTokenFromExistingUsers" },
+      console.log(
+        `Failed to revoke the token of a Fitbit user. User: ${currentUser}, Error: ${err}`
+      );
+      capture.error(err, {
+        extra: { context: "fitbit.revokeTokenFromExistingUsers", err, user: currentUser },
       });
     }
   }
@@ -425,19 +433,17 @@ export class Fitbit extends Provider implements OAuth2 {
   /**
    * Deletes all WH subscriptions for a user
    *
-   * @param activeSubscriptions
-   * @param fitbitUserId
-   * @param accessToken
+   * @param activeSubscriptions List of active WH subscriptions
+   * @param accessToken Authorization Bearer-type token
    */
   async deleteSubscriptions(
-    activeSubscriptions: string[],
-    fitbitUserId: string,
+    activeSubscriptions: FitbitWebhookSubscriptions,
     accessToken: string
   ): Promise<void> {
     try {
       await Promise.all(
-        activeSubscriptions.map(async subscriptionType => {
-          const url = `${Fitbit.URL}/${Fitbit.API_PATH}/${subscriptionType}/apiSubscriptions/${fitbitUserId}-${subscriptionType}.json`;
+        activeSubscriptions.map(async subscription => {
+          const url = `${Fitbit.URL}/${Fitbit.API_PATH}/${subscription.collectionType}/apiSubscriptions/${subscription.subscriptionId}.json`;
           await axios.delete(url, {
             headers: {
               Authorization: `Bearer ${accessToken}`,
@@ -456,32 +462,32 @@ export class Fitbit extends Provider implements OAuth2 {
   /**
    * Fetches existing subscriptions for the Fitbit user, and returns an array of subscribed collectionTypes
    *
-   * @param accessToken
-   * @returns
+   * @param accessToken Authorization Bearer-type token
+   * @returns List of active FitbitWebhookSubscriptions or undefined
    */
-  async getSubscriptionCollectionTypes(accessToken: string): Promise<string[]> {
+  async getActiveSubscriptions(
+    accessToken: string
+  ): Promise<FitbitWebhookSubscriptions | undefined> {
     const url = `${Fitbit.URL}/${Fitbit.API_PATH}/apiSubscriptions.json`;
-    const resp = await axios.get(url, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-    const subscriptions: string[] = [];
-    if (resp.status === status.OK) {
-      if (resp.data.apiSubscriptions) {
-        resp.data.apiSubscriptions.forEach((sub: { collectionType: string }) => {
-          subscriptions.push(sub.collectionType);
-        });
-      }
+    try {
+      const resp = await axios.get(url, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      if (resp.status === status.OK)
+        return fitbitWebhookSubscriptionSchema.parse(resp.data.apiSubscriptions);
+    } catch (err) {
+      console.log(`Failed to fetch active subscriptions. Url: ${url}, Error: ${err}.`);
+      capture.error(err, { extra: { context: `fitbit.getActiveSubscriptions`, url, err } });
     }
-    return subscriptions;
   }
 
   /**
    * Creates a WH subscription for the collectionTypes specified in the url
    *
-   * @param url
-   * @param accessToken
+   * @param url URL for subscription creation
+   * @param accessToken Authorization Bearer-type token
    */
   async createSubscription(url: string, accessToken: string): Promise<void> {
     try {
@@ -499,7 +505,7 @@ export class Fitbit extends Provider implements OAuth2 {
         resp.data
       );
     } catch (error) {
-      console.log("createSubscription for Fitbit failed");
+      console.log(`createSubscription for Fitbit failed. Cause: ${error}`);
       capture.error(error, {
         extra: { context: `fitbit.createSubscription`, url },
       });

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -371,7 +371,7 @@ export class Fitbit extends Provider implements OAuth2 {
     };
 
     const subscriptionId = fitbitUserId;
-    const activeSubscriptions = await this.checkExistingSubscriptions(accessToken);
+    const activeSubscriptions = await this.getSubscriptionCollectionTypes(accessToken);
     await this.revokeTokenFromExistingUsers(userId, fitbitUserId, activeSubscriptions, accessToken);
 
     // TODO #652: Implement userRevokedAccess
@@ -401,7 +401,7 @@ export class Fitbit extends Provider implements OAuth2 {
           fitbitUserId
         );
         await Promise.all(
-          Object.values(connectedUsers).map(async user => {
+          connectedUsers.map(async user => {
             if (user.dataValues.id !== userId) {
               await this.oauth.revokeLocal(user);
               user = await getConnectedUserOrFail({
@@ -422,7 +422,13 @@ export class Fitbit extends Provider implements OAuth2 {
     }
   }
 
-  // Deletes all WH subscriptions for a user
+  /**
+   * Deletes all WH subscriptions for a user
+   *
+   * @param activeSubscriptions
+   * @param fitbitUserId
+   * @param accessToken
+   */
   async deleteSubscriptions(
     activeSubscriptions: string[],
     fitbitUserId: string,
@@ -440,15 +446,20 @@ export class Fitbit extends Provider implements OAuth2 {
         })
       );
     } catch (err) {
-      console.log("Failed to delete existing Fitbit WH subscriptions", err);
+      console.log(`Failed to delete existing Fitbit WH subscriptions. Cause: ${err}`);
       capture.error("Failed to delete existing Fitbit WH subscriptions", {
         extra: { context: "fitbit.deleteSubscriptions" },
       });
     }
   }
 
-  // Fetches existing subscriptions for the Fitbit user, and returns an array of subscribed collectionTypes
-  async checkExistingSubscriptions(accessToken: string): Promise<string[]> {
+  /**
+   * Fetches existing subscriptions for the Fitbit user, and returns an array of subscribed collectionTypes
+   *
+   * @param accessToken
+   * @returns
+   */
+  async getSubscriptionCollectionTypes(accessToken: string): Promise<string[]> {
     const url = `${Fitbit.URL}/${Fitbit.API_PATH}/apiSubscriptions.json`;
     const resp = await axios.get(url, {
       headers: {
@@ -466,7 +477,12 @@ export class Fitbit extends Provider implements OAuth2 {
     return subscriptions;
   }
 
-  // Creates a WH subscription for the collectionTypes specified in the url
+  /**
+   * Creates a WH subscription for the collectionTypes specified in the url
+   *
+   * @param url
+   * @param accessToken
+   */
   async createSubscription(url: string, accessToken: string): Promise<void> {
     try {
       const resp = await axios.post(url, null, {

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -10,7 +10,10 @@ import {
 
 import axios from "axios";
 import status from "http-status";
-import { getConnectedUsersByTokenOrFail } from "../command/connected-user/get-connected-user";
+import {
+  getConnectedUserOrFail,
+  getConnectedUsersByTokenOrFail,
+} from "../command/connected-user/get-connected-user";
 import { sendProviderDisconnected } from "../command/webhook/devices";
 import { mapToActivity } from "../mappings/fitbit/activity";
 import { mapToBiometrics } from "../mappings/fitbit/biometrics";
@@ -358,9 +361,7 @@ export class Fitbit extends Provider implements OAuth2 {
   }
 
   async postAuth(token: string, userId: string) {
-    const accessToken = JSON.parse(token).access_token;
-    const fitbitUserId = JSON.parse(token).user_id;
-    const scopes = JSON.parse(token).scope;
+    const { access_token: accessToken, user_id: fitbitUserId, scope: scopes } = JSON.parse(token);
 
     const subscriptionTypes: Record<FitbitScopes, FitbitCollectionTypesWithoutUserRevokedAccess> = {
       [FitbitScopes.activity]: "activities",
@@ -371,7 +372,7 @@ export class Fitbit extends Provider implements OAuth2 {
 
     const subscriptionId = fitbitUserId;
     const activeSubscriptions = await this.checkExistingSubscriptions(accessToken);
-    await this.revokeTokenFromExistingUser(userId, fitbitUserId, activeSubscriptions, accessToken);
+    await this.revokeTokenFromExistingUsers(userId, fitbitUserId, activeSubscriptions, accessToken);
 
     // TODO #652: Implement userRevokedAccess
 
@@ -387,7 +388,7 @@ export class Fitbit extends Provider implements OAuth2 {
   }
 
   // Finds existing users connected to this Fitbit account, revokes their tokens and sends WH updates about the disconnections
-  async revokeTokenFromExistingUser(
+  async revokeTokenFromExistingUsers(
     userId: string,
     fitbitUserId: string,
     activeSubscriptions: string[],
@@ -403,7 +404,11 @@ export class Fitbit extends Provider implements OAuth2 {
           Object.values(connectedUsers).map(async user => {
             if (user.dataValues.id !== userId) {
               await this.oauth.revokeLocal(user);
-              await sendProviderDisconnected(user, [ProviderSource.fitbit]);
+              user = await getConnectedUserOrFail({
+                id: user.id,
+                cxId: user.cxId,
+              });
+              sendProviderDisconnected(user, [ProviderSource.fitbit]);
             }
           })
         );
@@ -412,7 +417,7 @@ export class Fitbit extends Provider implements OAuth2 {
     } catch (err) {
       console.log("Failed to revoke the token of a Fitbit user.", err);
       capture.error("Failed to revoke the token of a Fitbit user.", {
-        extra: { context: "fitbit.revokeTokenFromExistingUse" },
+        extra: { context: "fitbit.revokeTokenFromExistingUsers" },
       });
     }
   }
@@ -437,7 +442,7 @@ export class Fitbit extends Provider implements OAuth2 {
     } catch (err) {
       console.log("Failed to delete existing Fitbit WH subscriptions", err);
       capture.error("Failed to delete existing Fitbit WH subscriptions", {
-        extra: { context: "fitbit.revokeTokenFromExistingUse" },
+        extra: { context: "fitbit.deleteSubscriptions" },
       });
     }
   }

--- a/packages/api/src/providers/oauth2.ts
+++ b/packages/api/src/providers/oauth2.ts
@@ -16,7 +16,7 @@ export interface OAuth2 {
   getAuthUri(state: string): Promise<string>;
   revokeProviderAccess(connectedUser: ConnectedUser): Promise<void>;
   getTokenFromAuthCode(code: string): Promise<string>;
-  postAuth?(token: string): Promise<void>;
+  postAuth?(token: string, userId?: string): Promise<void>;
   getAccessToken(connectedUser: ConnectedUser): Promise<string>;
 }
 

--- a/packages/api/src/providers/oauth2.ts
+++ b/packages/api/src/providers/oauth2.ts
@@ -16,7 +16,7 @@ export interface OAuth2 {
   getAuthUri(state: string): Promise<string>;
   revokeProviderAccess(connectedUser: ConnectedUser): Promise<void>;
   getTokenFromAuthCode(code: string): Promise<string>;
-  postAuth?(token: string, userId?: string): Promise<void>;
+  postAuth?(token: string): Promise<void>;
   getAccessToken(connectedUser: ConnectedUser): Promise<string>;
 }
 

--- a/packages/api/src/providers/oauth2.ts
+++ b/packages/api/src/providers/oauth2.ts
@@ -16,7 +16,7 @@ export interface OAuth2 {
   getAuthUri(state: string): Promise<string>;
   revokeProviderAccess(connectedUser: ConnectedUser): Promise<void>;
   getTokenFromAuthCode(code: string): Promise<string>;
-  postAuth?(token: string, userId?: string): Promise<void>;
+  postAuth?(token: string, user?: ConnectedUser): Promise<void>;
   getAccessToken(connectedUser: ConnectedUser): Promise<string>;
 }
 

--- a/packages/api/src/routes/devices/internal-user.ts
+++ b/packages/api/src/routes/devices/internal-user.ts
@@ -1,13 +1,16 @@
+import { ProviderSource } from "@metriport/api-sdk";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import status from "http-status";
-import { asyncHandler } from "../util";
-import { getConnectedUserOrFail } from "../../command/connected-user/get-connected-user";
-import { Constants, providerOAuth2OptionsSchema } from "../../shared/constants";
+import {
+  getAllConnectedUsers,
+  getConnectedUserOrFail,
+} from "../../command/connected-user/get-connected-user";
 import { updateProviderData } from "../../command/connected-user/save-connected-user";
 import { sendProviderDisconnected } from "../../command/webhook/devices";
+import { Constants, providerOAuth2OptionsSchema } from "../../shared/constants";
 import { getUUIDFrom } from "../schemas/uuid";
-import { ConnectedUser } from "../../models/connected-user";
+import { asyncHandler } from "../util";
 
 const router = Router();
 
@@ -26,14 +29,6 @@ router.post(
   "/refresh-tokens",
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").optional();
-    // move this to a command if we need to use it elsewhere
-    const getAllConnectedUsers = async (cxId?: string): Promise<ConnectedUser[]> => {
-      return ConnectedUser.findAll({
-        where: {
-          ...(cxId ? { cxId } : undefined),
-        },
-      });
-    };
     const connectedUsers = await getAllConnectedUsers(cxId);
     let disconnectCount = 0;
     for (const connectedUser of connectedUsers) {
@@ -68,6 +63,52 @@ router.post(
     return res.status(status.OK).json({
       usersProcessed: connectedUsers.length,
       usersWithDisconnectedProviders: disconnectCount,
+    });
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * POST /internal/user/resubscribe-fitbit-webhooks
+ *
+ * Finds all existing users that are connected to Fitbit and recreates their webhook subscriptions.
+ *
+ * @param req.query.cxId - (Optional) the customer/account's ID.
+ * @return Count of users processed and count of users with disconnected providers.
+ */
+router.post(
+  "/resubscribe-fitbit-webhooks",
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").optional();
+    const connectedUsers = await getAllConnectedUsers(cxId);
+
+    let usersAffected = 0;
+    for (const connectedUser of connectedUsers) {
+      const providers = connectedUser.providerMap ? Object.keys(connectedUser.providerMap) : [];
+      for (const providerStr of providers) {
+        if (providerStr === ProviderSource.fitbit) {
+          const providerOAuth2Type = providerOAuth2OptionsSchema.safeParse(providerStr);
+          if (providerOAuth2Type.success) {
+            try {
+              const fitbitToken = connectedUser.providerMap?.fitbit?.token;
+              if (fitbitToken) {
+                await Constants.PROVIDER_OAUTH2_MAP[ProviderSource.fitbit].postAuth?.(
+                  fitbitToken,
+                  connectedUser
+                );
+                usersAffected++;
+              }
+            } catch (err) {
+              console.log(
+                `Failed to add webhook subscriptions through the internal user route. User: ${connectedUser}, Provider: ${providerStr}, Error: ${err}.`
+              );
+            }
+          }
+        }
+      }
+    }
+    return res.status(status.OK).json({
+      usersProcessed: connectedUsers.length,
+      usersAffected,
     });
   })
 );

--- a/packages/api/src/routes/devices/internal-user.ts
+++ b/packages/api/src/routes/devices/internal-user.ts
@@ -82,6 +82,10 @@ router.post(
     const connectedUsers = await getAllConnectedUsers(cxId);
 
     let usersAffected = 0;
+    const errorsCaught: { count: number; errors: unknown[] } = {
+      count: 0,
+      errors: [],
+    };
     for (const connectedUser of connectedUsers) {
       const providers = connectedUser.providerMap ? Object.keys(connectedUser.providerMap) : [];
       for (const providerStr of providers) {
@@ -98,6 +102,8 @@ router.post(
                 usersAffected++;
               }
             } catch (err) {
+              errorsCaught.count++;
+              errorsCaught.errors.push(err);
               console.log(
                 `Failed to add webhook subscriptions through the internal user route. User: ${connectedUser}, Provider: ${providerStr}, Error: ${err}.`
               );
@@ -109,6 +115,7 @@ router.post(
     return res.status(status.OK).json({
       usersProcessed: connectedUsers.length,
       usersAffected,
+      errorsCaught,
     });
   })
 );

--- a/packages/api/src/routes/middlewares/oauth2.ts
+++ b/packages/api/src/routes/middlewares/oauth2.ts
@@ -35,7 +35,7 @@ export const processOAuth2 = async (
     },
   });
 
-  Constants.PROVIDER_OAUTH2_MAP[provider].postAuth?.(token);
+  Constants.PROVIDER_OAUTH2_MAP[provider].postAuth?.(token, userId);
 
   return connectedUser;
 };

--- a/packages/api/src/routes/middlewares/oauth2.ts
+++ b/packages/api/src/routes/middlewares/oauth2.ts
@@ -35,7 +35,7 @@ export const processOAuth2 = async (
     },
   });
 
-  Constants.PROVIDER_OAUTH2_MAP[provider].postAuth?.(token, userId);
+  Constants.PROVIDER_OAUTH2_MAP[provider].postAuth?.(token);
 
   return connectedUser;
 };

--- a/packages/api/src/routes/middlewares/oauth2.ts
+++ b/packages/api/src/routes/middlewares/oauth2.ts
@@ -35,7 +35,7 @@ export const processOAuth2 = async (
     },
   });
 
-  Constants.PROVIDER_OAUTH2_MAP[provider].postAuth?.(token, userId);
+  Constants.PROVIDER_OAUTH2_MAP[provider].postAuth?.(token, connectedUser);
 
   return connectedUser;
 };


### PR DESCRIPTION
Ref: #_[735]_(https://github.com/metriport/metriport/issues/735)
Ref: #_[747]_(https://github.com/metriport/metriport/issues/747)

### Description

- Multiple users from the same CX connecting to the same Fitbit user is now managed properly
- One user connecting to the same Fitbit user from 2 different CX is now managed properly and WH payloads are now sent to both CX
- New internal route that allows us to create WH subscriptions to existing users who connected to Fitbit before WH were implemented

### Release Plan

- THIS IS POINTING TO MASTER!
- Merge this
- Hit the following endpoints on prod:  `internal/user/refresh-tokens` followed by `internal/user/resubscribe-fitbit-webhooks` 