### PR TITLE
934 add gitleaks to prevent secrets on remote

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+npm run check-secrets
+
 npm run lint-staged

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lambdas:no-run": "cd packages/lambdas && npm $SCRIPT && cd ../..",
     "lambdas": "cd packages/lambdas && npm run $SCRIPT && cd ../..",
     "commit": "cz",
+    "check-secrets": "docker run -v $(pwd):/path zricethezav/gitleaks:v8.17.0 protect --source='/path' --staged --no-banner -v",
     "publish:alpha": "npm run build && npx lerna publish --dist-tag next",
     "publish": "npm run build && npx lerna publish",
     "ddb-admin": "DYNAMO_ENDPOINT=http://localhost:8000 dynamodb-admin"


### PR DESCRIPTION
Ref. metriport/metriport-internal#934

### Dependencies

- related: https://github.com/metriport/metriport-internal/pull/938

### Description

Add [gitleaks](https://gitleaks.io/) to prevent secrets on remote.

It runs as a Git hook (pre-commit) triggered by Husky.

We're using the `protect` command to check code that's being pushed to remote (it relies on `git diff`). Other commands, including `detect` that checks code using `git log` or folders, can be seen [here](https://github.com/gitleaks/gitleaks#commands).

We're running it using Docker (slower) so its easier to setup now. If we want we can use the Go version compiled to the local OS, it should be faster (albeit requiring more initial setup). Let's see how this goes and I can adjust if needed.

### Release Plan

- nothing special other communicate this to other devs