### PR TITLE
feat(dapi): fitbit get subscription issue fixed; error array fixed fo…

### DIFF
--- a/packages/api/src/routes/devices/internal-user.ts
+++ b/packages/api/src/routes/devices/internal-user.ts
@@ -101,11 +101,14 @@ router.post(
                 );
                 usersAffected++;
               }
-            } catch (err) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } catch (err: any) {
               errorsCaught.count++;
-              errorsCaught.errors.push(err);
+              errorsCaught.errors.push(err.cause);
               console.log(
-                `Failed to add webhook subscriptions through the internal user route. User: ${connectedUser}, Provider: ${providerStr}, Error: ${err}.`
+                `Failed to add webhook subscriptions through the internal user route. User: ${JSON.stringify(
+                  connectedUser
+                )}, Provider: ${providerStr}, Error: ${err}.`
               );
             }
           }


### PR DESCRIPTION
…r internal route

refs. metriport/metriport#735

### Description

- Fixed the issue where the same user coming from a different CX would render the other UAT inactive, but wouldn't delete it
- Fixed the problem with Fitbit's getSubscriptions endpoint breaking if not all scopes are authorized
- Fixed the internal route `resubscribe-fitbit-webhooks` to properly populate the errors array, providing useful feedback on what went wrong

### Release Plan
- THIS IS POINTING TO MASTER!
- Merge this
- Run `/internal/user/refresh-tokens` followed by `/internal/user/resubscribe-fitbit-webhooks`