### PR TITLE
docs: update to include expo instructions for dapi

### DIFF
--- a/docs/devices-api/sdks/connect-widget/react-native.mdx
+++ b/docs/devices-api/sdks/connect-widget/react-native.mdx
@@ -13,7 +13,7 @@ description: "A library to integrate with Metriport on React Native - including 
   If you're using Expo Go, you'll need to prebuild your app to use this library. You can read more
   about this [here](https://docs.expo.dev/workflow/customizing/). **Note that Apple Health lives on
   the user's device, and requires the native bridge to work. So, Apple Health integrations simply
-  won't work on Expo Go by defualt, and this is true of any other library/vendor.**
+  won't work on Expo Go by default, and this is true of any other library/vendor.**
 </Warning>
 
 ## Installation

--- a/docs/devices-api/sdks/connect-widget/react-native.mdx
+++ b/docs/devices-api/sdks/connect-widget/react-native.mdx
@@ -5,9 +5,16 @@ description: "A library to integrate with Metriport on React Native - including 
 
 <Info>
   If you haven't already, and you're developing on iOS, visit the [Apple Health
-  docs](/devices-api/getting-started/apple-health#1-enable-healthkit) and follow the "Enable HealthKit"
-  section to configure HealthKit.
+  docs](/devices-api/getting-started/apple-health#1-enable-healthkit) and follow the "Enable
+  HealthKit" section to configure HealthKit.
 </Info>
+
+<Warning>
+  If you're using Expo Go, you'll need to prebuild your app to use this library. You can read more
+  about this [here](https://docs.expo.dev/workflow/customizing/). **Note that Apple Health lives on
+  the user's device, and requires the native bridge to work. So, Apple Health integrations simply
+  won't work on Expo Go by defualt, and this is true of any other library/vendor.**
+</Warning>
 
 ## Installation
 
@@ -24,6 +31,27 @@ pod install
 ```
 
 <Snippet file="metriport-sdk-appdelegate.mdx" />
+
+<Info>
+  If using Expo, your `Info.plist` file may be getting overwritten in the prebuild. If this is the
+  case, you'll need to add the following to your `app.json` file:
+  ```json
+  {
+    "expo": {
+      "ios": {
+        "infoPlist": {
+          "NSHealthShareUsageDescription": "<< your usage description here >>",
+          "NSHealthUpdateUsageDescription": "<< your usage description here >>"
+        },
+        "entitlements": {
+          "com.apple.developer.healthkit": true,
+          "com.apple.developer.healthkit.background-delivery": true
+        }
+      }
+    }
+  }
+  ```
+</Info>
 
 ## Usage
 


### PR DESCRIPTION
Ref: metriport/metriport-internal#940

### Dependencies

n/a

### Description

⚠️ pointing to master
update to include expo instructions for dapi

### Release Plan

asap
