### PR TITLE
944 ts fixes

### DIFF
--- a/.github/workflows/_deploy_api.yml
+++ b/.github/workflows/_deploy_api.yml
@@ -98,10 +98,6 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-        # TODO: #156 disabled bc its not working, waiting Sentry support
-        # https://metriport.slack.com/archives/C04FZ9859FZ/p1680112432771159?thread_ts=1680110062.829999&cid=C04FZ9859FZ
-        # if: env.SENTRY_AUTH_TOKEN != null && env.SENTRY_ORG != null
-        if: false
         with:
           environment: ${{ inputs.deploy_env }}
           version: ${{ github.sha }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "workbench.colorCustomizations": {
       "statusBar.background": "#007acc"
     },
+    "typescript.tsdk": "node_modules/typescript/lib",
     "githubPullRequests.ignoredPullRequestBranches": [
       "develop"
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,6 @@
         "packages/infra",
         "packages/utils"
       ],
-      "dependencies": {
-        "typescript": "^4.9.4"
-      },
       "devDependencies": {
         "@commitlint/cli": "^17.4.2",
         "@commitlint/config-conventional": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -51,9 +51,6 @@
       "path": "@commitlint/cz-commitlint"
     }
   },
-  "dependencies": {
-    "typescript": "^4.9.4"
-  },
   "devDependencies": {
     "@commitlint/cli": "^17.4.2",
     "@commitlint/config-conventional": "^17.4.2",

--- a/packages/api-sdk/tsconfig.json
+++ b/packages/api-sdk/tsconfig.json
@@ -20,12 +20,5 @@
     "outDir": "./dist"
   },
   "include": ["./src"],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.*",
-    "**/*.spec.*",
-    "**/__mocks__/",
-    "**/__tests__/"
-  ]
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -12,6 +12,7 @@
     "allowUnreachableCode": false,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
+    "noUnusedLocals": true,
     "checkJs": true,
     // #340 - Left this ones out bc it was causing too many changes
     // "exactOptionalPropertyTypes": true,
@@ -30,12 +31,5 @@
     "resolveJsonModule": true
   },
   "include": ["./src/**/*"],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.*",
-    "**/*.spec.*",
-    "**/__mocks__/",
-    "**/__tests__/"
-  ]
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/commonwell-cert-runner/tsconfig.json
+++ b/packages/commonwell-cert-runner/tsconfig.json
@@ -24,12 +24,5 @@
     "noPropertyAccessFromIndexSignature": false
   },
   "include": ["./src"],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.*",
-    "**/*.spec.*",
-    "**/__mocks__/",
-    "**/__tests__/"
-  ]
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/commonwell-jwt-maker/tsconfig.json
+++ b/packages/commonwell-jwt-maker/tsconfig.json
@@ -23,12 +23,5 @@
     "noPropertyAccessFromIndexSignature": false
   },
   "include": ["./src"],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.*",
-    "**/*.spec.*",
-    "**/__mocks__/",
-    "**/__tests__/"
-  ]
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/commonwell-sdk/tsconfig.json
+++ b/packages/commonwell-sdk/tsconfig.json
@@ -22,12 +22,5 @@
     "outDir": "./dist"
   },
   "include": ["./src"],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.*",
-    "**/*.spec.*",
-    "**/__mocks__/",
-    "**/__tests__/"
-  ]
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/connect-widget/tsconfig.json
+++ b/packages/connect-widget/tsconfig.json
@@ -7,16 +7,9 @@
     "allowUnreachableCode": false,
     "noImplicitOverride": true,
     "noUnusedLocals": true,
-    "checkJs": true,
+    "checkJs": true
     // END
   },
   "include": ["src"],
-  "exclude": [
-    "build",
-    "node_modules",
-    "**/*.test.*",
-    "**/*.spec.*",
-    "**/__mocks__/",
-    "**/__tests__/"
-  ]
+  "exclude": ["build", "node_modules"]
 }

--- a/packages/infra/tsconfig.json
+++ b/packages/infra/tsconfig.json
@@ -19,13 +19,5 @@
     "preserveSymlinks": true
   },
   "include": ["bin", "lib", "config"],
-  "exclude": [
-    "cdk.out",
-    "dist",
-    "node_modules",
-    "**/*.test.*",
-    "**/*.spec.*",
-    "**/__mocks__/",
-    "**/__tests__/"
-  ]
+  "exclude": ["cdk.out", "dist", "node_modules"]
 }

--- a/packages/lambdas/tsconfig.json
+++ b/packages/lambdas/tsconfig.json
@@ -12,14 +12,5 @@
     "outDir": "./dist" /* Specify an output folder for all emitted files. */
   },
   "include": ["./src/**/*"],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.*",
-    "**/*.spec.*",
-    "**/__mocks__/",
-    "**/__tests__/",
-    "layers",
-    "static"
-  ]
+  "exclude": ["dist", "node_modules", "layers", "static"]
 }

--- a/packages/react-native-sdk/tsconfig.json
+++ b/packages/react-native-sdk/tsconfig.json
@@ -35,13 +35,5 @@
     "strict": true
   },
   "include": ["./src"],
-  "exclude": [
-    "lib",
-    "node_modules",
-    "**/*.test.*",
-    "**/*.spec.*",
-    "**/__mocks__/",
-    "**/__tests__/"
-  ]
-
+  "exclude": ["lib", "node_modules"]
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -5,12 +5,5 @@
     "outDir": "./dist"
   },
   "include": ["./src"],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.*",
-    "**/*.spec.*",
-    "**/__mocks__/",
-    "**/__tests__/"
-  ]
+  "exclude": ["dist", "node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "typeRoots": ["./types", "./node_modules/@types"],
     "noErrorTruncation": true,
   },
-  "exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts"],
+  "exclude": ["node_modules"],
   "files": [],
   "references": [
     {


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/944

### Dependencies

- upstream: none
- downstream: TBD

### Description

- do not exclude tests on tsconfig 
- typescript only as dev dependency 
- re-enable Sentry's GH Action

### Release Plan

- nothing special