### PR TITLE
fix(widget): description meta tag updated

### DIFF
--- a/packages/connect-widget/public/index.html
+++ b/packages/connect-widget/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Connect Widget for Healthcare Providers"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--

--- a/packages/connect-widget/public/index.html
+++ b/packages/connect-widget/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Connect Widget for Healthcare Providers"
+      content="Connect Widget for Healthcare Data Providers"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--


### PR DESCRIPTION
refs. metriport/metriport-internal#881

### Description

- Widget's meta tag updated from "Web site created using create-react-app" to "Connect Widget for Healthcare Data Providers"

### Release Plan

- nothing special