### PR TITLE
fix(dapi): fitbit wh get/refresh access token once per user

### DIFF
--- a/packages/api/src/providers/provider.ts
+++ b/packages/api/src/providers/provider.ts
@@ -16,6 +16,7 @@ export enum ConsumerHealthDataType {
 
 export type DAPIParams = {
   timezoneId?: string;
+  accessToken?: string;
 };
 
 export type ConsumerHealthDataTypeMap = {


### PR DESCRIPTION
refs. metriport/metriport#774

### Description

- Instead of getting the access token in `getActivityData` and similar functions, we now get it once for each user in the WH notification and pass it over

### Release Plan

- nothing special