### PR TITLE
704 fix find duplicated person display enrolment

### DIFF
--- a/packages/api/src/external/commonwell/admin/find-patient-duplicates.ts
+++ b/packages/api/src/external/commonwell/admin/find-patient-duplicates.ts
@@ -195,8 +195,8 @@ export async function findDuplicatedPersonsByPatient(
 }
 
 const getLinkInfo = (person?: Person, links?: PatientLinkSearchResp) => ({
-  amountOfLinks: links?._embedded?.patientLink?.length || undetermined,
-  enrolled: person?.enrolled || undetermined,
+  amountOfLinks: links?._embedded?.patientLink?.length ?? undetermined,
+  enrolled: person?.enrolled ?? undetermined,
   enroller: person?.enrollmentSummary?.enroller || undetermined,
   enrollmentDate: person?.enrollmentSummary?.dateEnrolled || undetermined,
 });


### PR DESCRIPTION
Ref. metriport/metriport#704

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/777
- Downstream: none

### Description

Fix after the test on upstream: https://github.com/metriport/metriport/pull/777#issuecomment-1676137636

### Release Plan

- nothing special, asap to get to the release train