### PR TITLE
fix(dapi): fitbit loggedFood.locale nullish

### DIFF
--- a/packages/api/src/mappings/fitbit/models/food.ts
+++ b/packages/api/src/mappings/fitbit/models/food.ts
@@ -10,8 +10,8 @@ export const fitbitFoodResp = z.object({
       loggedFood: z.object({
         accessLevel: z.string(),
         amount: z.number(),
-        brand: z.string(),
-        calories: z.number(),
+        brand: z.string().nullish(),
+        calories: z.number().nullish(),
         foodId: z.number(),
         locale: z.string().nullish(),
         mealTypeId: z.number(),
@@ -25,7 +25,7 @@ export const fitbitFoodResp = z.object({
       }),
       nutritionalValues: z
         .object({
-          calories: z.number(),
+          calories: z.number().nullish(),
           carbs: z.number(),
           fat: z.number(),
           fiber: z.number(),

--- a/packages/api/src/mappings/fitbit/models/food.ts
+++ b/packages/api/src/mappings/fitbit/models/food.ts
@@ -13,7 +13,7 @@ export const fitbitFoodResp = z.object({
         brand: z.string(),
         calories: z.number(),
         foodId: z.number(),
-        locale: z.string(),
+        locale: z.string().nullish(),
         mealTypeId: z.number(),
         name: z.string(),
         unit: z.object({

--- a/packages/api/src/mappings/fitbit/models/food.ts
+++ b/packages/api/src/mappings/fitbit/models/food.ts
@@ -10,10 +10,10 @@ export const fitbitFoodResp = z.object({
       loggedFood: z.object({
         accessLevel: z.string(),
         amount: z.number(),
-        brand: z.string().nullish(),
-        calories: z.number().nullish(),
+        brand: z.string().optional(),
+        calories: z.number().optional(),
         foodId: z.number(),
-        locale: z.string().nullish(),
+        locale: z.string().optional(),
         mealTypeId: z.number(),
         name: z.string(),
         unit: z.object({
@@ -25,7 +25,7 @@ export const fitbitFoodResp = z.object({
       }),
       nutritionalValues: z
         .object({
-          calories: z.number().nullish(),
+          calories: z.number().optional(),
           carbs: z.number(),
           fat: z.number(),
           fiber: z.number(),
@@ -37,7 +37,7 @@ export const fitbitFoodResp = z.object({
   ),
   goals: z.object({ calories: z.number() }).optional(),
   summary: z.object({
-    calories: z.number().nullish(),
+    calories: z.number().optional(),
     carbs: z.number(),
     fat: z.number(),
     fiber: z.number(),

--- a/packages/api/src/mappings/fitbit/models/food.ts
+++ b/packages/api/src/mappings/fitbit/models/food.ts
@@ -37,7 +37,7 @@ export const fitbitFoodResp = z.object({
   ),
   goals: z.object({ calories: z.number() }).optional(),
   summary: z.object({
-    calories: z.number(),
+    calories: z.number().nullish(),
     carbs: z.number(),
     fat: z.number(),
     fiber: z.number(),


### PR DESCRIPTION
refs. metriport/metriport-internal#956

### Description

- Made a few food attributes nullish in the schema based on [Fitbit docs](https://dev.fitbit.com/build/reference/web-api/nutrition/create-food-log/#:~:text=logged%2Din%20user.-,Query%20Parameters,-foodId)

### Release Plan

- THIS IS POINTING TO MASTER
- nothing special