### PR TITLE
PATCH RELEASE 699 fix docref-mapping sequelize setup and create

### DIFF
--- a/packages/api/src/command/medical/docref-mapping/get-docref-mapping.ts
+++ b/packages/api/src/command/medical/docref-mapping/get-docref-mapping.ts
@@ -1,6 +1,7 @@
 import { DocRefMapping } from "../../../domain/medical/docref-mapping";
 import { MedicalDataSource } from "../../../external";
 import { DocRefMappingModel } from "../../../models/medical/docref-mapping";
+import { uuidv7 } from "../../../shared/uuid-v7";
 
 export const getDocRefMapping = async (id: string): Promise<DocRefMapping | undefined> => {
   const docRef = await DocRefMappingModel.findByPk(id);
@@ -21,7 +22,10 @@ export const getOrCreateDocRefMapping = async ({
   const docRef = { cxId, patientId, externalId, source };
   const [res] = await DocRefMappingModel.findOrCreate({
     where: docRef,
-    // no need for `defaults` since all columns for the new record are part of the filter
+    defaults: {
+      id: uuidv7(),
+      ...docRef,
+    },
   });
   return res;
 };

--- a/packages/api/src/models/db.ts
+++ b/packages/api/src/models/db.ts
@@ -4,6 +4,7 @@ import updateDB from "../sequelize";
 import { Config } from "../shared/config";
 import { ConnectedUser } from "./connected-user";
 import { initDDBDev, initLocalCxAccount } from "./db-dev";
+import { DocRefMappingModel } from "./medical/docref-mapping";
 import { FacilityModel } from "./medical/facility";
 import { MAPIAccess } from "./medical/mapi-access";
 import { OrganizationModel } from "./medical/organization";
@@ -21,6 +22,7 @@ const models: ModelSetup[] = [
   FacilityModel.setup,
   PatientModel.setup,
   MAPIAccess.setup,
+  DocRefMappingModel.setup,
 ];
 
 export type MetriportDB = {


### PR DESCRIPTION
Ref. metriport/metriport#699

### Dependencies

none

### Description

Fix docref-mapping sequelize setup and create

Context: https://metriport.slack.com/archives/C04T256DQPQ/p1692050898168939

### Release Plan

- ⚠️ This is pointing to `master`
- asap