### PR TITLE
fix(dapi): stringified objects in logs

### DIFF
--- a/packages/api/src/command/webhook/fitbit.ts
+++ b/packages/api/src/command/webhook/fitbit.ts
@@ -40,7 +40,7 @@ const log = Util.log(`Fitbit Webhook`);
  * @param data Fitbit webhook notification
  */
 export const processData = async (data: FitbitWebhook): Promise<void> => {
-  console.log(`Starting to process a Fitbit webhook: ${data}`);
+  console.log(`Starting to process a Fitbit webhook: ${JSON.stringify(data)}`);
 
   const groupedNotifications = groupByUser(data);
   const dataMappedByConnectedUser = await mapDataByConnectedUser(groupedNotifications);


### PR DESCRIPTION
refs. metriport/metriport#774

### Description
 
- Added `JSON.stringify` to a log statement for better readability of the processes

### Release Plan

- nothing special
