### PR TITLE
307 add region to deploy script/GH workflow

### DIFF
--- a/.github/workflows/_deploy_widget.yml
+++ b/.github/workflows/_deploy_widget.yml
@@ -22,6 +22,9 @@ on:
         required: false
         type: string
         default: "deploy-widget.sh"
+      AWS_REGION:
+        required: true
+        type: string
       S3_BUCKET:
         description: "The URI of the S3 bucket to deploy to"
         required: true
@@ -122,5 +125,6 @@ jobs:
           ./packages/scripts/${{ inputs.script_name }}
         working-directory: "./"
         env:
+          AWS_REGION: ${{ inputs.AWS_REGION }}
           S3_BUCKET: ${{ inputs.S3_BUCKET }}
           CF_DISTRIB_ID: ${{ inputs.CF_DISTRIB_ID }}

--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -11,8 +11,9 @@ jobs:
     with:
       build_env: "staging"
       deploy_env: "staging"
+      AWS_REGION: ${{ vars.WIDGET_REGION_STAGING }}
       S3_BUCKET: ${{ vars.S3_BUCKET_STAGING }}
-      CF_DISTRIB_ID: ${{ vars.CF_DISTRIB_ID_STAGING }}
+      CF_DISTRIB_ID: ${{ vars.WIDGET_CF_DISTRIB_ID_STAGING }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -54,7 +54,7 @@ jobs:
       deploy_env: "production"
       AWS_REGION: ${{ vars.WIDGET_REGION_PRODUCTION }}
       S3_BUCKET: ${{ vars.S3_BUCKET_PRODUCTION }}
-      CF_DISTRIB_ID: ${{ vars.CF_DISTRIB_ID_PRODUCTION }}
+      CF_DISTRIB_ID: ${{ vars.WIDGET_CF_DISTRIB_ID_PRODUCTION }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -52,6 +52,7 @@ jobs:
     with:
       build_env: "production"
       deploy_env: "production"
+      AWS_REGION: ${{ vars.WIDGET_REGION_PRODUCTION }}
       S3_BUCKET: ${{ vars.S3_BUCKET_PRODUCTION }}
       CF_DISTRIB_ID: ${{ vars.CF_DISTRIB_ID_PRODUCTION }}
     secrets:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -53,7 +53,7 @@ jobs:
       deploy_env: "staging"
       AWS_REGION: ${{ vars.WIDGET_REGION_STAGING }}
       S3_BUCKET: ${{ vars.S3_BUCKET_STAGING }}
-      CF_DISTRIB_ID: ${{ vars.CF_DISTRIB_ID_STAGING }}
+      CF_DISTRIB_ID: ${{ vars.WIDGET_CF_DISTRIB_ID_STAGING }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -51,6 +51,7 @@ jobs:
     with:
       build_env: "staging"
       deploy_env: "staging"
+      AWS_REGION: ${{ vars.WIDGET_REGION_STAGING }}
       S3_BUCKET: ${{ vars.S3_BUCKET_STAGING }}
       CF_DISTRIB_ID: ${{ vars.CF_DISTRIB_ID_STAGING }}
     secrets:

--- a/packages/scripts/deploy-widget.sh
+++ b/packages/scripts/deploy-widget.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [[ -z "${AWS_REGION}" ]]; then
+  echo "AWS_REGION is missing"
+  exit 1
+fi
 if [[ -z "${S3_BUCKET}" ]]; then
   echo "S3_BUCKET is missing"
   exit 1
@@ -18,6 +22,7 @@ pushd packages/connect-widget
 # it can cause a bad cache entry in CloudFront.
 
 aws s3 cp build/ "s3://${S3_BUCKET}/" \
+  --region "$AWS_REGION" \
   --recursive \
   --cache-control "public, max-age=31536000" \
   --exclude "*.html" \
@@ -30,12 +35,14 @@ aws s3 cp build/ "s3://${S3_BUCKET}/" \
 # because they reference the previously uploaded hashed files.
 
 aws s3 cp build/ "s3://${S3_BUCKET}/" \
+  --region "$AWS_REGION" \
   --recursive \
   --cache-control "no-cache" \
   --exclude "*" \
   --include "asset-manifest.json"
 
 aws s3 cp build/ "s3://${S3_BUCKET}/" \
+  --region "$AWS_REGION" \
   --recursive \
   --cache-control "no-cache" \
   --exclude "*" \
@@ -46,6 +53,7 @@ aws s3 cp build/ "s3://${S3_BUCKET}/" \
 
 aws cloudfront create-invalidation \
   --no-cli-pager \
+  --region "$AWS_REGION" \
   --distribution-id ${CF_DISTRIB_ID} \
   --paths "/*"
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#307

### Dependencies

- Related: https://github.com/metriport/metriport-internal/pull/927

### Description

Add region to deploy script/GH workflow

### Release Plan

- [ ] add CF distrib ID vars to GH
   - `WIDGET_CF_DISTRIB_ID_STAGING`
   - `WIDGET_CF_DISTRIB_ID_PRODUCTION`
- [ ] merge this