### PR TITLE
fix(docs): make clear the pod update for latest version

### DIFF
--- a/docs/devices-api/sdks/connect-widget/react-native.mdx
+++ b/docs/devices-api/sdks/connect-widget/react-native.mdx
@@ -30,6 +30,12 @@ cd ios
 pod install
 ```
 
+<Info>
+  As pod version's are updated, you may need to run `pod update MetriportSDK` in the `ios` directory
+  to get the latest version. To verify latest, go to
+  https://github.com/metriport/metriport-ios-sdk/releases.
+</Info>
+
 <Snippet file="metriport-sdk-appdelegate.mdx" />
 
 <Info>

--- a/docs/devices-api/sdks/connect-widget/react-native.mdx
+++ b/docs/devices-api/sdks/connect-widget/react-native.mdx
@@ -31,7 +31,7 @@ pod install
 ```
 
 <Info>
-  As pod version's are updated, you may need to run `pod update MetriportSDK` in the `ios` directory
+  As pod versions are updated, you may need to run `pod update MetriportSDK` in the `ios` directory
   to get the latest version. To verify latest, go to
   https://github.com/metriport/metriport-ios-sdk/releases.
 </Info>


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ref: 799

### Description

Some customers have issues updating the pod version, add a blurb in the docs to clarify

### Release Plan

- [ ] Once approved