### PR TITLE
963 fix getProviderDataForType

### DIFF
--- a/packages/api/src/routes/helpers/provider-route-helper.ts
+++ b/packages/api/src/routes/helpers/provider-route-helper.ts
@@ -31,9 +31,14 @@ export async function getProviderDataForType<T>(
     const providerName = p as ProviderOptions; // not proud of this :/
     const provider = Constants.PROVIDER_MAP[providerName];
     if (provider.consumerHealthDataTypeSupported(type)) {
-      const getData = Constants.PROVIDER_MAP[providerName][`get${type}Data`];
       requests.push(
-        (getData(connectedUser, date, params) as Promise<T>).catch(error => {
+        (
+          Constants.PROVIDER_MAP[providerName][`get${type}Data`](
+            connectedUser,
+            date,
+            params
+          ) as Promise<T>
+        ).catch(error => {
           console.error(String(error));
           capture.error(error, {
             extra: {


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/963

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/797
- Downstream: none

### Description

Fixes the issue at `getProviderDataForType` - [context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1692231923653749)

### Release Plan

- nothing special