### PR TITLE
fix(ops): run e2e regardless if other deploys do not

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -162,6 +162,10 @@ jobs:
   e2e-tests:
     uses: ./.github/workflows/_e2e-tests.yml
     needs: release
+    # run even if one of the dependencies didn't
+    # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."
+    # can't use ${{ ! failure() && contains(needs.*.result, 'success') }} because if anything that came before succeeded, even if not a direct dependency, it will run
+    if: ${{ !failure() && (needs.widget.result == 'success' || needs.api.result == 'success' || needs.infra-api-lambdas.result == 'success' || needs.infra-widget.result == 'success') }}
     with:
       deploy_env: "production"
       api_url: ${{ vars.API_URL_PRODUCTION }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -127,6 +127,10 @@ jobs:
   e2e-tests:
     uses: ./.github/workflows/_e2e-tests.yml
     needs: release
+    # run even if one of the dependencies didn't
+    # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."
+    # can't use ${{ ! failure() && contains(needs.*.result, 'success') }} because if anything that came before succeeded, even if not a direct dependency, it will run
+    if: ${{ !failure() && (needs.widget.result == 'success' || needs.api.result == 'success' || needs.infra-api-lambdas.result == 'success' || needs.infra-widget.result == 'success') }}
     with:
       deploy_env: "staging"
       api_url: ${{ vars.API_URL_STAGING }}

--- a/packages/api/src/routes/webhook/apple.ts
+++ b/packages/api/src/routes/webhook/apple.ts
@@ -46,7 +46,6 @@ routes.post(
       });
     } else {
       const mappedData = mapData(appleSchema.parse(payload), hourly);
-
       processAppleData(mappedData, metriportUserId, cxId);
     }
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#672

Ref: 672

### Description

Run e2e script even if all the deploys dont run

### Release Plan

- [ ] Once approved
