### PR TITLE
968 update zod version to 3.22.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35449,8 +35449,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.21.4",
-      "license": "MIT",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.1.tgz",
+      "integrity": "sha512-+qUhAMl414+Elh+fRNtpU+byrwjDFOS1N7NioLY+tSlcADTx4TkCUua/hxJvxwDXcV4397/nZ420jy4n4+3WUg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -35495,7 +35496,7 @@
         "ts-essentials": "^9.3.0",
         "umzug": "^3.2.1",
         "uuid": "^8.3.2",
-        "zod": "^3.20.2"
+        "zod": "^3.22.1"
       },
       "devDependencies": {
         "@faker-js/faker": "^8.0.2",
@@ -35537,7 +35538,7 @@
         "@metriport/commonwell-sdk": "^4.5.3-alpha.0",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
-        "zod": "^3.20.2"
+        "zod": "^3.22.1"
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.2",
@@ -35653,7 +35654,7 @@
         "axios": "^1.3.5",
         "http-status": "^1.6.2",
         "jsonwebtoken": "^9.0.0",
-        "zod": "^3.20.2"
+        "zod": "^3.22.1"
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35457,7 +35457,7 @@
       }
     },
     "packages/api": {
-      "version": "1.1.3-alpha.0",
+      "version": "1.1.3-alpha.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -35532,10 +35532,10 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "6.1.3-alpha.0",
+      "version": "6.1.3-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.5.3-alpha.0",
+        "@metriport/commonwell-sdk": "^4.5.3-alpha.1",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
         "zod": "^3.22.1"
@@ -35571,10 +35571,10 @@
     "packages/api/packages/commonwell-sdk": {},
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.6.3-alpha.0",
+      "version": "1.6.3-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.5.3-alpha.0",
+        "@metriport/commonwell-sdk": "^4.5.3-alpha.1",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -35613,10 +35613,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.3.3-alpha.0",
+      "version": "1.3.3-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.5.3-alpha.0",
+        "@metriport/commonwell-sdk": "^4.5.3-alpha.1",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -35648,7 +35648,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.5.3-alpha.0",
+      "version": "4.5.3-alpha.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",
@@ -35696,13 +35696,13 @@
       }
     },
     "packages/connect-widget": {
-      "version": "1.1.3-alpha.0",
+      "version": "1.1.3-alpha.1",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.12",
         "@chakra-ui/react": "^2.4.1",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
-        "@metriport/api-sdk": "^6.1.3-alpha.0",
+        "@metriport/api-sdk": "^6.1.3-alpha.1",
         "@sentry/react": "^7.45.0",
         "@sentry/tracing": "^7.45.0",
         "@testing-library/jest-dom": "^5.16.5",
@@ -35800,7 +35800,7 @@
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.1.2-alpha.0",
+      "version": "1.1.2-alpha.1",
       "dependencies": {
         "aws-cdk-lib": "^2.87.0",
         "constructs": "^10.2.69",
@@ -35847,7 +35847,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.1.2-alpha.0",
+      "version": "1.1.2-alpha.1",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -36873,13 +36873,13 @@
       }
     },
     "packages/utils": {
-      "version": "1.1.3-alpha.0",
+      "version": "1.1.3-alpha.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",
         "@medplum/core": "^2.0.14",
         "@medplum/fhirtypes": "^2.0.14",
-        "@metriport/api-sdk": "^6.1.3-alpha.0",
+        "@metriport/api-sdk": "^6.1.3-alpha.1",
         "aws-sdk": "2.1243",
         "axios": "^1.3.2",
         "commander": "^10.0.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "6.1.3-alpha.0",
+  "version": "6.1.3-alpha.1",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -55,7 +55,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.5.3-alpha.0",
+    "@metriport/commonwell-sdk": "^4.5.3-alpha.1",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
     "zod": "^3.22.1"

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -58,13 +58,13 @@
     "@metriport/commonwell-sdk": "^4.5.3-alpha.0",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
-    "zod": "^3.20.2"
+    "zod": "^3.22.1"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.2",
+    "@types/jest": "29.5.3",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",
-    "@types/jest": "29.5.3",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "prettier": "^2.8.3",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -61,7 +61,7 @@
     "ts-essentials": "^9.3.0",
     "umzug": "^3.2.1",
     "uuid": "^8.3.2",
-    "zod": "^3.20.2"
+    "zod": "^3.22.1"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.1.3-alpha.0",
+  "version": "1.1.3-alpha.1",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.6.3-alpha.0",
+  "version": "1.6.3-alpha.1",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.5.3-alpha.0",
+    "@metriport/commonwell-sdk": "^4.5.3-alpha.1",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.3.3-alpha.0",
+  "version": "1.3.3-alpha.1",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.5.3-alpha.0",
+    "@metriport/commonwell-sdk": "^4.5.3-alpha.1",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.5.3-alpha.0",
+  "version": "4.5.3-alpha.1",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -62,7 +62,7 @@
     "axios": "^1.3.5",
     "http-status": "^1.6.2",
     "jsonwebtoken": "^9.0.0",
-    "zod": "^3.20.2"
+    "zod": "^3.22.1"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.2",

--- a/packages/connect-widget/package.json
+++ b/packages/connect-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-widget",
-  "version": "1.1.3-alpha.0",
+  "version": "1.1.3-alpha.1",
   "private": true,
   "scripts": {
     "clean": "rimraf build && rimraf node_modules",
@@ -38,7 +38,7 @@
     "@chakra-ui/react": "^2.4.1",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@metriport/api-sdk": "^6.1.3-alpha.0",
+    "@metriport/api-sdk": "^6.1.3-alpha.1",
     "@sentry/react": "^7.45.0",
     "@sentry/tracing": "^7.45.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.1.2-alpha.0",
+  "version": "1.1.2-alpha.1",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.1.2-alpha.0",
+  "version": "1.1.2-alpha.1",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.1.3-alpha.0",
+  "version": "1.1.3-alpha.1",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,
@@ -23,7 +23,7 @@
     "@aws-sdk/client-cognito-identity-provider": "^3.301.0",
     "@medplum/core": "^2.0.14",
     "@medplum/fhirtypes": "^2.0.14",
-    "@metriport/api-sdk": "^6.1.3-alpha.0",
+    "@metriport/api-sdk": "^6.1.3-alpha.1",
     "aws-sdk": "2.1243",
     "axios": "^1.3.2",
     "commander": "^10.0.0",


### PR DESCRIPTION
Ref. metriport/metriport-internal#968

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/969

### Description

Update zod version to 3.22.1

### Release Plan

- asap
- `staging`
   - [x] release alpha version of NPM packages
- `production`
   - [ ] release latest version of NPM packages