### PR TITLE
fix(api): convert apple decimal to percentage

### DIFF
--- a/packages/api/src/mappings/apple/body.ts
+++ b/packages/api/src/mappings/apple/body.ts
@@ -32,9 +32,12 @@ export function mapDataToBody(data: AppleHealth, hourly: boolean) {
     addToBody(appleItem, "lean_mass_kg")
   );
   data.HKQuantityTypeIdentifierBodyMass?.forEach(appleItem => addToBody(appleItem, "weight_kg"));
-  data.HKQuantityTypeIdentifierBodyFatPercentage?.forEach(appleItem =>
-    addToBody(appleItem, "body_fat_pct")
-  );
+  data.HKQuantityTypeIdentifierBodyFatPercentage?.forEach(appleItem => {
+    const CONVERT_DECIMAL = 100;
+
+    appleItem.value = appleItem.value * CONVERT_DECIMAL;
+    addToBody(appleItem, "body_fat_pct");
+  });
 
   return body;
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ref: 799

### Dependencies

- Downstream: https://github.com/metriport/metriport-ios-sdk/pull/15

### Description

Apple health sends decimals for percentages

### Release Plan

- [ ] Once approved
