### PR TITLE
fix(packages): remove baseadress from tsdoc

### DIFF
--- a/packages/api-sdk/src/devices/client/metriport.ts
+++ b/packages/api-sdk/src/devices/client/metriport.ts
@@ -37,7 +37,6 @@ export class MetriportDevicesApi {
    * @param options - Optional parameters
    * @param options.sandbox - Indicates whether to connect to the sandbox, default false.
    * @param options.timeout - Connection timeout in milliseconds, default 20 seconds.
-   * @param options.baseAddress - Base address to be used instead of the default.
    */
   constructor(apiKey: string, options: Options = {}) {
     const { sandbox, timeout } = options;

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -60,7 +60,6 @@ export class MetriportMedicalApi {
    * @param options.additionalHeaders - HTTP headers to be used in all requests.
    * @param options.axios - Axios instance, default, useful when the dependency is not being imported
    *          properly by NPM.
-   * @param options.baseAddress - Base address to be used instead of the default.
    * @param options.sandbox - Indicates whether to connect to the sandbox, default false.
    * @param options.timeout - Connection timeout in milliseconds, default 20 seconds.
    */


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ref: 799

### Description

We dont want to expose baseaddress in our sdk so i am removing it

### Release Plan

- [ ] Once approved
