### PR TITLE
363 increase fitbit auth timeout

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -31,6 +31,8 @@ import { Secrets, getSecrets } from "./shared/secrets";
 import { provideAccessToQueue } from "./shared/sqs";
 import { isProd, isSandbox, mbToBytes } from "./shared/util";
 
+const FITBIT_LAMBDA_TIMEOUT = Duration.seconds(60);
+
 interface APIStackProps extends StackProps {
   config: EnvConfig;
   version: string | undefined;
@@ -724,10 +726,12 @@ export class APIStack extends Stack {
         API_URL: `http://${server.loadBalancer.loadBalancerDnsName}/webhook/fitbit`,
         ENV_TYPE: envType,
         FITBIT_CLIENT_SECRET: fitbitClientSecret,
+        FITBIT_TIMEOUT_MS: FITBIT_LAMBDA_TIMEOUT.toMilliseconds().toString(),
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
       vpc,
       alarmSnsAction: alarmAction,
+      timeout: FITBIT_LAMBDA_TIMEOUT,
     });
 
     const fitbitSubscriberVerificationLambda = createLambda({

--- a/packages/lambdas/src/fitbit-auth.ts
+++ b/packages/lambdas/src/fitbit-auth.ts
@@ -1,19 +1,22 @@
 import { getSecret } from "@aws-lambda-powertools/parameters/secrets";
 import * as Sentry from "@sentry/serverless";
+import { APIGatewayEvent } from "aws-lambda";
 import axios from "axios";
 import { createHmac } from "crypto";
 import status from "http-status";
 import { capture } from "./shared/capture";
 import { getEnvOrFail } from "./shared/env";
-import { APIGatewayEvent } from "aws-lambda";
 
 // Keep this as early on the file as possible
 capture.init();
 
 const apiServerURL = getEnvOrFail("API_URL");
 const fitbitClientSecretName = getEnvOrFail("FITBIT_CLIENT_SECRET");
+const fitbitTimeoutInMillis = getEnvOrFail("FITBIT_TIMEOUT_MS");
 
-const api = axios.create();
+const api = axios.create({
+  timeout: Math.max(Number(fitbitTimeoutInMillis) - 100, 100),
+});
 
 const buildResponse = (status: number, body?: unknown) => ({
   statusCode: status,

--- a/packages/lambdas/src/shared/capture.ts
+++ b/packages/lambdas/src/shared/capture.ts
@@ -15,7 +15,7 @@ export const capture = {
    *
    * @param tracesSampleRate Sample rate to determine trace sampling.
    */
-  init: (tracesSampleRate = 1.0): void => {
+  init: (tracesSampleRate = 0.5): void => {
     Sentry.init({
       dsn: sentryDsn,
       enabled: sentryDsn != null,


### PR DESCRIPTION
Ref. metriport/metriport-internal#363

### Dependencies

none

### Description

- increase fitbit auth timeout
- lower the rate at which we send trace info to Sentry

Context: https://metriport.slack.com/archives/C04DMKE9DME/p1692630919307759

### Release Plan

- nothing special