### PR TITLE
fix(api): handle empty payloads

### DIFF
--- a/packages/api/src/mappings/oura/activity.ts
+++ b/packages/api/src/mappings/oura/activity.ts
@@ -144,7 +144,7 @@ export const ouraDailyActivityResponse = z.object({
   total_calories: z.number(),
   day: z.string(),
   timestamp: z.string(),
-});
+}).optional();
 
 export type OuraDailyActivity = z.infer<typeof ouraDailyActivityResponse>;
 

--- a/packages/api/src/mappings/whoop/models/cycle.ts
+++ b/packages/api/src/mappings/whoop/models/cycle.ts
@@ -20,6 +20,6 @@ export const whoopCycleResp = z.object({
     })
     .nullable()
     .optional(),
-});
+}).optional();
 
 export type WhoopCycle = z.infer<typeof whoopCycleResp>;

--- a/packages/api/src/mappings/whoop/models/recovery.ts
+++ b/packages/api/src/mappings/whoop/models/recovery.ts
@@ -20,6 +20,6 @@ export const whoopRecoveryResp = z.object({
     })
     .nullable()
     .optional(),
-});
+}).optional();
 
 export type WhoopRecovery = z.infer<typeof whoopRecoveryResp>;


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ref: 799

### Description

Certain payloads are throwing zod errors in the console because they come back empty.

### Release Plan

- [ ] Asap
