### PR TITLE
fix(api): make values nullable for whoop

### DIFF
--- a/packages/api/src/mappings/whoop/models/sleep.ts
+++ b/packages/api/src/mappings/whoop/models/sleep.ts
@@ -32,9 +32,9 @@ export const whoopSleepResp = z
           need_from_recent_nap_milli: z.number(),
         }),
         respiratory_rate: z.number(),
-        sleep_performance_percentage: z.number(),
-        sleep_consistency_percentage: z.number(),
-        sleep_efficiency_percentage: z.number(),
+        sleep_performance_percentage: z.number().nullish(),
+        sleep_consistency_percentage: z.number().nullish(),
+        sleep_efficiency_percentage: z.number().nullish(),
       })
       .nullable()
       .optional(),


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ref: 799

### Description

Issue here from zod https://metriport-inc.sentry.io/issues/4421333620/?alert_rule_id=14031188&alert_type=issue&project=4504912884924416&referrer=slack

Zod was throwing errors for whoop sleep because some values came back nullable

### Release Plan

- [ ] Once approved
