### PR TITLE
feat(dapi): added revoke token for tenovi

### DIFF
--- a/packages/api/src/providers/tenovi.ts
+++ b/packages/api/src/providers/tenovi.ts
@@ -12,6 +12,7 @@ import { updateProviderData } from "../command/connected-user/save-connected-use
 import { PROVIDER_TENOVI } from "../shared/constants";
 import { capture } from "../shared/notifications";
 import stringify from "json-stringify-safe";
+import MetriportError from "../errors/metriport-error";
 
 export const TENOVI_DEFAULT_TOKEN_VALUE = "N/A";
 
@@ -50,9 +51,10 @@ export class Tenovi extends Provider {
 
       const rejected = res.filter(r => r.status === "rejected");
       if (rejected.length) {
-        throw new Error(
-          `Failed to disconnect ${rejected.length} devices from Tenovi Gateway. User: ${connectedUser.id}`
-        );
+        throw new MetriportError(`Failed to disconnect device(s) from Tenovi Gateway.`, {
+          numberOfDevices: rejected.length,
+          user: connectedUser.dataValues.id,
+        });
       }
       try {
         await updateProviderData({

--- a/packages/api/src/providers/tenovi.ts
+++ b/packages/api/src/providers/tenovi.ts
@@ -51,8 +51,8 @@ export class Tenovi extends Provider {
 
       const rejected = res.filter(r => r.status === "rejected");
       if (rejected.length) {
-        throw new MetriportError(`Failed to disconnect device(s) from Tenovi Gateway.`, {
-          numberOfDevices: rejected.length,
+        throw new MetriportError(`Failed to disconnect device(s) from Tenovi Gateway.`, undefined, {
+          numberOfDevices: rejected.length.toString(),
           user: connectedUser.dataValues.id,
         });
       }
@@ -99,7 +99,7 @@ export class Tenovi extends Provider {
 
         if (updateUser) {
           const index = connectedDevices.indexOf(deviceId);
-          if (index !== undefined && index !== -1) {
+          if (index !== -1) {
             connectedDevices.splice(index, 1);
           }
 

--- a/packages/api/src/providers/tenovi.ts
+++ b/packages/api/src/providers/tenovi.ts
@@ -118,6 +118,16 @@ export class Tenovi extends Provider {
         });
         throw err;
       }
+    } else {
+      capture.message(`Device ID not found for this user.`, {
+        extra: {
+          context: "tenovi.disconnectDevice",
+          deviceId,
+          connectedDevices,
+          user: connectedUser.dataValues,
+        },
+      });
+      throw new Error(`Device ${deviceId} not found for this user.`);
     }
   }
 

--- a/packages/api/src/providers/tenovi.ts
+++ b/packages/api/src/providers/tenovi.ts
@@ -8,6 +8,8 @@ import { mapToBody } from "../mappings/tenovi/body";
 import { ConnectedUser } from "../models/connected-user";
 import { Config } from "../shared/config";
 import Provider, { ConsumerHealthDataType, DAPIParams } from "./provider";
+import { updateProviderData } from "../command/connected-user/save-connected-user";
+import { PROVIDER_TENOVI } from "../shared/constants";
 
 export class Tenovi extends Provider {
   static URL = "https://api2.tenovi.com";
@@ -24,6 +26,15 @@ export class Tenovi extends Provider {
       [ConsumerHealthDataType.Nutrition]: false,
       [ConsumerHealthDataType.Sleep]: false,
       [ConsumerHealthDataType.User]: false,
+    });
+  }
+
+  async revokeProviderAccess(connectedUser: ConnectedUser): Promise<void> {
+    await updateProviderData({
+      id: connectedUser.id,
+      cxId: connectedUser.cxId,
+      provider: PROVIDER_TENOVI,
+      providerItem: undefined,
     });
   }
 

--- a/packages/api/src/providers/tenovi.ts
+++ b/packages/api/src/providers/tenovi.ts
@@ -10,6 +10,8 @@ import { Config } from "../shared/config";
 import Provider, { ConsumerHealthDataType, DAPIParams } from "./provider";
 import { updateProviderData } from "../command/connected-user/save-connected-user";
 import { PROVIDER_TENOVI } from "../shared/constants";
+import { capture } from "../shared/notifications";
+import stringify from "json-stringify-safe";
 
 export class Tenovi extends Provider {
   static URL = "https://api2.tenovi.com";
@@ -29,13 +31,91 @@ export class Tenovi extends Provider {
     });
   }
 
+  /**
+   * Disconnects all connected devices from the user's Tenovi Gateway.
+   * Removes Tenovi from the user's ProviderMap.
+   *
+   * @param connectedUser The user to disconnect the device from
+   */
   async revokeProviderAccess(connectedUser: ConnectedUser): Promise<void> {
-    await updateProviderData({
-      id: connectedUser.id,
-      cxId: connectedUser.cxId,
-      provider: PROVIDER_TENOVI,
-      providerItem: undefined,
-    });
+    if (connectedUser.providerMap?.tenovi?.connectedDeviceIds) {
+      const res = await Promise.allSettled(
+        connectedUser.providerMap?.tenovi?.connectedDeviceIds?.map(async deviceId => {
+          await this.disconnectDevice(connectedUser, deviceId, false);
+        })
+      );
+
+      const rejected = res.filter(r => r.status === "rejected");
+      if (rejected.length) {
+        throw new Error(
+          `Failed to disconnect ${rejected.length} devices from Tenovi Gateway. User: ${connectedUser.id}`
+        );
+      } else {
+        try {
+          await updateProviderData({
+            id: connectedUser.id,
+            cxId: connectedUser.cxId,
+            provider: PROVIDER_TENOVI,
+            providerItem: undefined,
+          });
+        } catch (err) {
+          console.log("Failed to remove Tenovi from ProviderMap", stringify(err));
+          capture.error(err, {
+            extra: { context: "tenovi.revokeProviderAccess", err, user: connectedUser.dataValues },
+          });
+          throw err;
+        }
+      }
+    }
+  }
+
+  /**
+   * Disconnects the device from the user's Tenovi Gateway.
+   * Optionally updates the user's connected devices list.
+   *
+   * @param connectedUser The user to disconnect the device from
+   * @param deviceId      The device to disconnect
+   * @param updateUser    Whether to update the user's connected devices list
+   */
+  async disconnectDevice(
+    connectedUser: ConnectedUser,
+    deviceId: string,
+    updateUser = true
+  ): Promise<void> {
+    const url = `${Tenovi.URL}/${Tenovi.API_PATH}/hwi/unlink-gateway/${deviceId}/`;
+
+    try {
+      await axios.get(url, {
+        headers: {
+          Authorization: `Api-Key ${Tenovi.apiKey}`,
+        },
+      });
+
+      if (updateUser) {
+        const connectedDevices = connectedUser.providerMap?.tenovi?.connectedDeviceIds;
+        const index = connectedDevices?.indexOf(deviceId);
+        if (index !== undefined && index !== -1) {
+          connectedDevices?.splice(index, 1);
+        }
+
+        await updateProviderData({
+          id: connectedUser.id,
+          cxId: connectedUser.cxId,
+          provider: PROVIDER_TENOVI,
+          providerItem: {
+            token: "N/A",
+            connectedDeviceIds: connectedDevices,
+            deviceUserId: connectedUser.providerMap?.tenovi?.deviceUserId,
+          },
+        });
+      }
+    } catch (err) {
+      console.log("Failed to disconnect devices from Tenovi Gateway", stringify(err));
+      capture.error(err, {
+        extra: { context: "tenovi.revokeProviderAccess", err, user: connectedUser.dataValues },
+      });
+      throw err;
+    }
   }
 
   async fetchPatientData(url: string): Promise<TenoviMeasurementData> {

--- a/packages/api/src/routes/middlewares/connect-device.ts
+++ b/packages/api/src/routes/middlewares/connect-device.ts
@@ -3,6 +3,7 @@ import { updateProviderData } from "../../command/connected-user/save-connected-
 import { getUserToken } from "../../command/cx-user/get-user-token";
 import UnauthorizedError from "../../errors/unauthorized";
 import { ConnectedUser } from "../../models/connected-user";
+import { TENOVI_DEFAULT_TOKEN_VALUE } from "../../providers/tenovi";
 import { RPMDeviceProviderOptions } from "../../shared/constants";
 
 /**
@@ -38,7 +39,7 @@ export const saveRpmDevice = async (
     cxId,
     provider,
     providerItem: {
-      token: "N/A",
+      token: TENOVI_DEFAULT_TOKEN_VALUE,
       connectedDeviceIds,
       deviceUserId,
     },

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -28,7 +28,7 @@ import {
 import { capture } from "../shared/notifications";
 import { getProviderDataForType } from "./helpers/provider-route-helper";
 import { getUserIdFrom } from "./schemas/user-id";
-import { asyncHandler, getCxIdOrFail } from "./util";
+import { asyncHandler, getCxIdOrFail, getFromQuery } from "./util";
 
 const router = Router();
 
@@ -317,13 +317,16 @@ router.get("/connect", async (req: Request, res: Response) => {
 async function removeDevice(req: Request, userId: string) {
   const cxId = getCxIdOrFail(req);
   const connectedUser = await getConnectedUserOrFail({ id: userId, cxId });
-  if (!req.query.provider || !req.query.deviceId) throw new BadRequestError();
+  const provider = getFromQuery("provider", req);
+  const deviceId = getFromQuery("deviceId", req);
 
-  if (req.query.provider === PROVIDER_TENOVI) {
+  if (!provider || !deviceId) throw new BadRequestError();
+
+  if (provider === PROVIDER_TENOVI) {
     const tenovi = new Tenovi();
-    await tenovi.disconnectDevice(connectedUser, String(req.query.deviceId));
+    await tenovi.disconnectDevice(connectedUser, String(deviceId));
   } else {
-    throw new BadRequestError(`Provider not supported: ${req.query.provider}`);
+    throw new BadRequestError(`Provider not supported: ${provider}`);
   }
 }
 

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -26,7 +26,7 @@ import {
 import { capture } from "../shared/notifications";
 import { getProviderDataForType } from "./helpers/provider-route-helper";
 import { getUserIdFrom } from "./schemas/user-id";
-import { asyncHandler, getCxIdOrFail, getFromQuery } from "./util";
+import { asyncHandler, getCxIdOrFail, getFrom } from "./util";
 
 const router = Router();
 
@@ -338,10 +338,8 @@ router.delete(
     const cxId = getCxIdOrFail(req);
     const connectedUser = await getConnectedUserOrFail({ id: userId, cxId });
 
-    const provider = getFromQuery("provider", req);
-    const deviceId = getFromQuery("deviceId", req);
-    if (!provider) throw new BadRequestError("Missing required query param: provider");
-    if (!deviceId) throw new BadRequestError("Missing required query param: deviceId");
+    const provider = getFrom("query").orFail("provider", req);
+    const deviceId = getFrom("query").orFail("deviceId", req);
 
     await removeDevice(connectedUser, provider, deviceId);
     return res

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -15,10 +15,12 @@ import { ConnectedUser } from "../models/connected-user";
 
 import { Apple } from "../providers/apple";
 import { ConsumerHealthDataType } from "../providers/provider";
+import { Tenovi } from "../providers/tenovi";
 import { Config } from "../shared/config";
 import {
   Constants,
   PROVIDER_APPLE,
+  PROVIDER_TENOVI,
   providerOAuth1OptionsSchema,
   providerOAuth2OptionsSchema,
 } from "../shared/constants";
@@ -158,9 +160,14 @@ router.get(
   })
 );
 
+const noAuthProviders = {
+  [PROVIDER_APPLE]: Apple,
+  [PROVIDER_TENOVI]: Tenovi,
+};
+
 async function revokeUserProviderAccess(
   connectedUser: ConnectedUser,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  //eslint-disable-next-line @typescript-eslint/no-explicit-any
   provider: any
 ): Promise<void> {
   const providerOAuth2 = providerOAuth2OptionsSchema.safeParse(provider);
@@ -172,9 +179,10 @@ async function revokeUserProviderAccess(
     const token = connectedUser.dataValues.providerMap?.garmin?.token;
     const cxId = connectedUser.dataValues.cxId;
     if (token) await Constants.PROVIDER_OAUTH1_MAP[providerOAuth1.data].deregister([token], cxId);
-  } else if (provider === PROVIDER_APPLE) {
-    const apple = new Apple();
-    await apple.revokeProviderAccess(connectedUser);
+  } else if (Object.keys(noAuthProviders).includes(provider)) {
+    const prov = provider as typeof PROVIDER_APPLE | typeof PROVIDER_TENOVI;
+    const noAuthProvider = new (noAuthProviders[prov] as typeof Apple | typeof Tenovi)();
+    await noAuthProvider.revokeProviderAccess(connectedUser);
   } else {
     throw new BadRequestError(`Provider not supported: ${provider}`);
   }

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -313,22 +313,17 @@ router.get("/connect", async (req: Request, res: Response) => {
 
 /**
  * Removes the device from the user's profile.
- *
- * @param req
- * @param userId
- * @returns
  */
 async function removeDevice(req: Request, userId: string) {
   const cxId = getCxIdOrFail(req);
   const connectedUser = await getConnectedUserOrFail({ id: userId, cxId });
-  const { provider, deviceId } = req.query;
-  if (!provider || !deviceId) throw new BadRequestError();
+  if (!req.query.provider || !req.query.deviceId) throw new BadRequestError();
 
-  if (provider === PROVIDER_TENOVI) {
+  if (req.query.provider === PROVIDER_TENOVI) {
     const tenovi = new Tenovi();
-    await tenovi.disconnectDevice(connectedUser, String(deviceId));
+    await tenovi.disconnectDevice(connectedUser, String(req.query.deviceId));
   } else {
-    throw new BadRequestError(`Provider not supported: ${provider}`);
+    throw new BadRequestError(`Provider not supported: ${req.query.provider}`);
   }
 }
 

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -167,7 +167,7 @@ const noAuthProviders = {
 
 async function revokeUserProviderAccess(
   connectedUser: ConnectedUser,
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   provider: any
 ): Promise<void> {
   const providerOAuth2 = providerOAuth2OptionsSchema.safeParse(provider);

--- a/packages/api/src/shared/constants.ts
+++ b/packages/api/src/shared/constants.ts
@@ -63,6 +63,12 @@ export class Constants {
   } = {
     garmin: new Garmin(),
   };
+
+  static readonly noAuthProviders = {
+    [PROVIDER_APPLE]: Apple,
+    [PROVIDER_TENOVI]: Tenovi,
+  };
+
   static readonly PROVIDER_OAUTH2_MAP: {
     [k in ProviderOAuth2Options]: OAuth2;
   } = {

--- a/packages/api/src/shared/constants.ts
+++ b/packages/api/src/shared/constants.ts
@@ -44,7 +44,7 @@ export const providerOAuth2OptionsSchema = z.enum([
 ]);
 export type ProviderOAuth2Options = z.infer<typeof providerOAuth2OptionsSchema>;
 
-export const providerNoAuthSchema = z.enum([PROVIDER_APPLE]);
+export const providerNoAuthSchema = z.enum([PROVIDER_APPLE, PROVIDER_TENOVI]);
 export type ProviderNoAuthSchema = z.infer<typeof providerNoAuthSchema>;
 
 export type ProviderOptions =


### PR DESCRIPTION
refs. metriport/metriport#812

### Description

- Users can now revoke their token for Tenovi, which disconnects all their devices from the Tenovi Gateway, preventing any future webhooks from coming through
- Users can now delete one device at a time from their user

### Release Plan

- Nothing special