### PR TITLE
fix(dash): sandbox non-default patients query completes with no data

### DIFF
--- a/packages/api/src/external/commonwell/document/document-query-sandbox.ts
+++ b/packages/api/src/external/commonwell/document/document-query-sandbox.ts
@@ -44,7 +44,15 @@ export async function sandboxGetDocRefsAndUpsert({
   await Util.sleep(Math.random() * sandboxSleepTime);
 
   const patientData = getSandboxSeedData(patient.data.firstName);
-  if (!patientData) return [];
+  if (!patientData) {
+    await appendDocQueryProgress({
+      patient: { id: patient.id, cxId: patient.cxId },
+      downloadProgress: {
+        status: "completed",
+      },
+    });
+    return [];
+  }
 
   const entries = patientData.docRefs;
   log(`Got ${entries.length} doc refs`);


### PR DESCRIPTION
refs. metriport/metriport-internal#864

### Description

- We were lacking the query completion return on Sandbox for non-default patients, resulting in infinite requests to obtain their docs. This fixes the issue.

### Release Plan

- Nothing special
