### PR TITLE
118 rename toISODate to be explicit about unit

### DIFF
--- a/packages/api/src/mappings/garmin/activity.ts
+++ b/packages/api/src/mappings/garmin/activity.ts
@@ -7,7 +7,7 @@ import { groupBy, partition } from "lodash";
 import { z } from "zod";
 import { garminMetaSchema, User, UserData } from ".";
 import { PROVIDER_GARMIN } from "../../shared/constants";
-import { toISODate, toISODateTime } from "../../shared/date";
+import { secondsToISODate, secondsToISODateTime } from "../../shared/date";
 import { Util } from "../../shared/util";
 import { activityTypeReadable } from "./activity-types";
 
@@ -90,7 +90,7 @@ export const garminActivitySummaryToActivityLog = (
 ): ActivityLog => {
   const res: ActivityLog = {
     metadata: {
-      date: toISODate(activity.startTimeInSeconds),
+      date: secondsToISODate(activity.startTimeInSeconds),
       source: PROVIDER_GARMIN,
     },
   };
@@ -101,10 +101,10 @@ export const garminActivitySummaryToActivityLog = (
     res.type = activityTypeReadable(activity.activityType);
   }
   if (activity.startTimeInSeconds != null) {
-    res.start_time = toISODateTime(activity.startTimeInSeconds);
+    res.start_time = secondsToISODateTime(activity.startTimeInSeconds);
   }
   if (activity.startTimeInSeconds != null && activity.durationInSeconds != null) {
-    res.end_time = toISODateTime(activity.startTimeInSeconds + activity.durationInSeconds);
+    res.end_time = secondsToISODateTime(activity.startTimeInSeconds + activity.durationInSeconds);
   }
   // durations: ActivityDurations, // nothing from Garmin's Activity Details, comes from Health API
   if (activity.activeKilocalories != null) {

--- a/packages/api/src/mappings/garmin/bloodPressure.ts
+++ b/packages/api/src/mappings/garmin/bloodPressure.ts
@@ -6,7 +6,7 @@ import { DeepNonNullable, DeepRequired } from "ts-essentials";
 import { z } from "zod";
 import { garminMetaSchema, garminTypes, User, UserData } from ".";
 import { PROVIDER_GARMIN } from "../../shared/constants";
-import { toISODate, toISODateTime } from "../../shared/date";
+import { secondsToISODate, secondsToISODateTime } from "../../shared/date";
 
 export const mapToBiometricsFromBloodPressure = (
   items: GarminBloodPressureList
@@ -20,7 +20,7 @@ export const mapToBiometricsFromBloodPressure = (
       userAccessToken: uat,
     };
     // group by calendar date
-    const userDataByDate = groupBy(userData, v => toISODate(v.measurementTimeInSeconds));
+    const userDataByDate = groupBy(userData, v => secondsToISODate(v.measurementTimeInSeconds));
     const mappedItems: (UserData<Biometrics> | undefined)[] = Object.keys(userDataByDate).map(
       date => {
         const userDataOfDate: GarminBloodPressure[] = userDataByDate[date].filter(
@@ -81,7 +81,7 @@ export const mapToDiastolicSamples = (
   if (bp.length < 1) return undefined;
   return {
     samples: bp.map(v => ({
-      time: toISODateTime(v.measurementTimeInSeconds),
+      time: secondsToISODateTime(v.measurementTimeInSeconds),
       value: v.diastolic,
     })),
   };
@@ -99,7 +99,7 @@ export const mapToSystolicSamples = (
   if (bp.length < 1) return undefined;
   return {
     samples: bp.map(v => ({
-      time: toISODateTime(v.measurementTimeInSeconds),
+      time: secondsToISODateTime(v.measurementTimeInSeconds),
       value: v.systolic,
     })),
   };
@@ -115,7 +115,7 @@ export const mapToHeartRateSamples = (
   if (pulses.length < 1) return undefined;
   return {
     samples_bpm: pulses.map(v => ({
-      time: toISODateTime(v.measurementTimeInSeconds),
+      time: secondsToISODateTime(v.measurementTimeInSeconds),
       value: v.pulse,
     })),
   };

--- a/packages/api/src/mappings/garmin/body-composition.ts
+++ b/packages/api/src/mappings/garmin/body-composition.ts
@@ -4,7 +4,7 @@ import { groupBy } from "lodash";
 import { z } from "zod";
 import { garminMetaSchema, garminTypes, User, UserData } from ".";
 import { PROVIDER_GARMIN } from "../../shared/constants";
-import { toISODate } from "../../shared/date";
+import { secondsToISODate } from "../../shared/date";
 
 export const mapToBody = (items: GarminBodyCompositionList): UserData<Body>[] => {
   const type = "body";
@@ -26,7 +26,7 @@ export const garminBodyCompositionToBody = (gBody: GarminBodyComposition): Body 
   const res: Body = {
     metadata: {
       // TODO https://github.com/metriport/metriport-internal/issues/166
-      date: toISODate(gBody.measurementTimeInSeconds),
+      date: secondsToISODate(gBody.measurementTimeInSeconds),
       source: PROVIDER_GARMIN,
     },
   };

--- a/packages/api/src/mappings/garmin/respiration.ts
+++ b/packages/api/src/mappings/garmin/respiration.ts
@@ -4,7 +4,7 @@ import { groupBy } from "lodash";
 import { z } from "zod";
 import { garminMetaSchema, garminTypes, User, UserData } from ".";
 import { PROVIDER_GARMIN } from "../../shared/constants";
-import { toISODate } from "../../shared/date";
+import { secondsToISODate } from "../../shared/date";
 
 type BreathAndDate = { date: string; breath: { time: string; value: number } };
 
@@ -50,7 +50,7 @@ const toBreaths = (userData: GarminRespirationList): BreathAndDate[] => {
     const offsets = Object.keys(timeOffsetEpochToBreaths).map(Number);
     if (offsets.length < 1) return undefined;
     return offsets.map(offset => {
-      const date = toISODate(v.startTimeInSeconds);
+      const date = secondsToISODate(v.startTimeInSeconds);
       const time = dayjs.unix(v.startTimeInSeconds + offset).toISOString();
       const value = timeOffsetEpochToBreaths[offset];
       return { date, breath: { time, value } };

--- a/packages/api/src/mappings/garmin/sleep.ts
+++ b/packages/api/src/mappings/garmin/sleep.ts
@@ -4,7 +4,7 @@ import { groupBy } from "lodash";
 import { z } from "zod";
 import { garminMetaSchema, garminTypes, User, UserData } from ".";
 import { PROVIDER_GARMIN } from "../../shared/constants";
-import { toISODateTime } from "../../shared/date";
+import { secondsToISODateTime } from "../../shared/date";
 
 export const mapToSleep = (sleepList: GarminSleepList): UserData<Sleep>[] => {
   const type = "sleep";
@@ -26,9 +26,9 @@ export const garminSleepToSleep = (gSleep: GarminSleep): Sleep => {
       source: PROVIDER_GARMIN,
     },
   };
-  res.start_time = toISODateTime(gSleep.startTimeInSeconds);
+  res.start_time = secondsToISODateTime(gSleep.startTimeInSeconds);
   if (gSleep.durationInSeconds != null) {
-    res.end_time = toISODateTime(gSleep.startTimeInSeconds + gSleep.durationInSeconds);
+    res.end_time = secondsToISODateTime(gSleep.startTimeInSeconds + gSleep.durationInSeconds);
   }
   res.durations = toDurations(gSleep);
   res.biometrics = toBiometrics(gSleep);

--- a/packages/api/src/shared/date.ts
+++ b/packages/api/src/shared/date.ts
@@ -25,11 +25,11 @@ export const getStartAndEndDate = (date: string) => {
   };
 };
 
-export const toISODate = (unixTime: number): string => {
+export const secondsToISODate = (unixTime: number): string => {
   return dayjs.unix(unixTime).format(ISO_DATE);
 };
 
-export const toISODateTime = (unixTime: number): string => {
+export const secondsToISODateTime = (unixTime: number): string => {
   return dayjs.unix(unixTime).toISOString();
 };
 


### PR DESCRIPTION
Ref: metriport/metriport-internal#118

### Dependencies

none

### Description

Rename `toISODate` to `secondsToISODate` to be more explicit about unit; especially b/c time is usually represented in milliseconds and not seconds.

### Release Plan

- nothing special