### PR TITLE
PATCH RELEASE re-add "create patient consolidate" to docs menu

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -129,7 +129,8 @@
           "pages": [
             "medical-api/api-reference/fhir/consolidated-data-query-post",
             "medical-api/api-reference/fhir/consolidated-data-query-get",
-            "medical-api/api-reference/fhir/consolidated-data-count"
+            "medical-api/api-reference/fhir/consolidated-data-count",
+            "medical-api/api-reference/fhir/create-patient-consolidated"
           ]
         }
       ]


### PR DESCRIPTION
Ref: metriport/metriport-internal#895

### Dependencies

Re-add "create patient consolidate" to docs menu

Context: https://metriport.slack.com/archives/C04DMKE9DME/p1694022303449149

### Description

- ⚠️ This is pointing to `master`