### PR TITLE
846 doc reprocess use subjectId for patient

### DIFF
--- a/packages/api/src/external/commonwell/patient-shared.ts
+++ b/packages/api/src/external/commonwell/patient-shared.ts
@@ -187,7 +187,10 @@ export async function getPatientData(
   const { organization, facilities } = await getPatientWithDependencies(patient);
   const facility = facilities.find(f => f.id === facilityId);
   if (!facility) {
-    throw new BadRequestError(`Patient not associated with given facility`);
+    throw new BadRequestError(`Patient not associated with given facility`, undefined, {
+      patientId: patient.id,
+      facilityId,
+    });
   }
   return { organization, facility };
 }


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/846

### Dependencies

none

### Description

Doc reprocess use subjectId for patient instead of contained.id

### Release Plan

- nothing special