### PR TITLE
PATCH RELEASE make Garmin overallSleepScore.value nullish

### DIFF
--- a/packages/api/src/mappings/garmin/index.ts
+++ b/packages/api/src/mappings/garmin/index.ts
@@ -97,8 +97,8 @@ export const garminTypes = {
   timeOffsetSleepRespiration: respirationMeasurements,
   timeOffsetSleepSpo2: spo2Measurements,
   overallSleepScore: z.object({
-    value: z.number(),
-    qualifierKey: z.string(),
+    value: z.number().nullish(),
+    qualifierKey: z.string().nullish(),
   }),
   //
   activeKilocalories: garminUnits.kilocalories,


### PR DESCRIPTION
Ref: metriport/metriport-internal#1035

### Description

Make Garmin overallSleepScore.value nullish

### Release Plan

- ⚠️ This is pointing to `master`
- nothing special, asap