### PR TITLE
fix(lambdas): fixed a bug in cda-to-vis lambda 

### DIFF
--- a/packages/lambdas/src/cda-to-visualization.ts
+++ b/packages/lambdas/src/cda-to-visualization.ts
@@ -154,6 +154,7 @@ const convertStoreAndReturnPdfDocUrl = async ({
     capture.error(error, {
       extra: { context: "convertStoreAndReturnPdfDocUrl", lambdaName, error },
     });
+    throw error;
   } finally {
     // Close the puppeteer browser
     if (browser !== null) {


### PR DESCRIPTION
refs. metriport/metriport#598

### Description

- The lambda was catching the error, but wasn't rethrowing it, which resulted in a return of broken URLs for doc downloads. 

### Release Plan

- Nothing special
