### PR TITLE
PATCH RELEASE make Garmin sleepLevelsMap props nullish

### DIFF
--- a/packages/api/src/mappings/garmin/index.ts
+++ b/packages/api/src/mappings/garmin/index.ts
@@ -63,8 +63,8 @@ export const timeRange = z.object({
 });
 
 export const sleepLevelsSchema = z.object({
-  deep: z.array(timeRange),
-  light: z.array(timeRange),
+  deep: z.array(timeRange).nullish(),
+  light: z.array(timeRange).nullish(),
 });
 
 export const respirationMeasurements = z.record(garminUnits.timeKey, garminUnits.respiration);


### PR DESCRIPTION
Ref: metriport/metriport-internal#1037

### Description

Make Garmin sleepLevelsMap props nullish

### Release Plan

- ⚠️ This is pointing to `master`