### PR TITLE
fix(api): move making cw api into functoin

### DIFF
--- a/packages/api/src/external/commonwell/__tests__/organization.ts
+++ b/packages/api/src/external/commonwell/__tests__/organization.ts
@@ -5,12 +5,11 @@ import { OID_PREFIX } from "../../../shared/oid";
 import { Util } from "../../../shared/util";
 import { makeCommonWellAPI, metriportQueryMeta } from "../api";
 
-const commonWell = makeCommonWellAPI(Config.getCWMemberOrgName(), Config.getCWMemberOID());
-
 /**
  * For E2E testing locally and staging.
  */
 export const getOne = async (orgOid: string): Promise<CWOrganization | undefined> => {
+  const commonWell = makeCommonWellAPI(Config.getCWMemberOrgName(), Config.getCWMemberOID());
   const { log, debug } = Util.out(`CW get - id ${orgOid}`);
   const cwId = OID_PREFIX.concat(orgOid);
   try {


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ref: 799

### Description

https://metriport.slack.com/archives/C04DBBJSKGB/p1694284896308459

Issue above but the cwmembername not in prod so move into function

### Release Plan

- [ ] Merge once approved
