### PR TITLE
fix(dapi): fixed a bug causing unnecessary db calls

### DIFF
--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -69,14 +69,13 @@ async function listConnectedUsers(req: Request): Promise<ConnectedUserInfo[]> {
   const results = await getConnectedUsers({ cxId });
   const connectedUsers = await Promise.all(
     results.map(async user => {
-      const connectedUser = await getConnectedUserOrFail({ id: user.id, cxId });
       let connectedProviders;
       const userInfo: ConnectedUserInfo = {
         metriportUserId: user.id,
         appUserId: user.cxUserId,
       };
-      if (connectedUser.providerMap) {
-        connectedProviders = Object.keys(connectedUser.providerMap).map((key: string) => {
+      if (user.providerMap) {
+        connectedProviders = Object.keys(user.providerMap).map((key: string) => {
           return key;
         });
         userInfo.connectedProviders = connectedProviders;


### PR DESCRIPTION
refs. metriport/metriport-internal#1041

### Description

- No need to getConnectedUserOrFail on users that have already been fetched from the db


### Context
Sentry issue: https://metriport-inc.sentry.io/issues/4473462837/?alert_rule_id=14031188&alert_type=issue&notification_uuid=4c271dfd-663d-41fd-96c7-0fedc29a2ec0&project=4504912884924416&referrer=slack

### Release Plan

- Nothing special