### PR TITLE
feat(mapi): altered usage reporting for post doc query

### DIFF
--- a/packages/api/src/command/usage/report-usage.ts
+++ b/packages/api/src/command/usage/report-usage.ts
@@ -10,12 +10,13 @@ export type ReportUsageCommand = {
   cxId: string;
   entityId: string;
   product: Product;
+  docQuery?: boolean;
 };
 
-export const reportUsage = ({ cxId, entityId, product }: ReportUsageCommand): void => {
+export const reportUsage = ({ cxId, entityId, product, docQuery }: ReportUsageCommand): void => {
   const url = Config.getUsageUrl();
   if (!url) return;
-  const payload = { cxId, entityId, apiType: product };
+  const payload = { cxId, entityId, apiType: product, docQuery };
 
   // intentionally asynchronous
   axios.post(`${url}`, payload).catch(err => {

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -112,7 +112,13 @@ export async function queryAndProcessDocuments({
         ignoreDocRefOnFHIRServer,
       });
 
-      if (fhirDocRefs.length) reportDocQueryUsage(patient);
+      if (
+        fhirDocRefs.length &&
+        forceDownload === undefined &&
+        ignoreDocRefOnFHIRServer === undefined
+      ) {
+        reportDocQueryUsage(patient);
+      }
 
       log(`Finished processing ${fhirDocRefs.length} documents.`);
       return fhirDocRefs.length;

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -112,7 +112,7 @@ export async function queryAndProcessDocuments({
         ignoreDocRefOnFHIRServer,
       });
 
-      reportDocQueryUsage(patient);
+      if (fhirDocRefs.length) reportDocQueryUsage(patient);
 
       log(`Finished processing ${fhirDocRefs.length} documents.`);
       return fhirDocRefs.length;

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -667,10 +667,11 @@ async function jitterSingleDownload(): Promise<void> {
   );
 }
 
-function reportDocQueryUsage(patient: Patient): void {
+function reportDocQueryUsage(patient: Patient, docQuery = true): void {
   reportUsage({
     cxId: patient.cxId,
     entityId: patient.id,
     product: Product.medical,
+    docQuery,
   });
 }


### PR DESCRIPTION
refs. metriport/metriport-internal#1036

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1042

### Description

- `POST /document/query` reports usage with a flag to indicate a document query for `per-doc-query` billing model
- The usage is reported only if at least 1 document was retrieved with the query

### Release Plan

- Merge the upstream PR on internal
- Merge this
