### PR TITLE
fix(api): remove testid

### DIFF
--- a/packages/api/src/routes/medical/__tests__/mapi/e2e/shared.ts
+++ b/packages/api/src/routes/medical/__tests__/mapi/e2e/shared.ts
@@ -8,7 +8,6 @@ export const ACCOUNT_PATH = "/internal/admin/cx-account";
 export const CUSTOMER_PATH = "/internal/customer";
 export const MAPI_ACCESS = "/internal/mapi-access";
 
-export const testId = getEnvVarOrFail("TEST_ACC_ID");
 export const testApiKey = getEnvVarOrFail("TEST_API_KEY");
 export const fhirHeaders = { headers: { "x-api-key": testApiKey } };
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ref: #799

### Description

Remove testid to not break prod (not being used now)

### Release Plan

- [ ] Once approved