### PR TITLE
fix(mapi): updated the scenario for sentry alert

### DIFF
--- a/packages/api/src/external/fhir/document/index.ts
+++ b/packages/api/src/external/fhir/document/index.ts
@@ -282,15 +282,17 @@ export function convertToFHIRResource(
   if (resource.resourceType === "Practitioner") {
     return containedPractitionerToFHIRResource(resource, patientId, log);
   }
-  const msg = `New Resource type on toFHIR conversion - might need to handle in CW doc ref mapping`;
-  log(`${msg}: ${JSON.stringify(resource)}`);
-  capture.message(msg, {
-    extra: {
-      context: `toFHIR.convertToFHIRResource`,
-      resource,
-      patientId,
-    },
-  });
+  if (resource.resourceType) {
+    const msg = `New Resource type on toFHIR conversion - might need to handle in CW doc ref mapping`;
+    log(`${msg}: ${JSON.stringify(resource)}`);
+    capture.message(msg, {
+      extra: {
+        context: `toFHIR.convertToFHIRResource`,
+        resource,
+        patientId,
+      },
+    });
+  }
   return undefined;
 }
 


### PR DESCRIPTION
refs. metriport/metriport-internal#1054

### Description

- Now we'll get notified only when a new resource type shows up in CW docs contained, rather than for any ref to another resource without additional context

### Release Plan
- ⚠️ THIS IS POINTING TO MASTER
- Nothing special