### PR TITLE
fix(infra): remove alarm for download lambda

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -879,6 +879,11 @@ export class APIStack extends Stack {
     return cdaToVisualizationLambda;
   }
 
+  /**
+   * We are intentionally not setting an alarm action for this lambda, as many issues
+   * may be caused outside of our system. To eliminate noise, we will not alarm on this
+   * lambda.
+   */
   private setupDocumentDownloader(ownProps: {
     lambdaLayers: lambda.ILayerVersion[];
     vpc: ec2.IVpc;

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -247,7 +247,6 @@ export class APIStack extends Stack {
       bucketName: props.config.medicalDocumentsBucketName,
       envType: props.config.environmentType,
       sentryDsn: props.config.lambdasSentryDSN,
-      alarmAction: slackNotification?.alarmAction,
     });
 
     //-------------------------------------------
@@ -889,7 +888,6 @@ export class APIStack extends Stack {
     bucketName: string | undefined;
     envType: string;
     sentryDsn: string | undefined;
-    alarmAction: SnsAction | undefined;
   }): Lambda {
     const {
       lambdaLayers,
@@ -900,7 +898,6 @@ export class APIStack extends Stack {
       bucketName,
       sentryDsn,
       envType,
-      alarmAction,
     } = ownProps;
 
     const documentDownloaderLambda = createLambda({
@@ -921,7 +918,6 @@ export class APIStack extends Stack {
       memory: 512,
       timeout: Duration.minutes(5),
       vpc,
-      alarmSnsAction: alarmAction,
     });
 
     // granting secrets read access to lambda


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ref: 799

### Description

Remove alarm sns action for download lambda

Error reference
https://metriport.slack.com/archives/C04T256DQPQ/p1695182213373639

### Release Plan

Nothing special 

- [ ] Once approved
