### PR TITLE
fix(test): added 15 sec timeouts to all e2e tests

### DIFF
--- a/packages/api-sdk/src/medical/client/__tests__/metriport.test.e2e.ts
+++ b/packages/api-sdk/src/medical/client/__tests__/metriport.test.e2e.ts
@@ -4,6 +4,8 @@ import { v4 as uuidv4 } from "uuid";
 import { getEnvVar, getEnvVarOrFail, ISO_DATE } from "../../../shared";
 import { MetriportMedicalApi } from "../metriport";
 
+jest.setTimeout(15000);
+
 const METRIPORT = "METRIPORT";
 const COMMONWELL = "COMMONWELL";
 

--- a/packages/api/src/external/fhir/__tests__/api.test.e2e.ts
+++ b/packages/api/src/external/fhir/__tests__/api.test.e2e.ts
@@ -5,6 +5,8 @@ import { v4 as uuidv4 } from "uuid";
 import { makeOrgNumber } from "../../../models/medical/__tests__/organization";
 import { makeFhirAdminApi } from "../api/api-factory";
 
+jest.setTimeout(15000);
+
 const fhirApi = makeFhirAdminApi();
 
 // For e2e tests we need to use the fhir api and the vpc is currently not connnected

--- a/packages/api/src/routes/__tests__/settings.test.e2e.ts
+++ b/packages/api/src/routes/__tests__/settings.test.e2e.ts
@@ -1,6 +1,8 @@
 import { MetriportDevicesApi } from "@metriport/api-sdk";
 import { testApiKey, baseURL } from "./shared";
 
+jest.setTimeout(15000);
+
 const metriportClient = new MetriportDevicesApi(testApiKey, { baseAddress: baseURL });
 
 describe("Metriport TestSuite", () => {

--- a/packages/api/src/routes/medical/__tests__/document.test.e2e.ts
+++ b/packages/api/src/routes/medical/__tests__/document.test.e2e.ts
@@ -4,6 +4,8 @@ import * as docCmd from "../../../external/fhir/document/get-documents";
 import { makePatient } from "../../../models/medical/__tests__/patient";
 import { api } from "../../__tests__/shared";
 
+jest.setTimeout(15000);
+
 const path = "/medical/v1/document";
 
 let getDocumentsMock: jest.SpyInstance;

--- a/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/document.test.e2e.ts
+++ b/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/document.test.e2e.ts
@@ -4,6 +4,8 @@ import { makeBinary } from "./binary";
 import { makeDocument } from "./document";
 import { makePatient } from "./patient";
 
+jest.setTimeout(15000);
+
 const binary = makeBinary();
 const patient = makePatient();
 const document = makeDocument({ patient, binary });

--- a/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/organization.test.e2e.ts
+++ b/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/organization.test.e2e.ts
@@ -2,6 +2,8 @@ import { AxiosResponse } from "axios";
 import { makeOrganization } from "./organization";
 import { api } from "../../../../__tests__/shared";
 
+jest.setTimeout(15000);
+
 const org = makeOrganization();
 
 describe("Integration FHIR Org", () => {

--- a/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/patient.test.e2e.ts
+++ b/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/patient.test.e2e.ts
@@ -5,6 +5,8 @@ import { AxiosResponse } from "axios";
 import { api } from "../../../../__tests__/shared";
 import { makePatient } from "./patient";
 
+jest.setTimeout(15000);
+
 const patient = makePatient();
 
 describe("Integration FHIR Patient", () => {

--- a/packages/connect-widget/src/__tests__/connect.test.e2e.ts
+++ b/packages/connect-widget/src/__tests__/connect.test.e2e.ts
@@ -3,6 +3,8 @@ import { MetriportDevicesApi } from "@metriport/api-sdk";
 import { v4 as uuidv4 } from "uuid";
 import { getTestConfig } from "./shared";
 
+jest.setTimeout(15000);
+
 const widgetUrl = getTestConfig().widgetUrl;
 const apiUrl = getTestConfig().apiUrl;
 const testApiKey = getTestConfig().testApiKey;


### PR DESCRIPTION
refs. metriport/metriport-internal#1059

### Description

- Added jest timeouts of 15 seconds to all existing e2e tests


### Context 

https://metriport.slack.com/archives/C04DBBJSKGB/p1695282996695729?thread_ts=1695282996.493279&cid=C04DBBJSKGB

### Release Plan

- Nothing special
