### PR TITLE
fix(api): fix doc query check for xml type

### DIFF
--- a/packages/lambdas/src/document-downloader.ts
+++ b/packages/lambdas/src/document-downloader.ts
@@ -118,7 +118,10 @@ export const handler = Sentry.AWSLambda.wrapHandler(
       isNew: true,
     };
 
-    if (downloadedDocument && document.mimeType === "application/xml") {
+    if (
+      downloadedDocument &&
+      (document.mimeType === "application/xml" || document.mimeType === "text/xml")
+    ) {
       const containsB64 = downloadedDocument.includes("nonXMLBody");
 
       if (containsB64) {


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ref: 799

### Description

Some doc references use text/xml so need to account for this in the if check

### Release Plan

POINTING TO MASTER

ASAP

- [ ] Merge once approved