### PR TITLE
fix(mapi): increased the memory capacity of SidechainFHIRConverterLambda

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -871,7 +871,7 @@ export class APIStack extends Stack {
       },
       layers: [...lambdaLayers, chromiumLayer],
       memory: 512,
-      timeout: Duration.minutes(5),
+      timeout: Duration.minutes(15),
       vpc,
       alarmSnsAction: alarmAction,
     });

--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -27,7 +27,7 @@ function settings() {
   const lambdaTimeout = maxExecutionTimeout.minus(Duration.seconds(5));
   return {
     connectorName: "FHIRConverter",
-    lambdaMemory: 512,
+    lambdaMemory: 1024,
     // Number of messages the lambda pull from SQS at once
     lambdaBatchSize: 1,
     // Max number of concurrent instances of the lambda that an Amazon SQS event source can invoke [2 - 1000].

--- a/packages/infra/lib/api-stack/sidechain-fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/sidechain-fhir-converter-connector.ts
@@ -17,7 +17,7 @@ function settings() {
   const lambdaTimeout = MAXIMUM_LAMBDA_TIMEOUT.minus(Duration.seconds(5));
   return {
     connectorName: "SidechainFHIRConverter",
-    lambdaMemory: 512,
+    lambdaMemory: 1024,
     // Number of messages the lambda pull from SQS at once
     lambdaBatchSize: 1,
     // Max number of concurrent instances of the lambda that an Amazon SQS event source can invoke [2 - 1000].


### PR DESCRIPTION
refs. metriport/metriport-internal#1062

### Description

- Increasing the memory allocation for the SidechainFHIRConverterLambda to quickly improve coverage 

### Release Plan

- Merge this
- Rerun DLQ jobs 