### PR TITLE
fix(widget): removed the jest timeout for connect widget test

### DIFF
--- a/packages/connect-widget/src/__tests__/connect.test.e2e.ts
+++ b/packages/connect-widget/src/__tests__/connect.test.e2e.ts
@@ -3,8 +3,6 @@ import { MetriportDevicesApi } from "@metriport/api-sdk";
 import { v4 as uuidv4 } from "uuid";
 import { getTestConfig } from "./shared";
 
-jest.setTimeout(15000);
-
 const widgetUrl = getTestConfig().widgetUrl;
 const apiUrl = getTestConfig().apiUrl;
 const testApiKey = getTestConfig().testApiKey;


### PR DESCRIPTION
refs. metriport/metriport-internal#1059

### Description

- We keep getting `jest is not defined` with this e2e test on the connect widget and decided it's not worth the time right now to try and figure this out. So we're going to remove this timeout to avoid the error. 

### Release Plan

- Nothing special