### PR TITLE
fix(mapi): increased iops alarm threshold to 100_000

### DIFF
--- a/packages/infra/dashboards/cw-dashboard-prod.json
+++ b/packages/infra/dashboards/cw-dashboard-prod.json
@@ -389,8 +389,8 @@
                 "annotations": {
                     "horizontal": [
                         {
-                            "label": "VolumeWriteIOPs >= 10_000 for 1 datapoints within 5 minutes",
-                            "value": 10000,
+                            "label": "VolumeWriteIOPs >= 100_000 for 1 datapoints within 5 minutes",
+                            "value": 100000,
                             "yAxis": "right"
                         }
                     ]

--- a/packages/infra/dashboards/cw-dashboard-prod.json
+++ b/packages/infra/dashboards/cw-dashboard-prod.json
@@ -326,8 +326,8 @@
                 "annotations": {
                     "horizontal": [
                         {
-                            "label": "VolumeWriteIOPs >= 5000 for 1 datapoints within 5 minutes",
-                            "value": 5000,
+                            "label": "VolumeWriteIOPs >= 100000 for 1 datapoints within 5 minutes",
+                            "value": 100000,
                             "yAxis": "right"
                         }
                     ]
@@ -389,8 +389,8 @@
                 "annotations": {
                     "horizontal": [
                         {
-                            "label": "VolumeWriteIOPs >= 5000 for 1 datapoints within 5 minutes",
-                            "value": 5000,
+                            "label": "VolumeWriteIOPs >= 100000 for 1 datapoints within 5 minutes",
+                            "value": 100000,
                             "yAxis": "right"
                         }
                     ]

--- a/packages/infra/dashboards/cw-dashboard-prod.json
+++ b/packages/infra/dashboards/cw-dashboard-prod.json
@@ -326,8 +326,8 @@
                 "annotations": {
                     "horizontal": [
                         {
-                            "label": "VolumeWriteIOPs >= 100000 for 1 datapoints within 5 minutes",
-                            "value": 100000,
+                            "label": "VolumeWriteIOPs >= 10_000 for 1 datapoints within 5 minutes",
+                            "value": 10000,
                             "yAxis": "right"
                         }
                     ]
@@ -389,8 +389,8 @@
                 "annotations": {
                     "horizontal": [
                         {
-                            "label": "VolumeWriteIOPs >= 100000 for 1 datapoints within 5 minutes",
-                            "value": 100000,
+                            "label": "VolumeWriteIOPs >= 10_000 for 1 datapoints within 5 minutes",
+                            "value": 10000,
                             "yAxis": "right"
                         }
                     ]

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1192,7 +1192,7 @@ export class APIStack extends Stack {
 
     const writeIOPsMetric = dbCluster.metricVolumeWriteIOPs();
     const wIOPSAlarm = writeIOPsMetric.createAlarm(this, `${dbClusterName}VolumeWriteIOPsAlarm`, {
-      threshold: 100_000, // IOPs per second
+      threshold: 10_000, // IOPs per second
       evaluationPeriods: 1,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1192,7 +1192,7 @@ export class APIStack extends Stack {
 
     const writeIOPsMetric = dbCluster.metricVolumeWriteIOPs();
     const wIOPSAlarm = writeIOPsMetric.createAlarm(this, `${dbClusterName}VolumeWriteIOPsAlarm`, {
-      threshold: 10000, // IOPs per second
+      threshold: 100000, // IOPs per second
       evaluationPeriods: 1,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1183,7 +1183,7 @@ export class APIStack extends Stack {
 
     const readIOPsMetric = dbCluster.metricVolumeReadIOPs();
     const rIOPSAlarm = readIOPsMetric.createAlarm(this, `${dbClusterName}VolumeReadIOPsAlarm`, {
-      threshold: 20000, // IOPs per second
+      threshold: 20_000, // IOPs per second
       evaluationPeriods: 1,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
@@ -1192,7 +1192,7 @@ export class APIStack extends Stack {
 
     const writeIOPsMetric = dbCluster.metricVolumeWriteIOPs();
     const wIOPSAlarm = writeIOPsMetric.createAlarm(this, `${dbClusterName}VolumeWriteIOPsAlarm`, {
-      threshold: 100000, // IOPs per second
+      threshold: 100_000, // IOPs per second
       evaluationPeriods: 1,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
@@ -1210,7 +1210,7 @@ export class APIStack extends Stack {
       this,
       `${dynamoConstructName}ConsumedReadCapacityUnitsAlarm`,
       {
-        threshold: 10000, // units per second
+        threshold: 10_000, // units per second
         evaluationPeriods: 1,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }
@@ -1223,7 +1223,7 @@ export class APIStack extends Stack {
       this,
       `${dynamoConstructName}ConsumedWriteCapacityUnitsAlarm`,
       {
-        threshold: 10000, // units per second
+        threshold: 10_000, // units per second
         evaluationPeriods: 1,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }


### PR DESCRIPTION
refs. metriport/metriport-internal#1065

### Description

- WriteIOPS alarm threshold on fhir-server dashboards -> 100_000

### Context
https://metriport.slack.com/archives/C04DMKE9DME/p1695435636328739

### Release Plan

- Update the prod dashboards to reflect the change