### PR TITLE
fix(api): add environment as env variable for test to listen too

### DIFF
--- a/.github/workflows/_e2e-tests.yml
+++ b/.github/workflows/_e2e-tests.yml
@@ -23,6 +23,7 @@ on:
         description: "the ID of a test patient for e2e tests"
         required: false
         type: string
+
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -106,6 +107,7 @@ jobs:
           API_URL: ${{ inputs.api_url }}
           WIDGET_URL: ${{ inputs.widget_url }}
           FHIR_SERVER_URL: ${{ inputs.fhir_url }}
+          ENV_TYPE: ${{ inputs.deploy_env }}
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ref: 799

### Description

Quick fix for the e2e test, its not running because its missing the env type variable.

### Release Plan

- [ ] Once approved