### PR TITLE
fix(mapi): checkingif patient is associated with given facility

### DIFF
--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -14,6 +14,7 @@ import { emptyFunction, Util } from "../../../shared/util";
 import { uuidv7 } from "../../../shared/uuid-v7";
 import { appendDocQueryProgress, SetDocQueryProgress } from "../patient/append-doc-query-progress";
 import { getPatientOrFail } from "../patient/get-patient";
+import { isPatientAssociatedWithFacility } from "../../../domain/medical/patient-facility";
 
 export function isProgressEqual(a?: Progress, b?: Progress): boolean {
   return (
@@ -202,16 +203,4 @@ function getOrGenerateRequestId(docQueryProgress: DocumentQueryProgress | undefi
     return docQueryProgress.requestId;
   }
   return uuidv7();
-}
-
-/**
- * Checks if the patient's list of associated facility IDs contains the facility ID parameter passed by the user.
- *
- * @param patient The patient for which to check the association with a facility
- * @param facilityId The ID of the facility passed in by the user
- * @returns a boolean indicating whether this patient is associated with this facility ID
- */
-function isPatientAssociatedWithFacility(patient: Patient, facilityId: string): boolean {
-  if (patient.facilityIds.includes(facilityId)) return true;
-  return false;
 }

--- a/packages/api/src/domain/medical/patient-facility.ts
+++ b/packages/api/src/domain/medical/patient-facility.ts
@@ -1,0 +1,12 @@
+import { Patient } from "../../models/medical/patient";
+
+/**
+ * Checks if the patient's list of associated facility IDs contains the facility ID parameter passed by the user.
+ *
+ * @param patient The patient for which to check the association with a facility
+ * @param facilityId The ID of the facility passed in by the user
+ * @returns a boolean indicating whether this patient is associated with this facility ID
+ */
+export function isPatientAssociatedWithFacility(patient: Patient, facilityId: string): boolean {
+  return patient.facilityIds.some(id => id === facilityId);
+}


### PR DESCRIPTION
refs. metriport/metriport#923

### Description

- Checking if facility ID passed in by the user is in the list of facility IDs that the patient is associated with
- If this check fails, the document query never gets created for the patient and will not be stuck in `processing` state. 

### Release Plan

- Nothing special
