### PR TITLE
1092 add endpoint to redrive sidechain msgs from DLQ

### DIFF
--- a/packages/api/src/command/medical/admin/redrive-dlq.ts
+++ b/packages/api/src/command/medical/admin/redrive-dlq.ts
@@ -1,0 +1,93 @@
+import { SQS } from "aws-sdk";
+import { uniqBy } from "lodash";
+import BadRequestError from "../../../errors/bad-request";
+import { attributesToSend, getMessagesFromQueue, sqs } from "../../../external/aws/sqs";
+import { Config } from "../../../shared/config";
+import { uuidv4 } from "../../../shared/uuid-v7";
+
+const dlqUrl = Config.getSidechainFHIRConverterDQLURL();
+const regularUrl = Config.getSidechainFHIRConverterQueueURL();
+
+const maxNumberOfMessagesPerQuery = 10;
+const systemMaxNumberOfMessages = 100_000;
+
+/**
+ * ADMIN LOGIC - not to be used by other endpoints/services.
+ *
+ * Gets all messages from the Sidechain DLQ, unique, and sends them to the
+ * regular queue for re-processing.
+ */
+export async function redriveSidechainDLQ(maxNumberOfMessages: number): Promise<{
+  originalCount: number;
+  uniqueCount: number;
+}> {
+  if (!dlqUrl) throw new BadRequestError("Missing sidechain DLQ URL");
+  if (!regularUrl) throw new BadRequestError("Missing sidechain DLQ URL");
+  return redriveSQSUnique({
+    sourceQueueUrl: dlqUrl,
+    destinationQueueUrl: regularUrl,
+    maxNumberOfMessages,
+    contentComparator: (m: SQS.Message) => (m.Body ? JSON.parse(m.Body).s3FileName : ""),
+  });
+}
+
+// TODO consider exposing this to a shared library in core, along with Lambda's SQSUtils
+async function redriveSQSUnique({
+  sourceQueueUrl,
+  destinationQueueUrl,
+  maxNumberOfMessages,
+  contentComparator = defaultComparator,
+}: {
+  sourceQueueUrl: string;
+  destinationQueueUrl: string;
+  maxNumberOfMessages: number;
+  contentComparator?: ContentComparator;
+}): Promise<{
+  originalCount: number;
+  uniqueCount: number;
+}> {
+  const convertedMaxNumberOfMessages =
+    maxNumberOfMessages < 0 ? systemMaxNumberOfMessages : maxNumberOfMessages;
+  const actualMaxNumberOfMessages = Math.min(
+    convertedMaxNumberOfMessages,
+    systemMaxNumberOfMessages
+  );
+  console.log(`>>> Getting messages from source queue...`);
+  const messages = await getMessagesFromQueue(sourceQueueUrl, {
+    maxNumberOfMessagesPerQuery,
+    maxNumberOfMessages: actualMaxNumberOfMessages,
+    poolUntilEmpty: true,
+  });
+  console.log(`>>> Messages from source queue:`);
+  messages.forEach(message => {
+    console.log("... ", message.Body);
+  });
+
+  const uniqueMessages = uniqBy(messages, contentComparator);
+  console.log(`>>> Unique messages:`);
+  uniqueMessages.forEach(message => {
+    console.log("... ", message.Body);
+  });
+
+  console.log(`>>> Sending unique messages to destination queue...`);
+  await sqs
+    .sendMessageBatch({
+      QueueUrl: destinationQueueUrl,
+      Entries: uniqueMessages.map(m => ({
+        Id: m.MessageId ?? uuidv4(),
+        MessageBody: m.Body ?? "",
+        MessageAttributes: m.MessageAttributes && attributesToSend(m.MessageAttributes),
+      })),
+    })
+    .promise();
+
+  const result = {
+    originalCount: messages.length,
+    uniqueCount: uniqueMessages.length,
+  };
+  console.log(`>>> Success! ${JSON.stringify(result)})}`);
+  return result;
+}
+
+type ContentComparator = (m: SQS.Message) => string;
+const defaultComparator: ContentComparator = (m: SQS.Message) => m.Body ?? "";

--- a/packages/api/src/command/medical/admin/redrive-dlq.ts
+++ b/packages/api/src/command/medical/admin/redrive-dlq.ts
@@ -60,7 +60,7 @@ async function redriveSQSUnique({
 
   const messageCount = await getMessageCountFromQueue(sourceQueueUrl);
   console.log(`>>> Message count: ${messageCount}`);
-  const numberOfParallelRequests = Math.floor(messageCount / maxNumberOfMessagesPerQuery);
+  const numberOfParallelRequests = Math.ceil(messageCount / maxNumberOfMessagesPerQuery);
 
   console.log(`>>> Getting messages from source queue...`);
   const messages: SQS.Message[] = [];

--- a/packages/api/src/command/medical/admin/upload-doc.ts
+++ b/packages/api/src/command/medical/admin/upload-doc.ts
@@ -13,11 +13,11 @@ const docContributionUrl = `${apiUrl}/doc-contribution/commonwell/`;
 const smallId = () => String(randomInt(3)).padStart(3, "0");
 
 /**
- * ADMIN LOGIC
+ * ADMIN LOGIC - not to be used by other endpoints/services.
+ *
  * This function is to be able to create a document reference
  * and upload it to the FHIR server with the purpose of testing.
  */
-
 export async function createAndUploadDocReference({
   cxId,
   patientId,

--- a/packages/api/src/external/aws/sqs.ts
+++ b/packages/api/src/external/aws/sqs.ts
@@ -157,7 +157,7 @@ async function _getMessagesFromQueue(
   const messages = resultReceive.Messages ?? [];
   const result = [...rollingResult, ...messages];
 
-  if (removeMessages) await deleteMessagesFromQueue(queueUrl, messagesToDelete(messages));
+  if (removeMessages) await deleteMessagesFromQueue(queueUrl, toDeleteFormat(messages));
 
   if (poolUntilEmpty) {
     const updatedTotal = await getMessageCountFromQueue(queueUrl);
@@ -181,7 +181,7 @@ export async function getMessageCountFromQueue(queueUrl: string): Promise<number
   return total;
 }
 
-function messagesToDelete(messages: SQS.Message[]): MessageToDelete[] {
+function toDeleteFormat(messages: SQS.Message[]): MessageToDelete[] {
   return messages.flatMap(m => {
     if (!m.MessageId || !m.ReceiptHandle) return [];
     return {

--- a/packages/api/src/external/aws/sqs.ts
+++ b/packages/api/src/external/aws/sqs.ts
@@ -1,5 +1,6 @@
-import { SQS } from "aws-sdk";
+import { AWSError, SQS } from "aws-sdk";
 import { MessageBodyAttributeMap } from "aws-sdk/clients/sqs";
+import { PromiseResult } from "aws-sdk/lib/request";
 import { Config } from "../../shared/config";
 
 const sqsConfig = {
@@ -13,7 +14,7 @@ export const sqs = new SQS({
 export type SQSMessageAttributes = Record<string, string> & {
   cxId?: string;
 };
-export type SQSParameters =
+export type SendMessageSQSParameters =
   | {
       fifo?: never | false;
       messageGroupId?: never;
@@ -34,8 +35,8 @@ export type SQSParameters =
 export async function sendMessageToQueue(
   queueUrl: string,
   messageBody: string,
-  sqsParams: SQSParameters
-): Promise<void> {
+  sqsParams: SendMessageSQSParameters
+): Promise<PromiseResult<SQS.SendMessageResult, AWSError>> {
   const {
     messageGroupId,
     messageAttributes,
@@ -62,5 +63,189 @@ export async function sendMessageToQueue(
       ...(messageAttributesRaw ? messageAttributesRaw : {}),
     },
   };
-  await sqs.sendMessage(messageParams).promise();
+  return sqs.sendMessage(messageParams).promise();
+}
+
+export type GetMessageSQSParameters = SharedInternalGetMessageSQSParameters & {
+  /**
+   * How many messages to return per query, from 1 to 10. Defaults to 1.
+   */
+  maxNumberOfMessagesPerQuery?: number;
+  /**
+   * Maximum number of messages to return. Defaults to 10.
+   */
+  maxNumberOfMessages?: number;
+  /**
+   * Determines whether it should keep pooling until the queue is empty or `maxNumberOfMessages`
+   * has been reached. Defaults to false, which means it will only pool once.
+   */
+  poolUntilEmpty?: boolean;
+};
+
+/**
+ * Reads and removes messages from the queue. If poolUntilEmpty is true, it will keep pooling
+ * until the queue is empty (as determined by `getMessageCountFromQueue()`).
+ */
+export async function getMessagesFromQueue(
+  queueUrl: string,
+  sqsParams: GetMessageSQSParameters
+): Promise<SQS.Message[]> {
+  return _getMessagesFromQueue(queueUrl, {
+    ...sqsParams,
+    removeMessages: true,
+    poolUntilEmpty: sqsParams.poolUntilEmpty ?? false,
+  });
+}
+
+export type PeekMessageSQSParameters = SharedInternalGetMessageSQSParameters;
+
+/**
+ * Reads messages from the queue, returns them, but does not remove them.
+ * Only queries the queue once.
+ */
+export async function peekMessagesFromQueue(
+  queueUrl: string,
+  sqsParams: GetMessageSQSParameters
+): Promise<SQS.Message[]> {
+  return _getMessagesFromQueue(queueUrl, {
+    ...sqsParams,
+    removeMessages: false,
+    poolUntilEmpty: false,
+  });
+}
+
+type SharedInternalGetMessageSQSParameters = {
+  maxNumberOfMessagesPerQuery?: number;
+  visibilityTimeout?: number;
+  waitTimeSeconds?: number;
+};
+type InternalGetMessageSQSParameters = SharedInternalGetMessageSQSParameters & {
+  maxNumberOfMessages?: number;
+  removeMessages: boolean;
+  poolUntilEmpty: boolean;
+};
+
+async function _getMessagesFromQueue(
+  queueUrl: string,
+  sqsParams: InternalGetMessageSQSParameters,
+  rollingResult: SQS.Message[] = []
+): Promise<SQS.Message[]> {
+  const {
+    removeMessages,
+    poolUntilEmpty,
+    maxNumberOfMessages = 10,
+    maxNumberOfMessagesPerQuery = 1,
+  } = sqsParams;
+  if (!removeMessages && poolUntilEmpty) {
+    throw new Error("Cannot pool until empty if not removing messages");
+  }
+
+  const remainingMessagesToQuery = maxNumberOfMessages - rollingResult.length;
+  const maxMessagesOnQuery = Math.min(maxNumberOfMessagesPerQuery, remainingMessagesToQuery);
+  if (maxMessagesOnQuery <= 0) return rollingResult;
+
+  const messageParams: SQS.Types.ReceiveMessageRequest = {
+    QueueUrl: queueUrl,
+    MaxNumberOfMessages: maxMessagesOnQuery,
+    VisibilityTimeout: sqsParams.visibilityTimeout,
+    WaitTimeSeconds: sqsParams.waitTimeSeconds ?? 1,
+    AttributeNames: ["All"],
+    MessageAttributeNames: ["All"],
+  };
+
+  const resultReceive = await sqs.receiveMessage(messageParams).promise();
+  const messages = resultReceive.Messages ?? [];
+  const result = [...rollingResult, ...messages];
+
+  if (removeMessages) await deleteMessagesFromQueue(queueUrl, messagesToDelete(messages));
+
+  if (poolUntilEmpty) {
+    const updatedTotal = await getMessageCountFromQueue(queueUrl);
+    if (updatedTotal <= 0) return result;
+    return _getMessagesFromQueue(queueUrl, sqsParams, result);
+  }
+  return result;
+}
+
+/**
+ * Returns the approximate count of messages in the queue. Returns -1 if not available.
+ */
+export async function getMessageCountFromQueue(queueUrl: string): Promise<number> {
+  const resultTotal = await sqs
+    .getQueueAttributes({
+      QueueUrl: queueUrl,
+      AttributeNames: ["ApproximateNumberOfMessages"],
+    })
+    .promise();
+  const total = Number(resultTotal.Attributes?.ApproximateNumberOfMessages ?? "-1");
+  return total;
+}
+
+function messagesToDelete(messages: SQS.Message[]): MessageToDelete[] {
+  return messages.flatMap(m => {
+    if (!m.MessageId || !m.ReceiptHandle) return [];
+    return {
+      id: m.MessageId,
+      receiptHandle: m.ReceiptHandle,
+    };
+  });
+}
+
+export type MessageToDelete = {
+  id: string;
+  receiptHandle: string;
+};
+
+export async function deleteMessagesFromQueue(
+  queueUrl: string,
+  messages: MessageToDelete[]
+): Promise<{
+  successful: SQS.DeleteMessageBatchResultEntryList;
+  failed: SQS.BatchResultErrorEntryList;
+}> {
+  if (!messages || !messages.length) return { successful: [], failed: [] };
+  const entries: SQS.Types.DeleteMessageBatchRequestEntryList = messages.map(m => ({
+    Id: m.id,
+    ReceiptHandle: m.receiptHandle,
+  }));
+  const messageParams: SQS.Types.DeleteMessageBatchRequest = {
+    QueueUrl: queueUrl,
+    Entries: entries,
+  };
+  const result = await sqs.deleteMessageBatch(messageParams).promise();
+  if (result.Failed.length) {
+    console.log(`Failed to delete messages from SQS: ${JSON.stringify(result.Failed)}`);
+  }
+  return { successful: result.Successful, failed: result.Failed };
+}
+
+/**
+ * @deprecated move to core w/ Lambda's SQSUtils
+ */
+export function attributesToSend(
+  inboundMessageAttribs: SQS.MessageBodyAttributeMap
+): SQS.MessageBodyAttributeMap {
+  let res = {};
+  for (const [key, value] of Object.entries(inboundMessageAttribs)) {
+    res = {
+      ...res,
+      ...singleAttributeToSend(key, value.StringValue),
+    };
+  }
+  return res;
+}
+
+/**
+ * @deprecated move to core w/ Lambda's SQSUtils
+ */
+export function singleAttributeToSend(
+  key: string,
+  value: string | undefined
+): SQS.MessageBodyAttributeMap {
+  return {
+    [key]: {
+      DataType: "String",
+      StringValue: value,
+    },
+  };
 }

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -219,6 +219,9 @@ export class Config {
   static getSidechainFHIRConverterQueueURL(): string | undefined {
     return getEnvVar("SIDECHAIN_FHIR_CONVERTER_QUEUE_URL");
   }
+  static getSidechainFHIRConverterDQLURL(): string | undefined {
+    return getEnvVar("SIDECHAIN_FHIR_CONVERTER_DLQ_URL");
+  }
 
   static getConvertDocLambdaName(): string | undefined {
     return getEnvVar("CONVERT_DOC_LAMBDA_NAME");

--- a/packages/infra/lib/api-service.ts
+++ b/packages/infra/lib/api-service.ts
@@ -11,10 +11,12 @@ import { IFunction as ILambda } from "aws-cdk-lib/aws-lambda";
 import * as r53 from "aws-cdk-lib/aws-route53";
 import * as r53_targets from "aws-cdk-lib/aws-route53-targets";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
+import { IQueue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
 import { EnvConfig } from "../config/env-config";
 import { DnsZones } from "./shared/dns";
 import { Secrets } from "./shared/secrets";
+import { provideAccessToQueue } from "./shared/sqs";
 import { isProd } from "./shared/util";
 
 interface ApiServiceProps extends StackProps {
@@ -35,7 +37,8 @@ export function createAPIService(
   fhirServerQueueUrl: string | undefined,
   fhirConverterQueueUrl: string | undefined,
   fhirConverterServiceUrl: string | undefined,
-  sidechainFHIRConverterQueueUrl: string | undefined,
+  sidechainFHIRConverterQueue: IQueue | undefined,
+  sidechainFHIRConverterDLQ: IQueue | undefined,
   cdaToVisualizationLambda: ILambda,
   documentDownloaderLambda: ILambda
 ): {
@@ -114,8 +117,11 @@ export function createAPIService(
           ...(fhirConverterServiceUrl && {
             FHIR_CONVERTER_SERVER_URL: fhirConverterServiceUrl,
           }),
-          ...(sidechainFHIRConverterQueueUrl && {
-            SIDECHAIN_FHIR_CONVERTER_QUEUE_URL: sidechainFHIRConverterQueueUrl,
+          ...(sidechainFHIRConverterQueue && {
+            SIDECHAIN_FHIR_CONVERTER_QUEUE_URL: sidechainFHIRConverterQueue.queueUrl,
+          }),
+          ...(sidechainFHIRConverterDLQ && {
+            SIDECHAIN_FHIR_CONVERTER_DLQ_URL: sidechainFHIRConverterDLQ.queueUrl,
           }),
         },
       },
@@ -140,8 +146,21 @@ export function createAPIService(
   dynamoDBTokenTable.grantReadWriteData(fargateService.taskDefinition.taskRole);
 
   cdaToVisualizationLambda.grantInvoke(fargateService.taskDefinition.taskRole);
-
   documentDownloaderLambda.grantInvoke(fargateService.taskDefinition.taskRole);
+
+  sidechainFHIRConverterQueue &&
+    provideAccessToQueue({
+      accessType: "send",
+      queue: sidechainFHIRConverterQueue,
+      resource: fargateService.service.taskDefinition.taskRole,
+    });
+  sidechainFHIRConverterDLQ &&
+    provideAccessToQueue({
+      accessType: "send",
+      queue: sidechainFHIRConverterDLQ,
+      resource: fargateService.service.taskDefinition.taskRole,
+    });
+
   // CloudWatch Alarms and Notifications
 
   // Allow the service to publish metrics to cloudwatch

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -270,7 +270,8 @@ export class APIStack extends Stack {
       fhirServerQueue?.queueUrl,
       fhirConverterQueue.queueUrl,
       fhirConverter ? `http://${fhirConverter.address}` : undefined,
-      sidechainFHIRConverterQueue?.queueUrl,
+      sidechainFHIRConverterQueue,
+      sidechainFHIRConverterDLQ,
       cdaToVisualizationLambda,
       documentDownloaderLambda
     );
@@ -337,11 +338,6 @@ export class APIStack extends Stack {
       : undefined;
 
     // sidechain FHIR converter
-    provideAccessToQueue({
-      accessType: "send",
-      queue: sidechainFHIRConverterQueue,
-      resource: apiService.service.taskDefinition.taskRole,
-    });
     const sidechainFHIRConverterLambda = fhirServerQueue?.queueUrl
       ? sidechainFHIRConverterConnector.createLambda({
           envType: props.config.environmentType,

--- a/packages/lambdas/src/shared/sqs.ts
+++ b/packages/lambdas/src/shared/sqs.ts
@@ -1,6 +1,7 @@
 import { SQSMessageAttributes, SQSRecord } from "aws-lambda";
 import * as AWS from "aws-sdk";
 import { SQS } from "aws-sdk";
+import { MessageBodyAttributeMap } from "aws-sdk/clients/sqs";
 import { capture } from "./capture";
 
 export class SQSUtils {
@@ -70,7 +71,7 @@ export class SQSUtils {
     }
   }
 
-  attributesToSend(inboundMessageAttribs: SQSMessageAttributes) {
+  attributesToSend(inboundMessageAttribs: SQSMessageAttributes): MessageBodyAttributeMap {
     let res = {};
     for (const [key, value] of Object.entries(inboundMessageAttribs)) {
       res = {
@@ -81,7 +82,7 @@ export class SQSUtils {
     return res;
   }
 
-  singleAttributeToSend(key: string, value: string | undefined) {
+  singleAttributeToSend(key: string, value: string | undefined): MessageBodyAttributeMap {
     return {
       [key]: {
         DataType: "String",

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -235,14 +235,7 @@ async function postToSidechainConverter(payload: unknown, patientId: string, log
         "SenderId": "AROAWX27OVJFOXNNHQRAU:FHIRConverter_Retry_Lambda",
         "ApproximateFirstReceiveTimestamp": "1684700300546"
     },
-    "messageAttributes": {
-      cxId: {
-        stringValue: '7006E0FB-33C8-42F4-B675-A3FD05717446',
-        stringListValues: [],
-        binaryListValues: [],
-        dataType: 'String'
-      }
-    },
+    "messageAttributes": ...,
     "md5OfBody": "543u5y34ui53uih543uh5ui4",
     "eventSource": "aws:sqs",
     "eventSourceARN": "arn:aws:sqs:<region>:<acc>>:<queue-name>",

--- a/packages/utils/src/sqs/populate-sqs.ts
+++ b/packages/utils/src/sqs/populate-sqs.ts
@@ -1,0 +1,36 @@
+// TODO move this to a shared library in core, so we can turn this into a script and not endoint, so it can live
+// in the codebase uncommented and ready for use.
+/**
+ * Endpoint to populate the DLQ with messages for testing purposes
+ */
+// router.post(
+//   "/sqs-populate",
+//   asyncHandler(async (req: Request, res: Response) => {
+//     const dlqUrl = Config.getSidechainFHIRConverterDQLURL();
+//     if (!dlqUrl) throw new BadRequestError("Missing sidechain DLQ URL");
+//     const messageCountRaw = getFrom("query").optional("maxNumberOfMessages", req);
+//     const randomizeFilename = getFrom("query").optional("randomizeFilename", req) === "true";
+//     console.log(
+//       `Params: messageCountRaw=${messageCountRaw}, randomizeFilename=${randomizeFilename}`
+//     );
+//     const body = req.body;
+//     if (randomizeFilename) body.s3FileName = uuidv4();
+//     const payload = JSON.stringify(body);
+//     const messageCount = messageCountRaw ? parseInt(messageCountRaw) : 11;
+//     console.log(`Sending ${messageCount} messages to the queue`);
+//     await Promise.allSettled(
+//       [...Array(messageCount).keys()].map(async () => {
+//         return sendMessageToQueue(dlqUrl ?? "NA", payload, {
+//           messageAttributes: {
+//             cxId: uuidv4(),
+//             // intentional so it fails to process
+//             // patientId: uuidv4(),
+//             jobIdId: uuidv4(),
+//           },
+//         });
+//       })
+//     );
+
+//     return res.sendStatus(200);
+//   })
+// );


### PR DESCRIPTION
Ref: metriport/metriport-internal#1092

### Dependencies

none

### Description

Add endpoint to redrive sidechain msgs from DLQ to the regular queue.

### Release Plan

- [ ] merge this
- [ ] execute `POST /internal/redrive-sidechain-dlq` w/o params (all messages)