### PR TITLE
1092 allow API to RW to DLQ and handle errors

### DIFF
--- a/packages/infra/lib/api-service.ts
+++ b/packages/infra/lib/api-service.ts
@@ -156,7 +156,7 @@ export function createAPIService(
     });
   sidechainFHIRConverterDLQ &&
     provideAccessToQueue({
-      accessType: "send",
+      accessType: "both",
       queue: sidechainFHIRConverterDLQ,
       resource: fargateService.service.taskDefinition.taskRole,
     });


### PR DESCRIPTION
Ref: metriport/metriport-internal#1092

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/933
- Downstream: none

### Description

- allow API to RW to DLQ
- handle erros from getMessagesFromQueue

### Release Plan

- infra changes
- asap