### PR TITLE
RELEASE 2023-10-01

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35362,7 +35362,7 @@
       }
     },
     "packages/api": {
-      "version": "1.4.2-alpha.1",
+      "version": "1.4.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -35437,7 +35437,7 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.0.2-alpha.2",
+      "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^4.8.0",
@@ -35523,7 +35523,7 @@
     "packages/api/packages/commonwell-sdk": {},
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.9.2-alpha.1",
+      "version": "1.9.2",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^4.8.0",
@@ -35612,7 +35612,7 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.6.2-alpha.1",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^4.8.0",
@@ -35694,7 +35694,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.8.1-alpha.0",
+      "version": "4.8.1",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^8.0.2",
@@ -35743,13 +35743,13 @@
       }
     },
     "packages/connect-widget": {
-      "version": "1.4.2-alpha.2",
+      "version": "1.4.2",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.12",
         "@chakra-ui/react": "^2.4.1",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
-        "@metriport/api-sdk": "^7.0.2-alpha.2",
+        "@metriport/api-sdk": "^7.0.2",
         "@sentry/react": "^7.45.0",
         "@sentry/tracing": "^7.45.0",
         "@testing-library/jest-dom": "^5.16.5",
@@ -35846,7 +35846,7 @@
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.4.2-alpha.0",
+      "version": "1.4.2",
       "dependencies": {
         "aws-cdk-lib": "^2.87.0",
         "constructs": "^10.2.69",
@@ -35893,7 +35893,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.4.1-alpha.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -36919,7 +36919,7 @@
       }
     },
     "packages/utils": {
-      "version": "1.4.1-alpha.0",
+      "version": "1.4.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.0.2-alpha.2",
+  "version": "7.0.2",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.4.2-alpha.1",
+  "version": "1.4.2",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/src/sequelize/migrations/2023-07-27_01_alter-patient-remove-patientNumber.ts
+++ b/packages/api/src/sequelize/migrations/2023-07-27_01_alter-patient-remove-patientNumber.ts
@@ -1,8 +1,8 @@
 import { DataTypes } from "sequelize";
 import type { Migration } from "..";
 
-const tableName = "facility";
-const columnName = "facility_number";
+const tableName = "patient";
+const columnName = "patient_number";
 
 // Use 'Promise.all' when changes are independent of each other
 export const up: Migration = async ({ context: queryInterface }) => {

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.9.2-alpha.1",
+  "version": "1.9.2",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.6.2-alpha.1",
+  "version": "1.6.2",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.8.1-alpha.0",
+  "version": "4.8.1",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/connect-widget/package.json
+++ b/packages/connect-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-widget",
-  "version": "1.4.2-alpha.2",
+  "version": "1.4.2",
   "private": true,
   "scripts": {
     "clean": "rimraf build && rimraf node_modules",
@@ -38,7 +38,7 @@
     "@chakra-ui/react": "^2.4.1",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@metriport/api-sdk": "^7.0.2-alpha.2",
+    "@metriport/api-sdk": "^7.0.2",
     "@sentry/react": "^7.45.0",
     "@sentry/tracing": "^7.45.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.4.2-alpha.0",
+  "version": "1.4.2",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.4.1-alpha.0",
+  "version": "1.4.1",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.4.1-alpha.0",
+  "version": "1.4.1",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/1092

### Dependencies

https://github.com/metriport/metriport/pull/933
https://github.com/metriport/metriport/pull/934

### Description

Add endpoint to redrive sidechain msgs from DLQ to the regular queue.

### Release Plan

- ⚠️ This is pointing to `master`
- Contains infra changes
- [ ] merge this
- [ ] execute POST /internal/redrive-sidechain-dlq w/o params (all messages)