### PR TITLE
1095 add endpoint to peek into DLQ

### DIFF
--- a/packages/api/src/command/medical/admin/peek-dlq.ts
+++ b/packages/api/src/command/medical/admin/peek-dlq.ts
@@ -1,0 +1,75 @@
+import BadRequestError from "../../../errors/bad-request";
+import { getSignedUrl } from "../../../external/aws/s3";
+import { getMessageCountFromQueue, peekMessagesFromQueue } from "../../../external/aws/sqs";
+import { Config } from "../../../shared/config";
+
+const dlqUrl = Config.getSidechainFHIRConverterDQLURL();
+
+const maxNumberOfMessagesPerQuery = 10;
+const linkDurationInSeconds = 10 * 60; // 10 minutes
+
+export type ConversionDLQMessageType = {
+  cxId: string;
+  patientId: string;
+  jobId?: string;
+  s3FileName: string;
+  s3BucketName: string;
+  documentExtension: unknown;
+  downloadLink: string;
+};
+
+/**
+ * ADMIN LOGIC - not to be used by other endpoints/services.
+ *
+ * Read the first 10 messages from the sidechain DLQ without removing them,
+ * and return a link to download the files they point to.
+ */
+export async function peekIntoSidechainDLQ(): Promise<{
+  messageCount: number;
+  first10Items: ConversionDLQMessageType[];
+}> {
+  if (!dlqUrl) throw new BadRequestError("Missing sidechain DLQ URL");
+
+  const messageCount = await getMessageCountFromQueue(dlqUrl);
+  console.log(`>>> Message count: ${messageCount}`);
+
+  console.log(`>>> Getting messages from source queue...`);
+  const messagesOfRequest = await peekMessagesFromQueue(dlqUrl, {
+    maxNumberOfMessagesPerQuery,
+    maxNumberOfMessages: maxNumberOfMessagesPerQuery,
+  });
+
+  if (!messagesOfRequest || !messagesOfRequest.length) {
+    console.log(`>>> No messages found`);
+    return { messageCount: 0, first10Items: [] };
+  }
+
+  const promises = messagesOfRequest.map(async m => {
+    const cxId = m.MessageAttributes?.cxId?.StringValue ?? "na";
+    const patientId = m.MessageAttributes?.patientId?.StringValue ?? "na";
+    const jobId = m.MessageAttributes?.jobId?.StringValue ?? "na";
+    const body = m.Body ? JSON.parse(m.Body) : undefined;
+    const s3FileName = body.s3FileName ?? "na";
+    const s3BucketName = body.s3BucketName ?? "na";
+    const documentExtension = body.documentExtension ?? "na";
+    const downloadLink = await getSignedUrl({
+      bucketName: s3BucketName,
+      fileName: s3FileName,
+      durationSeconds: linkDurationInSeconds,
+    });
+    return {
+      cxId,
+      patientId,
+      jobId,
+      s3FileName,
+      s3BucketName,
+      documentExtension,
+      downloadLink,
+    };
+  });
+  const messages = await Promise.all(promises);
+
+  const result = { messageCount: messages.length, first10Items: messages };
+  console.log(`>>> Success! ${JSON.stringify(result)})}`);
+  return result;
+}

--- a/packages/api/src/command/medical/admin/redrive-dlq.ts
+++ b/packages/api/src/command/medical/admin/redrive-dlq.ts
@@ -85,11 +85,6 @@ async function redriveSQSUnique({
     );
   }
 
-  // console.log(`>>> Messages from source queue:`);
-  // messages.forEach(message => {
-  //   console.log("... ", message.Body);
-  // });
-
   if (!messages || !messages.length) {
     console.log(`>>> No messages to send`);
     return { originalCount: messages.length, uniqueCount: -1 };

--- a/packages/api/src/external/aws/s3.ts
+++ b/packages/api/src/external/aws/s3.ts
@@ -4,3 +4,21 @@ import { Config } from "../../shared/config";
 export function makeS3Client() {
   return new AWS.S3({ signatureVersion: "v4", region: Config.getAWSRegion() });
 }
+
+const DEFAULT_SIGNED_URL_DURATION_SECONDS = 3 * 60; // 3 minutes
+
+export async function getSignedUrl({
+  bucketName,
+  fileName,
+  durationSeconds,
+}: {
+  bucketName: string;
+  fileName: string;
+  durationSeconds?: number;
+}): Promise<string> {
+  return makeS3Client().getSignedUrl("getObject", {
+    Bucket: bucketName,
+    Key: fileName,
+    Expires: durationSeconds ?? DEFAULT_SIGNED_URL_DURATION_SECONDS,
+  });
+}

--- a/packages/api/src/external/aws/s3.ts
+++ b/packages/api/src/external/aws/s3.ts
@@ -1,11 +1,14 @@
 import * as AWS from "aws-sdk";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
 import { Config } from "../../shared/config";
+
+dayjs.extend(duration);
+const DEFAULT_SIGNED_URL_DURATION = dayjs.duration({ minutes: 3 }).asSeconds();
 
 export function makeS3Client() {
   return new AWS.S3({ signatureVersion: "v4", region: Config.getAWSRegion() });
 }
-
-const DEFAULT_SIGNED_URL_DURATION_SECONDS = 3 * 60; // 3 minutes
 
 export async function getSignedUrl({
   bucketName,
@@ -19,6 +22,6 @@ export async function getSignedUrl({
   return makeS3Client().getSignedUrl("getObject", {
     Bucket: bucketName,
     Key: fileName,
-    Expires: durationSeconds ?? DEFAULT_SIGNED_URL_DURATION_SECONDS,
+    Expires: durationSeconds ?? DEFAULT_SIGNED_URL_DURATION,
   });
 }

--- a/packages/api/src/external/aws/sqs.ts
+++ b/packages/api/src/external/aws/sqs.ts
@@ -114,6 +114,7 @@ export async function peekMessagesFromQueue(
     ...sqsParams,
     removeMessages: false,
     poolUntilEmpty: false,
+    visibilityTimeout: 1, // we don't want to leave them "in flight" after we peek into them
   });
 }
 

--- a/packages/api/src/models/db-dev.ts
+++ b/packages/api/src/models/db-dev.ts
@@ -65,11 +65,6 @@ const createTokenTable = async (ddb: AWS.DynamoDB): Promise<void> => {
   }
 };
 export const initDDBDev = async (): Promise<AWS.DynamoDB.DocumentClient> => {
-  AWS.config.update({
-    region: "us-west-1",
-    accessKeyId: "xxxx",
-    secretAccessKey: "xxxx",
-  });
   const doc = new AWS.DynamoDB.DocumentClient({
     apiVersion: "2012-08-10",
     endpoint: process.env.DYNAMODB_ENDPOINT,

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -1,5 +1,6 @@
 import { Request, Response, Router } from "express";
 import httpStatus from "http-status";
+import { peekIntoSidechainDLQ } from "../command/medical/admin/peek-dlq";
 import {
   populateFhirServer,
   PopulateFhirServerResponse,
@@ -120,6 +121,20 @@ router.post(
     const maxNumberOfMessages = maxNumberOfMessagesRaw ? parseInt(maxNumberOfMessagesRaw) : -1;
 
     const result = await redriveSidechainDLQ(maxNumberOfMessages);
+    return res.json(result);
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * POST /internal/peek-sidechain-dlq
+ *
+ * Read the first 10 messages from the sidechain DLQ without removing them, and return a link
+ * to download the files they point to.
+ */
+router.post(
+  "/peek-sidechain-dlq",
+  asyncHandler(async (req: Request, res: Response) => {
+    const result = await peekIntoSidechainDLQ();
     return res.json(result);
   })
 );

--- a/packages/infra/lib/api-service.ts
+++ b/packages/infra/lib/api-service.ts
@@ -156,7 +156,7 @@ export function createAPIService(
     });
   sidechainFHIRConverterDLQ &&
     provideAccessToQueue({
-      accessType: "send",
+      accessType: "both",
       queue: sidechainFHIRConverterDLQ,
       resource: fargateService.service.taskDefinition.taskRole,
     });

--- a/packages/utils/src/sqs/populate-sqs.ts
+++ b/packages/utils/src/sqs/populate-sqs.ts
@@ -69,7 +69,6 @@ async function main() {
       const s3FileName = item.s3FileName;
       const cxId = s3FileName.split("/")[0];
       const patientId = s3FileName.split("/")[1];
-      // console.log(`...cxId=${cxId}, patientId=${patientId}, fileName=${s3FileName}`);
       return {
         Id: uuidv4(),
         MessageBody: JSON.stringify(item),

--- a/packages/utils/src/sqs/populate-sqs.ts
+++ b/packages/utils/src/sqs/populate-sqs.ts
@@ -1,36 +1,113 @@
-// TODO move this to a shared library in core, so we can turn this into a script and not endoint, so it can live
-// in the codebase uncommented and ready for use.
-/**
- * Endpoint to populate the DLQ with messages for testing purposes
- */
-// router.post(
-//   "/sqs-populate",
-//   asyncHandler(async (req: Request, res: Response) => {
-//     const dlqUrl = Config.getSidechainFHIRConverterDQLURL();
-//     if (!dlqUrl) throw new BadRequestError("Missing sidechain DLQ URL");
-//     const messageCountRaw = getFrom("query").optional("maxNumberOfMessages", req);
-//     const randomizeFilename = getFrom("query").optional("randomizeFilename", req) === "true";
-//     console.log(
-//       `Params: messageCountRaw=${messageCountRaw}, randomizeFilename=${randomizeFilename}`
-//     );
-//     const body = req.body;
-//     if (randomizeFilename) body.s3FileName = uuidv4();
-//     const payload = JSON.stringify(body);
-//     const messageCount = messageCountRaw ? parseInt(messageCountRaw) : 11;
-//     console.log(`Sending ${messageCount} messages to the queue`);
-//     await Promise.allSettled(
-//       [...Array(messageCount).keys()].map(async () => {
-//         return sendMessageToQueue(dlqUrl ?? "NA", payload, {
-//           messageAttributes: {
-//             cxId: uuidv4(),
-//             // intentional so it fails to process
-//             // patientId: uuidv4(),
-//             jobIdId: uuidv4(),
-//           },
-//         });
-//       })
-//     );
+import { SQS } from "aws-sdk";
+import * as fs from "fs";
+import { chunk, uniq } from "lodash";
+import path from "path";
+import { uuidv4 } from "../shared/uuid-v7";
 
-//     return res.sendStatus(200);
-//   })
-// );
+/**
+ * Script to populate the SQS queue with messages from a JSON file.
+ *
+ * It was originally created to send messages pulled from a DLQ but that failed to be sent
+ * to the destination queue.
+ *
+ * The file is expected to be with the following format:
+ * [
+ *   { "s3FileName": "cxId/patientId/fileName", "s3BucketName": "bucketName", "documentExtension": "pdf" },
+ *   ...
+ * ]
+ */
+
+const cwd = process.cwd();
+const paths = [cwd, ...(cwd.includes("src") ? [] : ["src"])];
+
+/**
+ * UPDATE THESE
+ */
+const fileName = path.resolve(...paths, "sqs", "messages.json");
+const destinationQueueUrl = "";
+const awsRegion = "";
+
+const maxItemsPerBatch = 10;
+const sqsConfig = {
+  awsRegion,
+};
+export const sqs = new SQS({
+  apiVersion: "2012-11-05",
+  region: sqsConfig.awsRegion,
+});
+
+async function main() {
+  console.log(
+    `Running with:\n` +
+      `- fileName: ${fileName}\n` +
+      `- destinationQueueUrl: ${destinationQueueUrl}\n` +
+      `- awsRegion: ${awsRegion}\n` +
+      `- maxItemsPerBatch: ${maxItemsPerBatch}\n`
+  );
+  console.log(`Reading file ${fileName}...`);
+  const contents = fs.readFileSync(fileName, "utf8");
+
+  console.log(`Parsing its contents...`);
+  const payload = JSON.parse(contents) as {
+    s3FileName: string;
+    s3BucketName: string;
+    documentExtension: unknown;
+  }[];
+  if (!Array.isArray(payload)) {
+    throw new Error(`Payload is not an array`);
+  }
+
+  const filteredPayload = payload.filter(item => !item.s3FileName.includes(".pdf"));
+  console.log(`Started w/ ${payload.length}, filtered to ${filteredPayload.length} messages`);
+
+  const chunks = chunk(filteredPayload, maxItemsPerBatch);
+  const n = chunks.length;
+  console.log(`Sending messages to the queue in ${n} chunks in parallel...`);
+
+  const promises = chunks.map(chunk => {
+    const batchEntries = chunk.map(item => {
+      const s3FileName = item.s3FileName;
+      const cxId = s3FileName.split("/")[0];
+      const patientId = s3FileName.split("/")[1];
+      // console.log(`...cxId=${cxId}, patientId=${patientId}, fileName=${s3FileName}`);
+      return {
+        Id: uuidv4(),
+        MessageBody: JSON.stringify(item),
+        MessageAttributes: {
+          ...singleAttributeToSend("cxId", cxId),
+          ...singleAttributeToSend("patientId", patientId),
+        },
+      };
+    });
+    // Max individual entry and total request size can't be more than 256KB
+    return sqs.sendMessageBatch({ QueueUrl: destinationQueueUrl, Entries: batchEntries }).promise();
+  });
+
+  const res = await Promise.allSettled(promises);
+  const failed = res.flatMap(r => (r.status === "rejected" ? String(r.reason) : []));
+  if (failed.length) {
+    const succeeded = res.filter(r => r.status === "fulfilled");
+    const uniqueMsgs = uniq(failed);
+    console.log(
+      `>>> Failed to get messages from SQS (total errors ${failed.length}, ` +
+        `unique errors ${uniqueMsgs.length}, succeeded ${succeeded.length}): ` +
+        `${uniqueMsgs.join("; ")}`
+    );
+  }
+
+  console.log(`Done.`);
+}
+
+function singleAttributeToSend(
+  key: string,
+  value: string | undefined
+): SQS.MessageBodyAttributeMap {
+  return {
+    [key]: {
+      DataType: "String",
+      StringValue: value,
+    },
+  };
+}
+
+main();


### PR DESCRIPTION
Ref: metriport/metriport-internal#1095

### Dependencies

none

### Description

- add endpoint to peek into a conversion DLQ
- also return a presigned download URL for easy review of the file
- also send the update for the redrive function so it deals with errors properly and return when no there's no message to process

### Release Plan

- nothing special