### PR TITLE
1102 cda to pdf increase timeout

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -32,6 +32,7 @@ import { provideAccessToQueue } from "./shared/sqs";
 import { isProd, isSandbox, mbToBytes } from "./shared/util";
 
 const FITBIT_LAMBDA_TIMEOUT = Duration.seconds(60);
+const CDA_TO_VIS_TIMEOUT = Duration.minutes(15);
 
 interface APIStackProps extends StackProps {
   config: EnvConfig;
@@ -878,11 +879,12 @@ export class APIStack extends Stack {
         ...(bucketName && {
           MEDICAL_DOCUMENTS_BUCKET_NAME: bucketName,
         }),
+        CDA_TO_VIS_TIMEOUT_MS: CDA_TO_VIS_TIMEOUT.toMilliseconds().toString(),
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
       layers: [...lambdaLayers, chromiumLayer],
       memory: 512,
-      timeout: Duration.minutes(15),
+      timeout: CDA_TO_VIS_TIMEOUT,
       vpc,
       alarmSnsAction: alarmAction,
     });

--- a/packages/lambdas/src/cda-to-visualization.ts
+++ b/packages/lambdas/src/cda-to-visualization.ts
@@ -112,13 +112,15 @@ const convertStoreAndReturnPdfDocUrl = async ({
   let browser: puppeteer.Browser | null = null;
 
   try {
+    const puppeteerTimeoutInMillis =
+      parseInt(cdaToVisTimeoutInMillis) - GRACEFUL_SHUTDOWN_ALLOWANCE_MS;
     // Defines browser
     browser = await puppeteer.launch({
       args: chromium.args,
       defaultViewport: chromium.defaultViewport,
       executablePath: await chromium.executablePath,
       headless: chromium.headless,
-      timeout: parseInt(cdaToVisTimeoutInMillis) - GRACEFUL_SHUTDOWN_ALLOWANCE_MS,
+      timeout: puppeteerTimeoutInMillis,
     });
 
     // Defines page

--- a/packages/lambdas/src/cda-to-visualization.ts
+++ b/packages/lambdas/src/cda-to-visualization.ts
@@ -18,7 +18,8 @@ capture.init();
 const lambdaName = getEnv("AWS_LAMBDA_FUNCTION_NAME");
 // Set by us
 const bucketName = getEnvOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
-
+const cdaToVisTimeoutInMillis = getEnvOrFail("CDA_TO_VIS_TIMEOUT_MS");
+const GRACEFUL_SHUTDOWN_ALLOWANCE_MS = 3_000;
 const SIGNED_URL_DURATION_SECONDS = 60;
 
 const s3client = new AWS.S3({
@@ -117,6 +118,7 @@ const convertStoreAndReturnPdfDocUrl = async ({
       defaultViewport: chromium.defaultViewport,
       executablePath: await chromium.executablePath,
       headless: chromium.headless,
+      timeout: parseInt(cdaToVisTimeoutInMillis) - GRACEFUL_SHUTDOWN_ALLOWANCE_MS,
     });
 
     // Defines page


### PR DESCRIPTION
Ref: #https://github.com/metriport/metriport-internal/issues/1102

### Description

- The CDA-to-Visualization lambda will not pass its timeout to the env vars, and the handler will use that to set the puppeteer timeout 

### Release Plan

- Nothing special
