### PR TITLE
fix(lambda): use pipe instead of websocket for puppeteer connection

### DIFF
--- a/packages/lambdas/src/cda-to-visualization.ts
+++ b/packages/lambdas/src/cda-to-visualization.ts
@@ -116,6 +116,7 @@ const convertStoreAndReturnPdfDocUrl = async ({
       parseInt(cdaToVisTimeoutInMillis) - GRACEFUL_SHUTDOWN_ALLOWANCE_MS;
     // Defines browser
     browser = await puppeteer.launch({
+      pipe: true,
       args: chromium.args,
       defaultViewport: chromium.defaultViewport,
       executablePath: await chromium.executablePath,


### PR DESCRIPTION
refs. metriport/metriport-internal#1103

### Description

- Looks like the issue is rare enough that we don't need to dive too far into the details at this point
- [This solution](https://github.com/puppeteer/puppeteer/issues/2735#issuecomment-470309033) seems promising based on the popularity in that thread. 
- Using a pipe is arguably better than the default websocket anyway and has no drawbacks based on [this](https://stackoverflow.com/questions/54922756/what-are-the-advantages-and-disadvantages-of-connecting-puppeteer-over-pipe-inst).

### Additional Information

- People are reportedly having this issue when converting to PDF some large images

### Release Plan

- Merge this
- Monitor if the issue shows up again on Slack
