### PR TITLE
fix(api): fix check for convert by looking at file type

### DIFF
--- a/packages/api/src/command/medical/patient/append-doc-query-progress.ts
+++ b/packages/api/src/command/medical/patient/append-doc-query-progress.ts
@@ -6,6 +6,7 @@ import { getPatientOrFail } from "./get-patient";
 export type SetDocQueryProgress = {
   patient: Pick<Patient, "id" | "cxId">;
   convertibleDownloadErrors?: number;
+  increaseCountConvertible?: number;
   requestId?: string | undefined;
 } & (
   | {
@@ -31,6 +32,7 @@ export async function appendDocQueryProgress({
   downloadProgress,
   convertProgress,
   convertibleDownloadErrors,
+  increaseCountConvertible,
   reset,
   requestId,
 }: SetDocQueryProgress): Promise<Patient> {
@@ -75,6 +77,10 @@ export async function appendDocQueryProgress({
       convert.total = Math.max((convert.total ?? 0) - convertibleDownloadErrors, 0);
       // since we updated the total above, we should update the status as well
       convert.status = getStatusFromProgress(convert);
+    }
+
+    if (convert && increaseCountConvertible != null && increaseCountConvertible > 0) {
+      convert.total = (convert.total ?? 0) + increaseCountConvertible;
     }
 
     const updatedPatient = {

--- a/packages/api/src/command/medical/patient/append-doc-query-progress.ts
+++ b/packages/api/src/command/medical/patient/append-doc-query-progress.ts
@@ -79,8 +79,8 @@ export async function appendDocQueryProgress({
       convert.status = getStatusFromProgress(convert);
     }
 
-    if (convert && increaseCountConvertible != null && increaseCountConvertible > 0) {
-      convert.total = (convert.total ?? 0) + increaseCountConvertible;
+    if (convert && increaseCountConvertible != null && increaseCountConvertible !== 0) {
+      convert.total = Math.min(0, (convert.total ?? 0) + increaseCountConvertible);
     }
 
     const updatedPatient = {

--- a/packages/api/src/external/commonwell/document/document-query-sandbox.ts
+++ b/packages/api/src/external/commonwell/document/document-query-sandbox.ts
@@ -66,7 +66,7 @@ export async function sandboxGetDocRefsAndUpsert({
         content: { mimeType: entry.docRef.content?.[0]?.attachment?.contentType },
       };
     })
-    .filter(doc => isConvertible(doc.content.mimeType)).length;
+    .filter(doc => isConvertible(doc.content?.mimeType)).length;
 
   // set initial download/convert totals
   await appendDocQueryProgress({

--- a/packages/api/src/external/commonwell/document/document-query-sandbox.ts
+++ b/packages/api/src/external/commonwell/document/document-query-sandbox.ts
@@ -66,7 +66,7 @@ export async function sandboxGetDocRefsAndUpsert({
         content: { mimeType: entry.docRef.content?.[0]?.attachment?.contentType },
       };
     })
-    .filter(isConvertible).length;
+    .filter(doc => isConvertible(doc.content.mimeType)).length;
 
   // set initial download/convert totals
   await appendDocQueryProgress({

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -753,7 +753,7 @@ async function triggerDownloadDocument({
   return newFile;
 }
 
-const fileIsConvertible = (f: File) => f && isConvertible(f.contentType);
+const fileIsConvertible = (f: File) => isConvertible(f.contentType);
 
 async function sleepBetweenChunks(): Promise<void> {
   return Util.sleepRandom(DOC_DOWNLOAD_CHUNK_DELAY_MAX_MS, DOC_DOWNLOAD_CHUNK_DELAY_MIN_PCT / 100);

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -473,6 +473,7 @@ export async function downloadDocsAndUpsertFHIR({
         let errorReported = false;
         let uploadToS3: () => Promise<File>;
         let file: Awaited<ReturnType<typeof uploadToS3>> | undefined = undefined;
+        const isConvertibleDoc = isConvertible(doc.content.mimeType);
 
         try {
           const fileInfo = fileInfoByDocId(doc.id);
@@ -576,8 +577,10 @@ export async function downloadDocsAndUpsertFHIR({
                 log(
                   `Error triggering conversion of doc ${doc.id}, just increasing errorCountConvertible - ${err}`
                 );
-                errorCountConvertible++;
               }
+            } else if (isConvertibleDoc) {
+              // where if doc was convertible but file is not then remove one from the initial count
+              errorCountConvertible++;
             }
           } else {
             // count this doc as an error so we can decrement the total to be converted in the query status
@@ -606,7 +609,6 @@ export async function downloadDocsAndUpsertFHIR({
             const isFileConvertible = fileIsConvertible(file);
             if (isFileConvertible) errorCountConvertible++;
           } else {
-            const isConvertibleDoc = isConvertible(doc.content.mimeType);
             if (isConvertibleDoc) errorCountConvertible++;
           }
 

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -461,7 +461,7 @@ export async function downloadDocsAndUpsertFHIR({
   const fileInfoByDocId = (docId: string) => filesWithStorageInfo.find(f => f.docId === docId);
 
   const convertibleDocCount = docsToDownload.filter(doc =>
-    isConvertible(doc.content.mimeType)
+    isConvertible(doc.content?.mimeType)
   ).length;
   log(`I have ${docsToDownload.length} docs to download (${convertibleDocCount} convertible)`);
   await initPatientDocQuery(patient, docsToDownload.length, convertibleDocCount, requestId);
@@ -474,12 +474,12 @@ export async function downloadDocsAndUpsertFHIR({
         let errorReported = false;
         let uploadToS3: () => Promise<File>;
         let file: Awaited<ReturnType<typeof uploadToS3>> | undefined = undefined;
-        const isConvertibleDoc = isConvertible(doc.content.mimeType);
+        const isConvertibleDoc = isConvertible(doc.content?.mimeType);
 
         try {
           const fileInfo = fileInfoByDocId(doc.id);
           if (!fileInfo) {
-            if (isConvertibleDoc && !ignoreFhirConversionAndUpsert) errorCountConvertible++;
+            if (isConvertibleDoc && !ignoreFhirConversionAndUpsert) increaseCountConvertible--;
             throw new MetriportError("Missing file info", undefined, { docId: doc.id });
           }
 
@@ -568,7 +568,7 @@ export async function downloadDocsAndUpsertFHIR({
           };
 
           if (!shouldConvertCDA && isConvertibleDoc) {
-            errorCountConvertible++;
+            increaseCountConvertible--;
           } else if (shouldConvertCDA && !isConvertibleDoc) {
             increaseCountConvertible++;
           }

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -553,7 +553,13 @@ export async function downloadDocsAndUpsertFHIR({
             },
           };
 
-          if (file.isNew && !ignoreFhirConversionAndUpsert) {
+          // If an xml document contained b64 data, we will parse, convert and store it in s3 as the default downloaded document.
+          // Because of this the document content type may not match the s3 file content type hence this check.
+          // This will prevent us from converting non xml documents to FHIR.
+          const fileIsConvertible =
+            file.contentType === "application/xml" || file.contentType === "text/xml";
+
+          if (file.isNew && fileIsConvertible && !ignoreFhirConversionAndUpsert) {
             try {
               await convertCDAToFHIR({
                 patient,

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -751,23 +751,6 @@ async function triggerDownloadDocument({
   return newFile;
 }
 
-// const isHandlingDocCount = ({
-//   isNew,
-//   flagDisableConversion,
-//   isDocConvertible,
-//   isConvertCDA,
-// }: {
-//   isNew?: boolean;
-//   flagDisableConversion?: boolean;
-//   isDocConvertible?: boolean;
-//   isConvertCDA?: boolean;
-// }): boolean => {
-//   if (isNew) return true;
-//   if (flagDisableConversion) return false;
-//   if (isDocConvertible && isConvertCDA) return true;
-//   return false;
-// };
-
 const fileIsConvertible = (f: File) => isConvertible(f.contentType);
 
 async function sleepBetweenChunks(): Promise<void> {


### PR DESCRIPTION
Ref. metriport/metriport-internal#1098

Ref: 1098

### Description

There was an issue where when we downloaded a document and extracted b64 we were then also trying to convert that document to fhir. This is an issue as we can only convert xml and the extracted b64 in most instances is a pdf. 

Logic for decreasing total count converted
https://docs.google.com/spreadsheets/d/19B9nGAoJgzlG4hR41NQ-II9qq0Rt94p2VJxIpOaAKP0/edit#gid=0

Sentry error
https://metriport-inc.sentry.io/issues/4326963216/?alert_rule_id=14442454&alert_type=issue&notification_uuid=fb4e5b2c-4cbe-4d61-ada3-8fedfcc60192&project=4505252341153792&referrer=slack

### Release Plan

- [ ] Once approved