### PR TITLE
build: deploy_cdk GH workflow to use master on sandbox too

### DIFF
--- a/.github/workflows/_deploy_cdk.yml
+++ b/.github/workflows/_deploy_cdk.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: metriport/metriport-internal
-          ref: ${{ inputs.deploy_env == 'production' && 'master' || 'develop' }}
+          ref: ${{ (inputs.deploy_env == 'production' || inputs.deploy_env == 'sandbox') && 'master' || 'develop' }}
           token: ${{ secrets.SERVICE_PAT }} # secret token from user 'metriport-service'
           path: metriport-internal
           sparse-checkout: |
@@ -114,7 +114,7 @@ jobs:
       - name: Lambdas test
         run: npm run test
         working-directory: "metriport/packages/lambdas"
-        
+
         # SENTRY
       - name: Create Sentry release
         uses: getsentry/action-release@v1

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -31,6 +31,7 @@ import { Secrets, getSecrets } from "./shared/secrets";
 import { provideAccessToQueue } from "./shared/sqs";
 import { isProd, isSandbox, mbToBytes } from "./shared/util";
 
+// TODO Comment to trigger a deploy, remove it when you see this
 const FITBIT_LAMBDA_TIMEOUT = Duration.seconds(60);
 const CDA_TO_VIS_TIMEOUT = Duration.minutes(15);
 


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/799

### Dependencies

none

### Description

Fix `_deploy_cdk` GH workflow, make it use `master` on sandbox too

Context: https://metriport.slack.com/archives/C04DBBJSKGB/p1696433688557939?thread_ts=1696430990.014879&cid=C04DBBJSKGB

### Release Plan

- ⚠️ This is pointing to `master`
- ASAP