### PR TITLE
build: allow ingestion lambda to access OS secret

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -210,7 +210,7 @@ export class APIStack extends Stack {
       queue: ccdaSearchQueue,
       searchDomain: ccdaSearchDomain,
       searchDomainUserName: ccdaSearchUserName,
-      searchDomainSecretName: ccdaSearchSecretName,
+      searchDomainSecret: ccdaSearchSecret,
       indexName: ccdaSearchIndexName,
     } = ccdaSearch.setup({
       stack: this,
@@ -318,7 +318,7 @@ export class APIStack extends Stack {
       documentDownloaderLambda,
       ccdaSearchQueue,
       ccdaSearchDomain.domainEndpoint,
-      { userName: ccdaSearchUserName, secretName: ccdaSearchSecretName },
+      { userName: ccdaSearchUserName, secret: ccdaSearchSecret },
       ccdaSearchIndexName
     );
 

--- a/packages/infra/lib/api-stack/ccda-search-connector.ts
+++ b/packages/infra/lib/api-stack/ccda-search-connector.ts
@@ -5,6 +5,7 @@ import { IFunction, ILayerVersion } from "aws-cdk-lib/aws-lambda";
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { IDomain } from "aws-cdk-lib/aws-opensearchservice";
 import * as s3 from "aws-cdk-lib/aws-s3";
+import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
 import { IQueue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
 import { getConfig, METRICS_NAMESPACE } from "../shared/config";
@@ -89,7 +90,7 @@ export function setup({
   lambda: IFunction;
   searchDomain: IDomain;
   searchDomainUserName: string;
-  searchDomainSecretName: string;
+  searchDomainSecret: ISecret;
   indexName: string;
 } {
   const config = getConfig();
@@ -164,7 +165,7 @@ export function setup({
     lambda,
     searchDomain: openSearch.domain,
     searchDomainUserName: openSearch.creds.username,
-    searchDomainSecretName: openSearch.creds.secret.secretName,
+    searchDomainSecret: openSearch.creds.secret,
     indexName: openSearchConfig.indexName,
   };
 }

--- a/packages/infra/lib/api-stack/ccda-search-connector.ts
+++ b/packages/infra/lib/api-stack/ccda-search-connector.ts
@@ -139,7 +139,7 @@ export function setup({
       DLQ_URL: dlq.queue.queueUrl,
       SEARCH_HOST: openSearch.domain.domainEndpoint,
       SEARCH_USER: openSearch.creds.username,
-      SEARCH_SECRET_NAME: openSearch.creds.secretName,
+      SEARCH_SECRET_NAME: openSearch.creds.secret.secretName,
       SEARCH_INDEX_NAME: openSearchConfig.indexName,
     },
     timeout,
@@ -157,13 +157,14 @@ export function setup({
   );
   provideAccessToQueue({ accessType: "both", queue, resource: lambda });
   provideAccessToQueue({ accessType: "send", queue: dlq.queue, resource: lambda });
+  openSearch.creds.secret.grantRead(lambda);
 
   return {
     queue,
     lambda,
     searchDomain: openSearch.domain,
     searchDomainUserName: openSearch.creds.username,
-    searchDomainSecretName: openSearch.creds.secretName,
+    searchDomainSecretName: openSearch.creds.secret.secretName,
     indexName: openSearchConfig.indexName,
   };
 }

--- a/packages/infra/lib/shared/open-search-construct.ts
+++ b/packages/infra/lib/shared/open-search-construct.ts
@@ -8,6 +8,7 @@ import {
   IDomain,
 } from "aws-cdk-lib/aws-opensearchservice";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
+import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 
 const masterUserName = "admin";
@@ -23,7 +24,7 @@ export interface OpenSearchConstructProps {
 
 export default class OpenSearchConstruct extends Construct {
   public readonly domain: IDomain;
-  public readonly creds: { username: string; secretName: string };
+  public readonly creds: { username: string; secret: ISecret };
 
   constructor(scope: Construct, id: string, props: OpenSearchConstructProps) {
     super(scope, `${id}Construct`);
@@ -38,7 +39,7 @@ export default class OpenSearchConstruct extends Construct {
     });
     this.creds = {
       username: masterUserName,
-      secretName,
+      secret: credsSecret,
     };
 
     const osSg = new ec2.SecurityGroup(this, `${id}-sg`, {


### PR DESCRIPTION
Ref: metriport/metriport-internal#1050

### Dependencies

none

### Description

Allow ingestion lambda to access OS secret

Context: https://metriport.slack.com/archives/C04T5Q9JHFX/p1696465042642929

### Release Plan

- asap