### PR TITLE
1050 fix core's e2e script

### DIFF
--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -198,10 +198,6 @@ export class Config {
     return getEnvVar("POST_HOG_API_KEY");
   }
 
-  static getTestApiKey(): string | undefined {
-    return getEnvVar("TEST_API_KEY");
-  }
-
   static getMedicalDocumentsBucketName(): string {
     return getEnvVarOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "lint-fix": "npm run lint --fix",
     "prettier-fix": "npx prettier '**/*.ts' --write",
     "test": "jest --runInBand --detectOpenHandles --passWithNoTests",
-    "test:e2e": "E2E=true jest --runInBand --detectOpenHandles"
+    "test:e2e": "E2E=true jest --runInBand --detectOpenHandles --passWithNoTests"
   },
   "dependencies": {
     "@opensearch-project/opensearch": "^2.3.1",


### PR DESCRIPTION
Ref: metriport/metriport-internal#1050

### Dependencies

none

### Description

Fix the script to run E2E tests on core (introduced in one of the last couple PRs). Context [here](https://metriport.slack.com/archives/C04FZ9859FZ/p1696517895400859?thread_ts=1696514103.592759&cid=C04FZ9859FZ).

Also remove a function not being used on API's Config.

### Release Plan

- nothing special
- asap