### PR TITLE
1050 filter OS by cx and patient

### DIFF
--- a/packages/api/docker-compose.dev.yml
+++ b/packages/api/docker-compose.dev.yml
@@ -39,6 +39,7 @@ services:
       - "9229:9229"
     volumes:
       - ./src:/usr/src/app/packages/api/src
+      - ../core/dist:/usr/src/app/packages/core/dist
       - ../api-sdk/dist:/usr/src/app/packages/api-sdk/dist
       - ../commonwell-sdk/dist:/usr/src/app/packages/commonwell-sdk/dist
     extra_hosts:

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -198,10 +198,6 @@ export class Config {
     return getEnvVar("POST_HOG_API_KEY");
   }
 
-  static getTestApiKey(): string | undefined {
-    return getEnvVar("TEST_API_KEY");
-  }
-
   static getMedicalDocumentsBucketName(): string {
     return getEnvVarOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "lint-fix": "npm run lint --fix",
     "prettier-fix": "npx prettier '**/*.ts' --write",
     "test": "jest --runInBand --detectOpenHandles --passWithNoTests",
-    "test:e2e": "E2E=true jest --runInBand --detectOpenHandles"
+    "test:e2e": "E2E=true jest --runInBand --detectOpenHandles --passWithNoTests"
   },
   "dependencies": {
     "@opensearch-project/opensearch": "^2.3.1",

--- a/packages/core/src/external/opensearch/file-searcher.ts
+++ b/packages/core/src/external/opensearch/file-searcher.ts
@@ -6,6 +6,8 @@ export type IndexFields = {
 };
 
 export type SearchRequest = {
+  cxId: string;
+  patientId: string;
   // https://www.elastic.co/guide/en/elasticsearch/reference/8.5/query-dsl-query-string-query.html#_boolean_operators
   query: string;
 };


### PR DESCRIPTION
Ref: metriport/metriport-internal#1050

### Dependencies

none

### Description

- Filter OpenSearch by cx and patientx
- Fix issue with docker-compose missing `core` package

### Release Plan

- nothing special
- asap to fix docker-compose