### PR TITLE
1118 return 404 on not found

### DIFF
--- a/packages/api/src/providers/tenovi.ts
+++ b/packages/api/src/providers/tenovi.ts
@@ -6,6 +6,7 @@ import stringify from "json-stringify-safe";
 import { updateProviderData } from "../command/connected-user/save-connected-user";
 import BadRequestError from "../errors/bad-request";
 import MetriportError from "../errors/metriport-error";
+import NotFoundError from "../errors/not-found";
 import { TenoviMeasurementData, tenoviMeasurementDataSchema } from "../mappings/tenovi";
 import { mapToBiometrics } from "../mappings/tenovi/biometrics";
 import { mapToBody } from "../mappings/tenovi/body";
@@ -176,7 +177,7 @@ export class Tenovi extends Provider implements NoAuth {
           cxName: xTenoviClientName,
         },
       });
-      throw new MetriportError("Device not found for this user.", undefined, { deviceId });
+      throw new NotFoundError("Device not found for this user.", undefined, { deviceId });
     }
   }
 

--- a/packages/infra/dashboards/cw-dashboard-prod.json
+++ b/packages/infra/dashboards/cw-dashboard-prod.json
@@ -326,8 +326,8 @@
                 "annotations": {
                     "horizontal": [
                         {
-                            "label": "VolumeWriteIOPs >= 10_000 for 1 datapoints within 5 minutes",
-                            "value": 10000,
+                            "label": "VolumeWriteIOPs >= 5000 for 1 datapoints within 5 minutes",
+                            "value": 5000,
                             "yAxis": "right"
                         }
                     ]
@@ -389,8 +389,8 @@
                 "annotations": {
                     "horizontal": [
                         {
-                            "label": "VolumeWriteIOPs >= 100_000 for 1 datapoints within 5 minutes",
-                            "value": 100000,
+                            "label": "VolumeWriteIOPs >= 5000 for 1 datapoints within 5 minutes",
+                            "value": 5000,
                             "yAxis": "right"
                         }
                     ]
@@ -674,6 +674,25 @@
                 "period": 60,
                 "title": "FHIR DB - Connections",
                 "liveData": false
+            }
+        },
+        {
+            "height": 9,
+            "width": 12,
+            "y": 93,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "Metriport", "API Success", { "label": "2xx" } ],
+                    [ ".", "API Failures", { "label": "3xx | 4xx | 5xx" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-west-1",
+                "stat": "Sum",
+                "period": 300,
+                "title": "API Responses"
             }
         }
     ]

--- a/packages/infra/dashboards/cw-dashboard-prod.json
+++ b/packages/infra/dashboards/cw-dashboard-prod.json
@@ -326,8 +326,8 @@
                 "annotations": {
                     "horizontal": [
                         {
-                            "label": "VolumeWriteIOPs >= 5000 for 1 datapoints within 5 minutes",
-                            "value": 5000,
+                            "label": "VolumeWriteIOPs >= 10_000 for 1 datapoints within 5 minutes",
+                            "value": 10000,
                             "yAxis": "right"
                         }
                     ]
@@ -389,8 +389,8 @@
                 "annotations": {
                     "horizontal": [
                         {
-                            "label": "VolumeWriteIOPs >= 5000 for 1 datapoints within 5 minutes",
-                            "value": 5000,
+                            "label": "VolumeWriteIOPs >= 100_000 for 1 datapoints within 5 minutes",
+                            "value": 100000,
                             "yAxis": "right"
                         }
                     ]


### PR DESCRIPTION
Ref: metriport/metriport-internal#1118

### Dependencies

none

### Description

Return 404 on device not found.

Also update the dashboard's source w/ an additional widget to list API responses.

### Release Plan

- nothing special