### PR TITLE
PATCH RELEASE 1050 add master node for OS in prod

### DIFF
--- a/packages/infra/lib/api-stack/ccda-search-connector.ts
+++ b/packages/infra/lib/api-stack/ccda-search-connector.ts
@@ -39,10 +39,11 @@ export function settings(): {
     // https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-instance-types.html
     openSearch: {
       capacity: {
-        dataNodes: isLarge ? 3 : 1,
+        dataNodes: isLarge ? 2 : 1,
         dataNodeInstanceType: isLarge ? "m6g.large.search" : "t3.small.search",
-        masterNodes: isLarge ? undefined : undefined, // odd number, 3+; when not set this is done by data nodes
-        masterNodeInstanceType: isLarge ? undefined : undefined,
+        masterNodes: isLarge ? 3 : undefined, // odd number, 3+; when not set this is done by data nodes
+        // https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains-dedicatedmasternodes.html#dedicatedmasternodes-instance
+        masterNodeInstanceType: isLarge ? "m6g.large.search" : undefined,
         warmNodes: 0,
       },
       ebs: {


### PR DESCRIPTION
Ref: metriport/metriport-internal#1050

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/964
- Downstream: none

### Description

Add master node for OS in prod to fix node count vs AZ count

Context: https://metriport.slack.com/archives/C04DBBJSKGB/p1696719838472629?thread_ts=1696719266.048889&cid=C04DBBJSKGB

### Release Plan

- ⚠️ This is pointing to `master`
- [x] merge this
- [ ] resume the release plan of the upstream PR