### PR TITLE
1103 add timeout navigation and print

### DIFF
--- a/packages/lambdas/src/cda-to-visualization.ts
+++ b/packages/lambdas/src/cda-to-visualization.ts
@@ -127,6 +127,8 @@ const convertStoreAndReturnPdfDocUrl = async ({
     // Defines page
     const page = await browser.newPage();
 
+    await page.setDefaultNavigationTimeout(0);
+
     await page.setContent(convertDoc);
 
     // Wait 2.5 seconds

--- a/packages/lambdas/src/cda-to-visualization.ts
+++ b/packages/lambdas/src/cda-to-visualization.ts
@@ -127,7 +127,7 @@ const convertStoreAndReturnPdfDocUrl = async ({
     // Defines page
     const page = await browser.newPage();
 
-    await page.setDefaultNavigationTimeout(0);
+    await page.setDefaultNavigationTimeout(puppeteerTimeoutInMillis);
 
     await page.setContent(convertDoc);
 
@@ -139,6 +139,7 @@ const convertStoreAndReturnPdfDocUrl = async ({
       path: pdfFilepath,
       printBackground: true,
       format: "A4",
+      timeout: puppeteerTimeoutInMillis,
       margin: {
         top: "20px",
         left: "20px",


### PR DESCRIPTION
Ref. metriport/metriport-internal#1103

Ref: #1103

### Description

Issue with the conversion lambda timeing out and needed to add timeout to navigation and print pdf

https://metriport-inc.sentry.io/issues/4413933361/?alert_rule_id=14442454&alert_type=issue&notification_uuid=d30527ea-0489-4bc9-b6c2-5b1edf3bc5a6&project=4505252341153792&referrer=slack

### Release Plan

Tested in staging with a large xml

- [ ] Merge once approved