### PR TITLE
1050 internal endpoint to count fhir resources per cx

### DIFF
--- a/packages/api/src/external/fhir/patient/count-resources.ts
+++ b/packages/api/src/external/fhir/patient/count-resources.ts
@@ -12,48 +12,26 @@ export type ResourceCount = {
   };
 };
 
-export async function countResourcesPerPatient({
+export type CountResourcesParams = {
+  patient: Pick<Patient, "cxId"> & Partial<Pick<Patient, "id" | "cxId">>;
+  resources?: ResourceTypeForConsolidation[];
+  dateFrom?: string;
+  dateTo?: string;
+};
+
+const summaryCount = "&_summary=count";
+
+export async function countResources({
   patient,
   resources = [],
   dateFrom,
   dateTo,
-}: {
-  patient: Pick<Patient, "id" | "cxId">;
-  resources?: ResourceTypeForConsolidation[];
-  dateFrom?: string;
-  dateTo?: string;
-}): Promise<ResourceCount> {
-  const { log } = Util.out(
-    `countResourcesPerPatient - cxId ${patient.cxId}, patientId ${patient.id}`
-  );
-  const fhir = makeFhirApi(patient.cxId);
+}: CountResourcesParams): Promise<ResourceCount> {
+  const { log } = Util.out(`countResources - cxId ${patient.cxId}, patientId ${patient.id}`);
 
-  const {
-    resourcesByPatient,
-    resourcesBySubject,
-    dateFilter: fullDateQuery,
-  } = getPatientFilter({
-    resources,
-    dateFrom,
-    dateTo,
-  });
-
-  const summaryCount = "&_summary=count";
-
-  const result = await Promise.allSettled([
-    ...resourcesByPatient.map(async resource => {
-      const dateFilter = fullDateQueryForResource(fullDateQuery, resource);
-      const filter = `patient=${patient.id}${dateFilter}${summaryCount}`;
-      const res = await fhir.search(resource, filter);
-      return { resourceType: resource, count: res.total ?? 0 };
-    }),
-    ...resourcesBySubject.map(async resource => {
-      const dateFilter = fullDateQueryForResource(fullDateQuery, resource);
-      const filter = `subject=${patient.id}${dateFilter}${summaryCount}`;
-      const res = await fhir.search(resource, filter);
-      return { resourceType: resource, count: res.total ?? 0 };
-    }),
-  ]);
+  const result = patient.id
+    ? await getResourceCountByPatient({ patient, resources, dateFrom, dateTo })
+    : await getResourceCountByCustomer({ cxId: patient.cxId, resources, dateFrom, dateTo });
   const succeeded = result.flatMap(r => (r.status === "fulfilled" ? r.value : []));
   const failed = result.flatMap(r => (r.status === "rejected" ? r.reason : []));
 
@@ -72,7 +50,7 @@ export async function countResourcesPerPatient({
     );
     capture.message(`Failed to count FHIR resources`, {
       extra: {
-        context: `countResourcesPerPatient`,
+        context: `countResources`,
         patientId: patient.id,
         succeeded: succeeded.length,
         failed: failed.length,
@@ -86,4 +64,70 @@ export async function countResourcesPerPatient({
     total,
     resources: countPerResource,
   };
+}
+
+async function getResourceCountByPatient({
+  patient,
+  resources = [],
+  dateFrom,
+  dateTo,
+}: CountResourcesParams) {
+  const fhir = makeFhirApi(patient.cxId);
+
+  const {
+    resourcesByPatient,
+    resourcesBySubject,
+    dateFilter: fullDateQuery,
+  } = getPatientFilter({
+    resources,
+    dateFrom,
+    dateTo,
+  });
+
+  const result = await Promise.allSettled([
+    ...resourcesByPatient.map(async resource => {
+      const dateFilter = fullDateQueryForResource(fullDateQuery, resource);
+      const filter = `patient=${patient.id}${dateFilter}${summaryCount}`;
+      const res = await fhir.search(resource, filter);
+      return { resourceType: resource, count: res.total ?? 0 };
+    }),
+    ...resourcesBySubject.map(async resource => {
+      const dateFilter = fullDateQueryForResource(fullDateQuery, resource);
+      const filter = `subject=${patient.id}${dateFilter}${summaryCount}`;
+      const res = await fhir.search(resource, filter);
+      return { resourceType: resource, count: res.total ?? 0 };
+    }),
+  ]);
+
+  return result;
+}
+
+async function getResourceCountByCustomer({
+  cxId,
+  resources = [],
+  dateFrom,
+  dateTo,
+}: Omit<CountResourcesParams, "patient"> & { cxId: string }) {
+  const fhir = makeFhirApi(cxId);
+
+  const {
+    resourcesByPatient,
+    resourcesBySubject,
+    dateFilter: fullDateQuery,
+  } = getPatientFilter({
+    resources,
+    dateFrom,
+    dateTo,
+  });
+
+  const result = await Promise.allSettled([
+    ...[...resourcesByPatient, ...resourcesBySubject].map(async resource => {
+      const dateFilter = fullDateQueryForResource(fullDateQuery, resource);
+      const filter = `${dateFilter}${summaryCount}`;
+      const res = await fhir.search(resource, filter);
+      return { resourceType: resource, count: res.total ?? 0 };
+    }),
+  ]);
+
+  return result;
 }

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -8,6 +8,7 @@ import {
 import { redriveSidechainDLQ } from "../command/medical/admin/redrive-dlq";
 import { allowMapiAccess, revokeMapiAccess } from "../command/medical/mapi-access";
 import BadRequestError from "../errors/bad-request";
+import { countResources } from "../external/fhir/patient/count-resources";
 import { OrganizationModel } from "../models/medical/organization";
 import userRoutes from "./devices/internal-user";
 import docsRoutes from "./medical/internal-docs";
@@ -126,15 +127,29 @@ router.post(
 );
 
 /** ---------------------------------------------------------------------------
- * POST /internal/peek-sidechain-dlq
+ * GET /internal/peek-sidechain-dlq
  *
  * Read the first 10 messages from the sidechain DLQ without removing them, and return a link
  * to download the files they point to.
  */
-router.post(
+router.get(
   "/peek-sidechain-dlq",
   asyncHandler(async (req: Request, res: Response) => {
     const result = await peekIntoSidechainDLQ();
+    return res.json(result);
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * GET /internal/count-fhir-resources
+ *
+ * Count all resources for this customer in the FHIR server.
+ */
+router.get(
+  "/count-fhir-resources",
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").orFail();
+    const result = await countResources({ patient: { cxId } });
     return res.json(result);
   })
 );

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -16,7 +16,7 @@ import { processAsyncError } from "../../errors";
 import BadRequestError from "../../errors/bad-request";
 import cwCommands from "../../external/commonwell";
 import { toFHIR } from "../../external/fhir/patient";
-import { countResourcesPerPatient } from "../../external/fhir/patient/count-resources";
+import { countResources } from "../../external/fhir/patient/count-resources";
 import { upsertPatientToFHIRServer } from "../../external/fhir/patient/upsert-patient";
 import { validateFhirEntries } from "../../external/fhir/shared/json-validator";
 import { PatientModel as Patient } from "../../models/medical/patient";
@@ -321,7 +321,7 @@ async function putConsolidated(req: Request, res: Response) {
 
   // Limit the amount of resources per patient
   if (!Config.isCloudEnv() || Config.isSandbox()) {
-    const { total: currentAmount } = await countResourcesPerPatient({
+    const { total: currentAmount } = await countResources({
       patient: { id: patientId, cxId },
     });
     if (currentAmount + incomingAmount > MAX_RESOURCE_STORED_LIMIT) {
@@ -370,7 +370,7 @@ router.get(
     const dateFrom = parseISODate(getFrom("query").optional("dateFrom", req));
     const dateTo = parseISODate(getFrom("query").optional("dateTo", req));
 
-    const resourceCount = await countResourcesPerPatient({
+    const resourceCount = await countResources({
       patient: { id: patientId, cxId },
       resources,
       dateFrom,


### PR DESCRIPTION
Ref: metriport/metriport-internal#1050

### Dependencies

none

### Description

Add internal endpoint to count FHIR resources per cx.

Move `/peek-sidechain-dlq` from POST to GET

### Release Plan

- nothing special