### PR TITLE
670 make executeAsync easier to use

### DIFF
--- a/packages/api/src/command/medical/document/check-doc-queries.ts
+++ b/packages/api/src/command/medical/document/check-doc-queries.ts
@@ -116,52 +116,53 @@ export async function updateDocQueryStatus(patients: PatientsWithValidationResul
   );
 }
 
-async function updatePatientsInSequence(patients: [string, GroupedValidationResult][]) {
-  for (const [patientId, { cxId, ...whatToUpdate }] of patients) {
-    await executeOnDBTx(PatientModel.prototype, async transaction => {
-      const patientFilter = {
-        id: patientId,
-        cxId: cxId,
-      };
-      const patient = await getPatientOrFail({
-        ...patientFilter,
-        transaction,
-      });
-      const docProgress = patient.data.documentQueryProgress;
-      if (!docProgress) {
-        console.log(`Patient without doc query progress @ update, skipping it: ${patient.id} `);
-        return;
-      }
-      if (whatToUpdate.convert) {
-        const convert = docProgress.convert;
-        docProgress.convert = convert
-          ? {
-              ...convert,
-              status: getStatus(convert),
-              total: calculateTotal(convert),
-            }
-          : undefined;
-      }
-      if (whatToUpdate.download) {
-        const download = docProgress.download;
-        docProgress.download = download
-          ? {
-              ...download,
-              status: getStatus(download),
-              total: calculateTotal(download),
-            }
-          : undefined;
-      }
-      const updatedPatient = {
-        ...patient,
-        data: {
-          ...patient.data,
-          documentQueryProgress: docProgress,
-        },
-      };
-      await PatientModel.update(updatedPatient, { where: patientFilter, transaction });
+async function updatePatientsInSequence([patientId, { cxId, ...whatToUpdate }]: [
+  string,
+  GroupedValidationResult
+]) {
+  await executeOnDBTx(PatientModel.prototype, async transaction => {
+    const patientFilter = {
+      id: patientId,
+      cxId: cxId,
+    };
+    const patient = await getPatientOrFail({
+      ...patientFilter,
+      transaction,
     });
-  }
+    const docProgress = patient.data.documentQueryProgress;
+    if (!docProgress) {
+      console.log(`Patient without doc query progress @ update, skipping it: ${patient.id} `);
+      return;
+    }
+    if (whatToUpdate.convert) {
+      const convert = docProgress.convert;
+      docProgress.convert = convert
+        ? {
+            ...convert,
+            status: getStatus(convert),
+            total: calculateTotal(convert),
+          }
+        : undefined;
+    }
+    if (whatToUpdate.download) {
+      const download = docProgress.download;
+      docProgress.download = download
+        ? {
+            ...download,
+            status: getStatus(download),
+            total: calculateTotal(download),
+          }
+        : undefined;
+    }
+    const updatedPatient = {
+      ...patient,
+      data: {
+        ...patient.data,
+        documentQueryProgress: docProgress,
+      },
+    };
+    await PatientModel.update(updatedPatient, { where: patientFilter, transaction });
+  });
 }
 
 export async function getPatientsToUpdate(patientIds?: string[]): Promise<Patient[]> {

--- a/packages/core/src/util/__tests__/concurrency.test.ts
+++ b/packages/core/src/util/__tests__/concurrency.test.ts
@@ -1,19 +1,31 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { executeAsynchronously } from "../concurrency";
 import * as sleepFile from "../sleep";
+import { sleep } from "../sleep";
 
 beforeEach(() => {
+  jest.restoreAllMocks();
+});
+afterAll(() => {
   jest.restoreAllMocks();
 });
 
 describe("executeAsynchronously", () => {
   it("runs splits list and runs it asynchronously", async () => {
-    const list = [1, 2, 3, 4, 5];
-    const fn = jest.fn();
-    await executeAsynchronously(list, fn, { numberOfParallelExecutions: 2 });
-    expect(fn).toHaveBeenCalledTimes(2);
-    expect(fn).toHaveBeenNthCalledWith(1, [1, 2, 3], 0, 2);
-    expect(fn).toHaveBeenNthCalledWith(2, [4, 5], 1, 2);
+    const list = ["a", "b", "c", "d", "e"];
+    const fn = jest.fn(async () => {
+      await sleep(20);
+    });
+    await executeAsynchronously(list, fn, {
+      numberOfParallelExecutions: 2,
+      maxJitterMillis: 10,
+      jitterPct: 1,
+    });
+    expect(fn).toHaveBeenNthCalledWith(1, "a", 0, 0, 2);
+    expect(fn).toHaveBeenNthCalledWith(2, "d", 0, 1, 2);
+    expect(fn).toHaveBeenNthCalledWith(3, "b", 1, 0, 2);
+    expect(fn).toHaveBeenNthCalledWith(4, "e", 1, 1, 2);
+    expect(fn).toHaveBeenNthCalledWith(5, "c", 2, 0, 2);
   });
 
   it("defaults async runs to to number of items on list", async () => {
@@ -32,7 +44,10 @@ describe("executeAsynchronously", () => {
       .mockImplementation(() => randomNumbers[lastRandom++]);
     const list = [1, 2, 3, 4];
     const fn = jest.fn();
-    await executeAsynchronously(list, fn, { numberOfParallelExecutions: 2, maxJitterMillis: 1000 });
+    await executeAsynchronously(list, fn, {
+      numberOfParallelExecutions: 2,
+      maxJitterMillis: 1000,
+    });
     expect(random_mock).toHaveBeenCalledTimes(2);
     expect(sleep_mock).toHaveBeenCalledTimes(2);
     expect(sleep_mock).toHaveBeenNthCalledWith(1, 100);

--- a/packages/core/src/util/concurrency.ts
+++ b/packages/core/src/util/concurrency.ts
@@ -1,10 +1,6 @@
 import { chunk } from "lodash";
 import { sleep } from "./sleep";
 
-export const executeInChunksDefaultOptions = {
-  maxJitterMillis: 0,
-};
-
 export type ExecuteInChunksOptions = {
   /**
    * How many promises should execute at the same time.
@@ -22,30 +18,77 @@ export type ExecuteInChunksOptions = {
   jitterPct?: number;
 };
 
+export type FunctionType<T> = (
+  item: T,
+  itemIndex: number,
+  promiseIndex: number,
+  promiseCount: number
+) => Promise<void>;
+
+/**
+ * Process an array or items asynchronously.
+ *
+ * For example, with an array of 19 elements and 4 parallel executions,
+ * we would have something like this being executed, where:
+ * - each row is a promise, like a thread running in parallel to the other promises;
+ * - each column is a function call with the respective item of the array, it runs in sequence
+ *   to other calls on the same row;
+ *
+ * promise
+ * idx| items being executed
+ *   -|---------------------------------------> time
+ *   1| item1 | item2 | item3 | item4 | item5 |
+ *   -|---------------------------------------|
+ *   2| item1 | item2 | item3 | item4 | item5 |
+ *   -|---------------------------------------|
+ *   3| item1 | item2 | item3 | item4 | item5 |
+ *   -|---------------------------------------|
+ *   4| item1 | item2 | item3 | item4 |
+ *   -|---------------------------------------> time
+ *
+ * @param collection array of elements to be processed
+ * @param fn the function to be executed asynchronously
+ * @param options additional settings
+ * @param options.numberOfParallelExecutions the number of executions to run in parallel, defaults
+ *    to the length of the collection, which means all elements will be processed at the same time
+ * @param options.maxJitterMillis maximum jitter in milliseconds before each run. Makes promises
+ *    start at slight different times. Defaults to no jitter.
+ */
 export async function executeAsynchronously<T>(
   collection: T[],
-  fn: (chunk: T[], chunkIndex: number, chunkCount: number) => Promise<void>,
+  fn: FunctionType<T>,
   {
-    numberOfParallelExecutions: numberOfAsyncRuns = collection.length,
-    maxJitterMillis: maxJitterMillis = executeInChunksDefaultOptions.maxJitterMillis,
+    numberOfParallelExecutions = collection.length,
+    maxJitterMillis = 0,
     jitterPct,
-  }: ExecuteInChunksOptions = executeInChunksDefaultOptions
+  }: ExecuteInChunksOptions = {}
 ): Promise<void> {
   if (jitterPct) {
     if (jitterPct < 0) throw new Error(`maxJitterMillis must be >= 0`);
     if (jitterPct > 1) throw new Error(`maxJitterMillis must be <= 1`);
   }
-  const numElementsPerRun = Math.min(collection.length, numberOfAsyncRuns);
-  const asyncRuns = chunk(collection, Math.ceil(collection.length / numElementsPerRun));
-  const n = asyncRuns.length;
+  const numItemsPerRun = Math.min(collection.length, numberOfParallelExecutions);
+  const asyncRuns = chunk(collection, Math.ceil(collection.length / numItemsPerRun));
+  const amountOfPromises = asyncRuns.length;
 
-  await Promise.all(
-    asyncRuns.map(async (itemsOfRun, i) => {
-      // possible jitter before each run so that they don't start at the same time
-      const jitter = Math.floor((jitterPct ?? Math.random()) * maxJitterMillis);
-      await sleep(jitter);
+  const promises = asyncRuns.map(async (itemsOfPromise, promiseIndex) => {
+    // possible jitter before each run so that they don't start at the same time
+    const jitter = Math.floor((jitterPct ?? Math.random()) * maxJitterMillis);
+    await sleep(jitter);
 
-      await fn(itemsOfRun, i, n);
-    })
-  );
+    await executeSynchronously(itemsOfPromise, fn, promiseIndex, amountOfPromises);
+  });
+  await Promise.all(promises);
+}
+
+export async function executeSynchronously<T>(
+  itemsOfPromise: T[],
+  fn: FunctionType<T>,
+  promiseIndex: number,
+  amountOfPromises: number
+): Promise<void> {
+  let itemIndex = 0;
+  for (const item of itemsOfPromise) {
+    await fn(item, itemIndex++, promiseIndex, amountOfPromises);
+  }
 }


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/670

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/994
- Downstream: none

### Description

Make `executeAsynchronously()` easier to use.

### Release Plan

- nothing special