### PR TITLE
1169 increase CdaToVisualization lambda memory

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -680,6 +680,7 @@ export class APIStack extends Stack {
         ENV_TYPE: envType,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
+      architecture: lambda.Architecture.ARM_64,
     });
   }
 
@@ -930,7 +931,7 @@ export class APIStack extends Stack {
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
       layers: [...lambdaLayers, chromiumLayer],
-      memory: 512,
+      memory: 1024,
       timeout: CDA_TO_VIS_TIMEOUT,
       vpc,
       alarmSnsAction: alarmAction,


### PR DESCRIPTION
Ref: metriport/metriport-internal#1169

### Dependencies

none

### Description

- increase the memory of the CDA to Vis lambda from 512 to 1024MB
- add alternative to select architecture while creating a lambda, and test it w/ the tester lambda
   - why: https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html#foundation-arch-adv

### Release Plan

- asap