### PR TITLE
801 fix doc query checker to use now()

### DIFF
--- a/packages/api/src/command/medical/document/check-doc-queries.ts
+++ b/packages/api/src/command/medical/document/check-doc-queries.ts
@@ -218,7 +218,7 @@ function getQuery(patientIds: string[] = []): string {
 
   const baseQuery =
     `select * from patient ` +
-    `where updated_at < current_date - interval '${MAX_TIME_TO_PROCESS.asMinutes()}' minute ` +
+    `where updated_at < now() - interval '${MAX_TIME_TO_PROCESS.asMinutes()}' minute ` +
     `  and ((${convert}->'${total}')::int <> (${convert}->'${successful}')::int + (${convert}->'${errors}')::int ` +
     `        or ` +
     `        ${convert}->>'${status}' = '${processing}' ` +


### PR DESCRIPTION
Ref: metriport/metriport-internal#801

### Dependencies

none

### Description

While testing the local document downloader I notices the query for patients to fix for doc query status is using a Postgres function that returns date, not datetime. Moved to `now()` and tested it local, it works better.

### Release Plan

- nothing special