### PR TITLE
1181 dont load all patients to trigger doc query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35483,7 +35483,7 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.1.2",
+      "version": "7.1.3-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^4.8.4",
@@ -35653,13 +35653,13 @@
       }
     },
     "packages/connect-widget": {
-      "version": "1.4.6",
+      "version": "1.4.7-alpha.0",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.12",
         "@chakra-ui/react": "^2.4.1",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
-        "@metriport/api-sdk": "^7.1.2",
+        "@metriport/api-sdk": "^7.1.3-alpha.0",
         "@sentry/react": "^7.45.0",
         "@sentry/tracing": "^7.45.0",
         "@testing-library/jest-dom": "^5.16.5",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.1.2",
+  "version": "7.1.3-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -426,8 +426,9 @@ export class MetriportMedicalApi {
    * Start a document query for the given patient across HIEs.
    *
    * @param patientId Patient ID for which to retrieve document metadata.
-   * @param facilityId The facility providing the NPI to support this operation If not provided and
-   *        the patient has only one facility, that one will be used.
+   * @param facilityId The facility providing the NPI to support this operation (optional).
+   *        If not provided and the patient has only one facility, that one will be used.
+   *        If not provided and the patient has multiple facilities, an error will be thrown.
    * @return The document query request ID, progress & status indicating whether its being executed or not.
    */
   async startDocumentQuery(patientId: string, facilityId?: string): Promise<DocumentQuery> {

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -426,10 +426,11 @@ export class MetriportMedicalApi {
    * Start a document query for the given patient across HIEs.
    *
    * @param patientId Patient ID for which to retrieve document metadata.
-   * @param facilityId The facility providing the NPI to support this operation.
+   * @param facilityId The facility providing the NPI to support this operation If not provided and
+   *        the patient has only one facility, that one will be used.
    * @return The document query request ID, progress & status indicating whether its being executed or not.
    */
-  async startDocumentQuery(patientId: string, facilityId: string): Promise<DocumentQuery> {
+  async startDocumentQuery(patientId: string, facilityId?: string): Promise<DocumentQuery> {
     const resp = await this.api.post(`${DOCUMENT_URL}/query`, null, {
       params: {
         patientId,

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -54,6 +54,16 @@ export async function queryDocumentsAcrossHIEs({
       facilityId,
     });
   }
+  if (!facilityId && patient.facilityIds.length > 1) {
+    throw new BadRequestError(
+      `Patient is associated with more than one facility (facilityId is required)`,
+      undefined,
+      {
+        patientId: patient.id,
+        facilityIdCount: patient.facilityIds.length,
+      }
+    );
+  }
   const docQueryProgress = patient.data.documentQueryProgress;
   const requestId = getOrGenerateRequestId(docQueryProgress);
 

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -42,13 +42,13 @@ export async function queryDocumentsAcrossHIEs({
 }: {
   cxId: string;
   patientId: string;
-  facilityId: string;
+  facilityId?: string;
   override?: boolean;
 }): Promise<DocumentQueryProgress> {
   const { log } = Util.out(`queryDocumentsAcrossHIEs - M patient ${patientId}`);
 
   const patient = await getPatientOrFail({ id: patientId, cxId });
-  if (!isPatientAssociatedWithFacility(patient, facilityId)) {
+  if (facilityId && !isPatientAssociatedWithFacility(patient, facilityId)) {
     throw new BadRequestError(`Patient not associated with given facility`, undefined, {
       patientId: patient.id,
       facilityId,

--- a/packages/api/src/errors/bad-request.ts
+++ b/packages/api/src/errors/bad-request.ts
@@ -7,7 +7,7 @@ export default class BadRequestError extends MetriportError {
   constructor(
     message = "Unexpected issue with the request - check inputs and try again",
     cause?: unknown,
-    additionalInfo?: Record<string, string | undefined | null>
+    additionalInfo?: Record<string, string | number | undefined | null>
   ) {
     super(message, cause, additionalInfo);
     this.status = numericStatus;

--- a/packages/api/src/errors/metriport-error.ts
+++ b/packages/api/src/errors/metriport-error.ts
@@ -8,7 +8,7 @@ export default class MetriportError extends Error {
   constructor(
     message: string,
     cause?: unknown,
-    readonly additionalInfo?: Record<string, string | undefined | null>
+    readonly additionalInfo?: Record<string, string | number | undefined | null>
   ) {
     super(message);
     this.cause = cause;

--- a/packages/api/src/external/commonwell/patient-shared.ts
+++ b/packages/api/src/external/commonwell/patient-shared.ts
@@ -9,6 +9,7 @@ import {
   RequestMetadata,
   StrongId,
 } from "@metriport/commonwell-sdk";
+import { MetriportError } from "@metriport/core/util/error/metriport-error";
 import _, { minBy } from "lodash";
 import { getPatientWithDependencies } from "../../command/medical/patient/get-patient";
 import { Facility } from "../../domain/medical/facility";
@@ -174,23 +175,69 @@ function idsToAlertMessage(cwPatientId: string, personIds: string[]): string {
   return `Patient CW ID: ${cwPatientId}; Person IDs: ${personIds.join(", ")}`;
 }
 
-export async function getPatientData(
-  patient: {
-    id: string;
-    cxId: string;
-  },
-  facilityId: string
-): Promise<{
+export type PatientDataWithOneFacility = {
   organization: Organization;
   facility: Facility;
-}> {
+  type: "single";
+};
+export type PatientDataWithMultipleFacilities = {
+  organization: Organization;
+  facilities: Facility[];
+  type: "multiple";
+};
+export async function getPatientData(
+  patient: Pick<Patient, "id" | "cxId">
+): Promise<PatientDataWithMultipleFacilities>;
+export async function getPatientData(
+  patient: Pick<Patient, "id" | "cxId">,
+  facilityId: string
+): Promise<PatientDataWithOneFacility>;
+export async function getPatientData(
+  patient: Pick<Patient, "id" | "cxId">,
+  facilityId?: string
+): Promise<PatientDataWithOneFacility | PatientDataWithMultipleFacilities> {
   const { organization, facilities } = await getPatientWithDependencies(patient);
-  const facility = facilities.find(f => f.id === facilityId);
-  if (!facility) {
-    throw new BadRequestError(`Patient not associated with given facility`, undefined, {
+  if (facilityId) {
+    const facility = facilities.find(f => f.id === facilityId);
+    if (!facility) {
+      throw new BadRequestError(`Patient not associated with given facility`, undefined, {
+        patientId: patient.id,
+        facilityId,
+      });
+    }
+    return { organization, facility, type: "single" };
+  }
+
+  return { organization, facilities, type: "multiple" };
+}
+
+export async function getPatientDataWithSingleFacility(
+  patient: Pick<Patient, "id" | "cxId">,
+  facilityId?: string
+): Promise<Omit<PatientDataWithOneFacility, "type">> {
+  const data = facilityId
+    ? await getPatientData(patient, facilityId)
+    : await getPatientData(patient);
+  const organization = data.organization;
+  if (data.type === "single") {
+    return { organization, facility: data.facility };
+  }
+  const facility = data.facilities[0];
+  if (!data.facilities || !facility) {
+    throw new MetriportError(`Could not determine facility for patient`, undefined, {
       patientId: patient.id,
       facilityId,
     });
+  }
+  if (data.facilities.length > 1) {
+    throw new MetriportError(
+      `Patient has more than one facility, facilityId is required`,
+      undefined,
+      {
+        patientId: patient.id,
+        facilities: data.facilities.length,
+      }
+    );
   }
   return { organization, facility };
 }

--- a/packages/api/src/routes/medical/document.ts
+++ b/packages/api/src/routes/medical/document.ts
@@ -94,7 +94,7 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const patientId = getFromQueryOrFail("patientId", req);
-    const facilityId = getFromQueryOrFail("facilityId", req);
+    const facilityId = getFrom("query").optional("facilityId", req);
     const override = stringToBoolean(getFrom("query").optional("override", req));
 
     const docQueryProgress = await queryDocumentsAcrossHIEs({

--- a/packages/api/src/shared/util.ts
+++ b/packages/api/src/shared/util.ts
@@ -1,9 +1,9 @@
 import { Sample } from "@metriport/api-sdk/devices/models/common/sample";
+import { debug as coreDebug, log as coreLog } from "@metriport/core/util/log";
 import convert from "convert-units";
 import crypto from "crypto";
 import { mean } from "lodash";
 import { Stream } from "stream";
-import { debug } from "./log";
 
 // Useful as catch handler for asynchonous promises so we don't get an unhandled promise rejection
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -79,21 +79,11 @@ export class Util {
   /**
    * @deprecated Use @metriport/core instead
    */
-  static log =
-    (prefix: string, suffix?: string) =>
-    //eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (msg: string, ...optionalParams: any[]): void =>
-      optionalParams
-        ? console.log(`[${prefix}] ${msg}`, ...[...optionalParams, ...([suffix] ?? [])])
-        : console.log(`[${prefix}] ${msg} - ${suffix}`);
+  static log = coreLog;
   /**
    * @deprecated Use @metriport/core instead
    */
-  static debug =
-    (prefix: string, suffix?: string) =>
-    //eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (msg: string, ...optionalParams: any[]): void =>
-      debug(`[${prefix}] ${msg}`, ...[...optionalParams, ...([suffix] ?? [])]);
+  static debug = coreDebug;
   /**
    * @deprecated Use @metriport/core instead
    */

--- a/packages/connect-widget/package.json
+++ b/packages/connect-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-widget",
-  "version": "1.4.6",
+  "version": "1.4.7-alpha.0",
   "private": true,
   "scripts": {
     "clean": "rimraf build && rimraf node_modules",
@@ -38,7 +38,7 @@
     "@chakra-ui/react": "^2.4.1",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@metriport/api-sdk": "^7.1.2",
+    "@metriport/api-sdk": "^7.1.3-alpha.0",
     "@sentry/react": "^7.45.0",
     "@sentry/tracing": "^7.45.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/packages/core/src/util/error/metriport-error.ts
+++ b/packages/core/src/util/error/metriport-error.ts
@@ -5,7 +5,7 @@ export class MetriportError extends Error {
   constructor(
     message: string,
     readonly cause?: unknown,
-    readonly additionalInfo?: Record<string, string | undefined | null>
+    readonly additionalInfo?: Record<string, string | number | undefined | null>
   ) {
     super(message);
     this.cause = cause;

--- a/packages/lambdas/package-lock.json
+++ b/packages/lambdas/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/client-secrets-manager": "^3.348.0",
         "@medplum/core": "^2.0.32",
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/api-sdk": "^7.1.2",
+        "@metriport/api-sdk": "^7.1.3-alpha.0",
         "@metriport/commonwell-sdk": "^4.8.0",
         "@metriport/core": "^1.2.2",
         "@opensearch-project/opensearch": "^2.3.1",
@@ -1948,9 +1948,9 @@
       }
     },
     "node_modules/@metriport/api-sdk": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@metriport/api-sdk/-/api-sdk-7.1.2.tgz",
-      "integrity": "sha512-Mp8FMf+y0mOMq5qybGhiT956fCg5o90hph/+96aFID6P9h3/6Dv9jqdwQFzjJZUskrUr8AhJdK7Sqng392vQHw==",
+      "version": "7.1.3-alpha.0",
+      "resolved": "https://registry.npmjs.org/@metriport/api-sdk/-/api-sdk-7.1.3-alpha.0.tgz",
+      "integrity": "sha512-zWulBro8ZPbg3SH4W1wKCeNVwIW8GcHdoTwaZdLf+p/gNbBV1F9oPT/VxqH3d/ZjTUFGvJmLGd9kw7Kcn8dYyA==",
       "dependencies": {
         "@metriport/commonwell-sdk": "^4.8.4",
         "axios": "^1.3.4",

--- a/packages/lambdas/package.json
+++ b/packages/lambdas/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/client-secrets-manager": "^3.348.0",
     "@medplum/core": "^2.0.32",
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/api-sdk": "^7.1.2",
+    "@metriport/api-sdk": "^7.1.3-alpha.0",
     "@metriport/commonwell-sdk": "^4.8.0",
     "@metriport/core": "^1.2.2",
     "@opensearch-project/opensearch": "^2.3.1",

--- a/packages/utils/src/bulk-query-patients.ts
+++ b/packages/utils/src/bulk-query-patients.ts
@@ -1,22 +1,30 @@
 /**
  * This script kicks off document queries in bulk for the configured cx.
+ *
+ * This is expensive!
+ *
+ * Make sure to update the `patientWhitelist` with the list of Patient IDs
+ * you want to trigger document queries for, otherwise it will do it for all
+ * Patients of the respective customer.
  */
 
 import * as dotenv from "dotenv";
 dotenv.config();
 // keep that ^ on top
-import { ConsolidatedCountResponse, MetriportMedicalApi, PatientDTO } from "@metriport/api-sdk";
+import { ConsolidatedCountResponse, MetriportMedicalApi } from "@metriport/api-sdk";
 import { getEnvVar, getEnvVarOrFail } from "@metriport/core/util/env-var";
+import axios from "axios";
 import fs from "fs";
+import { chunk } from "lodash";
 
 // auth stuff
+const cxId = getEnvVarOrFail("CX_ID");
+const cxName = getEnvVarOrFail("CX_NAME");
 const apiKey = getEnvVarOrFail("API_KEY");
-const facilityId = getEnvVarOrFail("FACILITY_ID");
 const apiUrl = getEnvVarOrFail("API_URL");
 const metriportAPI = new MetriportMedicalApi(apiKey, {
   baseAddress: apiUrl,
 });
-
 // query stuff
 const delayTime = parseInt(getEnvVar("BULK_QUERY_DELAY_TIME") ?? "5000");
 const patientChunkSize = parseInt(getEnvVar("PATIENT_CHUNK_SIZE") ?? "25");
@@ -25,10 +33,9 @@ const queryPollDurationMs = 10_000;
 const maxQueryDurationMs = 71_000; // CW has a 70s timeout, so this is the maximum duration any doc query can take
 const maxDocQueryAttemts = 3;
 // add patient IDs here to kick off queries for specific patient IDs
-const patientWhitelist: string[] = [];
+const patientIds: string[] = ["...", "...", "...", "..."];
 
 // csv stuff
-const cxName = getEnvVarOrFail("CX_NAME");
 const csvHeader =
   "patientId,firstName,lastName,state,queryAttemptCount,docCount,fhirResourceCount,fhirResourceDetails,status\n";
 const curDateTime = new Date();
@@ -46,103 +53,111 @@ function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-async function queryDocsForPatient(patient: PatientDTO) {
-  let docQueryAttempts = 0;
-  let docCount = 0;
-  let totalFhirResourceCount = 0;
-  let status: "completed" | "docs-not-found" = "docs-not-found";
-  let queryComplete = false;
-  let fhirResourceTypesToCounts: ConsolidatedCountResponse = {
-    filter: { resources: "" },
-    resources: {},
-    total: 0,
-  };
-  while (docQueryAttempts < maxDocQueryAttemts) {
-    console.log(`>>> Starting doc query for patient ${patient.id}...`);
-    await metriportAPI.startDocumentQuery(patient.id, patient.facilityIds[0]);
-    // add a bit of jitter to the requests
-    await sleep(200 + Math.random() * patientChunkDelayJitterMs);
-    const queryStartTime = Date.now();
-    while (Date.now() - queryStartTime < maxQueryDurationMs) {
-      const docQueryStatus = await metriportAPI.getDocumentQueryStatus(patient.id);
-      // ensure at least 1 doc was returned
-      if (
-        docQueryStatus.download &&
-        docQueryStatus.download.total &&
-        docQueryStatus.download.total > 0
-      ) {
-        queryComplete = true;
-        break;
-      }
-      await sleep(queryPollDurationMs);
-    }
-    docQueryAttempts++;
-    if (queryComplete) break;
-    console.log(`>>> Didn't find docs for patient ${patient.id} on attmept ${docQueryAttempts}...`);
-  }
-  if (queryComplete) {
-    status = "completed";
-    // get count of resulting FHIR resources
-    fhirResourceTypesToCounts = await metriportAPI.countPatientConsolidated(patient.id);
-    // get total doc refs for the patient
-    const docRefs = await metriportAPI.listDocuments(patient.id);
-    docCount = docRefs.documents.length;
-    for (const val of Object.values(fhirResourceTypesToCounts.resources)) {
-      totalFhirResourceCount += val;
-    }
-  }
+async function getAllPatientIds(): Promise<string[]> {
+  const resp = await axios.get(`${apiUrl}/internal/patient/ids?cxId=${cxId}`);
+  const patientIds = resp.data.patientIds;
+  return (Array.isArray(patientIds) ? patientIds : []) as string[];
+}
 
-  // write line to results csv
-  const state = Array.isArray(patient.address) ? patient.address[0].state : patient.address.state;
-  fs.appendFileSync(
-    csvName,
-    `${patient.id},${patient.firstName},${
-      patient.lastName
-    },${state},${docQueryAttempts},${docCount},${totalFhirResourceCount},${replaceAll(
-      JSON.stringify(fhirResourceTypesToCounts),
-      ",",
-      " "
-    )},${status}\n`
-  );
-  console.log(`>>> Done doc query for patient ${patient.id} with status ${status}...`);
+async function queryDocsForPatient(patientId: string) {
+  try {
+    let docQueryAttempts = 0;
+    let docCount = 0;
+    let totalFhirResourceCount = 0;
+    let status: "completed" | "docs-not-found" = "docs-not-found";
+    let queryComplete = false;
+    let fhirResourceTypesToCounts: ConsolidatedCountResponse = {
+      filter: { resources: "" },
+      resources: {},
+      total: 0,
+    };
+    const docQueryPromise = async () => {
+      while (docQueryAttempts < maxDocQueryAttemts) {
+        console.log(`>>> Starting doc query for patient ${patientId}...`);
+        await metriportAPI.startDocumentQuery(patientId);
+        // add a bit of jitter to the requests
+        await sleep(200 + Math.random() * patientChunkDelayJitterMs);
+        const queryStartTime = Date.now();
+        while (Date.now() - queryStartTime < maxQueryDurationMs) {
+          const docQueryStatus = await metriportAPI.getDocumentQueryStatus(patientId);
+          // ensure at least 1 doc was returned
+          if (
+            docQueryStatus.download &&
+            docQueryStatus.download.total &&
+            docQueryStatus.download.total > 0
+          ) {
+            queryComplete = true;
+            break;
+          }
+          await sleep(queryPollDurationMs);
+        }
+        docQueryAttempts++;
+        if (queryComplete) break;
+        console.log(
+          `>>> Didn't find docs for patient ${patientId} on attempt ${docQueryAttempts}...`
+        );
+      }
+    };
+    const getPatientPromise = async () => metriportAPI.getPatient(patientId);
+    const [patient] = await Promise.all([getPatientPromise(), docQueryPromise()]);
+
+    if (queryComplete) {
+      status = "completed";
+      // get count of resulting FHIR resources
+      fhirResourceTypesToCounts = await metriportAPI.countPatientConsolidated(patientId);
+      // get total doc refs for the patient
+      const docRefs = await metriportAPI.listDocuments(patientId);
+      docCount = docRefs.documents.length;
+      for (const val of Object.values(fhirResourceTypesToCounts.resources)) {
+        totalFhirResourceCount += val;
+      }
+    }
+
+    // write line to results csv
+    const state = Array.isArray(patient.address) ? patient.address[0].state : patient.address.state;
+    fs.appendFileSync(
+      csvName,
+      `${patient.id},${patient.firstName},${
+        patient.lastName
+      },${state},${docQueryAttempts},${docCount},${totalFhirResourceCount},${replaceAll(
+        JSON.stringify(fhirResourceTypesToCounts),
+        ",",
+        " "
+      )},${status}\n`
+    );
+    console.log(`>>> Done doc query for patient ${patient.id} with status ${status}...`);
+    //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    console.log(`ERROR processing patient ${patientId}: `, error.message);
+  }
 }
 
 async function main() {
+  const startedAt = Date.now();
   initCsv();
-  console.log(`>>> Getting all patients for facility ${facilityId}...`);
-  const patients = await metriportAPI.listPatients(facilityId);
+  console.log(`>>> Starting with ${patientIds.length} patient IDs...`);
 
-  console.log(`>>> Found ${patients.length} patients`);
-  if (patientWhitelist.length > 0) {
-    console.log(
-      `... but will only query for the ${patientWhitelist.length} patients specified in the whitelist`
-    );
+  const patientIdsToQuery = patientIds.length > 0 ? patientIds : await getAllPatientIds();
+  const chunks = chunk(patientIdsToQuery, patientChunkSize);
 
-    // remove patients not in the whitelist
-    let i = patients.length;
-    while (i--) {
-      if (!patientWhitelist.includes(patients[i].id)) {
-        patients.splice(i, 1);
-      }
-    }
-  }
-  for (const patient of patients) {
-    console.log(patient.id);
-  }
-
-  for (let i = 0; i < patients.length; i += patientChunkSize) {
-    const chunk = patients.slice(i, i + patientChunkSize);
+  let count = 0;
+  for (const chunk of chunks) {
     console.log(`>>> Querying docs for chunk of ${chunk.length} patients...`);
     const docQueries: Promise<void>[] = [];
-    for (const patient of chunk) {
-      docQueries.push(queryDocsForPatient(patient));
+    for (const patientId of chunk) {
+      docQueries.push(queryDocsForPatient(patientId));
+      count++;
     }
     await Promise.allSettled(docQueries);
 
-    console.log(`>>> Progress: ${i + 1}/${patients.length} patient doc queries complete`);
+    console.log(
+      `>>> Progress: ${count + 1}/${patientIdsToQuery.length} patient doc queries complete`
+    );
     console.log(`>>> Sleeping for ${delayTime} ms before the next chunk...`);
     await new Promise(f => setTimeout(f, delayTime));
   }
+
+  console.log(`>>> Done querying docs for all patients in ${Date.now() - startedAt} ms`);
 }
 
 main();


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/1181

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1016
- Downstream: none

### Description

- Don't load all patients to trigger doc query
- Make facility optional to trigger doc query
- Create internal endpoint to load all patient IDs of a cx

### Release Plan

- staging
    - [x] update NPM package
    - [x] update lambda
    - [ ] merge this
- production
    - [ ] update NPM package
    - [ ] update lambda
    - [ ] merge this