### PR TITLE
1064 update CICD dependencies for packages/libs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,8 +5,11 @@ on:
     branches:
       - master
     paths:
-      - "packages/connect-widget/**"
       - "packages/api/**"
+      - "packages/api-sdk/**"
+      - "packages/commonwell-sdk/**"
+      - "packages/connect-widget/**"
+      - "packages/core/**"
       - "packages/infra/**"
       - "packages/lambdas/**"
   workflow_dispatch: # manually executed by a user
@@ -38,6 +41,7 @@ jobs:
             api:
               - "packages/api/**"
               - "packages/api-sdk/**"
+              - "packages/commonwell-sdk/**"
               - "packages/core/**"
               - "package*.json"
             infra-lambdas:
@@ -46,7 +50,6 @@ jobs:
               - "package*.json"
             widget:
               - "packages/connect-widget/**"
-              - "packages/api-sdk/**"
               - "package*.json"
 
   widget:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,8 +5,11 @@ on:
     branches:
       - develop
     paths:
-      - "packages/connect-widget/**"
       - "packages/api/**"
+      - "packages/api-sdk/**"
+      - "packages/commonwell-sdk/**"
+      - "packages/connect-widget/**"
+      - "packages/core/**"
       - "packages/infra/**"
       - "packages/lambdas/**"
   workflow_dispatch: # manually executed by a user
@@ -37,6 +40,7 @@ jobs:
             api:
               - "packages/api/**"
               - "packages/api-sdk/**"
+              - "packages/commonwell-sdk/**"
               - "packages/core/**"
               - "package*.json"
             infra-lambdas:
@@ -45,7 +49,6 @@ jobs:
               - "package*.json"
             widget:
               - "packages/connect-widget/**"
-              - "packages/api-sdk/**"
               - "package*.json"
 
   widget:

--- a/packages/infra/dashboards/cw-dashboard-prod.json
+++ b/packages/infra/dashboards/cw-dashboard-prod.json
@@ -24,7 +24,7 @@
         {
             "height": 8,
             "width": 10,
-            "y": 28,
+            "y": 36,
             "x": 4,
             "type": "metric",
             "properties": {
@@ -82,7 +82,7 @@
         {
             "height": 9,
             "width": 12,
-            "y": 74,
+            "y": 82,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -112,7 +112,7 @@
         {
             "height": 9,
             "width": 12,
-            "y": 83,
+            "y": 91,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -136,7 +136,7 @@
         {
             "height": 9,
             "width": 12,
-            "y": 101,
+            "y": 109,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -157,7 +157,7 @@
         {
             "height": 8,
             "width": 10,
-            "y": 38,
+            "y": 46,
             "x": 4,
             "type": "metric",
             "properties": {
@@ -178,7 +178,7 @@
         {
             "height": 9,
             "width": 12,
-            "y": 100,
+            "y": 108,
             "x": 12,
             "type": "metric",
             "properties": {
@@ -199,7 +199,7 @@
         {
             "height": 8,
             "width": 10,
-            "y": 28,
+            "y": 36,
             "x": 14,
             "type": "metric",
             "properties": {
@@ -231,7 +231,7 @@
         {
             "height": 2,
             "width": 24,
-            "y": 26,
+            "y": 34,
             "x": 0,
             "type": "text",
             "properties": {
@@ -242,7 +242,7 @@
         {
             "height": 2,
             "width": 24,
-            "y": 36,
+            "y": 44,
             "x": 0,
             "type": "text",
             "properties": {
@@ -253,7 +253,7 @@
         {
             "height": 8,
             "width": 10,
-            "y": 38,
+            "y": 46,
             "x": 14,
             "type": "metric",
             "properties": {
@@ -274,7 +274,7 @@
         {
             "height": 2,
             "width": 24,
-            "y": 72,
+            "y": 80,
             "x": 0,
             "type": "text",
             "properties": {
@@ -337,7 +337,7 @@
         {
             "height": 2,
             "width": 24,
-            "y": 62,
+            "y": 70,
             "x": 0,
             "type": "text",
             "properties": {
@@ -348,7 +348,7 @@
         {
             "height": 8,
             "width": 10,
-            "y": 64,
+            "y": 72,
             "x": 4,
             "type": "metric",
             "properties": {
@@ -369,7 +369,7 @@
         {
             "height": 8,
             "width": 10,
-            "y": 46,
+            "y": 54,
             "x": 4,
             "type": "metric",
             "properties": {
@@ -400,7 +400,7 @@
         {
             "height": 8,
             "width": 10,
-            "y": 54,
+            "y": 62,
             "x": 4,
             "type": "metric",
             "properties": {
@@ -421,7 +421,7 @@
         {
             "height": 8,
             "width": 4,
-            "y": 64,
+            "y": 72,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -439,7 +439,7 @@
         {
             "height": 8,
             "width": 4,
-            "y": 38,
+            "y": 46,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -457,7 +457,7 @@
         {
             "height": 8,
             "width": 4,
-            "y": 28,
+            "y": 36,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -493,7 +493,7 @@
         {
             "height": 8,
             "width": 4,
-            "y": 46,
+            "y": 54,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -531,7 +531,7 @@
         {
             "height": 8,
             "width": 10,
-            "y": 64,
+            "y": 72,
             "x": 14,
             "type": "log",
             "properties": {
@@ -545,7 +545,7 @@
         {
             "height": 8,
             "width": 10,
-            "y": 46,
+            "y": 54,
             "x": 14,
             "type": "log",
             "properties": {
@@ -559,7 +559,7 @@
         {
             "height": 9,
             "width": 12,
-            "y": 82,
+            "y": 90,
             "x": 12,
             "type": "metric",
             "properties": {
@@ -582,7 +582,7 @@
         {
             "height": 9,
             "width": 12,
-            "y": 91,
+            "y": 99,
             "x": 12,
             "type": "metric",
             "properties": {
@@ -607,7 +607,7 @@
         {
             "height": 9,
             "width": 12,
-            "y": 92,
+            "y": 100,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -660,7 +660,7 @@
         {
             "height": 8,
             "width": 10,
-            "y": 54,
+            "y": 62,
             "x": 14,
             "type": "metric",
             "properties": {
@@ -679,7 +679,7 @@
         {
             "height": 9,
             "width": 12,
-            "y": 109,
+            "y": 117,
             "x": 12,
             "type": "metric",
             "properties": {
@@ -715,11 +715,11 @@
             }
         },
         {
-            "type": "metric",
-            "x": 12,
-            "y": 74,
-            "width": 12,
             "height": 8,
+            "width": 12,
+            "y": 82,
+            "x": 12,
+            "type": "metric",
             "properties": {
                 "metrics": [
                     [ "AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", "CCDAOpenSearchDLQ", { "region": "us-west-1" } ],
@@ -737,6 +737,89 @@
                 "stat": "Maximum",
                 "period": 300,
                 "title": "SQS Messages Visible"
+            }
+        },
+        {
+            "height": 8,
+            "width": 7,
+            "y": 26,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ES", "SearchableDocuments", "DomainName", "ccdaopensearch-domain", "ClientId", "463519787594", { "yAxis": "left" } ],
+                    [ ".", "FreeStorageSpace", ".", ".", ".", ".", { "yAxis": "right", "stat": "Minimum" } ],
+                    [ "...", { "yAxis": "right", "stat": "Maximum" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-west-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "OpenSearch - Storage",
+                "liveData": false
+            }
+        },
+        {
+            "height": 8,
+            "width": 7,
+            "y": 18,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ES", "CPUUtilization", "DomainName", "ccdaopensearch-domain", "ClientId", "463519787594", { "label": "Nodes CPU", "region": "us-west-1" } ],
+                    [ ".", "MasterCPUUtilization", ".", ".", ".", ".", { "label": "Master CPU", "region": "us-west-1" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-west-1",
+                "stat": "Maximum",
+                "period": 300,
+                "title": "OpenSearch - CPU",
+                "liveData": false
+            }
+        },
+        {
+            "height": 8,
+            "width": 7,
+            "y": 18,
+            "x": 7,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ES", "JVMMemoryPressure", "DomainName", "ccdaopensearch-domain", "ClientId", "463519787594", { "yAxis": "left", "region": "us-west-1", "label": "Nodes JVMMemoryPressure" } ],
+                    [ ".", "MasterJVMMemoryPressure", ".", ".", ".", ".", { "yAxis": "left", "region": "us-west-1", "label": "Master JVMMemoryPressure" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-west-1",
+                "stat": "Maximum",
+                "period": 300,
+                "title": "OpenSearch - Memory",
+                "liveData": false
+            }
+        },
+        {
+            "height": 8,
+            "width": 7,
+            "y": 26,
+            "x": 7,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ES", "SearchLatency", "DomainName", "ccdaopensearch-domain", "ClientId", "463519787594" ],
+                    [ ".", "ReadLatency", ".", ".", ".", "." ],
+                    [ ".", "IndexingLatency", ".", ".", ".", "." ],
+                    [ ".", "WriteLatency", ".", ".", ".", "." ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-west-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "OpenSearch - Latency",
+                "liveData": false
             }
         }
     ]


### PR DESCRIPTION
Ref: metriport/metriport-internal#1064

### Dependencies

none

### Description

Update CICD dependencies for packages/libs.

API relies on other packages through the filesystem, so if they change the API needs to be updated as well; but because the dependency is through the FS and not NPM, the actual folder of the API might not have been changes and it still needs to be redeployed.

This is different in the case of lambdas, which rely on a specific NPM version and, thus, need to have its `package.json` updated to make reference to said package's updates. Thus, lambdas/infra don't need to be deployed if there are changes to `core` but no change to lambda's `package.json`, for example.

Also updates the dashboard to include OpenSearch metrics.

### Release Plan

- nothing special