### PR TITLE
branch-to-staging to use internal's feature branch

### DIFF
--- a/.github/workflows/_deploy_cdk.yml
+++ b/.github/workflows/_deploy_cdk.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: string
         default: "false"
+      is-branch-to-staging:
+          required: false
+          type: boolean
+          default: false
+          description: "whether this workflow should checkout internal's develop/master or a feature branch"
       AWS_REGION:
         required: true
         type: string
@@ -72,12 +77,24 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: metriport
-      # checkout the internal repo to get configs
-      - name: Checkout
+      # checkout the internal repo to get configs - default branches
+      - name: Checkout internal default branch
         uses: actions/checkout@v3
+        if: ${{ inputs.is-branch-to-staging == false }}
         with:
           repository: metriport/metriport-internal
           ref: ${{ (inputs.deploy_env == 'production' || inputs.deploy_env == 'sandbox') && 'master' || 'develop' }}
+          token: ${{ secrets.SERVICE_PAT }} # secret token from user 'metriport-service'
+          path: metriport-internal
+          sparse-checkout: |
+            config-oss/api-infra
+      # checkout the internal repo to get configs - feature branch when "branching to staging"
+      - name: Checkout internal feature branch
+        uses: actions/checkout@v3
+        if: ${{ inputs.is-branch-to-staging == true }}
+        with:
+          repository: metriport/metriport-internal
+          ref: ${{ github.ref }}
           token: ${{ secrets.SERVICE_PAT }} # secret token from user 'metriport-service'
           path: metriport-internal
           sparse-checkout: |

--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -42,6 +42,7 @@ jobs:
     uses: ./.github/workflows/_deploy_cdk.yml
     with:
       deploy_env: "staging"
+      is-branch-to-staging: true
       cdk_stack: ${{ vars.API_STACK_NAME_STAGING }}
       AWS_REGION: ${{ vars.API_REGION_STAGING }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_STAGING }}


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Dependencies

- Upstream: _[this PR points to another PR or depends on its release]_
- Downstream: _[PRs that depend on this one, either point to this or can only be released after this one is released]_

### Description

Branch to staging to use internal's feature branch instead of the default one (develop).

Currently, when one has a feature branch on OSS and related changes on the internal repo (configs), and wants to branch it to staging, they have to merge internal's change to `develop`, since CI/CD will pull internal repo's `develop` to get the configs.

This is not good since one might be midway through the development and not ready to merge to `develop` - and make a release to `prod`! Before it was not as bad as it its now, since we were grouping multiple PRs in one release (`develop` could be "dirty" for longer).

This PR fixes it:
- create a feature branch on OSS
- create a feature branch on internal **with the same name as the branch on OSS**
- push both to remote
- branch to staging on OSS
- CI/CD will use the same branch name to get the configs from internal
- 🚀 

### Release Plan

- nothing special
- asap