### PR TITLE
1040 don't run commitlint on master/develop

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -42,14 +42,10 @@ jobs:
           node-version: "18.14"
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 100 # bc of below
       - name: Log Git Ref
         run: |
           echo "Git ref: $(git rev-parse HEAD)"
         shell: bash
-      # check commits' messages to make sure they follow Conventional Commits
-      - uses: wagoid/commitlint-github-action@v5
 
       # run even when treat-as-package is false b/c of inter-package dependencies
       - name: Install on root

--- a/.github/workflows/_check-commits.yml
+++ b/.github/workflows/_check-commits.yml
@@ -1,0 +1,30 @@
+name: Check commit messages on non-shared branches
+
+on:
+  workflow_call:
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+jobs:
+  check-commit-messages:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.base.ref != 'master' && github.event.pull_request.base.ref != 'develop' }}
+    steps:
+      - name: Log Environment
+        run: |
+          env
+        shell: bash
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 100 # bc of below
+      # check commits' messages to make sure they follow Conventional Commits
+      - uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/pull-request_api-sdk.yml
+++ b/.github/workflows/pull-request_api-sdk.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-commits:
+    uses: ./.github/workflows/_check-commits.yml
+    secrets: inherit
   check-pr:
     uses: ./.github/workflows/_build.yml
     with:

--- a/.github/workflows/pull-request_api.yml
+++ b/.github/workflows/pull-request_api.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-commits:
+    uses: ./.github/workflows/_check-commits.yml
+    secrets: inherit
   check-pr:
     uses: ./.github/workflows/_build.yml
     with:

--- a/.github/workflows/pull-request_commonwell-cert-runner.yml
+++ b/.github/workflows/pull-request_commonwell-cert-runner.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-commits:
+    uses: ./.github/workflows/_check-commits.yml
+    secrets: inherit
   check-pr:
     uses: ./.github/workflows/_build.yml
     with:

--- a/.github/workflows/pull-request_commonwell-jwt-maker.yml
+++ b/.github/workflows/pull-request_commonwell-jwt-maker.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-commits:
+    uses: ./.github/workflows/_check-commits.yml
+    secrets: inherit
   check-pr:
     uses: ./.github/workflows/_build.yml
     with:

--- a/.github/workflows/pull-request_commonwell-sdk.yml
+++ b/.github/workflows/pull-request_commonwell-sdk.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-commits:
+    uses: ./.github/workflows/_check-commits.yml
+    secrets: inherit
   check-pr:
     uses: ./.github/workflows/_build.yml
     with:

--- a/.github/workflows/pull-request_infra.yml
+++ b/.github/workflows/pull-request_infra.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-commits:
+    uses: ./.github/workflows/_check-commits.yml
+    secrets: inherit
   check-pr:
     uses: ./.github/workflows/_build.yml
     with:

--- a/.github/workflows/pull-request_lambdas.yml
+++ b/.github/workflows/pull-request_lambdas.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-commits:
+    uses: ./.github/workflows/_check-commits.yml
+    secrets: inherit
   check-pr:
     uses: ./.github/workflows/_build.yml
     with:

--- a/.github/workflows/pull-request_react-native-sdk.yml
+++ b/.github/workflows/pull-request_react-native-sdk.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-commits:
+    uses: ./.github/workflows/_check-commits.yml
+    secrets: inherit
   check-pr:
     uses: ./.github/workflows/_build.yml
     with:

--- a/.github/workflows/pull-request_utils.yml
+++ b/.github/workflows/pull-request_utils.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-commits:
+    uses: ./.github/workflows/_check-commits.yml
+    secrets: inherit
   check-pr:
     uses: ./.github/workflows/_build.yml
     with:

--- a/.github/workflows/pull-request_widget.yml
+++ b/.github/workflows/pull-request_widget.yml
@@ -8,6 +8,10 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-commits:
+    uses: ./.github/workflows/_check-commits.yml
+    secrets: inherit
+
   check-pr-production:
     if: ${{ github.event.pull_request.base.ref == 'master' }}
     uses: ./.github/workflows/_build.yml

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ root folder's `package.json` under the `workspaces` section.
 To setup this repository for local development, issue this command on the root folder:
 
 ```shell
-$ npm run install-deps # only needs to be run once
+$ npm run init # only needs to be run once
 $ npm run build # packages depend on each other, so its best to build/compile them all
 ```
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "preinstall": "npm i -g rimraf",
     "prepare": "husky install",
+    "init": "npm i && SCRIPT='i' npm run lambdas:no-run",
     "clean": "npm run clean --workspaces --if-present && SCRIPT='clean' npm run lambdas && echo 'rimraf node_modules' && rimraf node_modules",
     "prep-lambdas": "cd packages/lambdas && npm run prep-deploy && npm ci --ignore-scripts --no-fund && npm run lint && npm run build && npm run test && cd ../..",
     "prep-deploy": "npm run install-deps && npm run lint && npm run build && npm run test && npm run prep-lambdas",


### PR DESCRIPTION
Ref: metriport/metriport-internal#1040

### Dependencies

none

### Description

Remove the commit lint verification from `develop`/`master` based CI/CD jobs. It's fine to check that on the feature PRs, where we can easily rewrite the commit history, but we shouldn’t block deploying once the changes made into the shared repos.

### Release Plan

- changes the CI/CD, will test when merged, so it might break and need follow-up PR to fix
- asap
- once done, replicate this to the internal repo