### PR TITLE
1220 logic to generate new request ID

### DIFF
--- a/packages/api/src/command/medical/document/__tests__/document-query_calculateAndUpdateDocQuery.test.ts
+++ b/packages/api/src/command/medical/document/__tests__/document-query_calculateAndUpdateDocQuery.test.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { v4 as uuidv4 } from "uuid";
+import { calculateConversionProgress } from "../../../../domain/medical/conversion-progress";
 import {
-  calculateConversionProgress,
   ConvertResult,
   DocumentQueryProgress,
   DocumentQueryStatus,
 } from "../../../../domain/medical/document-query";
 import { makeDocumentQueryProgress } from "../../../../domain/medical/__tests__/document-query";
-import { PatientModel } from "../../../../models/medical/patient";
 import { makePatient, makePatientData } from "../../../../domain/medical/__tests__/patient";
+import { PatientModel } from "../../../../models/medical/patient";
 import { mockStartTransaction } from "../../../../models/__tests__/transaction";
 import { updateConversionProgress } from "../document-query";
 

--- a/packages/api/src/command/medical/document/document-redownload.ts
+++ b/packages/api/src/command/medical/document/document-redownload.ts
@@ -31,6 +31,7 @@ import { Util } from "../../../shared/util";
 import { getDocRefMapping } from "../docref-mapping/get-docref-mapping";
 import { appendDocQueryProgress } from "../patient/append-doc-query-progress";
 import { getPatientOrFail } from "../patient/get-patient";
+import { areDocumentsProcessing } from "./document-status";
 
 export const options = [
   "re-query-doc-refs",
@@ -186,10 +187,7 @@ async function processDocuments({
   const { cxId, id: patientId } = patient;
   const { log } = Util.out(`processDocuments - M patientId ${patientId}`);
 
-  if (
-    patient.data.documentQueryProgress?.download?.status === "processing" ||
-    patient.data.documentQueryProgress?.convert?.status === "processing"
-  ) {
+  if (areDocumentsProcessing(patient)) {
     log(`Patient ${patientId} is already being processed, skipping ${docs.length} docs...`);
     return;
   }

--- a/packages/api/src/command/medical/document/document-status.ts
+++ b/packages/api/src/command/medical/document/document-status.ts
@@ -1,16 +1,17 @@
-import { getPatientOrFail } from "../patient/get-patient";
+import { DocumentQueryProgress, isProcessing } from "../../../domain/medical/document-query";
+import { Patient } from "../../../domain/medical/patient";
 
-export const areDocumentsProcessing = async ({
-  id,
-  cxId,
-}: {
-  id: string;
-  cxId: string;
-}): Promise<boolean> => {
-  const patient = await getPatientOrFail({ id, cxId });
+export function areDocumentsProcessing(patient: Patient): boolean;
+export function areDocumentsProcessing(progress: DocumentQueryProgress | undefined): boolean;
+export function areDocumentsProcessing(
+  param: Patient | DocumentQueryProgress | undefined
+): boolean {
+  if (!param) return false;
 
-  return (
-    patient.data.documentQueryProgress?.download?.status === "processing" ||
-    patient.data.documentQueryProgress?.convert?.status === "processing"
-  );
-};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const progress = (param as any).data
+    ? (param as Patient).data.documentQueryProgress
+    : (param as DocumentQueryProgress);
+
+  return isProcessing(progress?.download) || isProcessing(progress?.convert);
+}

--- a/packages/api/src/domain/medical/conversion-progress.ts
+++ b/packages/api/src/domain/medical/conversion-progress.ts
@@ -1,0 +1,36 @@
+import { DocumentQueryProgress, getStatusFromProgress } from "./document-query";
+import { Patient } from "./patient";
+
+export const convertResult = ["success", "failed"] as const;
+export type ConvertResult = (typeof convertResult)[number];
+
+export const calculateConversionProgress = ({
+  patient,
+  convertResult,
+}: {
+  patient: Pick<Patient, "id" | "cxId">;
+  convertResult: ConvertResult;
+} & {
+  patient: Pick<Patient, "data" | "id">;
+}): DocumentQueryProgress => {
+  const docQueryProgress = patient.data.documentQueryProgress ?? {};
+
+  const totalToConvert = docQueryProgress?.convert?.total ?? 0;
+
+  const successfulConvert = docQueryProgress?.convert?.successful ?? 0;
+  const successful = convertResult === "success" ? successfulConvert + 1 : successfulConvert;
+
+  const errorsConvert = docQueryProgress?.convert?.errors ?? 0;
+  const errors = convertResult === "failed" ? errorsConvert + 1 : errorsConvert;
+
+  const status = getStatusFromProgress({ successful, errors, total: totalToConvert });
+
+  docQueryProgress.convert = {
+    ...docQueryProgress?.convert,
+    status,
+    successful,
+    errors,
+  };
+
+  return docQueryProgress;
+};

--- a/packages/api/src/domain/medical/document-query.ts
+++ b/packages/api/src/domain/medical/document-query.ts
@@ -1,5 +1,3 @@
-import { Patient } from "./patient";
-
 export const documentQueryStatus = ["processing", "completed", "failed"] as const;
 export type DocumentQueryStatus = (typeof documentQueryStatus)[number];
 
@@ -19,41 +17,22 @@ export type DocumentQueryProgress = {
 export const convertResult = ["success", "failed"] as const;
 export type ConvertResult = (typeof convertResult)[number];
 
-export const calculateConversionProgress = ({
-  patient,
-  convertResult,
-}: {
-  patient: Pick<Patient, "id" | "cxId">;
-  convertResult: ConvertResult;
-} & {
-  patient: Pick<Patient, "data" | "id">;
-}): DocumentQueryProgress => {
-  const docQueryProgress = patient.data.documentQueryProgress ?? {};
-
-  const totalToConvert = docQueryProgress?.convert?.total ?? 0;
-
-  const successfulConvert = docQueryProgress?.convert?.successful ?? 0;
-  const successful = convertResult === "success" ? successfulConvert + 1 : successfulConvert;
-
-  const errorsConvert = docQueryProgress?.convert?.errors ?? 0;
-  const errors = convertResult === "failed" ? errorsConvert + 1 : errorsConvert;
-
-  const status = getStatusFromProgress({ successful, errors, total: totalToConvert });
-
-  docQueryProgress.convert = {
-    ...docQueryProgress?.convert,
-    status,
-    successful,
-    errors,
-  };
-
-  return docQueryProgress;
-};
-
 export function getStatusFromProgress(
   progress: Pick<Progress, "errors" | "successful" | "total">
 ): DocumentQueryStatus {
   const { successful, errors, total } = progress;
   const isConversionCompleted = (successful ?? 0) + (errors ?? 0) >= (total ?? 0);
   return isConversionCompleted ? "completed" : "processing";
+}
+
+export function isProcessingStatus(status?: DocumentQueryStatus | undefined) {
+  if (!status) return false;
+  return status === "processing";
+}
+export function isFinalStatus(status?: DocumentQueryStatus | undefined) {
+  return !isProcessingStatus(status);
+}
+
+export function isProcessing(progress?: Progress | undefined) {
+  return isProcessingStatus(progress?.status);
 }

--- a/packages/api/src/routes/medical/__tests__/mapi/e2e/mapi.test.e2e.ts
+++ b/packages/api/src/routes/medical/__tests__/mapi/e2e/mapi.test.e2e.ts
@@ -14,6 +14,7 @@ import { createFacility, validateFacility } from "./facility";
 import { validateCWOrg, validateFhirOrg, validateLocalOrg } from "./organization";
 import { createPatient, validateFhirPatient, validateLocalPatient } from "./patient";
 import { fhirApi, fhirHeaders, medicalApi } from "./shared";
+import { areDocumentsProcessing } from "../../../../../command/medical/document/document-status";
 
 const maxRetries = 4;
 
@@ -132,11 +133,7 @@ if (Config.isStaging() || Config.isDev()) {
       let status = await medicalApi.getDocumentQueryStatus(patient.id);
       let retryLimit = 0;
 
-      while (
-        (status.download?.status === "processing" ||
-          (status.convert && status.convert?.status === "processing")) &&
-        retryLimit < maxRetries
-      ) {
+      while (areDocumentsProcessing(status) && retryLimit < maxRetries) {
         await Util.sleep(5000);
         status = await medicalApi.getDocumentQueryStatus(patient.id);
         retryLimit++;

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -1,15 +1,16 @@
 import { patientCreateSchema } from "@metriport/api-sdk";
+import { consolidationConversionType } from "@metriport/core/domain/conversion/fhir-to-medical-record";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import status from "http-status";
-import { consolidationConversionType } from "@metriport/core/domain/conversion/fhir-to-medical-record";
+import { z } from "zod";
 import { areDocumentsProcessing } from "../../command/medical/document/document-status";
 import { createOrUpdateConsolidatedPatientData } from "../../command/medical/patient/consolidated-create";
 import {
   getConsolidatedPatientData,
   startConsolidatedQuery,
 } from "../../command/medical/patient/consolidated-get";
-import { PatientCreateCmd, createPatient } from "../../command/medical/patient/create-patient";
+import { createPatient, PatientCreateCmd } from "../../command/medical/patient/create-patient";
 import { deletePatient } from "../../command/medical/patient/delete-patient";
 import { getPatientOrFail, getPatients } from "../../command/medical/patient/get-patient";
 import { PatientUpdateCmd, updatePatient } from "../../command/medical/patient/update-patient";
@@ -38,7 +39,6 @@ import {
   schemaCreateToPatient,
   schemaUpdateToPatient,
 } from "./schemas/patient";
-import { z } from "zod";
 
 const router = Router();
 const MAX_RESOURCE_POST_COUNT = 50;
@@ -103,8 +103,8 @@ router.put(
     const facilityId = getFromQueryOrFail("facilityId", req);
     const payload = patientUpdateSchema.parse(req.body);
 
-    const isProcessing = await areDocumentsProcessing({ id, cxId });
-    if (isProcessing) {
+    const patient = await getPatientOrFail({ id, cxId });
+    if (areDocumentsProcessing(patient)) {
       return res.status(status.LOCKED).json("Document querying currently in progress");
     }
 

--- a/packages/utils/.gitignore
+++ b/packages/utils/.gitignore
@@ -132,3 +132,4 @@ scratch.ts
 
 *.csv
 bulk-insert-patient-ids.txt
+screenshot*


### PR DESCRIPTION
Ref: metriport/metriport-internal#1220

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1085
- Downstream: none

### Description

While testing the upstream PR I realized the internal endpoint was not creating a new doc ref, so I had to update `getOrGenerateRequestId()` to force it if we're skipping validation.

Then I found a bug and refactored the code to minimize the chances of new bugs related to doc query status:
- fix logic to generate new request ID
- concentrate logic to calculate doc query status
- remove circular dependency Patient <> DocumentQuery domain

### Release Plan

- nothing special