### PR TITLE
Document Upload - New endpoint and documentation updates

### DIFF
--- a/docs/medical-api/api-reference/document/post-upload-url.mdx
+++ b/docs/medical-api/api-reference/document/post-upload-url.mdx
@@ -135,7 +135,7 @@ const docRef: Partial<DocumentReference> = {
   },
 };
 
-const resp = await metriport.getUploadDocumentUrl("my-patient-id", docRef);
+const resp = await metriport.createDocumentReference("my-patient-id", docRef);
 
 // Upload the document using this url in a PUT request, something along these lines:
 

--- a/docs/medical-api/api-reference/document/post-upload-url.mdx
+++ b/docs/medical-api/api-reference/document/post-upload-url.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Upload Document"
 description: "Returns a URL to use for a medical document upload to our servers."
-api: "POST /medical/v1/document/upload"
+api: "POST /medical/v1/document/upload-url"
 ---
 
 This endpoint returns a URL to enable you to upload your patients' medical documents, making them available to other HIEs.

--- a/docs/medical-api/api-reference/document/post-upload-url.mdx
+++ b/docs/medical-api/api-reference/document/post-upload-url.mdx
@@ -101,7 +101,7 @@ The DocumentReference ID and a URL to be used for file upload.
 
 ```json
 {
-  "documentReferenceId": "<DocumentReference-ID-string>,
+  "documentReferenceId": "<DocumentReference-ID-string>",
   "uploadUrl": "<url-string>"
 }
 ```

--- a/docs/medical-api/api-reference/document/post-upload-url.mdx
+++ b/docs/medical-api/api-reference/document/post-upload-url.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Upload Document"
 description: "Returns a URL to use for a medical document upload to our servers."
-api: "POST /medical/v1/document/upload-url"
+api: "POST /medical/v1/document/upload"
 ---
 
 This endpoint returns a URL to enable you to upload your patients' medical documents, making them available to other HIEs.
@@ -134,12 +134,12 @@ const docRef: Partial<DocumentReference> = {
   },
 };
 
-const url = await metriportClient.getDocumentUploadUrl("my-patient-id", docRef);
+const response = await metriport.getUploadDocumentUrl("my-patient-id", docRef);
 
 // Upload the document using this url in a PUT request, something along these lines:
 
 // const fileContent = <medical-document-document-contents>;
-// await axios.put(url, document, {
+// await axios.put(response.url, document, {
 //     headers: {
 //         "Content-Length": <size-in-bytes>,
 //     },

--- a/docs/medical-api/api-reference/document/post-upload-url.mdx
+++ b/docs/medical-api/api-reference/document/post-upload-url.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Upload Document"
-description: "Returns a URL to use for a medical document upload to our servers."
+description: "Creates a DocumentReference and returns its ID and a URL to use for a medical document upload to our servers."
 api: "POST /medical/v1/document/upload"
 ---
 
-This endpoint returns a URL to enable you to upload your patients' medical documents, making them available to other HIEs.
+This endpoint returns the DocumentReference ID and a URL to enable you to upload your patients' medical documents, making them available to other HIEs.
 
 ## Overview
 
@@ -97,11 +97,12 @@ Example Payload:
 
 ## Response
 
-The URL to be used for file upload.
+The DocumentReference ID and a URL to be used for file upload.
 
 ```json
 {
-  "url": "<url-string>"
+  "documentReferenceId": "<DocumentReference-ID-string>,
+  "uploadUrl": "<url-string>"
 }
 ```
 
@@ -134,12 +135,12 @@ const docRef: Partial<DocumentReference> = {
   },
 };
 
-const response = await metriport.getUploadDocumentUrl("my-patient-id", docRef);
+const resp = await metriport.getUploadDocumentUrl("my-patient-id", docRef);
 
 // Upload the document using this url in a PUT request, something along these lines:
 
 // const fileContent = <medical-document-document-contents>;
-// await axios.put(response.url, document, {
+// await axios.put(resp.uploadUrl, document, {
 //     headers: {
 //         "Content-Length": <size-in-bytes>,
 //     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -37699,7 +37699,7 @@
       }
     },
     "packages/api": {
-      "version": "1.6.6",
+      "version": "1.6.7-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -37778,10 +37778,10 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.2.7",
+      "version": "7.3.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.8.13",
+        "@metriport/commonwell-sdk": "^4.8.14-alpha.0",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -37822,10 +37822,10 @@
     "packages/api/packages/core": {},
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.9.14",
+      "version": "1.9.15-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.8.13",
+        "@metriport/commonwell-sdk": "^4.8.14-alpha.0",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -37864,10 +37864,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.6.14",
+      "version": "1.6.15-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.8.13",
+        "@metriport/commonwell-sdk": "^4.8.14-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -37899,7 +37899,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.8.13",
+      "version": "4.8.14-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^8.0.2",
@@ -37948,13 +37948,13 @@
       }
     },
     "packages/connect-widget": {
-      "version": "1.4.15",
+      "version": "1.4.16-alpha.0",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.12",
         "@chakra-ui/react": "^2.4.1",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
-        "@metriport/api-sdk": "^7.2.7",
+        "@metriport/api-sdk": "^7.3.0-alpha.0",
         "@sentry/react": "^7.45.0",
         "@sentry/tracing": "^7.45.0",
         "@testing-library/jest-dom": "^5.16.5",
@@ -38051,7 +38051,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.4.8",
+      "version": "1.4.9-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -38088,7 +38088,7 @@
     "packages/core/packages/commonwell-sdk": {},
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.4.15",
+      "version": "1.4.16-alpha.0",
       "dependencies": {
         "aws-cdk-lib": "^2.87.0",
         "constructs": "^10.2.69",
@@ -38135,7 +38135,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.4.13",
+      "version": "1.4.14-alpha.0",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -39161,7 +39161,7 @@
       }
     },
     "packages/tester-node": {
-      "version": "1.0.10",
+      "version": "1.0.11-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@metriport/api-sdk": "file:packages/api-sdk",
@@ -39196,7 +39196,7 @@
     "packages/tester-node/packages/api-sdk": {},
     "packages/tester-node/packages/core": {},
     "packages/utils": {
-      "version": "1.5.5",
+      "version": "1.5.6-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.2.7",
+  "version": "7.3.0-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -56,7 +56,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.8.13",
+    "@metriport/commonwell-sdk": "^4.8.14-alpha.0",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/src/index.ts
+++ b/packages/api-sdk/src/index.ts
@@ -31,6 +31,7 @@ export {
   documentQueryStatusSchema,
   ListDocumentFilters,
   ListDocumentResult,
+  UploadDocumentResult,
 } from "./medical/models/document";
 export {
   Facility,

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -478,7 +478,8 @@ export class MetriportMedicalApi {
   }
 
   /**
-   * Returns a Presigned URL to upload a file to Metriport and make the document available to other HIEs.
+   * @deprecated - Use getUploadDocumentUrl() instead.
+   * Returns a URL to upload a file to Metriport and make the document available to other HIEs.
    * To upload your file contents, execute a PUT request using this Presigned URL with the file contents as the request body.
    * Refer to Metriport Documentation for more details:
    * https://docs.metriport.com/medical-api/api-reference/document/post-upload-url
@@ -487,13 +488,34 @@ export class MetriportMedicalApi {
    * @param docRef - a FHIR Document Reference for this file upload. Mandatory fields include DocumentReference.description, DocumentReference.type, and DocumentReference.context. Besides that, try to include as much metadata on the document as possible. Note that you DO NOT need to fill in the Organization or Patient fields under the author or contained fields - Metriport will fill this in and overwrite whatever you put in.
    * Refer to Metriport's documentation for more details: https://docs.metriport.com/medical-api/fhir/resources/documentreference.
    *
-   * @returns A Presigned URL to be used for subsequent file upload.
+   * @returns A URL string to be used for subsequent file upload.
    */
   async getDocumentUploadUrl(
     patientId: string,
     docRef: Partial<FHIRDocumentReference>
   ): Promise<string> {
     const url = `${DOCUMENT_URL}/upload-url/?patientId=${patientId}`;
+    const resp = await this.api.post(url, docRef);
+    return resp.data;
+  }
+
+  /**
+   * Returns a URL to upload a file to Metriport and make the document available to other HIEs.
+   * To upload your file contents, execute a PUT request using this URL with the file contents as the request body.
+   * Refer to Metriport Documentation for more details:
+   * https://docs.metriport.com/medical-api/api-reference/document/post-upload-url
+   *
+   * @param patientId - the ID of the patient.
+   * @param docRef - a FHIR Document Reference for this file upload. Mandatory fields include DocumentReference.description, DocumentReference.type, and DocumentReference.context. Besides that, try to include as much metadata on the document as possible. Note that you DO NOT need to fill in the Organization or Patient fields under the author or contained fields - Metriport will fill this in and overwrite whatever you put in.
+   * Refer to Metriport's documentation for more details: https://docs.metriport.com/medical-api/fhir/resources/documentreference.
+   *
+   * @returns A JSON object with a URL to be used for subsequent file upload.
+   */
+  async getUploadDocumentUrl(
+    patientId: string,
+    docRef: Partial<FHIRDocumentReference>
+  ): Promise<{ url: string }> {
+    const url = `${DOCUMENT_URL}/upload/?patientId=${patientId}`;
     const resp = await this.api.post(url, docRef);
     return resp.data;
   }

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -479,7 +479,7 @@ export class MetriportMedicalApi {
   }
 
   /**
-   * @deprecated - Use getUploadDocumentUrl() instead.
+   * @deprecated - Use createDocumentReference() instead.
    * Returns a URL to upload a file to Metriport and make the document available to other HIEs.
    * To upload your file contents, execute a PUT request using this Presigned URL with the file contents as the request body.
    * Refer to Metriport Documentation for more details:
@@ -512,7 +512,7 @@ export class MetriportMedicalApi {
    *
    * @returns The DocumentReference ID, and the URL to be used for subsequent file upload.
    */
-  async getUploadDocumentUrl(
+  async createDocumentReference(
     patientId: string,
     docRef: Partial<FHIRDocumentReference>
   ): Promise<UploadDocumentResult> {

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -13,6 +13,7 @@ import {
   DocumentReference,
   ListDocumentFilters,
   ListDocumentResult,
+  UploadDocumentResult,
   documentListSchema,
   documentQuerySchema,
 } from "../models/document";
@@ -500,8 +501,8 @@ export class MetriportMedicalApi {
   }
 
   /**
-   * Returns a URL to upload a file to Metriport and make the document available to other HIEs.
-   * To upload your file contents, execute a PUT request using this URL with the file contents as the request body.
+   * Creates a DocumentReference and returns its ID along with a URL to upload the respective Document file to Metriport and make this document available to other HIEs.
+   * To upload your file contents, execute a PUT request using the returned uploadUrl with the file contents as the request body.
    * Refer to Metriport Documentation for more details:
    * https://docs.metriport.com/medical-api/api-reference/document/post-upload-url
    *
@@ -509,12 +510,12 @@ export class MetriportMedicalApi {
    * @param docRef - a FHIR Document Reference for this file upload. Mandatory fields include DocumentReference.description, DocumentReference.type, and DocumentReference.context. Besides that, try to include as much metadata on the document as possible. Note that you DO NOT need to fill in the Organization or Patient fields under the author or contained fields - Metriport will fill this in and overwrite whatever you put in.
    * Refer to Metriport's documentation for more details: https://docs.metriport.com/medical-api/fhir/resources/documentreference.
    *
-   * @returns A JSON object with a URL to be used for subsequent file upload.
+   * @returns The DocumentReference ID, and the URL to be used for subsequent file upload.
    */
   async getUploadDocumentUrl(
     patientId: string,
     docRef: Partial<FHIRDocumentReference>
-  ): Promise<{ url: string }> {
+  ): Promise<UploadDocumentResult> {
     const url = `${DOCUMENT_URL}/upload/?patientId=${patientId}`;
     const resp = await this.api.post(url, docRef);
     return resp.data;

--- a/packages/api-sdk/src/medical/models/document.ts
+++ b/packages/api-sdk/src/medical/models/document.ts
@@ -58,3 +58,8 @@ export type ListDocumentFilters = {
 export type ListDocumentResult = {
   documents: FHIRDocumentReference[];
 };
+
+export type UploadDocumentResult = {
+  documentReferenceId: string;
+  uploadUrl: string;
+};

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.6.6",
+  "version": "1.6.7-alpha.0",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/src/routes/medical/document.ts
+++ b/packages/api/src/routes/medical/document.ts
@@ -242,7 +242,7 @@ router.post(
  * @param patientId - The ID of the patient.
  * @body - The DocumentReference with context for the file to be uploaded.
  *
- * @return A JSON object with a URL for document upload.
+ * @return The DocumentReference ID and the URL for document upload.
  * Refer to Metriport Documentation for more details:
  * https://docs.metriport.com/medical-api/api-reference/document/post-upload-url
  */

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.9.14",
+  "version": "1.9.15-alpha.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.8.13",
+    "@metriport/commonwell-sdk": "^4.8.14-alpha.0",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.6.14",
+  "version": "1.6.15-alpha.0",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.8.13",
+    "@metriport/commonwell-sdk": "^4.8.14-alpha.0",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.8.13",
+  "version": "4.8.14-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/connect-widget/package.json
+++ b/packages/connect-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-widget",
-  "version": "1.4.15",
+  "version": "1.4.16-alpha.0",
   "private": true,
   "scripts": {
     "clean": "rimraf build && rimraf node_modules",
@@ -38,7 +38,7 @@
     "@chakra-ui/react": "^2.4.1",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@metriport/api-sdk": "^7.2.7",
+    "@metriport/api-sdk": "^7.3.0-alpha.0",
     "@sentry/react": "^7.45.0",
     "@sentry/tracing": "^7.45.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.4.8",
+  "version": "1.4.9-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.4.15",
+  "version": "1.4.16-alpha.0",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.4.13",
+  "version": "1.4.14-alpha.0",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/tester-node/package.json
+++ b/packages/tester-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tester-node",
-  "version": "1.0.10",
+  "version": "1.0.11-alpha.0",
   "description": "",
   "private": true,
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.5.5",
+  "version": "1.5.6-alpha.0",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,

--- a/packages/utils/src/document/document-upload.ts
+++ b/packages/utils/src/document/document-upload.ts
@@ -13,7 +13,7 @@ const apiKey = getEnvVarOrFail("API_KEY");
 const apiUrl = getEnvVarOrFail("API_URL");
 const patientId = getEnvVarOrFail("PATIENT_ID");
 
-const filePath = "../src/pdf_example.pdf";
+const filePath = "./src/pdf_example.pdf";
 
 const metriportApi = new MetriportMedicalApi(apiKey, {
   baseAddress: apiUrl,
@@ -60,7 +60,7 @@ async function main() {
     },
   };
   const fileContent = await readFileAsync(filePath); // works for xml; doesn't work for pdf
-  // const fileContent = fs.readFileSync("./src/pdf_example.pdf"); // works for pdf; hasn't been tested with xml
+  // const fileContent = fs.readFileSync(filePath); // works for pdf; hasn't been tested with xml
   if (!fileContent) throw new Error("File content is empty");
 
   const presignedUrl = await metriportApi.getDocumentUploadUrl(patientId, docRef);

--- a/packages/utils/src/document/document-upload.ts
+++ b/packages/utils/src/document/document-upload.ts
@@ -53,7 +53,7 @@ async function main() {
   const fileContent = fs.readFileSync(filePath); // works for pdf and xml
   if (!fileContent) throw new Error("File content is empty");
 
-  const resp = await metriportApi.getUploadDocumentUrl(patientId, docRef);
+  const resp = await metriportApi.createDocumentReference(patientId, docRef);
   console.log("getUploadDocumentUrl response:", resp);
 
   try {

--- a/packages/utils/src/document/document-upload.ts
+++ b/packages/utils/src/document/document-upload.ts
@@ -53,12 +53,12 @@ async function main() {
   const fileContent = fs.readFileSync(filePath); // works for pdf and xml
   if (!fileContent) throw new Error("File content is empty");
 
-  const presignedUrl = await metriportApi.getUploadDocumentUrl(patientId, docRef);
-  console.log("presignedUrl", presignedUrl);
+  const resp = await metriportApi.getUploadDocumentUrl(patientId, docRef);
+  console.log("getUploadDocumentUrl response:", resp);
 
   try {
     console.log("Uploading file to S3...");
-    await put(presignedUrl.url, fileContent);
+    await put(resp.uploadUrl, fileContent);
     console.log("Upload successful! :)");
   } catch (err) {
     console.log("ERROR:", err);


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport/issues/1088

### Description

- Deprecated the `upload-doc` route and corresponding SDK function. Added new corrected functions for replacement.
- Document Upload endpoint now also returns the DocRef ID alongside the upload URL
- Updated the docs accordingly

### Release Plan

- Update SDK pkg
- Merge this