### PR TITLE
1220 add unit test to getOrGenerateRequestId

### DIFF
--- a/packages/api/src/command/medical/document/__tests__/document-query.test.ts
+++ b/packages/api/src/command/medical/document/__tests__/document-query.test.ts
@@ -1,16 +1,20 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+import * as uuidv7_file from "@metriport/core/util/uuid-v7";
+import { makeDocumentQueryProgress } from "../../../../domain/medical/__tests__/document-query";
+import { makePatient } from "../../../../domain/medical/__tests__/patient";
 import { PatientModel } from "../../../../models/medical/patient";
 import { makePatientModel } from "../../../../models/medical/__tests__/patient";
-import { makePatient } from "../../../../domain/medical/__tests__/patient";
 import { mockStartTransaction } from "../../../../models/__tests__/transaction";
-import * as whMedical from "../document-webhook";
 import * as docQueryProgress from "../../patient/append-doc-query-progress";
 import * as docQuery from "../document-query";
-import { updateDocQuery } from "../document-query";
+import { getOrGenerateRequestId, updateDocQuery } from "../document-query";
+import * as whMedical from "../document-webhook";
 
 const patientModel = makePatientModel();
 let docQuery_updateConversionProgress: jest.SpyInstance;
 let appendDocQueryProgress_mock: jest.SpyInstance;
+let uuidv7_mock: jest.SpyInstance;
+
 beforeEach(() => {
   jest.restoreAllMocks();
   mockStartTransaction();
@@ -22,6 +26,7 @@ beforeEach(() => {
     .spyOn(docQueryProgress, "appendDocQueryProgress")
     .mockImplementation(async () => patientModel);
   jest.spyOn(whMedical, "processPatientDocumentRequest").mockImplementation(async () => {});
+  uuidv7_mock = jest.spyOn(uuidv7_file, "uuidv7");
 });
 
 describe("document-query", () => {
@@ -62,6 +67,65 @@ describe("document-query", () => {
         const res = await updateDocQuery({ patient, convertProgress: { status: "processing" } });
         expect(res).toEqual(patientModel);
       });
+    });
+  });
+
+  describe("getOrGenerateRequestId", () => {
+    afterEach(() => {
+      uuidv7_mock.mockRestore();
+    });
+
+    it(`returns new reqId when no doc query status`, async () => {
+      const expectedResult = uuidv7_file.uuidv4();
+      uuidv7_mock.mockReturnValue(expectedResult);
+      const res = getOrGenerateRequestId(undefined);
+      expect(res).toEqual(expectedResult);
+    });
+
+    it(`returns existing when download is processing`, async () => {
+      const expectedResult = uuidv7_file.uuidv4();
+      const docQueryProgress = makeDocumentQueryProgress({
+        download: { status: "processing" },
+        convert: { status: "completed" },
+        requestId: expectedResult,
+      });
+      const res = getOrGenerateRequestId(docQueryProgress);
+      expect(res).toEqual(expectedResult);
+    });
+
+    it(`returns existing when convert is processing`, async () => {
+      const expectedResult = uuidv7_file.uuidv4();
+      const docQueryProgress = makeDocumentQueryProgress({
+        download: { status: "completed" },
+        convert: { status: "processing" },
+        requestId: expectedResult,
+      });
+      const res = getOrGenerateRequestId(docQueryProgress);
+      expect(res).toEqual(expectedResult);
+    });
+
+    it(`returns a new one when both are completed`, async () => {
+      const expectedResult = uuidv7_file.uuidv4();
+      uuidv7_mock.mockReturnValue(expectedResult);
+      const docQueryProgress = makeDocumentQueryProgress({
+        download: { status: "completed" },
+        convert: { status: "completed" },
+        requestId: uuidv7_file.uuidv4(),
+      });
+      const res = getOrGenerateRequestId(docQueryProgress);
+      expect(res).toEqual(expectedResult);
+    });
+
+    it(`returns a new one when both are failed`, async () => {
+      const expectedResult = uuidv7_file.uuidv4();
+      uuidv7_mock.mockReturnValue(expectedResult);
+      const docQueryProgress = makeDocumentQueryProgress({
+        download: { status: "failed" },
+        convert: { status: "failed" },
+        requestId: uuidv7_file.uuidv4(),
+      });
+      const res = getOrGenerateRequestId(docQueryProgress);
+      expect(res).toEqual(expectedResult);
     });
   });
 });

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -210,7 +210,7 @@ export const updateConversionProgress = async ({
  * @param forceNew Force creating a new request ID
  * @returns uuidv7 string ID for the request
  */
-function getOrGenerateRequestId(
+export function getOrGenerateRequestId(
   docQueryProgress: DocumentQueryProgress | undefined,
   forceNew = false
 ): string {

--- a/packages/api/src/domain/medical/__tests__/document-query.ts
+++ b/packages/api/src/domain/medical/__tests__/document-query.ts
@@ -18,5 +18,6 @@ export function makeDocumentQueryProgress(
   return {
     download: makeProgress(seed.download),
     convert: makeProgress(seed.convert),
+    requestId: seed.requestId === null ? undefined : seed.requestId ?? faker.datatype.uuid(),
   };
 }


### PR DESCRIPTION
Ref: metriport/metriport-internal#1220

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1091
- Downstream: none

### Description

Add unit test to getOrGenerateRequestId. I did some tests on staging but thought it would be good to go through all permutations just to be safe.

### Release Plan

- nothing special