### PR TITLE
PATCH RELEAES #1203

### DIFF
--- a/packages/api/src/mappings/tenovi/index.ts
+++ b/packages/api/src/mappings/tenovi/index.ts
@@ -16,9 +16,6 @@ export const tenoviMeasurementSchema = z.object({
   timestamp: z.string(),
   timezone_offset: z.number(),
   estimated_timestamp: z.boolean(),
-  filter_params: z.object({
-    measurement_index: z.number().optional(),
-  }),
 });
 
 export const tenoviMeasurementDataSchema = z.array(tenoviMeasurementSchema);


### PR DESCRIPTION
Ref: metriport/metriport-internal#1203

### Description

Patch release to fix schema validation of Tenovi's `filter_params`.

Remove it since its not being used.

### Release Plan

- ⚠️ This is pointing to `master`
- nothing special
- asap