### PR TITLE
1040 make facilityId optional on endpoints

### DIFF
--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -7,8 +7,7 @@ import {
   Progress,
 } from "../../../domain/medical/document-query";
 import { Patient } from "../../../domain/medical/patient";
-import { isPatientAssociatedWithFacility } from "../../../domain/medical/patient-facility";
-import BadRequestError from "../../../errors/bad-request";
+import { validateOptionalFacilityId } from "../../../domain/medical/patient-facility";
 import { getCxsWithEnhancedCoverageFeatureFlagValue } from "../../../external/aws/appConfig";
 import { queryAndProcessDocuments as getDocumentsFromCW } from "../../../external/commonwell/document/document-query";
 import { PatientDataCommonwell } from "../../../external/commonwell/patient-shared";
@@ -52,22 +51,9 @@ export async function queryDocumentsAcrossHIEs({
   const { log } = Util.out(`queryDocumentsAcrossHIEs - M patient ${patientId}`);
 
   const patient = await getPatientOrFail({ id: patientId, cxId });
-  if (facilityId && !isPatientAssociatedWithFacility(patient, facilityId)) {
-    throw new BadRequestError(`Patient not associated with given facility`, undefined, {
-      patientId: patient.id,
-      facilityId,
-    });
-  }
-  if (!facilityId && patient.facilityIds.length > 1) {
-    throw new BadRequestError(
-      `Patient is associated with more than one facility (facilityId is required)`,
-      undefined,
-      {
-        patientId: patient.id,
-        facilityIdCount: patient.facilityIds.length,
-      }
-    );
-  }
+
+  validateOptionalFacilityId(patient, facilityId);
+
   const docQueryProgress = patient.data.documentQueryProgress;
   const requestId = getOrGenerateRequestId(docQueryProgress, forceQuery);
 

--- a/packages/api/src/command/medical/patient/delete-patient.ts
+++ b/packages/api/src/command/medical/patient/delete-patient.ts
@@ -1,3 +1,4 @@
+import { getFacilityIdOrFail } from "../../../domain/medical/patient-facility";
 import cwCommands from "../../../external/commonwell";
 import { makeFhirApi } from "../../../external/fhir/api/api-factory";
 import { validateVersionForUpdate } from "../../../models/_default";
@@ -7,7 +8,7 @@ import { BaseUpdateCmdWithCustomer } from "../base-update-command";
 import { getPatientOrFail } from "./get-patient";
 
 export type PatientDeleteCmd = BaseUpdateCmdWithCustomer & {
-  facilityId: string;
+  facilityId?: string;
 };
 
 export type DeleteOptions = {
@@ -18,10 +19,12 @@ export const deletePatient = async (
   patientDelete: PatientDeleteCmd,
   options: DeleteOptions = {}
 ): Promise<void> => {
-  const { id, cxId, facilityId, eTag } = patientDelete;
+  const { id, cxId, facilityId: facilityIdParam, eTag } = patientDelete;
 
   const patient = await getPatientOrFail({ id, cxId });
   validateVersionForUpdate(patient, eTag);
+
+  const facilityId = getFacilityIdOrFail(patient, facilityIdParam);
 
   if (options.allEnvs || Config.isSandbox()) {
     const fhirApi = makeFhirApi(cxId);

--- a/packages/api/src/domain/medical/patient-facility.ts
+++ b/packages/api/src/domain/medical/patient-facility.ts
@@ -1,3 +1,5 @@
+import BadRequestError from "../../errors/bad-request";
+import MetriportError from "../../errors/metriport-error";
 import { Patient } from "./patient";
 
 /**
@@ -9,4 +11,47 @@ import { Patient } from "./patient";
  */
 export function isPatientAssociatedWithFacility(patient: Patient, facilityId: string): boolean {
   return patient.facilityIds.some(id => id === facilityId);
+}
+
+/**
+ * Returns a facility ID for the given Patient considering an optionally passed facility ID.
+ *
+ * Fails if the facility ID is not associated w/ the Patient or if no facility ID is passed
+ * and the Patient is associated with more than one facility.
+ */
+export function getFacilityIdOrFail(patient: Patient, facilityId?: string): string {
+  if (facilityId && !isPatientAssociatedWithFacility(patient, facilityId)) {
+    throw new BadRequestError(`Patient not associated with given facility`, undefined, {
+      patientId: patient.id,
+      facilityId,
+    });
+  }
+  if (!facilityId && patient.facilityIds.length > 1) {
+    throw new BadRequestError(
+      `Patient is associated with more than one facility (facilityId is required)`,
+      undefined,
+      {
+        patientId: patient.id,
+        facilityIdCount: patient.facilityIds.length,
+      }
+    );
+  }
+  if (facilityId !== patient.facilityIds[0]) {
+    throw new MetriportError(`Programming error - facility IDs mismatch`, undefined, {
+      patientId: patient.id,
+      facilityIdCount: patient.facilityIds.length,
+      facilityId,
+    });
+  }
+  return facilityId;
+}
+
+/**
+ * Utility function to validate that a facility ID is associated with a patient or that the
+ * patient only has one facility if none is provided.
+ * Throws if not valid.
+ */
+export function validateOptionalFacilityId(patient: Patient, facilityId?: string): true {
+  getFacilityIdOrFail(patient, facilityId);
+  return true;
 }

--- a/packages/api/src/external/commonwell/organization.ts
+++ b/packages/api/src/external/commonwell/organization.ts
@@ -1,8 +1,8 @@
 import { Organization as CWOrganization } from "@metriport/commonwell-sdk";
+import { OID_PREFIX } from "@metriport/core/domain/oid";
 import { Organization } from "../../domain/medical/organization";
 import { Config, getEnvVarOrFail } from "../../shared/config";
 import { capture } from "../../shared/notifications";
-import { OID_PREFIX } from "@metriport/core/domain/oid";
 import { Util } from "../../shared/util";
 import { getCertificate, makeCommonWellAPI, metriportQueryMeta } from "./api";
 

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -87,7 +87,7 @@ export async function create(
     commonWell = makeCommonWellAPI(orgName, oid(orgOID));
     const queryMeta = organizationQueryMeta(orgName, { npi: facilityNPI });
     const commonwellPatient = patientToCommonwell({ patient, orgName, orgOID });
-    debug(`Registering this Patient: ${JSON.stringify(commonwellPatient)}`);
+    debug(`Registering this Patient: `, () => JSON.stringify(commonwellPatient, null, 2));
 
     const { commonwellPatientId, patientRefLink } = await registerPatient({
       commonWell,

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -87,7 +87,7 @@ export async function create(
     commonWell = makeCommonWellAPI(orgName, oid(orgOID));
     const queryMeta = organizationQueryMeta(orgName, { npi: facilityNPI });
     const commonwellPatient = patientToCommonwell({ patient, orgName, orgOID });
-    debug(`Registering this Patient: ${JSON.stringify(commonwellPatient, undefined, 2)}`);
+    debug(`Registering this Patient: ${JSON.stringify(commonwellPatient)}`);
 
     const { commonwellPatientId, patientRefLink } = await registerPatient({
       commonWell,


### PR DESCRIPTION
Ref: metriport/metriport-internal#1040

### Dependencies

none

### Description

- (Make our lives easier by) make `facilityId` optional on endpoints.
- remove multi-line logs to keep our logs/ops sane (it should be fixed by https://github.com/metriport/metriport-internal/issues/693)

### Release Plan

- [ ] merge this
- [ ] update postman to disable `facilityId` where possible