### PR TITLE
PATCH RELEASE #1220

### DIFF
--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -41,13 +41,13 @@ export async function queryDocumentsAcrossHIEs({
   patientId,
   facilityId,
   override,
-  skipDocQueryStatusCheck = false,
+  forceQuery = false,
 }: {
   cxId: string;
   patientId: string;
   facilityId?: string;
   override?: boolean;
-  skipDocQueryStatusCheck?: boolean;
+  forceQuery?: boolean;
 }): Promise<DocumentQueryProgress> {
   const { log } = Util.out(`queryDocumentsAcrossHIEs - M patient ${patientId}`);
 
@@ -69,9 +69,9 @@ export async function queryDocumentsAcrossHIEs({
     );
   }
   const docQueryProgress = patient.data.documentQueryProgress;
-  const requestId = getOrGenerateRequestId(docQueryProgress, skipDocQueryStatusCheck);
+  const requestId = getOrGenerateRequestId(docQueryProgress, forceQuery);
 
-  const isCheckStatus = !skipDocQueryStatusCheck;
+  const isCheckStatus = !forceQuery;
   if (isCheckStatus && areDocumentsProcessing(docQueryProgress)) {
     log(`Patient ${patientId} documentQueryStatus is already 'processing', skipping...`);
     return createQueryResponse("processing", patient);
@@ -92,7 +92,7 @@ export async function queryDocumentsAcrossHIEs({
 
   const cxsWithEnhancedCoverageFeatureFlagValue =
     await getCxsWithEnhancedCoverageFeatureFlagValue();
-  if (!cxsWithEnhancedCoverageFeatureFlagValue.includes(patient.cxId)) {
+  if (forceQuery || !cxsWithEnhancedCoverageFeatureFlagValue.includes(patient.cxId)) {
     // kick off document query unless the cx has the enhanced coverage feature enabled
     getDocumentsFromCW({
       patient,

--- a/packages/api/src/routes/medical/internal-docs.ts
+++ b/packages/api/src/routes/medical/internal-docs.ts
@@ -325,7 +325,7 @@ router.post(
       cxId,
       patientId,
       facilityId,
-      skipDocQueryStatusCheck: true,
+      forceQuery: true,
     });
 
     return res.status(httpStatus.OK).json(docQueryProgress);


### PR DESCRIPTION
Ref: metriport/metriport-internal#1220

### Description

Bypass FF on internal doc query trigger

### Release Plan

- ⚠️ this is pointing to `master`
- nothing special
- asap