### PR TITLE
1040 dont log FF contents

### DIFF
--- a/packages/core/src/external/aws/appConfig.ts
+++ b/packages/core/src/external/aws/appConfig.ts
@@ -22,7 +22,7 @@ export async function getFeatureFlagValue<T>(
     .promise();
   const configContent = config.Content;
   console.log(
-    `From config with appId=${appId} configId=${configId} envName=${envName} featureFlagName=${featureFlagName} - got config content: ${configContent}`
+    `From config with appId=${appId} configId=${configId} envName=${envName} featureFlagName=${featureFlagName} - got config version: ${config.ConfigurationVersion}`
   );
   if (configContent && config.ContentType && config.ContentType === "application/json") {
     const configContentValue = JSON.parse(configContent.toString());


### PR DESCRIPTION
Ref: metriport/metriport-internal#1040

### Dependencies

none

### Description

Don't log FF contents, its too noisy.

For context, see [this log](https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#logsV2:log-groups/log-group/APIInfrastructureStack-APIFargateServiceTaskDefAPIServerLogGroup35E9518F-7A2oRfufKv3Z/log-events/APIFargateService$252FAPI-Server$252Fbf0406c399044d0c928ea1f6e8f4b98e$3Fstart$3D1698980656752$26refEventId$3D37888534725688643252297167981967795046756001947477016922).

### Release Plan

- nothing special