### PR TITLE
960 delete dup person @ CW

### DIFF
--- a/packages/api/src/external/commonwell/__tests__/organization.ts
+++ b/packages/api/src/external/commonwell/__tests__/organization.ts
@@ -14,7 +14,7 @@ export const getOne = async (orgOid: string): Promise<CWOrganization | undefined
   const cwId = OID_PREFIX.concat(orgOid);
   try {
     const resp = await commonWell.getOneOrg(metriportQueryMeta, cwId);
-    debug(`resp: ${JSON.stringify(resp, null, 2)}`);
+    debug(`resp: `, () => JSON.stringify(resp, null, 2));
     return resp;
   } catch (error) {
     const msg = `[E2E]: Failure getting Org @ CW`;

--- a/packages/api/src/external/commonwell/admin/patch-patient-duplicates.ts
+++ b/packages/api/src/external/commonwell/admin/patch-patient-duplicates.ts
@@ -50,6 +50,7 @@ export async function patchDuplicatedPersonsForPatient(
     const currentLinkedPerson = await commonWell.getPersonById(queryMeta, currentLinkedPersonId);
     if (isEnrolledBy(orgName, currentLinkedPerson)) {
       await commonWell.unenrollPerson(queryMeta, currentLinkedPersonId);
+      await commonWell.deletePerson(queryMeta, currentLinkedPersonId);
     }
   }
 

--- a/packages/api/src/external/commonwell/organization.ts
+++ b/packages/api/src/external/commonwell/organization.ts
@@ -67,13 +67,13 @@ export const create = async (org: Organization): Promise<void> => {
   const commonWell = makeCommonWellAPI(Config.getCWMemberOrgName(), Config.getCWMemberOID());
   try {
     const respCreate = await commonWell.createOrg(metriportQueryMeta, cwOrg);
-    debug(`resp respCreate: ${JSON.stringify(respCreate, null, 2)}`);
+    debug(`resp respCreate: `, () => JSON.stringify(respCreate, null, 2));
     const respAddCert = await commonWell.addCertificateToOrg(
       metriportQueryMeta,
       getCertificate(),
       org.oid
     );
-    debug(`resp respAddCert: ${JSON.stringify(respAddCert, null, 2)}`);
+    debug(`resp respAddCert: `, () => JSON.stringify(respAddCert, null, 2));
   } catch (error) {
     const msg = `Failure creating Org @ CW`;
     log(msg, error);

--- a/packages/api/src/external/commonwell/patient-shared.ts
+++ b/packages/api/src/external/commonwell/patient-shared.ts
@@ -1,14 +1,15 @@
 import {
   CommonWellAPI,
-  getDemographics,
-  getPersonId,
-  isEnrolled,
-  isUnenrolled,
   Patient as CommonwellPatient,
   Person as CommonwellPerson,
   RequestMetadata,
   StrongId,
+  getDemographics,
+  getPersonId,
+  isEnrolled,
+  isUnenrolled,
 } from "@metriport/commonwell-sdk";
+import { driversLicenseURIs } from "@metriport/core/domain/oid";
 import { MetriportError } from "@metriport/core/util/error/metriport-error";
 import _, { minBy } from "lodash";
 import { getPatientWithDependencies } from "../../command/medical/patient/get-patient";
@@ -18,7 +19,6 @@ import { Patient, PatientExternalDataEntry } from "../../domain/medical/patient"
 import BadRequestError from "../../errors/bad-request";
 import { filterTruthy } from "../../shared/filter-map-utils";
 import { capture } from "../../shared/notifications";
-import { driversLicenseURIs } from "@metriport/core/domain/oid";
 import { Util } from "../../shared/util";
 import { LinkStatus } from "../patient-link";
 import { makePersonForPatient } from "./patient-conversion";
@@ -71,7 +71,7 @@ export async function findOrCreatePerson({
   } else {
     // Search by demographics
     const respSearch = await commonWell.searchPersonByPatientDemo(queryMeta, commonwellPatientId);
-    debug(`resp searchPersonByPatientDemo: ${JSON.stringify(respSearch, null, 2)}`);
+    debug(`resp searchPersonByPatientDemo: `, () => JSON.stringify(respSearch, null, 2));
     const persons = respSearch._embedded?.person
       ? respSearch._embedded.person
           .flatMap(p => (p && getPersonId(p) ? p : []))
@@ -119,9 +119,9 @@ export async function findOrCreatePerson({
   }
 
   // If not found, enroll/add person
-  debug(`Enrolling this person: ${JSON.stringify(person, null, 2)}`);
+  debug(`Enrolling this person: `, () => JSON.stringify(person, null, 2));
   const respPerson = await commonWell.enrollPerson(queryMeta, person);
-  debug(`resp enrollPerson: ${JSON.stringify(respPerson, null, 2)}`);
+  debug(`resp enrollPerson: `, () => JSON.stringify(respPerson, null, 2));
   const personId = getPersonId(respPerson);
   if (!personId) {
     const msg = `Could not get person ID from CW response`;

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -1,20 +1,20 @@
 import {
   CommonWellAPI,
-  getIdTrailingSlash,
-  LOLA,
-  organizationQueryMeta,
   Patient as CommonwellPatient,
+  LOLA,
   Person,
   RequestMetadata,
   StrongId,
+  getIdTrailingSlash,
+  organizationQueryMeta,
 } from "@metriport/commonwell-sdk";
+import { oid } from "@metriport/core/domain/oid";
 import { MedicalDataSource } from "..";
 import { Facility } from "../../domain/medical/facility";
 import { Organization } from "../../domain/medical/organization";
 import { Patient, PatientExternalData } from "../../domain/medical/patient";
 import MetriportError from "../../errors/metriport-error";
 import { capture } from "../../shared/notifications";
-import { oid } from "@metriport/core/domain/oid";
 import { Util } from "../../shared/util";
 import { LinkStatus } from "../patient-link";
 import { makeCommonWellAPI } from "./api";
@@ -22,11 +22,11 @@ import { autoUpgradeNetworkLinks } from "./link/shared";
 import { makePersonForPatient, patientToCommonwell } from "./patient-conversion";
 import { setCommonwellId } from "./patient-external-data";
 import {
-  findOrCreatePerson,
   FindOrCreatePersonResponse,
+  PatientDataCommonwell,
+  findOrCreatePerson,
   getMatchingStrongIds,
   getPatientData,
-  PatientDataCommonwell,
 } from "./patient-shared";
 
 const createContext = "cw.patient.create";
@@ -162,11 +162,11 @@ export async function update(patient: Patient, facilityId: string): Promise<void
     try {
       try {
         const respPerson = await commonWell.updatePerson(queryMeta, person, personId);
-        debug(`resp updatePerson: ${JSON.stringify(respPerson, null, 2)}`);
+        debug(`resp updatePerson: `, () => JSON.stringify(respPerson, null, 2));
 
         if (!respPerson.enrolled) {
           const respReenroll = await commonWell.reenrollPerson(queryMeta, personId);
-          debug(`resp reenrolPerson: ${JSON.stringify(respReenroll, null, 2)}`);
+          debug(`resp reenrolPerson: `, () => JSON.stringify(respReenroll, null, 2));
         }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (err: any) {
@@ -219,7 +219,7 @@ export async function update(patient: Patient, facilityId: string): Promise<void
           // safe to get the first one, just need to match one of the person's strong IDs
           strongIds.length ? strongIds[0] : undefined
         );
-        debug(`resp patientLink: ${JSON.stringify(respLink, null, 2)}`);
+        debug(`resp patientLink: `, () => JSON.stringify(respLink, null, 2));
       }
     } catch (err) {
       log(
@@ -265,7 +265,7 @@ export async function remove(patient: Patient, facilityId: string): Promise<void
     commonWell = data.commonWell;
 
     const resp = await commonWell.deletePatient(queryMeta, commonwellPatientId);
-    debug(`resp deletePatient: ${JSON.stringify(resp, null, 2)}`);
+    debug(`resp deletePatient: `, () => JSON.stringify(resp, null, 2));
   } catch (err) {
     console.error(`Failed to delete patient ${patient.id} @ CW: `, err);
     capture.error(err, {
@@ -359,7 +359,7 @@ async function findOrCreatePersonAndLink({
       // safe to get the first one, just need to match one of the person's strong IDs
       strongIds.length ? strongIds[0] : undefined
     );
-    debug(`resp patientLink: ${JSON.stringify(respLink, null, 2)}`);
+    debug(`resp patientLink: `, () => JSON.stringify(respLink, null, 2));
   } catch (err) {
     log(`Error linking Patient<>Person @ CW - personId: ${personId}`);
     throw err;
@@ -392,7 +392,7 @@ async function registerPatient({
 
   const respPatient = await commonWell.registerPatient(queryMeta, commonwellPatient);
 
-  debug(`resp registerPatient: ${JSON.stringify(respPatient, null, 2)}`);
+  debug(`resp registerPatient: `, () => JSON.stringify(respPatient, null, 2));
   const commonwellPatientId = getIdTrailingSlash(respPatient);
   const log = Util.log(`${fnName} - CW patientId ${commonwellPatientId}`);
   if (!commonwellPatientId) {
@@ -438,7 +438,7 @@ async function updatePatient({
     commonwellPatientId
   );
 
-  debug(`resp updatePatient: ${JSON.stringify(respUpdate, null, 2)}`);
+  debug(`resp updatePatient: `, () => JSON.stringify(respUpdate, null, 2));
 
   const patientRefLink = respUpdate._links?.self?.href;
   if (!patientRefLink) {

--- a/packages/api/src/shared/log.ts
+++ b/packages/api/src/shared/log.ts
@@ -2,6 +2,9 @@ import { inspect } from "node:util";
 import { ZodError } from "zod";
 import { Config } from "./config";
 
+/**
+ * @deprecated Use @metriport/core instead
+ */
 //eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function debug(msg: string, ...optionalParams: any[]): void {
   if (Config.isCloudEnv()) return;

--- a/packages/core/src/util/__tests__/log.test.ts
+++ b/packages/core/src/util/__tests__/log.test.ts
@@ -1,0 +1,78 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { faker } from "@faker-js/faker";
+import { log as _log } from "../log";
+
+let consoleLog_mock: jest.SpyInstance;
+beforeAll(() => {
+  jest.restoreAllMocks();
+  consoleLog_mock = jest.spyOn(global.console, "log");
+});
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe("log", () => {
+  it("logs msg without prefix", async () => {
+    const msg = faker.lorem.sentence();
+    const log = _log();
+    log(msg);
+    expect(consoleLog_mock).toHaveBeenCalledWith(msg);
+  });
+
+  it("logs msg with prefix", async () => {
+    const prefix = faker.lorem.word();
+    const msg = faker.lorem.sentence();
+    const log = _log(prefix);
+    log(msg);
+    expect(consoleLog_mock).toHaveBeenCalledWith(`[${prefix}] ${msg}`);
+  });
+
+  it("logs msg with suffix", async () => {
+    const prefix = faker.lorem.word();
+    const suffix = faker.lorem.word();
+    const msg = faker.lorem.sentence();
+    const log = _log(prefix, suffix);
+    log(msg);
+    expect(consoleLog_mock).toHaveBeenCalledWith(`[${prefix}] ${msg}`, suffix);
+  });
+
+  it("logs msg additional string param", async () => {
+    const prefix = faker.lorem.word();
+    const msg = faker.lorem.sentence();
+    const log = _log(prefix);
+    const param = faker.lorem.word();
+    log(msg, param);
+    expect(consoleLog_mock).toHaveBeenCalledWith(`[${prefix}] ${msg}`, param);
+  });
+
+  it("logs msg additional number param", async () => {
+    const prefix = faker.lorem.word();
+    const msg = faker.lorem.sentence();
+    const log = _log(prefix);
+    const param = faker.number.int();
+    log(msg, param);
+    expect(consoleLog_mock).toHaveBeenCalledWith(`[${prefix}] ${msg}`, param);
+  });
+
+  it("logs msg additional boolean param", async () => {
+    const prefix = faker.lorem.word();
+    const msg = faker.lorem.sentence();
+    const log = _log(prefix);
+    const param = faker.datatype.boolean();
+    log(msg, param);
+    expect(consoleLog_mock).toHaveBeenCalledWith(`[${prefix}] ${msg}`, param);
+  });
+
+  it("logs msg additional function param", async () => {
+    const prefix = faker.lorem.word();
+    const msg = faker.lorem.sentence();
+    const log = _log(prefix);
+    const paramStr = faker.lorem.word();
+    const param = () => paramStr;
+    log(msg, param);
+    expect(consoleLog_mock).toHaveBeenCalledWith(`[${prefix}] ${msg}`, param());
+  });
+});

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -7,6 +7,12 @@ import { getEnvVar } from "./env-var";
  *   environment where core is being used
  */
 export class Config {
+  static readonly PROD_ENV = "production";
+
+  static isCloudEnv(): boolean {
+    return process.env.NODE_ENV === this.PROD_ENV;
+  }
+
   static getSlackAlertUrl(): string | undefined {
     return getEnvVar("SLACK_ALERT_URL");
   }

--- a/packages/core/src/util/log.ts
+++ b/packages/core/src/util/log.ts
@@ -1,13 +1,21 @@
-export function log(prefix: string, suffix?: string) {
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (msg: string, ...optionalParams: any[]): void =>
-    optionalParams
-      ? console.log(`[${prefix}] ${msg}`, ...[...optionalParams, ...(suffix ? [suffix] : [])])
-      : console.log(`[${prefix}] ${msg} - ${suffix}`);
+import { Config } from "./config";
+
+type LogParamBasic = string | number | boolean | unknown | null | undefined;
+export type LogParam = LogParamBasic | (() => LogParamBasic);
+
+export function log(prefix?: string, suffix?: string) {
+  return (msg: string, ...optionalParams: LogParam[]): void => {
+    const actualParams = (optionalParams ?? []).map(p => (typeof p === "function" ? p() : p));
+    return console.log(
+      `${prefix ? `[${prefix}] ` : ``}${msg}`,
+      ...[...actualParams, ...(suffix ? [suffix] : [])]
+    );
+  };
 }
 
-// TODO: implement environment-based debug - see package/api/src/shared/log.ts
 export function debug(prefix: string, suffix?: string) {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  if (Config.isCloudEnv()) () => {};
   return log(prefix, suffix);
 }
 

--- a/packages/utils/src/commonwell/doc-query-shared.ts
+++ b/packages/utils/src/commonwell/doc-query-shared.ts
@@ -57,10 +57,10 @@ export async function queryDocsForPatient({
 
   const metriportAPI = new MetriportMedicalApi(apiKey, {
     baseAddress: apiUrl,
-    // TODO 1106 Enable this
-    // triggerWHNotifications: triggerWHNotificationsToCx
   });
   async function triggerDocQuery(patientId: string): Promise<void> {
+    // TODO 1106 send this along the request
+    // triggerWHNotificationsToCx
     await axios.post(`${apiUrl}/internal/docs/query?cxId=${cxId}&patientId=${patientId}`);
   }
 


### PR DESCRIPTION
Ref: metriport/metriport-internal#960

### Dependencies

none

### Description

- delete dup person @ CW if created by us
- update `todo 1106`, enhanced coverage
- update log/debug code to minimize noise on cloud env

### Release Plan

- nothing special
- staging
   - [ ] merge this
   - [ ] test patching dup of patient `01899910-5311-7bca-8425-5b2fd125b17a`, cx ID `d94d0c54-3f9d-4b66-9f4d-4fce878efc88`