### PR TITLE
1195 make envType required to build lambdas

### DIFF
--- a/packages/core/src/util/__tests__/env-var.test.ts
+++ b/packages/core/src/util/__tests__/env-var.test.ts
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { faker } from "@faker-js/faker";
+import { getEnvType } from "../env-var";
+
+const envTypeVarName = "ENV_TYPE";
+let originalEnvType: string | undefined = undefined;
+
+beforeAll(() => {
+  jest.restoreAllMocks();
+});
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  originalEnvType = process.env[envTypeVarName];
+});
+afterEach(() => {
+  jest.resetAllMocks();
+  process.env[envTypeVarName] = originalEnvType;
+});
+
+const setEnvType = (v: string) => (process.env[envTypeVarName] = v);
+
+describe("getEnvType", () => {
+  it("returns staging", async () => {
+    const expectedEnvType = "staging";
+    setEnvType(expectedEnvType);
+    const res = getEnvType();
+    expect(res).toEqual(expectedEnvType);
+  });
+
+  it("returns staging", async () => {
+    const expectedEnvType = "sandbox";
+    setEnvType(expectedEnvType);
+    const res = getEnvType();
+    expect(res).toEqual(expectedEnvType);
+  });
+
+  it("returns staging", async () => {
+    const expectedEnvType = "production";
+    setEnvType(expectedEnvType);
+    const res = getEnvType();
+    expect(res).toEqual(expectedEnvType);
+  });
+
+  it("fails when development", async () => {
+    setEnvType("development");
+    expect(() => getEnvType()).toThrow();
+  });
+
+  it("fails when invalid envType", async () => {
+    setEnvType(faker.lorem.word());
+    expect(() => getEnvType()).toThrow();
+  });
+
+  it("fails when empty envType", async () => {
+    setEnvType("");
+    expect(() => getEnvType()).toThrow();
+  });
+});

--- a/packages/core/src/util/env-var.ts
+++ b/packages/core/src/util/env-var.ts
@@ -1,3 +1,11 @@
+import { MetriportError } from "./error/metriport-error";
+
+export enum EnvType {
+  production = "production",
+  sandbox = "sandbox",
+  staging = "staging",
+}
+
 export const getEnvVar = (varName: string): string | undefined => process.env[varName];
 
 export const getEnvVarOrFail = (varName: string): string => {
@@ -7,3 +15,12 @@ export const getEnvVarOrFail = (varName: string): string => {
   }
   return value;
 };
+
+export function getEnvType(): EnvType {
+  const envType = getEnvVarOrFail("ENV_TYPE");
+  const envTypeValues = Object.values(EnvType).map(v => v.toString());
+  if (!envTypeValues.includes(envType)) {
+    throw new MetriportError(`Invalid ENV_TYPE`, undefined, { envType });
+  }
+  return envType as EnvType;
+}

--- a/packages/infra/lib/api-stack/ccda-search-connector.ts
+++ b/packages/infra/lib/api-stack/ccda-search-connector.ts
@@ -8,7 +8,8 @@ import * as s3 from "aws-cdk-lib/aws-s3";
 import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
 import { IQueue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
-import { getConfig, METRICS_NAMESPACE } from "../shared/config";
+import { EnvType } from "../env-type";
+import { METRICS_NAMESPACE, getConfig } from "../shared/config";
 import { createLambda as defaultCreateLambda } from "../shared/lambda";
 import { LambdaLayers } from "../shared/lambda-layers";
 import OpenSearchConstruct, { OpenSearchConstructProps } from "../shared/open-search-construct";
@@ -83,6 +84,7 @@ export function setup({
   vpc,
   ccdaS3Bucket,
   lambdaLayers,
+  envType,
   alarmSnsAction,
 }: {
   stack: Construct;
@@ -90,6 +92,7 @@ export function setup({
   vpc: IVpc;
   ccdaS3Bucket: s3.IBucket;
   lambdaLayers: LambdaLayers;
+  envType: EnvType;
   alarmSnsAction?: SnsAction;
 }): {
   queue: IQueue;
@@ -124,6 +127,7 @@ export function setup({
     visibilityTimeout,
     maxReceiveCount,
     lambdaLayers: [lambdaLayers.shared],
+    envType,
     alarmSnsAction,
   });
 
@@ -138,9 +142,9 @@ export function setup({
     entry: "sqs-to-opensearch-xml",
     layers: [lambdaLayers.shared],
     memory,
+    envType: config.environmentType,
     envVars: {
       METRICS_NAMESPACE,
-      ENV_TYPE: config.environmentType,
       DELAY_WHEN_RETRY_SECONDS: delayWhenRetrying.toSeconds().toString(),
       ...(config.lambdasSentryDSN ? { SENTRY_DSN: config.lambdasSentryDSN } : {}),
       QUEUE_URL: queue.queueUrl,

--- a/packages/infra/lib/api-stack/doc-query-checker.ts
+++ b/packages/infra/lib/api-stack/doc-query-checker.ts
@@ -61,9 +61,9 @@ export function createDocQueryChecker(props: DocQueryCheckerProps): Lambda | und
     memory: lambdaMemory,
     timeout: lambdaTimeout,
     alarmSnsAction,
+    envType: config.environmentType,
     envVars: {
       TIMEOUT_MILLIS: String(httpTimeout.toMilliseconds()),
-      ENV_TYPE: config.environmentType,
       ...(config.lambdasSentryDSN ? { SENTRY_DSN: config.lambdasSentryDSN } : {}),
     },
   });

--- a/packages/infra/lib/api-stack/document-upload.ts
+++ b/packages/infra/lib/api-stack/document-upload.ts
@@ -32,8 +32,8 @@ export function createLambda({
     vpc,
     entry: "document-uploader",
     layers: [lambdaLayers.shared],
+    envType,
     envVars: {
-      ENV_TYPE: envType,
       API_URL: `http://${apiService.loadBalancer.loadBalancerDnsName}`,
       MEDICAL_DOCUMENTS_DESTINATION_BUCKET: medicalDocumentsBucket.bucketName,
       ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),

--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -51,10 +51,12 @@ function settings() {
 export function createQueueAndBucket({
   stack,
   lambdaLayers,
+  envType,
   alarmSnsAction,
 }: {
   stack: Construct;
   lambdaLayers: LambdaLayers;
+  envType: EnvType;
   alarmSnsAction?: SnsAction;
 }): FHIRConnector {
   const config = getConfig();
@@ -69,6 +71,7 @@ export function createQueueAndBucket({
     maxReceiveCount,
     createRetryLambda: true,
     lambdaLayers: [lambdaLayers.shared],
+    envType,
     alarmSnsAction,
   });
 
@@ -134,9 +137,9 @@ export function createLambda({
     entry: "sqs-to-converter",
     layers: [lambdaLayers.shared],
     memory: lambdaMemory,
+    envType,
     envVars: {
       METRICS_NAMESPACE,
-      ENV_TYPE: envType,
       AXIOS_TIMEOUT_SECONDS: axiosTimeout.toSeconds().toString(),
       MAX_TIMEOUT_RETRIES: String(maxTimeoutRetries),
       DELAY_WHEN_RETRY_SECONDS: delayWhenRetrying.toSeconds().toString(),

--- a/packages/infra/lib/api-stack/fhir-server-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-server-connector.ts
@@ -84,6 +84,7 @@ export function createConnector({
     visibilityTimeout,
     maxReceiveCount,
     lambdaLayers: [lambdaLayers.shared],
+    envType,
     alarmSnsAction,
   });
 
@@ -98,9 +99,9 @@ export function createConnector({
     entry: "sqs-to-fhir",
     layers: [lambdaLayers.shared],
     memory: lambdaMemory,
+    envType,
     envVars: {
       METRICS_NAMESPACE,
-      ENV_TYPE: envType,
       MAX_TIMEOUT_RETRIES: String(maxTimeoutRetries),
       DELAY_WHEN_RETRY_SECONDS: delayWhenRetrying.toSeconds().toString(),
       ...(config.lambdasSentryDSN ? { SENTRY_DSN: config.lambdasSentryDSN } : {}),

--- a/packages/infra/lib/ihe-stack.ts
+++ b/packages/infra/lib/ihe-stack.ts
@@ -54,8 +54,8 @@ export function createIHEStack(stack: Construct, props: IHEStackProps) {
     name: "IHE",
     entry: "ihe",
     layers: [props.lambdaLayers.shared],
+    envType: props.config.environmentType,
     envVars: {
-      ENV_TYPE: props.config.environmentType,
       ...(props.config.lambdasSentryDSN ? { SENTRY_DSN: props.config.lambdasSentryDSN } : {}),
     },
     vpc: props.vpc,

--- a/packages/infra/lib/shared/lambda.ts
+++ b/packages/infra/lib/shared/lambda.ts
@@ -8,8 +8,8 @@ import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import {
   Architecture,
   Code,
-  Function as Lambda,
   ILayerVersion,
+  Function as Lambda,
   Runtime,
   SingletonFunction,
 } from "aws-cdk-lib/aws-lambda";
@@ -17,7 +17,8 @@ import * as lambda_node from "aws-cdk-lib/aws-lambda-nodejs";
 import { FilterPattern } from "aws-cdk-lib/aws-logs";
 import { IQueue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
-import { getConfig, METRICS_NAMESPACE } from "./config";
+import { EnvType } from "../env-type";
+import { METRICS_NAMESPACE, getConfig } from "./config";
 
 export const DEFAULT_LAMBDA_TIMEOUT = Duration.seconds(30);
 export const MAXIMUM_LAMBDA_TIMEOUT = Duration.minutes(15);
@@ -44,6 +45,7 @@ export interface LambdaProps extends StackProps {
   readonly subnets?: ISubnet[];
   readonly role?: iam.Role;
   readonly envVars?: { [key: string]: string };
+  readonly envType: EnvType;
   readonly timeout?: Duration;
   readonly memory?: number;
   readonly reservedConcurrentExecutions?: number;
@@ -74,7 +76,10 @@ export function createLambda(props: LambdaProps): Lambda {
     memorySize: props.memory,
     reservedConcurrentExecutions: props.reservedConcurrentExecutions,
     role: props.role ?? undefined,
-    environment: props.envVars,
+    environment: {
+      ...props.envVars,
+      ENV_TYPE: props.envType,
+    },
     retryAttempts: props.retryAttempts ?? 0,
     maxEventAge: props.maxEventAge ?? undefined,
     architecture: props.architecture ?? Architecture.X86_64,

--- a/packages/infra/lib/shared/sqs.ts
+++ b/packages/infra/lib/shared/sqs.ts
@@ -6,6 +6,7 @@ import { IGrantable } from "aws-cdk-lib/aws-iam";
 import { ILayerVersion } from "aws-cdk-lib/aws-lambda";
 import { IQueue, Queue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs/lib/construct";
+import { EnvType } from "../env-type";
 import { DEFAULT_LAMBDA_TIMEOUT, createRetryLambda } from "./lambda";
 
 /**
@@ -35,6 +36,7 @@ export type QueueProps = (StandardQueueProps | FifoQueueProps) & {
         createDLQ?: true | undefined;
         createRetryLambda?: true | undefined;
         lambdaLayers: ILayerVersion[];
+        envType: EnvType;
       }
   );
 

--- a/packages/lambdas/src/document-downloader.ts
+++ b/packages/lambdas/src/document-downloader.ts
@@ -9,9 +9,10 @@ import { oid } from "@metriport/core/domain/oid";
 import { DownloadResult } from "@metriport/core/external/commonwell/document/document-downloader";
 import { DocumentDownloaderLambdaRequest } from "@metriport/core/external/commonwell/document/document-downloader-lambda";
 import { DocumentDownloaderLocal } from "@metriport/core/external/commonwell/document/document-downloader-local";
+import { getEnvType } from "@metriport/core/util/env-var";
 import * as Sentry from "@sentry/serverless";
 import { capture } from "./shared/capture";
-import { getEnv, getEnvOrFail, getEnvTypeRaw, isProduction } from "./shared/env";
+import { getEnv, getEnvOrFail, isProduction } from "./shared/env";
 
 // Keep this as early on the file as possible
 capture.init();
@@ -32,7 +33,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(
     capture.setUser({ id: cxId });
     capture.setExtra({ lambdaName });
     console.log(
-      `Running with envType: ${getEnvTypeRaw()}, apiMode: ${apiMode}, region: ${region}, ` +
+      `Running with envType: ${getEnvType()}, apiMode: ${apiMode}, region: ${region}, ` +
         `bucketName: ${bucketName}, orgName: ${orgName}, orgOid: ${orgOid}, ` +
         `npi: ${npi}, cxId: ${cxId}, fileInfo: ${JSON.stringify(fileInfo)}, ` +
         `document: ${JSON.stringify(document)}`

--- a/packages/lambdas/src/document-downloader.ts
+++ b/packages/lambdas/src/document-downloader.ts
@@ -11,7 +11,7 @@ import { DocumentDownloaderLambdaRequest } from "@metriport/core/external/common
 import { DocumentDownloaderLocal } from "@metriport/core/external/commonwell/document/document-downloader-local";
 import * as Sentry from "@sentry/serverless";
 import { capture } from "./shared/capture";
-import { getEnv, getEnvOrFail } from "./shared/env";
+import { getEnv, getEnvOrFail, getEnvTypeRaw, isProduction } from "./shared/env";
 
 // Keep this as early on the file as possible
 capture.init();
@@ -23,9 +23,8 @@ const region = getEnvOrFail("AWS_REGION");
 const bucketName = getEnvOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
 const cwOrgCertificateSecret = getEnvOrFail("CW_ORG_CERTIFICATE");
 const cwOrgPrivateKeySecret = getEnvOrFail("CW_ORG_PRIVATE_KEY");
-const envType = getEnvOrFail("ENV_TYPE");
 
-const apiMode = envType === "production" ? APIMode.production : APIMode.integration;
+const apiMode = isProduction() ? APIMode.production : APIMode.integration;
 
 export const handler = Sentry.AWSLambda.wrapHandler(
   async (req: DocumentDownloaderLambdaRequest): Promise<DownloadResult> => {
@@ -33,7 +32,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(
     capture.setUser({ id: cxId });
     capture.setExtra({ lambdaName });
     console.log(
-      `Running with envType: ${envType}, apiMode: ${apiMode}, region: ${region}, ` +
+      `Running with envType: ${getEnvTypeRaw()}, apiMode: ${apiMode}, region: ${region}, ` +
         `bucketName: ${bucketName}, orgName: ${orgName}, orgOid: ${orgOid}, ` +
         `npi: ${npi}, cxId: ${cxId}, fileInfo: ${JSON.stringify(fileInfo)}, ` +
         `document: ${JSON.stringify(document)}`

--- a/packages/lambdas/src/shared/capture.ts
+++ b/packages/lambdas/src/shared/capture.ts
@@ -1,10 +1,10 @@
 import { Capture } from "@metriport/core/util/capture";
+import { getEnvType, getEnvVar } from "@metriport/core/util/env-var";
 import * as Sentry from "@sentry/serverless";
 import { Extras } from "@sentry/types";
 import { ScopeContext } from "@sentry/types/types/scope";
-import { getEnv, getEnvTypeRaw } from "./env";
 
-const sentryDsn = getEnv("SENTRY_DSN");
+const sentryDsn = getEnvVar("SENTRY_DSN");
 
 export type UserData = Pick<Sentry.AWSLambda.User, "id" | "email">;
 
@@ -26,7 +26,7 @@ export const capture = {
     Sentry.init({
       dsn: sentryDsn,
       enabled: sentryDsn != null,
-      environment: getEnvTypeRaw(),
+      environment: getEnvType(),
       tracesSampleRate,
     });
   },

--- a/packages/lambdas/src/shared/capture.ts
+++ b/packages/lambdas/src/shared/capture.ts
@@ -2,9 +2,8 @@ import { Capture } from "@metriport/core/util/capture";
 import * as Sentry from "@sentry/serverless";
 import { Extras } from "@sentry/types";
 import { ScopeContext } from "@sentry/types/types/scope";
-import { getEnv, getEnvOrFail } from "./env";
+import { getEnv, getEnvTypeRaw } from "./env";
 
-const envType = getEnvOrFail("ENV_TYPE");
 const sentryDsn = getEnv("SENTRY_DSN");
 
 export type UserData = Pick<Sentry.AWSLambda.User, "id" | "email">;
@@ -27,7 +26,7 @@ export const capture = {
     Sentry.init({
       dsn: sentryDsn,
       enabled: sentryDsn != null,
-      environment: envType,
+      environment: getEnvTypeRaw(),
       tracesSampleRate,
     });
   },

--- a/packages/lambdas/src/shared/env.ts
+++ b/packages/lambdas/src/shared/env.ts
@@ -1,8 +1,34 @@
+import {
+  EnvType,
+  getEnvVar as coreGetEnvVar,
+  getEnvVarOrFail as coreGetEnvVarOrFail,
+} from "@metriport/core/util/env-var";
+
+/**
+ * @deprecated Use core's instead.
+ */
 export function getEnv(name: string) {
-  return process.env[name];
+  return coreGetEnvVar(name);
 }
+/**
+ * @deprecated Use core's instead.
+ */
 export function getEnvOrFail(name: string) {
-  const value = getEnv(name);
-  if (!value || value.trim().length < 1) throw new Error(`Missing env var ${name}`);
-  return value;
+  return coreGetEnvVarOrFail(name);
+}
+
+export function getEnvTypeRaw(): string | undefined {
+  return coreGetEnvVar("ENV_TYPE");
+}
+
+export function isProduction(): boolean {
+  return getEnvTypeRaw() === EnvType.production;
+}
+
+export function isSandbox(): boolean {
+  return getEnvTypeRaw() === EnvType.sandbox;
+}
+
+export function isStaging(): boolean {
+  return getEnvTypeRaw() === EnvType.staging;
 }

--- a/packages/lambdas/src/shared/env.ts
+++ b/packages/lambdas/src/shared/env.ts
@@ -1,5 +1,6 @@
 import {
   EnvType,
+  getEnvType,
   getEnvVar as coreGetEnvVar,
   getEnvVarOrFail as coreGetEnvVarOrFail,
 } from "@metriport/core/util/env-var";
@@ -17,18 +18,14 @@ export function getEnvOrFail(name: string) {
   return coreGetEnvVarOrFail(name);
 }
 
-export function getEnvTypeRaw(): string | undefined {
-  return coreGetEnvVar("ENV_TYPE");
-}
-
 export function isProduction(): boolean {
-  return getEnvTypeRaw() === EnvType.production;
+  return getEnvType() === EnvType.production;
 }
 
 export function isSandbox(): boolean {
-  return getEnvTypeRaw() === EnvType.sandbox;
+  return getEnvType() === EnvType.sandbox;
 }
 
 export function isStaging(): boolean {
-  return getEnvTypeRaw() === EnvType.staging;
+  return getEnvType() === EnvType.staging;
 }


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Dependencies

none

### Description

While working on #1195 I needed to check if the environment is staging. This should be simple, but it turns out we've been duplicating code over and over again, because we didn't want to create shared functions that would move the acquisition of the `ENV_TYPE` var from the lambda code to some shared code - which increases the chance of runtime error.

So I took the plunge and made `ENV_TYPE` required to create lambdas - and created shared functions to check the environment type.

### Release Plan

- infra changes
- validate on staging executing each lambda individually