### PR TITLE
1240 increase memory of CCDAOpenSearchLambda

### DIFF
--- a/.github/workflows/fern-check.yml
+++ b/.github/workflows/fern-check.yml
@@ -6,7 +6,7 @@ on:
     branches: [master, develop]
 
 jobs:
-  check:
+  fern-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/packages/infra/lib/api-stack/ccda-search-connector.ts
+++ b/packages/infra/lib/api-stack/ccda-search-connector.ts
@@ -58,7 +58,7 @@ export function settings(): {
     },
     connectorName: "CCDAOpenSearch",
     lambda: {
-      memory: 512,
+      memory: isLarge ? 1024 : 512,
       // Number of messages the lambda pull from SQS at once
       batchSize: 1,
       // Max number of concurrent instances of the lambda that an Amazon SQS event source can invoke [2 - 1000].


### PR DESCRIPTION
Ref: metriport/metriport-internal#1240

### Dependencies

none

### Description

Increase memory of CCDAOpenSearchLambda from 512 to 1024 MB

Also renamed the Fern check so we know what's about when we look at the PR's checks - this is what it looked like:

<img width="212" alt="image" src="https://github.com/metriport/metriport/assets/2132564/e496616f-5e2d-4dc6-bd84-5754b6eec092">

### Release Plan

- nothing special, asap