### PR TITLE
1096 fix FHIR E2E test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7443,15 +7443,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@ngneat/falso": {
-      "version": "6.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "seedrandom": "3.0.5",
-        "uuid": "8.3.2"
-      }
-    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "license": "MIT",
@@ -33491,11 +33482,6 @@
       "version": "2.7.0",
       "license": "BSD-3-Clause"
     },
-    "node_modules/seedrandom": {
-      "version": "3.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "license": "MIT"
@@ -37834,7 +37820,6 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^8.0.2",
-        "@ngneat/falso": "^6.4.0",
         "@tsconfig/node18": "^1.0.1",
         "@types/convert-units": "^2.3.5",
         "@types/cors": "^2.8.12",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -69,7 +69,6 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@ngneat/falso": "^6.4.0",
     "@tsconfig/node18": "^1.0.1",
     "@types/convert-units": "^2.3.5",
     "@types/cors": "^2.8.12",

--- a/packages/api/src/command/medical/organization/__tests__/create-organization.test.ts
+++ b/packages/api/src/command/medical/organization/__tests__/create-organization.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { randNumber } from "@ngneat/falso";
+import { faker } from "@faker-js/faker";
 import { v4 as uuidv4 } from "uuid";
 import {
   makeOrganization,
@@ -16,7 +16,7 @@ let createTenantIfNotExistsMock: jest.SpyInstance;
 
 beforeAll(() => {
   jest.restoreAllMocks();
-  const organizationNumber = randNumber();
+  const organizationNumber = faker.number.int();
   createOrganizationId_mock = jest.spyOn(createId, "createOrganizationId").mockResolvedValue({
     oid: makeOrganizationOID(organizationNumber),
     organizationNumber,
@@ -48,7 +48,7 @@ describe("createOrganization", () => {
 
   it("creates org with oid and number from createOrganizationId", async () => {
     OrganizationModel.findOne = jest.fn().mockResolvedValueOnce(undefined);
-    const organizationNumber = randNumber();
+    const organizationNumber = faker.number.int();
     const oid = makeOrganizationOID(organizationNumber);
     createOrganizationId_mock.mockResolvedValueOnce({ oid, organizationNumber });
     const org = makeOrganization({ oid, organizationNumber });
@@ -64,7 +64,7 @@ describe("createOrganization", () => {
 
   it("returns creates org", async () => {
     OrganizationModel.findOne = jest.fn().mockResolvedValueOnce(undefined);
-    const organizationNumber = randNumber();
+    const organizationNumber = faker.number.int();
     const id = makeOrganizationOID(organizationNumber);
     createOrganizationId_mock.mockResolvedValueOnce({ id, organizationNumber });
     const org = makeOrganization({ id, organizationNumber });

--- a/packages/api/src/domain/__tests__/base-domain.ts
+++ b/packages/api/src/domain/__tests__/base-domain.ts
@@ -1,11 +1,11 @@
-import { randUuid } from "@ngneat/falso";
+import { faker } from "@faker-js/faker";
 import { BaseDomain } from "../base-domain";
 
 export const makeBaseDomain = ({ id }: { id?: string } = {}): BaseDomain => {
   return {
-    id: id ?? randUuid(),
+    id: id ?? faker.string.uuid(),
     createdAt: new Date(),
     updatedAt: new Date(),
-    eTag: randUuid(),
+    eTag: faker.string.uuid(),
   };
 };

--- a/packages/api/src/domain/medical/__tests__/location-address.ts
+++ b/packages/api/src/domain/medical/__tests__/location-address.ts
@@ -1,12 +1,12 @@
-import { randCity, randState, randStreetName, randZipCode } from "@ngneat/falso";
+import { fakerEN_US as faker } from "@faker-js/faker";
 import { AddressStrict } from "../location-address";
 
 export const makeAddressStrict = (): AddressStrict => {
   return {
-    addressLine1: randStreetName(),
-    zip: randZipCode(),
-    city: randCity(),
-    state: randState(),
+    addressLine1: faker.location.streetAddress(),
+    zip: faker.location.zipCode(),
+    city: faker.location.city(),
+    state: faker.location.state({ abbreviated: true }),
     country: "US",
   };
 };

--- a/packages/api/src/domain/medical/__tests__/patient.ts
+++ b/packages/api/src/domain/medical/__tests__/patient.ts
@@ -1,7 +1,7 @@
-import { rand, randFirstName, randLastName, randPastDate, randUuid } from "@ngneat/falso";
+import { faker } from "@faker-js/faker";
+import { USState } from "@metriport/core/domain/geographic-locations";
 import dayjs from "dayjs";
 import { ISO_DATE } from "../../../shared/date";
-import { USState } from "@metriport/core/domain/geographic-locations";
 import { makeBaseDomain } from "../../__tests__/base-domain";
 import { Patient, PatientData, PersonalIdentifier } from "../patient";
 import { makeAddressStrict } from "./location-address";
@@ -9,16 +9,16 @@ import { makeAddressStrict } from "./location-address";
 export const makePersonalIdentifier = (): PersonalIdentifier => {
   return {
     type: "driversLicense",
-    value: randUuid(),
-    state: rand(Object.values(USState)),
+    value: faker.string.uuid(),
+    state: faker.helpers.arrayElement(Object.values(USState)),
   };
 };
 export const makePatientData = (data: Partial<PatientData> = {}): PatientData => {
   return {
-    firstName: data.firstName ?? randFirstName(),
-    lastName: data.lastName ?? randLastName(),
-    dob: data.dob ?? dayjs(randPastDate()).format(ISO_DATE),
-    genderAtBirth: data.genderAtBirth ?? rand(["F", "M"]),
+    firstName: data.firstName ?? faker.person.firstName(),
+    lastName: data.lastName ?? faker.person.lastName(),
+    dob: data.dob ?? dayjs(faker.date.past()).format(ISO_DATE),
+    genderAtBirth: data.genderAtBirth ?? faker.helpers.arrayElement(["F", "M"]),
     personalIdentifiers: data.personalIdentifiers ?? [makePersonalIdentifier()],
     address: data.address ?? [makeAddressStrict()],
     documentQueryProgress: data.documentQueryProgress,
@@ -30,8 +30,8 @@ export const makePatient = (params: Partial<Patient> = {}): Patient => {
   return {
     ...makeBaseDomain(),
     ...(params.id ? { id: params.id } : {}),
-    cxId: params.cxId ?? randUuid(),
-    facilityIds: params.facilityIds ?? [randUuid()],
+    cxId: params.cxId ?? faker.string.uuid(),
+    facilityIds: params.facilityIds ?? [faker.string.uuid()],
     data: makePatientData(params.data),
   };
 };

--- a/packages/api/src/external/commonwell/__tests__/error-categories.test.ts
+++ b/packages/api/src/external/commonwell/__tests__/error-categories.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+import { faker } from "@faker-js/faker";
 import { OperationOutcome } from "@metriport/commonwell-sdk";
-import { rand } from "@ngneat/falso";
 import { errorCategories, ErrorCategory, groupCWErrors } from "../error-categories";
 
 const makeOperationOutcomeError = (category?: ErrorCategory): OperationOutcome => {
@@ -27,7 +27,7 @@ const makeOperationOutcomeError = (category?: ErrorCategory): OperationOutcome =
 describe("groupCWErrors", () => {
   it("returns categories of each error", async () => {
     const cat1 = "Too many results found";
-    const cat2 = rand(errorCategories.slice(1));
+    const cat2 = faker.helpers.arrayElement(errorCategories.slice(1));
     const errors = [
       makeOperationOutcomeError(cat1),
       makeOperationOutcomeError(cat2),

--- a/packages/api/src/routes/medical/__tests__/document.test.e2e.ts
+++ b/packages/api/src/routes/medical/__tests__/document.test.e2e.ts
@@ -1,6 +1,4 @@
-import { randNumber, randUuid } from "@ngneat/falso";
-import * as patientCmd from "../../../command/medical/patient/get-patient";
-import * as docCmd from "../../../external/fhir/document/search-documents";
+import { faker } from "@faker-js/faker";
 import { makePatient } from "../../../domain/medical/__tests__/patient";
 import { api } from "../../__tests__/shared";
 
@@ -8,12 +6,8 @@ jest.setTimeout(15000);
 
 const path = "/medical/v1/document";
 
-let getDocumentsMock: jest.SpyInstance;
-let getPatientOrFailMock: jest.SpyInstance;
 beforeEach(() => {
   jest.restoreAllMocks();
-  getDocumentsMock = jest.spyOn(docCmd, "searchDocuments");
-  getPatientOrFailMock = jest.spyOn(patientCmd, "getPatientOrFail");
 });
 
 describe("Integration Document routes", () => {
@@ -21,7 +15,7 @@ describe("Integration Document routes", () => {
     it("returns response from FHIR server", async () => {
       try {
         // const patient = makePatient({ id: "2.16.840.1.113883.3.9621.5.2005.2.100" });
-        const patient = makePatient({ id: randUuid() });
+        const patient = makePatient({ id: faker.string.uuid() });
         const res = await api.get(path, { params: { patientId: patient.id } });
         expect(res.status).toBe(200);
         expect(res.data).toBeTruthy();
@@ -33,41 +27,6 @@ describe("Integration Document routes", () => {
           );
           return;
         }
-        console.log(error);
-        throw error;
-      }
-    });
-
-    // To enable this - which requires mocks, we'd need to run the server along the test process.
-    it.skip("returns processing and progress", async () => {
-      const expectedStatus = "processing";
-      const total = randNumber({ min: 10, mx: 100 });
-      const expectedProgress = {
-        total: total,
-        completed: Math.round(total / 2),
-      };
-      try {
-        getDocumentsMock.mockResolvedValueOnce([]);
-
-        const patient = makePatient({ id: randUuid() });
-        patient.data.documentQueryProgress = {
-          download: {
-            status: expectedStatus,
-            total: expectedProgress.total,
-            successful: expectedProgress.completed,
-          },
-        };
-
-        getPatientOrFailMock.mockResolvedValueOnce(patient);
-
-        const res = await api.get(path, { params: { patientId: patient.id } });
-
-        expect(res.status).toBe(200);
-        expect(res.data).toBeTruthy();
-        expect(res.data).toEqual({
-          documents: [],
-        });
-      } catch (error) {
         console.log(error);
         throw error;
       }

--- a/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/patient.test.e2e.ts
+++ b/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/patient.test.e2e.ts
@@ -1,13 +1,14 @@
 import * as dotenv from "dotenv";
 dotenv.config({ path: ".env.test" });
 // Keep dotenv import and config before everything else
+import { faker } from "@faker-js/faker";
 import { makePatient } from "@metriport/core/external/fhir/__tests__/patient";
 import { AxiosResponse } from "axios";
 import { api } from "../../../../__tests__/shared";
 
 jest.setTimeout(15000);
 
-const patient = makePatient();
+const patient = makePatient({ firstName: `${faker.name.firstName()}_${faker.string.nanoid()}` });
 
 describe("Integration FHIR Patient", () => {
   test("create patient", async () => {

--- a/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/patient.test.e2e.ts
+++ b/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/patient.test.e2e.ts
@@ -8,7 +8,7 @@ import { api } from "../../../../__tests__/shared";
 
 jest.setTimeout(15000);
 
-const patient = makePatient({ firstName: `${faker.name.firstName()}_${faker.string.nanoid()}` });
+const patient = makePatient({ firstName: `${faker.person.firstName()}_${faker.string.nanoid()}` });
 
 describe("Integration FHIR Patient", () => {
   test("create patient", async () => {

--- a/packages/core/src/external/fhir/__tests__/patient.ts
+++ b/packages/core/src/external/fhir/__tests__/patient.ts
@@ -1,11 +1,21 @@
+import { faker } from "@faker-js/faker";
 import { Patient } from "@medplum/fhirtypes";
-import { randFirstName, randLastName, randNumber, randPhoneNumber, randUuid } from "@ngneat/falso";
 
-const defaultId = randUuid();
+const defaultId = () => faker.string.uuid();
 
 export type PatientWithId = Omit<Patient, "id"> & Required<Pick<Patient, "id">>;
 
-export const makePatient = (id = defaultId): PatientWithId => ({
+export const makePatient = ({
+  id = defaultId(),
+  firstName = faker.person.firstName(),
+  lastName = faker.person.lastName(),
+  phoneNumber = faker.phone.number("555-###-###"),
+}: {
+  id?: string;
+  firstName?: string;
+  lastName?: string;
+  phoneNumber?: string;
+} = {}): PatientWithId => ({
   resourceType: "Patient",
   id,
   extension: [
@@ -71,7 +81,7 @@ export const makePatient = (id = defaultId): PatientWithId => ({
   identifier: [
     {
       system: "https://github.com/synthetichealth/synthea",
-      value: randUuid(),
+      value: faker.string.uuid(),
     },
     {
       type: {
@@ -85,21 +95,21 @@ export const makePatient = (id = defaultId): PatientWithId => ({
         text: "Driver's License",
       },
       system: "urn:oid:2.16.840.1.113883.4.3.49",
-      value: randNumber({ min: 10_000, max: 99_999 }).toString(),
+      value: faker.number.int({ min: 10_000, max: 99_999 }).toString(),
     },
   ],
   name: [
     {
       use: "official",
-      family: randLastName(),
-      given: [randFirstName()],
+      family: lastName,
+      given: [firstName],
       prefix: [],
     },
   ],
   telecom: [
     {
       system: "phone",
-      value: randPhoneNumber(),
+      value: phoneNumber,
       use: "home",
     },
   ],


### PR DESCRIPTION
Tickets:
- https://github.com/metriport/metriport-internal/issues/1096
- https://github.com/metriport/metriport/issues/420

### Dependencies

none

### Description

- Fix FHIR E2E test
- Remove `@ngneat/falso` - use only one test/mocking library

### Release Plan

- nothing special, only unit and E2E tests