### PR TITLE
PATCH RELESE 1195 fix API access to cookie secret

### DIFF
--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancement-init.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancement-init.ts
@@ -1,6 +1,8 @@
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
+import { MetriportError } from "@metriport/core/util/error/metriport-error";
 import { groupBy } from "lodash";
 import { getOrganizationOrFail } from "../../../command/medical/organization/get-organization";
+import { getPatients } from "../../../command/medical/patient/get-patient";
 import { getPatientsToEnhanceCoverage } from "./coverage-enhancement-get-patients";
 import { makeCoverageEnhancer } from "./coverage-enhancer-factory";
 import { setCQLinkStatus } from "./cq-link-status";
@@ -13,13 +15,28 @@ const coverageEnhancer = makeCoverageEnhancer();
  * Trigger the CQ link (enhanced coverage) for all patients that are not linked or are
  * already processing.
  */
-export async function initEnhancedCoverage(cxIds: string[], fromOrgPos?: number): Promise<void> {
+export async function initEnhancedCoverage(
+  cxIds: string[],
+  patientIds?: string[],
+  fromOrgPos?: number
+): Promise<void> {
   if (!coverageEnhancer) {
     console.log(`No coverage enhancher, skipping...`);
     return;
   }
 
-  const patients = await getPatientsToEnhanceCoverage(cxIds);
+  const getPatientsToProcess = async () => {
+    if (patientIds && patientIds.length > 0) {
+      const cxId = cxIds[0];
+      if (cxIds.length != 1 || !cxId) {
+        throw new MetriportError(`Exacly one cxId must be set when patientIds are present`);
+      }
+      return getPatients({ cxId, patientIds });
+    }
+    return getPatientsToEnhanceCoverage(cxIds);
+  };
+
+  const patients = await getPatientsToProcess();
   const patientsByCx = groupBy(patients, "cxId");
 
   const entries = Object.entries(patientsByCx);

--- a/packages/api/src/routes/schemas/shared.ts
+++ b/packages/api/src/routes/schemas/shared.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 
 export const stringListSchema = z.string().array();
 
+export const stringListFromQuerySchema = z.union([z.string(), stringListSchema]).transform(v => {
+  return Array.isArray(v) ? v : v.split(",").map(v => v.trim());
+});
+
 export const stringIntegerSchema = z
   .string()
   .regex(/^\d+$/, { message: "Invalid integer" })

--- a/packages/api/src/routes/schemas/uuid.ts
+++ b/packages/api/src/routes/schemas/uuid.ts
@@ -2,10 +2,10 @@ import { Request } from "express";
 import { z } from "zod";
 import { Context, getFrom, GetWithoutParams } from "../util";
 
-export const uuiSchema = z.string().uuid();
+export const uuidSchema = z.string().uuid();
 
 function validateUUID(id: string, propName?: string): string {
-  return uuiSchema.parse(
+  return uuidSchema.parse(
     id,
     propName
       ? {

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -260,7 +260,7 @@ export class Config {
     return getEnvVar("CW_MANAGEMENT_URL");
   }
   static getCWManagementCookieArn(): string | undefined {
-    return getEnvVar("CW_MANAGEMENT_COOKIE_ARN");
+    return getEnvVar("CW_MANAGEMENT_COOKIE_SECRET_ARN");
   }
   static getCWPatientLinkQueueUrl(): string | undefined {
     return getEnvVar("CW_CQ_PATIENT_LINK_QUEUE_URL");

--- a/packages/core/src/domain/auth/cookie-management/cookie-manager-on-secrets.ts
+++ b/packages/core/src/domain/auth/cookie-management/cookie-manager-on-secrets.ts
@@ -14,26 +14,34 @@ export class CookieManagerOnSecrets extends CookieManager {
    * Get Cookies from AWS SecretManager
    */
   async getCookies(): Promise<Cookie[]> {
-    const appSecret = await this.secretManager
-      .getSecretValue({ SecretId: this.secretArn })
-      .promise();
-    const secretAsString = appSecret.SecretString;
-    if (!secretAsString) {
-      throw new MetriportError(`Secret is empty`, undefined, { secretArn: this.secretArn });
+    try {
+      const appSecret = await this.secretManager
+        .getSecretValue({ SecretId: this.secretArn })
+        .promise();
+      const secretAsString = appSecret.SecretString;
+      if (!secretAsString) {
+        throw new MetriportError(`Secret is empty`, undefined, { secretArn: this.secretArn });
+      }
+      const cookies = JSON.parse(secretAsString) as Cookie[];
+      return cookies;
+    } catch (error) {
+      throw new MetriportError(`Error reading cookies/secrets`, error);
     }
-    const cookies = JSON.parse(secretAsString) as Cookie[];
-    return cookies;
   }
 
   /**
    * Store Cookies on AWS SecretManager
    */
   async updateCookies(cookies: Cookie[]): Promise<Cookie[]> {
-    if (!cookies) return [];
-    const cookiesAsString = JSON.stringify(cookies);
-    await this.secretManager
-      .updateSecret({ SecretId: this.secretArn, SecretString: cookiesAsString })
-      .promise();
-    return cookies;
+    try {
+      if (!cookies) return [];
+      const cookiesAsString = JSON.stringify(cookies);
+      await this.secretManager
+        .updateSecret({ SecretId: this.secretArn, SecretString: cookiesAsString })
+        .promise();
+      return cookies;
+    } catch (error) {
+      throw new MetriportError(`Error updating cookies/secrets`, error);
+    }
   }
 }

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -162,7 +162,7 @@ export function createAPIService(
             CW_MANAGEMENT_URL: coverageEnhancementConfig.managementUrl,
           }),
           ...(cookieStore && {
-            CW_MANAGEMENT_COOKIE_ARN: cookieStore.secretArn,
+            CW_MANAGEMENT_COOKIE_SECRET_ARN: cookieStore.secretArn,
           }),
         },
       },
@@ -214,7 +214,10 @@ export function createAPIService(
   //     queue: cqLinkPatientQueue,
   //     resource: fargateService.service.taskDefinition.taskRole,
   //   });
-  cookieStore && cookieStore.grantRead(fargateService.service.taskDefinition.taskRole);
+  if (cookieStore) {
+    cookieStore.grantRead(fargateService.service.taskDefinition.taskRole);
+    cookieStore.grantWrite(fargateService.service.taskDefinition.taskRole);
+  }
 
   // Allow access to search services/infra
   provideAccessToQueue({

--- a/packages/utils/src/commonwell/session-manager.ts
+++ b/packages/utils/src/commonwell/session-manager.ts
@@ -36,7 +36,6 @@ const isLocal = false;
 
 // If it fails to get the cookie, we might need to run this on a "headed" browser = update this to false:
 const headless = true;
-// const headless = false;
 
 /**
  * To get the cookies, login to the CW portal and go to this page: (https://portal.commonwellalliance.org/Organization/List).
@@ -69,7 +68,7 @@ const buildStores = () => {
       cookieManager: new CookieManagerInMemory(),
     };
   }
-  const cookiesSecretArn = getEnvVarOrFail("CW_COOKIES_SECRET_ARN");
+  const cookiesSecretArn = getEnvVarOrFail("CW_MANAGEMENT_COOKIE_SECRET_ARN");
   const codeChallengeSecretArn = getEnvVarOrFail("CW_CODE_CHALLENGE_SECRET_ARN");
   return {
     codeChallenge: new CodeChallengeFromSecretManager(
@@ -85,7 +84,7 @@ const { codeChallenge, cookieManager } = buildStores();
 const cwManagementApi = new CommonWellManagementAPI({ cookieManager, baseUrl: cwBaseUrl });
 
 export async function main() {
-  console.log(`Testing SessionManagement.keepSessionActive()... at ${new Date().toISOString()}`);
+  console.log(`Runnning at ${new Date().toISOString()}`);
 
   if (cookies && cookies.trim().length) {
     console.log(`Overwritting cookies...`);


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Description

- fix API access to cookie secret
- accept list of patient IDs for EC
- make env var name the same across services
- add stringListFromQuerySchema

### Release Plan

- ⚠️ This is pointing to `master`