### PR TITLE
PATCH RELEASE 1195 doc query once on EC + dont stop EC on error

### DIFF
--- a/packages/core/src/domain/document-query/trigger-and-query.ts
+++ b/packages/core/src/domain/document-query/trigger-and-query.ts
@@ -2,21 +2,27 @@ import { DocumentQuery } from "@metriport/api-sdk";
 import { sleep } from "../../util/sleep";
 import { webhookDisableFlagName } from "../webhook";
 
+const patientChunkDelayJitterMsDefault = 1000;
+const queryPollDurationMsDefault = 10_000;
+const maxQueryDurationMsDefault = 71_000;
+const maxDocQueryAttemptsDefault = 1;
+const minDocsToConsiderCompletedDefault = 1;
+
 export const disableWHMetadata = {
   [webhookDisableFlagName]: "true",
 };
 
 export type DetailedConfig = {
-  patientChunkDelayJitterMs: number;
-  queryPollDurationMs: number;
-  maxQueryDurationMs: number; // CW has a 70s timeout, so this is the maximum duration any doc query can take
-  maxDocQueryAttempts: number;
+  patientChunkDelayJitterMs?: number | undefined;
+  queryPollDurationMs?: number | undefined;
+  maxQueryDurationMs?: number | undefined; // CW has a 70s timeout, so this is the maximum duration any doc query can take
+  maxDocQueryAttempts?: number | undefined;
   /**
    * If the doc query returns less than this, we want to query again to try and get better
    * coverage. Had situation where we requeried a patient w/ 1 doc ref and it jumped from
    * 1 to 20.
    */
-  minDocsToConsiderCompleted: number;
+  minDocsToConsiderCompleted?: number | undefined;
 };
 
 export type QueryParams = {
@@ -43,13 +49,7 @@ export abstract class TriggerAndQueryDocRefs {
     cxId,
     patientId,
     triggerWHNotificationsToCx,
-    config = {
-      patientChunkDelayJitterMs: 1000,
-      queryPollDurationMs: 10_000,
-      maxQueryDurationMs: 71_000,
-      maxDocQueryAttempts: 3,
-      minDocsToConsiderCompleted: 2,
-    },
+    config = {},
     log = console.log,
   }: QueryParams): Promise<{
     docQueryAttempts: number;
@@ -57,11 +57,11 @@ export abstract class TriggerAndQueryDocRefs {
     queryComplete: boolean;
   }> {
     const {
-      patientChunkDelayJitterMs,
-      queryPollDurationMs,
-      maxQueryDurationMs,
-      maxDocQueryAttempts,
-      minDocsToConsiderCompleted,
+      patientChunkDelayJitterMs = patientChunkDelayJitterMsDefault,
+      queryPollDurationMs = queryPollDurationMsDefault,
+      maxQueryDurationMs = maxQueryDurationMsDefault,
+      maxDocQueryAttempts = maxDocQueryAttemptsDefault,
+      minDocsToConsiderCompleted = minDocsToConsiderCompletedDefault,
     } = config;
     let docsFound = 0;
 

--- a/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer-local.ts
+++ b/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer-local.ts
@@ -25,6 +25,7 @@ export class CoverageEnhancerLocal extends CoverageEnhancer {
     orgOID,
     patientIds,
     fromOrgChunkPos = 0,
+    stopOnErrors = false,
   }: CoverageEnhancementParams) {
     const startedAt = Date.now();
     const { log } = out(`${this.prefix}EC - MAIN - cx ${cxId}`);
@@ -51,11 +52,12 @@ export class CoverageEnhancerLocal extends CoverageEnhancer {
             cqOrgIds: orgIds,
           });
         } catch (error) {
-          log(
-            `ERROR - stopped at org chunk ${i} (relative) / ${i + fromOrgChunkPos} (absolute)`,
-            error
-          );
-          throw error;
+          const msg = `ERROR at org chunk ${i} (relative) / ${i + fromOrgChunkPos} (absolute)`;
+          if (stopOnErrors) {
+            log(msg + " - interrupting...", error);
+            throw error;
+          }
+          log(msg + " - continuing...", error);
         }
       }
     } finally {

--- a/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer.ts
+++ b/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer.ts
@@ -3,6 +3,7 @@ export type CoverageEnhancementParams = {
   orgOID: string;
   patientIds: string[];
   fromOrgChunkPos?: number;
+  stopOnErrors?: boolean;
 };
 
 export abstract class CoverageEnhancer {

--- a/packages/utils/src/commonwell/enhance-coverage.ts
+++ b/packages/utils/src/commonwell/enhance-coverage.ts
@@ -50,7 +50,6 @@ const downloadProgressIndex = 0;
 
 // If it fails to get the cookie, we might need to run this on a "headed" browser = update this to false:
 const headless = true;
-//const headless = false;
 
 /**
  * You shouldn't need to, but if you want to use existing cookies login to the CW portal and go to
@@ -69,6 +68,8 @@ const cxOrgOID = getEnvVarOrFail("ORG_OID");
 
 const WAIT_BETWEEN_LINKING_AND_DOC_QUERY = dayjs.duration({ seconds: 30 });
 const DOC_QUERIES_IN_PARALLEL = 25;
+const maxDocQueryAttempts = 3;
+const minDocsToConsiderCompleted = 2;
 const triggerWHNotificationsToCx = true;
 const prefix = "############################### ";
 
@@ -116,6 +117,7 @@ export async function main() {
     orgOID: cxOrgOID,
     patientIds,
     fromOrgChunkPos: downloadProgressIndex,
+    stopOnErrors: true,
   });
 
   console.log(`Giving some time for patients to be updated @ CW...`);
@@ -129,6 +131,10 @@ export async function main() {
         cxId: cxId,
         patientId: patientId,
         triggerWHNotificationsToCx,
+        config: {
+          maxDocQueryAttempts,
+          minDocsToConsiderCompleted,
+        },
       });
       console.log(`Done doc query for patient ${patientId}, found ${docsFound} docs`);
     },


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Dependencies

none

### Description

- doc query once on EC - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1699890950486569)
- don't stop EC on error - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1699892625200759)

### Release Plan

- ⚠️ This is pointing to `master`
- asap