### PR TITLE
1195 only set cqLinkStatus=unlinked when FF is set for cx

### DIFF
--- a/packages/api/src/command/medical/patient/calculate-patient-similarity.ts
+++ b/packages/api/src/command/medical/patient/calculate-patient-similarity.ts
@@ -1,5 +1,5 @@
-import { PatientData } from "../../../domain/medical/patient";
 import jaroWinkler from "jaro-winkler";
+import { PatientData } from "../../../domain/medical/patient";
 
 const SIMILARITY_THRESHOLD = 0.96;
 
@@ -75,6 +75,6 @@ export const calculatePatientSimilarity = (
 
   const totalScore = score / fieldCount;
   similarityScores["Total Score"] = [totalScore];
-  console.log(similarityScores);
+  console.log(`similarity score: ${JSON.stringify(similarityScores)}`);
   return totalScore;
 };

--- a/packages/api/src/external/aws/appConfig.ts
+++ b/packages/api/src/external/aws/appConfig.ts
@@ -34,3 +34,8 @@ export async function getCxsWithEnhancedCoverageFeatureFlagValue(): Promise<stri
   }
   return [];
 }
+
+export async function isEnhancedCoverageEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithECEnabled = await getCxsWithEnhancedCoverageFeatureFlagValue();
+  return cxIdsWithECEnabled.some(i => i === cxId);
+}

--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancement-check-stale.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancement-check-stale.ts
@@ -60,10 +60,11 @@ async function getPatientsWithStaleEC(cxIds: string[]): Promise<SimplifiedPatien
 function notifyStaleEC(patients: SimplifiedPatient[]): void {
   if (!patients || !patients.length) return;
 
+  const patientsByCx = groupBy(patients, "cxId");
   const msg = `Found patients with stale enhanced coverage`;
-  console.log(msg + ` - count: ${patients.length}`);
+  console.log(msg + ` - count: ${patients.length}: ${JSON.stringify(patientsByCx)}`);
   capture.message(msg, {
-    extra: { patientsByCx: groupBy(patients, "cxId") },
+    extra: { patientsByCx },
     level: "warning",
   });
 }

--- a/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer-local.ts
+++ b/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer-local.ts
@@ -32,19 +32,13 @@ export class CoverageEnhancerLocal extends CoverageEnhancer {
     try {
       const { total, chunks } = await getOrgChunksFromPos({ fromPos: fromOrgChunkPos });
 
-      log(
-        `# of patients: ${patientIds.length}, CQ orgs: ${total}, ` +
-          `total chunks (absolute): ${chunks.length + fromOrgChunkPos}, ` +
-          `chunks to process (relative): ${chunks.length}`
-      );
+      log(`CQ orgs: ${total}, chunks: ${chunks.length}/${chunks.length + fromOrgChunkPos}`);
+      log(`patients: ${patientIds.join(", ")}`);
 
       for (const [i, orgChunk] of chunks.entries()) {
         const orgIds = orgChunk.map(org => org.Id);
         log(`--------------------------------- Starting chunk ${i}/${chunks.length} (relative)`);
         try {
-          // log(
-          //   `==================> would be linking now, mimicking some delay... (${orgIds.length}, linkPatients ${this.linkPatients})`
-          // );
           await this.linkPatients.linkPatientsToOrgs({
             cxId,
             cxOrgOID: orgOID,


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Dependencies

none

### Description

- only set cqLinkStatus=unlinked when FF is set for cx
- log patient IDs on EC flow

### Release Plan

- merge/release this
- update patients from cxs not with EC FF enabled so their `cqLinkStatus` is undefined