### PR TITLE
PATCH RELEASE - bump fhir to mr lambda to 4gb

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1114,7 +1114,7 @@ export class APIStack extends Stack {
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
       layers: [lambdaLayers.shared, lambdaLayers.chromium],
-      memory: 1024,
+      memory: 4096,
       timeout: lambdaTimeout,
       vpc,
       alarmSnsAction: alarmAction,


### PR DESCRIPTION
refs. metriport/metriport-internal#1234


### Dependencies

n/a

### Description

⚠️ pointing to master
bump fhir to mr lambda to 4gb

### Release Plan

asap
