### PR TITLE
1195 parallel patient updates @ CW from 10 to 20

### DIFF
--- a/packages/api/src/external/commonwell/patient-updater-commonwell.ts
+++ b/packages/api/src/external/commonwell/patient-updater-commonwell.ts
@@ -7,6 +7,8 @@ import { errorToString } from "../../shared/log";
 import { capture } from "../../shared/notifications";
 import { getPatients } from "../../command/medical/patient/get-patient";
 
+const maxNumberOfParallelRequestsToCW = 20;
+
 /**
  * Implementation of the PatientUpdater that executes the logic on CommonWell.
  */
@@ -34,7 +36,7 @@ export class PatientUpdaterCommonWell extends PatientUpdater {
     };
     // Execute the promises in parallel
     await executeAsynchronously(patients, async patient => updatePatient(patient), {
-      numberOfParallelExecutions: 10,
+      numberOfParallelExecutions: maxNumberOfParallelRequestsToCW,
     });
 
     return { failedUpdateCount };

--- a/packages/infra/dashboards/cw-dashboard-prod.json
+++ b/packages/infra/dashboards/cw-dashboard-prod.json
@@ -286,7 +286,7 @@
             "height": 8,
             "width": 10,
             "y": 10,
-            "x": 4,
+            "x": 14,
             "type": "metric",
             "properties": {
                 "metrics": [
@@ -307,14 +307,13 @@
             "height": 8,
             "width": 10,
             "y": 10,
-            "x": 14,
+            "x": 4,
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "AWS/RDS", "WriteIOPS", "DBClusterIdentifier", "api-cluster", { "yAxis": "right", "region": "us-west-1" } ],
-                    [ ".", "VolumeWriteIOPs", ".", ".", { "region": "us-west-1", "yAxis": "right" } ],
-                    [ ".", "ReadIOPS", ".", ".", { "region": "us-west-1" } ],
-                    [ ".", "VolumeReadIOPS", ".", ".", { "region": "us-west-1" } ]
+                    [ { "expression": "m2*300", "label": "VolumeReadIOPs", "id": "e1", "region": "us-west-1" } ],
+                    [ "AWS/RDS", "VolumeWriteIOPs", "DBClusterIdentifier", "api-cluster", { "yAxis": "right", "id": "m1", "region": "us-west-1" } ],
+                    [ ".", "VolumeReadIOPs", ".", ".", { "period": 60, "id": "m2", "label": "VolumeReadIOPs-Billable", "visible": false, "region": "us-west-1" } ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
@@ -326,8 +325,8 @@
                 "annotations": {
                     "horizontal": [
                         {
-                            "label": "VolumeWriteIOPs >= 10_000 for 1 datapoints within 5 minutes",
-                            "value": 10000,
+                            "label": "VolumeWriteIOPs >= 50_000 for 1 datapoints within 5 minutes",
+                            "value": 50000,
                             "yAxis": "right"
                         }
                     ]
@@ -374,10 +373,8 @@
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "AWS/RDS", "WriteIOPS", "DBClusterIdentifier", "fhir-server", { "yAxis": "right" } ],
-                    [ ".", "VolumeWriteIOPs", ".", ".", { "region": "us-west-1", "yAxis": "right" } ],
-                    [ ".", "ReadIOPS", ".", "." ],
-                    [ ".", "VolumeReadIOPS", ".", ".", { "region": "us-west-1" } ]
+                    [ "AWS/RDS", "VolumeReadIOPs", "DBClusterIdentifier", "fhir-server", { "region": "us-west-1", "id": "m1", "label": "VolumeReadIOPs-Billable" } ],
+                    [ ".", "VolumeWriteIOPs", ".", ".", { "yAxis": "right", "region": "us-west-1", "id": "m2" } ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
@@ -389,8 +386,8 @@
                 "annotations": {
                     "horizontal": [
                         {
-                            "label": "VolumeWriteIOPs >= 100_000 for 1 datapoints within 5 minutes",
-                            "value": 100000,
+                            "label": "VolumeWriteIOPs >= 300_000 for 1 datapoints within 5 minutes",
+                            "value": 300000,
                             "yAxis": "right"
                         }
                     ]

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1367,7 +1367,8 @@ export class APIStack extends Stack {
 
     const readIOPsMetric = dbCluster.metricVolumeReadIOPs();
     const rIOPSAlarm = readIOPsMetric.createAlarm(this, `${dbClusterName}VolumeReadIOPsAlarm`, {
-      threshold: 20_000, // IOPs per second
+      // https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraMonitoring.Metrics.html
+      threshold: 166, // BILLED IOPS, that's ~50_000 regular IOPS
       evaluationPeriods: 1,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
@@ -1376,7 +1377,7 @@ export class APIStack extends Stack {
 
     const writeIOPsMetric = dbCluster.metricVolumeWriteIOPs();
     const wIOPSAlarm = writeIOPsMetric.createAlarm(this, `${dbClusterName}VolumeWriteIOPsAlarm`, {
-      threshold: 10_000, // IOPs per second
+      threshold: 50_000, // IOPS
       evaluationPeriods: 1,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Dependencies

related: https://github.com/metriport/fhir-server/pull/41

### Description

- parallel patient updates @ CW from 10 to 20
- increase API DB's volume IOPS alarms

### Release Plan

- nothing special