### PR TITLE
1195 log responses from CW

### DIFF
--- a/packages/api/src/external/commonwell/__tests__/organization.ts
+++ b/packages/api/src/external/commonwell/__tests__/organization.ts
@@ -14,7 +14,7 @@ export const getOne = async (orgOid: string): Promise<CWOrganization | undefined
   const cwId = OID_PREFIX.concat(orgOid);
   try {
     const resp = await commonWell.getOneOrg(metriportQueryMeta, cwId);
-    debug(`resp: `, () => JSON.stringify(resp, null, 2));
+    debug(`resp: `, JSON.stringify(resp));
     return resp;
   } catch (error) {
     const msg = `[E2E]: Failure getting Org @ CW`;

--- a/packages/api/src/external/commonwell/organization.ts
+++ b/packages/api/src/external/commonwell/organization.ts
@@ -67,13 +67,13 @@ export const create = async (org: Organization): Promise<void> => {
   const commonWell = makeCommonWellAPI(Config.getCWMemberOrgName(), Config.getCWMemberOID());
   try {
     const respCreate = await commonWell.createOrg(metriportQueryMeta, cwOrg);
-    debug(`resp respCreate: `, () => JSON.stringify(respCreate, null, 2));
+    debug(`resp respCreate: `, JSON.stringify(respCreate));
     const respAddCert = await commonWell.addCertificateToOrg(
       metriportQueryMeta,
       getCertificate(),
       org.oid
     );
-    debug(`resp respAddCert: `, () => JSON.stringify(respAddCert, null, 2));
+    debug(`resp respAddCert: `, JSON.stringify(respAddCert));
   } catch (error) {
     const msg = `Failure creating Org @ CW`;
     log(msg, error);
@@ -96,7 +96,7 @@ export const update = async (org: Organization): Promise<void> => {
   const commonWell = makeCommonWellAPI(Config.getCWMemberOrgName(), Config.getCWMemberOID());
   try {
     const respUpdate = await commonWell.updateOrg(metriportQueryMeta, cwOrg, cwOrg.organizationId);
-    debug(`resp respUpdate: `, () => JSON.stringify(respUpdate, null, 2));
+    debug(`resp respUpdate: `, JSON.stringify(respUpdate));
 
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {

--- a/packages/api/src/external/commonwell/patient-shared.ts
+++ b/packages/api/src/external/commonwell/patient-shared.ts
@@ -78,7 +78,7 @@ export async function findOrCreatePerson({
   } else {
     // Search by demographics
     const respSearch = await commonWell.searchPersonByPatientDemo(queryMeta, commonwellPatientId);
-    debug(`resp searchPersonByPatientDemo: `, () => JSON.stringify(respSearch, null, 2));
+    debug(`resp searchPersonByPatientDemo: `, JSON.stringify(respSearch));
     const persons = respSearch._embedded?.person
       ? respSearch._embedded.person
           .flatMap(p => (p && getPersonId(p) ? p : []))
@@ -126,9 +126,9 @@ export async function findOrCreatePerson({
   }
 
   // If not found, enroll/add person
-  debug(`Enrolling this person: `, () => JSON.stringify(person, null, 2));
+  debug(`Enrolling this person: `, JSON.stringify(person));
   const respPerson = await commonWell.enrollPerson(queryMeta, person);
-  debug(`resp enrollPerson: `, () => JSON.stringify(respPerson, null, 2));
+  debug(`resp enrollPerson: `, JSON.stringify(respPerson));
   const personId = getPersonId(respPerson);
   if (!personId) {
     const msg = `Could not get person ID from CW response`;

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -194,11 +194,11 @@ export async function update(patient: Patient, facilityId: string): Promise<void
     try {
       try {
         const respPerson = await commonWell.updatePerson(queryMeta, person, personId);
-        debug(`resp updatePerson: `, () => JSON.stringify(respPerson, null, 2));
+        debug(`resp updatePerson: `, JSON.stringify(respPerson));
 
         if (!respPerson.enrolled) {
           const respReenroll = await commonWell.reenrollPerson(queryMeta, personId);
-          debug(`resp reenrolPerson: `, () => JSON.stringify(respReenroll, null, 2));
+          debug(`resp reenrolPerson: `, JSON.stringify(respReenroll));
         }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (err: any) {
@@ -251,7 +251,7 @@ export async function update(patient: Patient, facilityId: string): Promise<void
           // safe to get the first one, just need to match one of the person's strong IDs
           strongIds.length ? strongIds[0] : undefined
         );
-        debug(`resp patientLink: `, () => JSON.stringify(respLink, null, 2));
+        debug(`resp patientLink: `, JSON.stringify(respLink));
       }
     } catch (err) {
       log(
@@ -297,7 +297,7 @@ export async function remove(patient: Patient, facilityId: string): Promise<void
     commonWell = data.commonWell;
 
     const resp = await commonWell.deletePatient(queryMeta, commonwellPatientId);
-    debug(`resp deletePatient: `, () => JSON.stringify(resp, null, 2));
+    debug(`resp deletePatient: `, JSON.stringify(resp));
   } catch (err) {
     console.error(`Failed to delete patient ${patient.id} @ CW: `, err);
     capture.error(err, {
@@ -391,7 +391,7 @@ async function findOrCreatePersonAndLink({
       // safe to get the first one, just need to match one of the person's strong IDs
       strongIds.length ? strongIds[0] : undefined
     );
-    debug(`resp patientLink: `, () => JSON.stringify(respLink, null, 2));
+    debug(`resp patientLink: `, JSON.stringify(respLink));
   } catch (err) {
     log(`Error linking Patient<>Person @ CW - personId: ${personId}`);
     throw err;
@@ -423,8 +423,8 @@ async function registerPatient({
   const debug = Util.debug(fnName);
 
   const respPatient = await commonWell.registerPatient(queryMeta, commonwellPatient);
+  debug(`resp registerPatient: `, JSON.stringify(respPatient));
 
-  debug(`resp registerPatient: `, () => JSON.stringify(respPatient, null, 2));
   const commonwellPatientId = getIdTrailingSlash(respPatient);
   const log = Util.log(`${fnName} - CW patientId ${commonwellPatientId}`);
   if (!commonwellPatientId) {
@@ -469,8 +469,7 @@ async function updatePatient({
     commonwellPatient,
     commonwellPatientId
   );
-
-  debug(`resp updatePatient: `, () => JSON.stringify(respUpdate, null, 2));
+  debug(`resp updatePatient: `, JSON.stringify(respUpdate));
 
   const patientRefLink = respUpdate._links?.self?.href;
   if (!patientRefLink) {


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Dependencies

none

### Description

Reverting the change I did a few weeks ago which stopped logging responses from CW. While we don't want to log those multiline to prevent trashing our logs, there's value to having those somewhere in case something goes wrong while integrating with CW.

This re-enables those even on cloud env, but one single line.

### Release Plan

- nothing special