### PR TITLE
1195 checkout internal from develop or feature branch

### DIFF
--- a/.github/workflows/_deploy_cdk.yml
+++ b/.github/workflows/_deploy_cdk.yml
@@ -48,6 +48,9 @@ on:
       SERVICE_PAT:
         required: true
 
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   deploy:
     # prevents 2+ devs/workflows trying to deploy to AWS at the same time
@@ -77,6 +80,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: metriport
+
       # checkout the internal repo to get configs - default branches
       - name: Checkout internal default branch
         uses: actions/checkout@v3
@@ -89,12 +93,26 @@ jobs:
           sparse-checkout: |
             config-oss/api-infra
       # checkout the internal repo to get configs - feature branch when "branching to staging"
+      - name: Determine which internal branch to checkout
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e # don't stop on failure
+          gh api /repos/metriport/metriport-internal/branches/${{ github.ref_name }} --silent
+          RESULT=$?
+          if [ $RESULT -eq 0 ]; then
+            INTERNAL_BRANCH=${{ github.ref }}
+          else
+            INTERNAL_BRANCH=develop
+          fi
+          echo "Internal branch for checkout: $INTERNAL_BRANCH"
+          echo "INTERNAL_BRANCH=$INTERNAL_BRANCH" >> $GITHUB_ENV
       - name: Checkout internal feature branch
         uses: actions/checkout@v3
         if: ${{ inputs.is-branch-to-staging == true }}
         with:
           repository: metriport/metriport-internal
-          ref: ${{ github.ref }}
+          ref: ${{ env.INTERNAL_BRANCH }}
           token: ${{ secrets.SERVICE_PAT }} # secret token from user 'metriport-service'
           path: metriport-internal
           sparse-checkout: |


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Dependencies

none

### Description

When building infra, checkout internal from `develop` or feature branch based on whether the feature branch exist on internal or not.

### Release Plan

- nothing special
- asap