### PR TITLE
feat(cicd): switch for service_pat

### DIFF
--- a/.github/workflows/_deploy_cdk.yml
+++ b/.github/workflows/_deploy_cdk.yml
@@ -48,9 +48,6 @@ on:
       SERVICE_PAT:
         required: true
 
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   deploy:
     # prevents 2+ devs/workflows trying to deploy to AWS at the same time
@@ -95,7 +92,7 @@ jobs:
       # checkout the internal repo to get configs - feature branch when "branching to staging"
       - name: Determine which internal branch to checkout
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SERVICE_PAT }}
         run: |
           set +e # don't stop on failure
           gh api /repos/metriport/metriport-internal/branches/${{ github.ref_name }} --silent


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport/pull/1197

### Description

- changing ci/cd to use SERVICE_PAT instead eof GITHUB_TOKEN to check if internal branch exists for branch to staging

### Release Plan

- [x] nothing special 
- [x] asap