### PR TITLE
1235 new line to get new version of api-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37850,7 +37850,7 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.7.0",
+      "version": "7.7.1-alpha10",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^4.9.2-alpha.0",
@@ -38026,13 +38026,13 @@
       }
     },
     "packages/connect-widget": {
-      "version": "1.7.2",
+      "version": "1.7.3-alpha10",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.12",
         "@chakra-ui/react": "^2.4.1",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
-        "@metriport/api-sdk": "^7.7.0",
+        "@metriport/api-sdk": "^7.7.1-alpha10",
         "@sentry/react": "^7.45.0",
         "@sentry/tracing": "^7.45.0",
         "@testing-library/jest-dom": "^5.16.5",
@@ -39269,10 +39269,10 @@
       "license": "MIT"
     },
     "packages/tester-node": {
-      "version": "1.1.2",
+      "version": "1.1.3-alpha10",
       "license": "ISC",
       "dependencies": {
-        "@metriport/api-sdk": "^7.7.0",
+        "@metriport/api-sdk": "^7.7.1-alpha10",
         "@metriport/core": "file:packages/core",
         "dotenv": "^16.0.3"
       },

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.7.0",
+  "version": "7.7.1-alpha10",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/api-sdk/src/index.ts
+++ b/packages/api-sdk/src/index.ts
@@ -10,6 +10,7 @@ export { SourceType } from "./devices/models/common/source-type";
 export { Nutrition } from "./devices/models/nutrition";
 export { Sleep } from "./devices/models/sleep";
 export { User } from "./devices/models/user";
+
 // Medical API
 export { MetriportMedicalApi } from "./medical/client/metriport";
 export { Address, addressSchema } from "./medical/models/common/address";

--- a/packages/connect-widget/package.json
+++ b/packages/connect-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-widget",
-  "version": "1.7.2",
+  "version": "1.7.3-alpha10",
   "private": true,
   "scripts": {
     "clean": "rimraf build && rimraf node_modules",
@@ -38,7 +38,7 @@
     "@chakra-ui/react": "^2.4.1",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@metriport/api-sdk": "^7.7.0",
+    "@metriport/api-sdk": "^7.7.1-alpha10",
     "@sentry/react": "^7.45.0",
     "@sentry/tracing": "^7.45.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/packages/tester-node/package.json
+++ b/packages/tester-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tester-node",
-  "version": "1.1.2",
+  "version": "1.1.3-alpha10",
   "description": "",
   "private": true,
   "scripts": {
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@metriport/api-sdk": "^7.7.0",
+    "@metriport/api-sdk": "^7.7.1-alpha10",
     "@metriport/core": "file:packages/core",
     "dotenv": "^16.0.3"
   },


### PR DESCRIPTION
Ref: metriport/metriport#1235

### Dependencies

none

### Description

Just deploy a new version of the SDK so `latest` is not pointing to the alpha version generated by Fern.

### Release Plan

- staging
   - [x] release NPM
   - [ ] merge this
- production
   - [ ] release NPM
   - [ ] merge this