### PR TITLE
1040 do not run EC w/o cxId + other goodies

### DIFF
--- a/docs/medical-api/more-info/webhooks.mdx
+++ b/docs/medical-api/more-info/webhooks.mdx
@@ -16,6 +16,8 @@ This is the usual flow to obtain Patient data:
    - depending on the amount of data this can take some time to crunch together, so results are sent through a webhook message:
      [patient consolidated data](#patient-consolidated-data)
 
+You should expect to get more than one Webhook message per patient per request (document query and/or consolidated data).
+
 To enable this integration approach with Metriport, and for some prerequesite reading to understand
 how the Webhook flow works, see [our Webhooks guide](/home/api-info/webhooks).
 

--- a/packages/api/src/external/commonwell/__tests__/organization.ts
+++ b/packages/api/src/external/commonwell/__tests__/organization.ts
@@ -14,7 +14,7 @@ export const getOne = async (orgOid: string): Promise<CWOrganization | undefined
   const cwId = OID_PREFIX.concat(orgOid);
   try {
     const resp = await commonWell.getOneOrg(metriportQueryMeta, cwId);
-    debug(`resp: `, () => JSON.stringify(resp, null, 2));
+    debug(`resp: `, JSON.stringify(resp));
     return resp;
   } catch (error) {
     const msg = `[E2E]: Failure getting Org @ CW`;

--- a/packages/api/src/external/commonwell/organization.ts
+++ b/packages/api/src/external/commonwell/organization.ts
@@ -67,13 +67,13 @@ export const create = async (org: Organization): Promise<void> => {
   const commonWell = makeCommonWellAPI(Config.getCWMemberOrgName(), Config.getCWMemberOID());
   try {
     const respCreate = await commonWell.createOrg(metriportQueryMeta, cwOrg);
-    debug(`resp respCreate: `, () => JSON.stringify(respCreate, null, 2));
+    debug(`resp respCreate: `, JSON.stringify(respCreate));
     const respAddCert = await commonWell.addCertificateToOrg(
       metriportQueryMeta,
       getCertificate(),
       org.oid
     );
-    debug(`resp respAddCert: `, () => JSON.stringify(respAddCert, null, 2));
+    debug(`resp respAddCert: `, JSON.stringify(respAddCert));
   } catch (error) {
     const msg = `Failure creating Org @ CW`;
     log(msg, error);
@@ -96,7 +96,7 @@ export const update = async (org: Organization): Promise<void> => {
   const commonWell = makeCommonWellAPI(Config.getCWMemberOrgName(), Config.getCWMemberOID());
   try {
     const respUpdate = await commonWell.updateOrg(metriportQueryMeta, cwOrg, cwOrg.organizationId);
-    debug(`resp respUpdate: `, () => JSON.stringify(respUpdate, null, 2));
+    debug(`resp respUpdate: `, JSON.stringify(respUpdate));
 
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {

--- a/packages/api/src/external/commonwell/patient-shared.ts
+++ b/packages/api/src/external/commonwell/patient-shared.ts
@@ -78,7 +78,7 @@ export async function findOrCreatePerson({
   } else {
     // Search by demographics
     const respSearch = await commonWell.searchPersonByPatientDemo(queryMeta, commonwellPatientId);
-    debug(`resp searchPersonByPatientDemo: `, () => JSON.stringify(respSearch, null, 2));
+    debug(`resp searchPersonByPatientDemo: `, JSON.stringify(respSearch));
     const persons = respSearch._embedded?.person
       ? respSearch._embedded.person
           .flatMap(p => (p && getPersonId(p) ? p : []))
@@ -126,9 +126,9 @@ export async function findOrCreatePerson({
   }
 
   // If not found, enroll/add person
-  debug(`Enrolling this person: `, () => JSON.stringify(person, null, 2));
+  debug(`Enrolling this person: `, JSON.stringify(person));
   const respPerson = await commonWell.enrollPerson(queryMeta, person);
-  debug(`resp enrollPerson: `, () => JSON.stringify(respPerson, null, 2));
+  debug(`resp enrollPerson: `, JSON.stringify(respPerson));
   const personId = getPersonId(respPerson);
   if (!personId) {
     const msg = `Could not get person ID from CW response`;

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -194,11 +194,11 @@ export async function update(patient: Patient, facilityId: string): Promise<void
     try {
       try {
         const respPerson = await commonWell.updatePerson(queryMeta, person, personId);
-        debug(`resp updatePerson: `, () => JSON.stringify(respPerson, null, 2));
+        debug(`resp updatePerson: `, JSON.stringify(respPerson));
 
         if (!respPerson.enrolled) {
           const respReenroll = await commonWell.reenrollPerson(queryMeta, personId);
-          debug(`resp reenrolPerson: `, () => JSON.stringify(respReenroll, null, 2));
+          debug(`resp reenrolPerson: `, JSON.stringify(respReenroll));
         }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (err: any) {
@@ -251,7 +251,7 @@ export async function update(patient: Patient, facilityId: string): Promise<void
           // safe to get the first one, just need to match one of the person's strong IDs
           strongIds.length ? strongIds[0] : undefined
         );
-        debug(`resp patientLink: `, () => JSON.stringify(respLink, null, 2));
+        debug(`resp patientLink: `, JSON.stringify(respLink));
       }
     } catch (err) {
       log(
@@ -297,7 +297,7 @@ export async function remove(patient: Patient, facilityId: string): Promise<void
     commonWell = data.commonWell;
 
     const resp = await commonWell.deletePatient(queryMeta, commonwellPatientId);
-    debug(`resp deletePatient: `, () => JSON.stringify(resp, null, 2));
+    debug(`resp deletePatient: `, JSON.stringify(resp));
   } catch (err) {
     console.error(`Failed to delete patient ${patient.id} @ CW: `, err);
     capture.error(err, {
@@ -391,7 +391,7 @@ async function findOrCreatePersonAndLink({
       // safe to get the first one, just need to match one of the person's strong IDs
       strongIds.length ? strongIds[0] : undefined
     );
-    debug(`resp patientLink: `, () => JSON.stringify(respLink, null, 2));
+    debug(`resp patientLink: `, JSON.stringify(respLink));
   } catch (err) {
     log(`Error linking Patient<>Person @ CW - personId: ${personId}`);
     throw err;
@@ -423,8 +423,8 @@ async function registerPatient({
   const debug = Util.debug(fnName);
 
   const respPatient = await commonWell.registerPatient(queryMeta, commonwellPatient);
+  debug(`resp registerPatient: `, JSON.stringify(respPatient));
 
-  debug(`resp registerPatient: `, () => JSON.stringify(respPatient, null, 2));
   const commonwellPatientId = getIdTrailingSlash(respPatient);
   const log = Util.log(`${fnName} - CW patientId ${commonwellPatientId}`);
   if (!commonwellPatientId) {
@@ -469,8 +469,7 @@ async function updatePatient({
     commonwellPatient,
     commonwellPatientId
   );
-
-  debug(`resp updatePatient: `, () => JSON.stringify(respUpdate, null, 2));
+  debug(`resp updatePatient: `, JSON.stringify(respUpdate));
 
   const patientRefLink = respUpdate._links?.self?.href;
   if (!patientRefLink) {

--- a/packages/api/src/routes/medical/internal-patient.ts
+++ b/packages/api/src/routes/medical/internal-patient.ts
@@ -29,7 +29,7 @@ import { stringToBoolean } from "../../shared/types";
 import { stringIntegerSchema, stringListFromQuerySchema } from "../schemas/shared";
 import { getUUIDFrom, uuidSchema } from "../schemas/uuid";
 import { asyncHandler, getFrom, getFromParamsOrFail } from "../util";
-import { PatientLinksDTO, dtoFromCW } from "./dtos/linkDTO";
+import { dtoFromCW, PatientLinksDTO } from "./dtos/linkDTO";
 import { linkCreateSchema } from "./schemas/link";
 
 dayjs.extend(duration);
@@ -352,6 +352,10 @@ router.post(
       const cxIds: string[] = cxId ? [cxId] : [];
       if (!cxIds.length) {
         cxIds.push(...(await getCxsWithEnhancedCoverageFeatureFlagValue()));
+      }
+      if (cxIds.length < 1) {
+        console.log(`No customers to Enhanced Coverage, skipping...`);
+        return res.status(status.OK).json({ patientIds: [] });
       }
       log(`Using these cxIds: ${cxIds.join(", ")}`);
 

--- a/packages/utils/src/bulk-insert-patients.ts
+++ b/packages/utils/src/bulk-insert-patients.ts
@@ -53,7 +53,11 @@ async function main() {
   // This will insert all the patients into a specific facility.
   // Based off the apiKey it will determine the cx to add to the patients.
   fs.createReadStream(path.join(__dirname, inputFileName))
-    .pipe(csv())
+    .pipe(
+      csv({
+        mapHeaders: ({ header }) => header.toLowerCase().replaceAll(" ", ""),
+      })
+    )
     .on("data", async data => {
       const metriportPatient = mapCSVPatientToMetriportPatient(data);
       if (metriportPatient) {

--- a/packages/utils/src/commonwell/enhance-coverage.ts
+++ b/packages/utils/src/commonwell/enhance-coverage.ts
@@ -43,6 +43,11 @@ import { firefox as runtime } from "playwright";
 const patientIds: string[] = [];
 
 /**
+ * Update this, each situation requires a diff value here.
+ */
+const triggerWHNotificationsToCx = false;
+
+/**
  * During the execution, if the cookie gets outdated and the script errors, you'll need to set the index below
  * to the last one that was successful.
  */
@@ -70,7 +75,6 @@ const WAIT_BETWEEN_LINKING_AND_DOC_QUERY = dayjs.duration({ seconds: 30 });
 const DOC_QUERIES_IN_PARALLEL = 25;
 const maxDocQueryAttempts = 3;
 const minDocsToConsiderCompleted = 2;
-const triggerWHNotificationsToCx = true;
 const prefix = "############################### ";
 
 class CodeChallengeFromTerminal implements CodeChallenge {

--- a/packages/utils/src/customer-requests/get-exams.ts
+++ b/packages/utils/src/customer-requests/get-exams.ts
@@ -1,0 +1,200 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import {
+  Bundle,
+  BundleEntry,
+  Coding,
+  Condition,
+  MedicationRequest,
+  Resource,
+} from "@medplum/fhirtypes";
+import { MetriportMedicalApi } from "@metriport/api-sdk";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
+import { getEnvVar, getEnvVarOrFail } from "@metriport/core/util/env-var";
+import { out } from "@metriport/core/util/log";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import isBetween from "dayjs/plugin/isBetween";
+import fs from "fs";
+
+dayjs.extend(duration);
+dayjs.extend(isBetween);
+
+/**
+ * Query patients for Exams. This will:
+ * - loop through patients in the list;
+ * - for each patient:
+ *   - query the patient's records;
+ *   - count the number of MedicationRequest resources;
+ *   - count the number of Condition resources with ICD-10 code Z00* and onset date within the last year;
+ * - write the results to a CSV file.
+ *
+ * To run this script, set the env vars, the date range, system/exam code, and the list of patient IDs below.
+ */
+
+// The date range is inclusive on both ends
+const fromDate = "2022-10-18";
+const toDate = "2023-10-18";
+// adjust according to the disired results
+const systemsToSearchForVisits = ["icd-10"];
+const examCode = "Z00";
+// Make sure to set the patient IDs below
+const patientIds: string[] = [];
+
+const apiUrl = getEnvVarOrFail("API_URL");
+const apiKey = getEnvVarOrFail("API_KEY");
+const cxName = getEnvVarOrFail("CX_NAME");
+const facilityId = getEnvVarOrFail("FACILITY_ID");
+const minJitterMillis = 100;
+const maxJitterMillis = 300;
+const numberOfParallelExecutions = parseInt(getEnvVar("PARALLEL_QUERIES") ?? "5");
+const curDateTime = new Date();
+const runName = `${cxName}`;
+const baseDir = `./${runName}`;
+const patientCsvHeader = "id,records,medications,exams\n";
+
+const metriportAPI = new MetriportMedicalApi(apiKey, {
+  baseAddress: apiUrl,
+  timeout: 120_000,
+});
+
+function buildFileName(): string {
+  return `${baseDir}/exam_${curDateTime.toISOString()}.csv`;
+}
+
+async function main() {
+  console.log(`########################## Running... - started at ${new Date().toISOString()}`);
+  const startedAt = Date.now();
+
+  const listPatient = await metriportAPI.listPatients(facilityId);
+
+  const patients = listPatient.filter(patient => patientIds.includes(patient.id));
+
+  fs.mkdirSync(baseDir);
+  console.log(`>>> Found ${patients.length} patients.`);
+  const fileName = buildFileName();
+  fs.writeFileSync(fileName, patientCsvHeader);
+
+  const errors: { patientId: string; error: Error }[] = [];
+  await executeAsynchronously(
+    patients,
+    async (patient, itemIndex, promiseIndex) => {
+      const { log } = out(`${promiseIndex + 1}-${itemIndex + 1}`);
+      try {
+        const payload = await queryResourceForPatient(patient.id);
+        fs.appendFileSync(fileName, createRow(payload).toString());
+        //eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        log(`Error getting resources for patient ${patient.id}`);
+        errors.push({ patientId: patient.id, error });
+      }
+    },
+    {
+      numberOfParallelExecutions: numberOfParallelExecutions,
+      minJitterMillis,
+      maxJitterMillis,
+    }
+  );
+  console.log(`>>> Errors (${errors.length}):`);
+  errors.forEach(e => console.log(`...patient ${e.patientId}: ${e.error.message}`));
+
+  const duration = Date.now() - startedAt;
+  const durationMin = dayjs.duration(duration).asMinutes();
+  console.log(`########################## Total time: ${duration} ms / ${durationMin} min`);
+}
+
+async function queryResourceForPatient(patientId: string): Promise<{
+  id: string;
+  recordsCount: number;
+  medicationCount: number;
+  examCount: number;
+}> {
+  const records = await metriportAPI.getPatientConsolidated(patientId, [], fromDate, toDate);
+  const medicationRequestCount = getMedicationRequests(records).length;
+  const conditions = getConditions(records);
+  const visitsForExam = conditions.length ? getVisitsForExam(conditions) : [];
+  return {
+    id: patientId,
+    recordsCount: records.entry?.length ?? 0,
+    medicationCount: medicationRequestCount ?? 0,
+    examCount: visitsForExam.length,
+  };
+}
+
+function getMedicationRequests(medicationRequests: Bundle<Resource>): MedicationRequest[] {
+  return (medicationRequests.entry ?? []).flatMap(entry =>
+    entry?.resource?.resourceType === "MedicationRequest" ? entry.resource : []
+  );
+}
+function getConditions(records: Bundle<Resource>): Condition[] {
+  return (records.entry ?? []).flatMap(entry =>
+    entry?.resource?.resourceType === "Condition" ? entry.resource : []
+  );
+}
+
+function getVisitsForExam(conditions: Condition[]): BundleEntry<Resource>[] {
+  const visits = conditions.filter(condition => {
+    const code = getSpecificCode(condition.code?.coding ?? [], systemsToSearchForVisits);
+    if (!code) return false;
+    return code.includes(examCode) && isWithinDateRange(condition.onsetDateTime);
+  });
+  return visits;
+}
+
+function isWithinDateRange(date: string | undefined): boolean {
+  if (!date) return false;
+  return dayjs(date).isBetween(fromDate, toDate, "day", "[]");
+}
+
+// return the first code that matches the system
+// systemList should be in order of priority
+function getSpecificCode(coding: Coding[], systemsList: string[]): string | null {
+  let specifiedCode: string | null = null;
+
+  if (systemsList.length) {
+    for (const system of systemsList) {
+      const code = coding.find(coding => {
+        return coding.system?.toLowerCase().includes(system);
+      })?.code;
+
+      if (code && !specifiedCode) {
+        specifiedCode = `${system.toUpperCase()}: ${code}`;
+      }
+    }
+  }
+
+  return specifiedCode;
+}
+type Row = {
+  toString: () => string;
+  data: Record<string, string | undefined>;
+};
+
+function createRow({
+  id,
+  recordsCount,
+  medicationCount,
+  examCount,
+}: {
+  id: string;
+  recordsCount: number;
+  medicationCount: number;
+  examCount: number;
+}): Row {
+  const row = {
+    id,
+    recordFound: recordsCount > 0 ? "Yes" : "No",
+    medicationsFound: medicationCount > 0 ? "Yes" : "No",
+    examCount: examCount > 0 ? "Yes" : "No",
+  };
+
+  const rowAsString =
+    `${row.id},` + `${row.recordFound},` + `${row.medicationsFound},` + `${row.examCount}\n`;
+  return {
+    toString: () => rowAsString,
+    data: row,
+  };
+}
+
+main();


### PR DESCRIPTION
Ref: metriport/metriport#1040

### Dependencies

none

### Description

Fix issues found when running AWE last night + add the AWE script itself.

- do not run EC w/o cxId
- local EC do not send WH by default
- bulk insert w/ more flexible column names
- add get-exam script
- update docs so CXs know they should expect more than one WH for requested data - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1699313863011839?thread_ts=1699312935.047899&cid=C04DMKE9DME)

### Release Plan

- nothing special