### PR TITLE
1195 create endpoint to reset CQ bridge include list

### DIFF
--- a/packages/api/src/external/commonwell/__tests__/organization.test.ts
+++ b/packages/api/src/external/commonwell/__tests__/organization.test.ts
@@ -6,7 +6,7 @@ import { CQOrgHydrated } from "@metriport/core/external/commonwell/cq-bridge/get
 import { makeSimpleOrg } from "@metriport/core/external/commonwell/cq-bridge/__tests__/cq-orgs";
 import { CommonWellManagementAPI } from "@metriport/core/external/commonwell/management/api";
 import * as api from "../api";
-import { linkOrgToCQFacilities } from "../organization";
+import { initCQOrgIncludeList } from "../organization";
 jest.mock("@metriport/core/external/commonwell/management/api");
 jest.mock("@metriport/core/domain/auth/cookie-management/cookie-manager-in-memory");
 
@@ -28,12 +28,12 @@ beforeEach(() => {
 });
 
 describe("organization", () => {
-  describe("linkOrgToCQFacilities", () => {
+  describe("initCQOrgIncludeList", () => {
     it("dont update if no managementApi", async () => {
       const orgOID = faker.string.uuid();
       makeCommonWellManagementAPI_mock.mockImplementationOnce(() => undefined);
 
-      await linkOrgToCQFacilities(orgOID);
+      await initCQOrgIncludeList(orgOID);
 
       expect(updateIncludeList_mock).not.toHaveBeenCalled();
     });
@@ -41,7 +41,7 @@ describe("organization", () => {
     it("updates if when managementApi is present", async () => {
       const orgOID = faker.string.uuid();
 
-      await linkOrgToCQFacilities(orgOID);
+      await initCQOrgIncludeList(orgOID);
 
       expect(updateIncludeList_mock).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -56,7 +56,7 @@ describe("organization", () => {
       const expectedCQOrgIds = orgs.map(o => o.id);
       getOrgsByPrio_mock.mockReturnValueOnce({ high: orgs });
 
-      await linkOrgToCQFacilities(orgOID);
+      await initCQOrgIncludeList(orgOID);
 
       expect(updateIncludeList_mock).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -70,7 +70,7 @@ describe("organization", () => {
       expect(orgs.length).toEqual(100);
       getOrgsByPrio_mock.mockReturnValueOnce({ high: orgs });
 
-      await linkOrgToCQFacilities(faker.string.uuid());
+      await initCQOrgIncludeList(faker.string.uuid());
 
       const param = updateIncludeList_mock.mock.calls[0][0];
       expect(param).toBeTruthy();
@@ -83,7 +83,7 @@ describe("organization", () => {
       updateIncludeList_mock.mockImplementationOnce(() => {
         throw new Error("test error");
       });
-      await expect(linkOrgToCQFacilities(faker.string.uuid())).resolves.not.toThrow();
+      await expect(initCQOrgIncludeList(faker.string.uuid())).resolves.not.toThrow();
     });
   });
 });

--- a/packages/api/src/external/commonwell/organization.ts
+++ b/packages/api/src/external/commonwell/organization.ts
@@ -84,7 +84,7 @@ export const create = async (org: Organization): Promise<void> => {
     debug(`resp respAddCert: `, JSON.stringify(respAddCert));
 
     // update the CQ bridge include list
-    await linkOrgToCQFacilities(org.oid);
+    await initCQOrgIncludeList(org.oid);
   } catch (error) {
     const msg = `Failure creating Org @ CW`;
     log(msg, error);
@@ -134,7 +134,7 @@ export const update = async (org: Organization): Promise<void> => {
  * TODO remove this when we disable/remove Enhanced Coverage in favour of CQ integration.
  * This is not sound as it's tying our Orgs to the CW's CQ bridge.
  */
-export async function linkOrgToCQFacilities(orgOID: string): Promise<void> {
+export async function initCQOrgIncludeList(orgOID: string): Promise<void> {
   try {
     const managementApi = makeCommonWellManagementAPI();
     if (!managementApi) {

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -7,13 +7,15 @@ import {
 } from "../command/medical/admin/populate-fhir";
 import { redriveSidechainDLQ } from "../command/medical/admin/redrive-dlq";
 import { allowMapiAccess, revokeMapiAccess } from "../command/medical/mapi-access";
+import { getOrganizationOrFail } from "../command/medical/organization/get-organization";
 import BadRequestError from "../errors/bad-request";
+import { initCQOrgIncludeList } from "../external/commonwell/organization";
 import { countResources } from "../external/fhir/patient/count-resources";
 import { OrganizationModel } from "../models/medical/organization";
 import userRoutes from "./devices/internal-user";
+import carequalityRoutes from "./medical/internal-cq";
 import docsRoutes from "./medical/internal-docs";
 import patientRoutes from "./medical/internal-patient";
-import carequalityRoutes from "./medical/internal-cq";
 import { getUUIDFrom } from "./schemas/uuid";
 import { asyncHandler, getFrom } from "./util";
 
@@ -153,6 +155,21 @@ router.get(
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const result = await countResources({ patient: { cxId } });
     return res.json(result);
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * POST /internal/cq-include-list/reset
+ *
+ * Resets the CQ include list on CW for the given customer.
+ */
+router.post(
+  "/cq-include-list/reset",
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").orFail();
+    const org = await getOrganizationOrFail({ cxId });
+    await initCQOrgIncludeList(org.oid);
+    return res.sendStatus(httpStatus.OK);
   })
 );
 


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1215
- Downstream: none

### Description

Create endpoint to reset CQ bridge include list 

### Release Plan

- nothing special