### PR TITLE
1195 add more CQ org chunks to EC

### DIFF
--- a/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer.ts
+++ b/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer.ts
@@ -2,7 +2,7 @@ import { PatientLoader } from "../../../domain/patient/patient-loader";
 import { CQOrgHydrated, getOrgChunksFromPos, getOrgsByPrio, OrgPrio } from "./get-orgs";
 
 // Try to keep it even to make testing easier
-export const defaultMaxOrgsToProcess = 200;
+export const defaultMaxOrgsToProcess = 300;
 
 export type CoverageEnhancementParams = {
   cxId: string;

--- a/packages/core/src/external/commonwell/management/api.ts
+++ b/packages/core/src/external/commonwell/management/api.ts
@@ -13,7 +13,7 @@ import { safeStringify } from "../../../util/string";
 dayjs.extend(duration);
 
 const DEFAULT_TIMEOUT_GET_MEMBER = dayjs.duration({ seconds: 20 });
-const DEFAULT_TIMEOUT_INCLUDE_LIST = dayjs.duration({ minutes: 3 });
+const DEFAULT_TIMEOUT_INCLUDE_LIST = dayjs.duration({ minutes: 5 });
 
 export const userAgent =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36";


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Dependencies

none

### Description

- add more CQ org chunks to EC from 4 to 6 (300 orgs)
- increase timeout on CW Include List from 3 to 5min

### Release Plan

- nothing special
- asap