### PR TITLE
PATCH RELEASE 1195 update ec run schedule

### DIFF
--- a/packages/infra/lib/api-stack/cw-enhanced-coverage-connector.ts
+++ b/packages/infra/lib/api-stack/cw-enhanced-coverage-connector.ts
@@ -38,7 +38,7 @@ export function settings(props: EnhancedCoverageConnectorProps) {
      * @see: https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html
      */
     scheduleExpression: isProd(config)
-      ? ["0/30 * ? * * *"] // Every 30min, every day
+      ? ["0/15 * ? * * *"] // Every 15min, every day
       : [],
     memory: 512,
     lambdaTimeout: Duration.minutes(2),


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Description

Update EC schedule to run every 15min instead of 30min.

### Release Plan

- ⚠️ This is pointing to `master`
- nothing special other than that