### PR TITLE
1195 fix call to GET /states

### DIFF
--- a/packages/core/src/domain/patient/patient-loader-metriport-api.ts
+++ b/packages/core/src/domain/patient/patient-loader-metriport-api.ts
@@ -11,9 +11,11 @@ export class PatientLoaderMetriportAPI extends PatientLoader {
   }
 
   public async getStatesFromPatientIds(cxId: string, patientIds: string[]): Promise<string[]> {
-    const resp = await axios.post(`${this.apiUrl}/internal/patient/states`, {
-      cxId,
-      patientIds,
+    const resp = await axios.get(`${this.apiUrl}/internal/patient/states`, {
+      params: {
+        cxId,
+        patientIds: patientIds.join(","),
+      },
     });
     return resp.data.states;
   }

--- a/packages/infra/lib/api-stack/cw-enhanced-coverage-connector.ts
+++ b/packages/infra/lib/api-stack/cw-enhanced-coverage-connector.ts
@@ -38,7 +38,7 @@ export function settings(props: EnhancedCoverageConnectorProps) {
      * @see: https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html
      */
     scheduleExpression: isProd(config)
-      ? ["0/15 * ? * * *"] // Every 15min, every day
+      ? ["0/20 * ? * * *"] // Every 20min, every day
       : [],
     memory: 512,
     lambdaTimeout: Duration.minutes(2),


### PR DESCRIPTION
Ref: metriport/metriport#1195

### Dependencies

none

### Description

Fix call to `GET /states`, did this local while running EC and forgot to push with the previous fixes

Increase the EC window so it runs every 20min instead of 15 - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1700791758967409?thread_ts=1700759304.075919&cid=C0616FCPAKZ).

### Release Plan

- nothing special