### PR TITLE
1230 docx playground

### DIFF
--- a/docs/_snippets/facility.mdx
+++ b/docs/_snippets/facility.mdx
@@ -8,7 +8,7 @@
   the Facility.
 </ParamField>
 
-<ParamField body="address" type="Address" required>
+<ParamField body="address" type="object" required>
   <Snippet file="address.mdx" />
 </ParamField>
 

--- a/docs/_snippets/organization.mdx
+++ b/docs/_snippets/organization.mdx
@@ -8,6 +8,7 @@
   `pharmacy`, `postAcuteCare`.
 </ParamField>
 
-<ParamField body="location" type="Address" required>
+<ParamField body="location" type="object" required>
+  The location of your organizaton of type `Address`
   <Snippet file="address.mdx" />
 </ParamField>

--- a/docs/_snippets/patient.mdx
+++ b/docs/_snippets/patient.mdx
@@ -26,7 +26,7 @@
   The Patient's gender at birth, can be one of `M` or `F`.
 </ParamField>
 
-<ParamField body="personalIdentifiers" type="PersonalIdentifier[]" optional>
+<ParamField body="personalIdentifiers" type="object[]" optional>
   An array of the Patient's personal IDs, such as a driver's license. May be empty.
 
   <Expandable title="PersonalIdentifier properties">
@@ -45,13 +45,13 @@
   </Expandable>
 </ParamField>
 
-<ParamField body="address" type="Address[]" required>
+<ParamField body="address" type="object[]" required>
   An array of `Address` objects, representing the Patient's current and/or previous addresses. May
   be empty.
   <Snippet file="patient-address.mdx" />
 </ParamField>
 
-<ParamField body="contact" type="Contact[]">
+<ParamField body="contact" type="object[]">
   An array of `Contact` objects, representing the Patient's current and/or previous contact information. May be empty.
   <Expandable title="Contact properties">
     <ParamField body="phone" type="string">

--- a/docs/_snippets/patient.mdx
+++ b/docs/_snippets/patient.mdx
@@ -46,6 +46,18 @@
       The assigning entity
     </ParamField>
 
+    <ParamField body="period" type="object" optional>
+       The start and/or end date for the id. You must supply either the start or the end date. 
+      <Expandable title="Period properties">     
+          <ParamField body="start" type="string" optional>
+            The start date, formatted `YYYY-MM-DD` as per ISO 8601.
+          </ParamField>      
+          <ParamField body="end" type="string" optional>
+            The end date, formatted `YYYY-MM-DD` as per ISO 8601.
+          </ParamField>      
+      </Expandable> 
+    </ParamField>
+
   </Expandable>
 </ParamField>
 

--- a/docs/_snippets/patient.mdx
+++ b/docs/_snippets/patient.mdx
@@ -42,6 +42,10 @@
       The ID number.
     </ParamField>
 
+    <ParamField body="assigner" type="string" optional>
+      The assigning entity
+    </ParamField>
+
   </Expandable>
 </ParamField>
 

--- a/docs/medical-api/api-reference/document/post-upload-url.mdx
+++ b/docs/medical-api/api-reference/document/post-upload-url.mdx
@@ -27,15 +27,15 @@ To use this endpoint, you will need to follow these steps:
 ## Body
 
     A FHIR [DocumentReference](/medical-api/fhir/resources/documentreference).
-    <ParamField body="type" type="CodeableConcept" required>
+    <ParamField body="type" type="object" required>
       A [CodeableConcept](/medical-api/fhir/data-types/codeableconcept) of the document type.
       <Expandable title="Type properties">
         <ParamField body="text" type="string" required>
           Plain text representation of the document kind - for example `Burn management Hospital Progress note`
         </ParamField>
 
-        <ParamField body="coding" type="Coding[]">
-          A [Coding](/medical-api/fhir/data-types/coding) property, which is a reference to a code defined by a terminology system (such as [LOINC](https://loinc.org/)) - for example `[{ code: "100556-0", system: "http://loinc.org", display: "Burn management Hospital Progress note"}]`
+        <ParamField body="coding" type="object[]">
+          A [Coding](/medical-api/fhir/data-types/coding) property of type `Coding[]`, which is a reference to a code defined by a terminology system (such as [LOINC](https://loinc.org/)) - for example `[{ code: "100556-0", system: "http://loinc.org", display: "Burn management Hospital Progress note"}]`
         </ParamField>
       </Expandable>
     </ParamField>
@@ -44,16 +44,16 @@ To use this endpoint, you will need to follow these steps:
       A brief description of the document - for example `Discharge Summary`.
     </ParamField>
 
-    <ParamField body="context" type="DocumentReferenceContext[]" required>
-      Context of the document content.
+    <ParamField body="context" type="object[]" required>
+      Context of the document content of type `DocumentReferenceContext[]`.
       <Expandable title="Context properties">
-        <ParamField body="period" type="Period" required>
-          A time [Period](/medical-api/fhir/data-types/period) property including ISO 8601 timestamp(s) - for example
+        <ParamField body="period" type="object" required>
+          A time [Period](/medical-api/fhir/data-types/period) property of type `Period` including ISO 8601 timestamp(s) - for example
           `{ start: "2023-10-10T14:14:17Z" },`
         </ParamField>
 
-        <ParamField body="facilityType" type="CodeableConcept">
-          An object that represents the facility type.
+        <ParamField body="facilityType" type="object">
+          An object of type `CodeableConcept` that represents the facility type.
             <Expandable title="Facility type properties">
               <ParamField body="text" type="string">
                 Plain text with the facility name and type - for example `John Snow Clinic - Acute Care Centre`.

--- a/docs/medical-api/api-reference/fhir/create-patient-consolidated.mdx
+++ b/docs/medical-api/api-reference/fhir/create-patient-consolidated.mdx
@@ -20,7 +20,7 @@ api: "PUT /medical/v1/patient/{id}/consolidated"
   The type needs to be "collection"
 </ParamField>
 
-<ParamField body="entry" type="array" required>
+<ParamField body="entry" type="object[]" required>
   The entry needs to be an array of [FHIR resources](/medical-api/fhir/resources).
 </ParamField>
 

--- a/fern/definition/medical/document.yml
+++ b/fern/definition/medical/document.yml
@@ -97,6 +97,12 @@ service:
             docs: |
               Value to search on the document reference (minimum 3 chars).
             type: optional<string>
+          output:
+            docs: |
+              The output format of the document. Either `fhir` or `dto`.
+            type: optional<string>
+            audiences: 
+              - internal
       response:
         type: MedplumDocumentReference
         docs: An array of objects describing the Documents that can be retrieved for the Patient.

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -2,6 +2,7 @@ groups:
   publish:
     audiences: 
       - public
+      - internal
     generators:
       - name: fernapi/fern-python-sdk
         version: 0.6.5

--- a/packages/api/src/routes/medical/schemas/patient.ts
+++ b/packages/api/src/routes/medical/schemas/patient.ts
@@ -1,4 +1,6 @@
 import { PatientCreate, patientCreateSchema } from "@metriport/api-sdk";
+import { defaultDateString } from "./shared";
+
 import { z } from "zod";
 import { driversLicenseType, generalTypes } from "../../../domain/medical/patient";
 import { USState } from "@metriport/core/domain/geographic-locations";
@@ -9,13 +11,13 @@ export const basePersonalIdentifierSchema = z.object({
   value: z.string(),
   period: z
     .object({
-      start: z.string(),
-      end: z.string().optional(),
+      start: defaultDateString,
+      end: defaultDateString.optional(),
     })
     .or(
       z.object({
-        start: z.string().optional(),
-        end: z.string(),
+        start: defaultDateString.optional(),
+        end: defaultDateString,
       })
     )
     .optional(),


### PR DESCRIPTION
Ref: #1230 

### Description

- converting body field parameters from type Addresss, Contact, etc. to type object so that mintlify can recognise them and pull them into the playground. See linked image for what they will now look like
- adding missing documentation details
- adding an internal audience to Fern for an internal param 
- I accidentally branched this PR not off develop so will wait to merge until sdk PR is merged. 

![image](https://github.com/metriport/metriport/assets/70026960/7cfca7fd-73a1-4185-944a-91866e811e0d)

### Release Plan

- [x] test on local
- [ ] merge
- [ ] release
- [ ] confirm looks correct on development
