### PR TITLE
1040 move coverage assessment from internal to OSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24521,7 +24521,8 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -39342,6 +39343,7 @@
         "express": "^4.18.1",
         "express-promise-router": "^4.1.1",
         "lodash": "^4.17.21",
+        "mime-types": "^2.1.35",
         "playwright": "^1.39.0",
         "readline-sync": "^1.4.10",
         "sequelize": "^6.31.0"

--- a/packages/api/src/command/medical/patient/get-patient.ts
+++ b/packages/api/src/command/medical/patient/get-patient.ts
@@ -1,7 +1,7 @@
 import { USState } from "@metriport/core/domain/geographic-locations";
 import { intersectionWith, isEqual, uniq } from "lodash";
 import { Op, Transaction } from "sequelize";
-import { Patient, PatientData, getStatesFromAddresses } from "../../../domain/medical/patient";
+import { getStatesFromAddresses, Patient, PatientData } from "../../../domain/medical/patient";
 import NotFoundError from "../../../errors/not-found";
 import { FacilityModel } from "../../../models/medical/facility";
 import { OrganizationModel } from "../../../models/medical/organization";

--- a/packages/utils/.gitignore
+++ b/packages/utils/.gitignore
@@ -133,3 +133,4 @@ scratch*
 *.csv
 bulk-insert-patient-ids.txt
 screenshot*
+runs

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,6 +10,9 @@
     "fhir-uploader": "ts-node src/fhir-uploader.ts",
     "doc-query": "ts-node src/document/document-query.ts",
     "cq-cert-check": "ts-node src/carequality/cq-cert-checker.ts",
+    "bulk-insert": "ts-node src/bulk-insert-patients",
+    "coverage-assessment": "ts-node src/commonwell/coverage-assessment",
+    "enhance-coverage": "ts-node src/commonwell/enhance-coverage",
     "build": "tsc -p .",
     "build:cloud": "npm run build",
     "typecheck": "tsc --noEmit",
@@ -39,6 +42,7 @@
     "express": "^4.18.1",
     "express-promise-router": "^4.1.1",
     "lodash": "^4.17.21",
+    "mime-types": "^2.1.35",
     "playwright": "^1.39.0",
     "readline-sync": "^1.4.10",
     "sequelize": "^6.31.0"

--- a/packages/utils/src/bulk-query-patients.ts
+++ b/packages/utils/src/bulk-query-patients.ts
@@ -28,6 +28,7 @@ const triggerWHNotificationsToCx = false;
 
 // auth stuff
 const cxId = getEnvVarOrFail("CX_ID");
+// TODO update these to use `getCxData()` instead
 const cxName = getEnvVarOrFail("CX_NAME");
 const apiKey = getEnvVarOrFail("API_KEY");
 const apiUrl = getEnvVarOrFail("API_URL");
@@ -50,13 +51,11 @@ const detailedConfig: DetailedConfig = {
 const csvHeader =
   "patientId,firstName,lastName,state,queryAttemptCount,docCount,fhirResourceCount,fhirResourceDetails,status\n";
 const curDateTime = new Date();
-const csvName = `./${replaceAll(cxName, " ", "").trim()}-DocQuery-${curDateTime.toISOString()}.csv`;
+const csvName = `./runs/${cxName
+  .replaceAll(" ", "")
+  .trim()}-DocQuery-${curDateTime.toISOString()}.csv`;
 
 const triggerAndQueryDocRefs = new TriggerAndQueryDocRefsRemote(apiUrl);
-
-function replaceAll(string: string, search: string, replace: string): string {
-  return string.split(search).join(replace);
-}
 
 function initCsv() {
   fs.writeFileSync(csvName, csvHeader);
@@ -109,11 +108,9 @@ async function queryDocsForPatient(patientId: string) {
       csvName,
       `${patient.id},${patient.firstName},${
         patient.lastName
-      },${state},${docQueryAttempts},${docCount},${totalFhirResourceCount},${replaceAll(
-        JSON.stringify(fhirResourceTypesToCounts),
-        ",",
-        " "
-      )},${status}\n`
+      },${state},${docQueryAttempts},${docCount},${totalFhirResourceCount},${JSON.stringify(
+        fhirResourceTypesToCounts
+      ).replaceAll(",", " ")},${status}\n`
     );
     console.log(`>>> Done doc query for patient ${patient.id} with status ${status}...`);
     //eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/utils/src/commonwell/coverage-assessment.ts
+++ b/packages/utils/src/commonwell/coverage-assessment.ts
@@ -1,0 +1,283 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// Keep dotenv import and config before everything else
+import {
+  APIMode,
+  CommonWell,
+  Document,
+  OperationOutcome,
+  PurposeOfUse,
+  RequestMetadata,
+} from "@metriport/commonwell-sdk";
+import { getEnvVarOrFail } from "@metriport/core/util/env-var";
+import * as fs from "fs";
+import * as mime from "mime-types";
+import { getCxData } from "../shared/get-cx-data";
+
+/**
+ * Utility to run a coverage check for a subset of a customer's patients.
+ *
+ * This will:
+ *    - create a new folder in the root dir for the current assessment
+ *    - run a coverage check for each patient in the patientIds array, saving corresponding CW responses to the patient's folder
+ *    - also, will optionally download documents if downloadDocs is `true`
+ *    - finally, spit out a csv containing the coverage report with a row for each patient
+ *
+ * Update the respective env variables and run `npm run coverage-assessment > output.txt`
+ */
+
+const pathToCerts = getEnvVarOrFail("ORG_CERTS_FOLDER");
+const cert = fs.readFileSync(`${pathToCerts}/cert1.pem`, "utf8");
+const privkey = fs.readFileSync(`${pathToCerts}/privkey1.pem`, "utf8");
+
+const apiKey = getEnvVarOrFail("API_KEY");
+
+/**
+ * Only need to provide the facilityId if the CX has more than one facility.
+ * Used to determine the NPI used to query CW.
+ */
+const facilityId: string = ""; // eslint-disable-line @typescript-eslint/no-inferrable-types
+
+/**
+ * List of patients to check coverage for.
+ */
+const patientIds: string[] = [];
+
+const cwApiMode = APIMode.production;
+const downloadDocs = false;
+const csvHeader =
+  "patientId,state,zip,firstName,lastName,dob,gender,personCreatedByOrg,numLinks,linksLOLA2+,docQueryMs,docQueryResults,docQueryErrs,fileTypes,docRetrieves,docRetrieveErrs\n";
+const curDateTime = new Date();
+const runName = (orgName: string) =>
+  `${orgName.replaceAll(" ", "-")}_Assessment_${curDateTime.toISOString()}`;
+const baseDir = (orgName: string) => `./runs/${runName(orgName)}`;
+const dedupMap: { [index: string]: string } = {};
+
+// This will do the assessment with "patientChunkSize" patients at a time, sleeping
+// for "intraChunkSleepMs" ms inbetween chunks - this is an attempt to improve on the
+// amount of 'Too many requests received for the patient - XDSRegistryError" errors
+// that are present, but it's still not clear whether this is effective, so play around with
+// these params as you see fit.
+const patientChunkSize = 5;
+const intraChunkSleepMs = 3000;
+
+function buildCWPatientId(orgOID: string, patientId: string): string {
+  return `${patientId}%5E%5E%5Eurn%3aoid%3a${orgOID}`;
+}
+
+function sanitizeName(name?: string[]): string {
+  return name ? name.map(str => str.replaceAll(",", " ")).join(" ") : "";
+}
+
+async function assessCoverageForPatient(
+  orgName: string,
+  orgOID: string,
+  patientId: string,
+  queryMeta: RequestMetadata,
+  cwApi: CommonWell,
+  resultsCsvFileName: string
+) {
+  const patientDirName = `${baseDir(orgName)}/${patientId}`;
+  const docDirName = `${patientDirName}/docs`;
+
+  //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function printAndSaveResponse(payload: any, fileName: string) {
+    log(`>>> Response:`);
+    log(JSON.stringify(payload, null, 2));
+    fs.writeFileSync(`${patientDirName}/${fileName}`, JSON.stringify(payload));
+  }
+
+  const cwPatientId = buildCWPatientId(orgOID, patientId);
+  let docQueryErrCnt = 0;
+  let docQueryCnt = 0;
+  let docRetrieveErrCnt = 0;
+  let docRetrieveCnt = 0;
+  let numLinks = 0;
+  let cnt = 0;
+  let personCreatedByOrg = false;
+  let allLinksLOLA2 = true;
+  let docQueryResponseTimeMs = 0;
+
+  log(`>>> Checking coverage for patient ${patientId}...`);
+  fs.mkdirSync(patientDirName);
+
+  log(`>>> Getting patient demographics...`);
+  const patient = await cwApi.getPatient(queryMeta, cwPatientId);
+  printAndSaveResponse(patient, "patient.json");
+  const patientAddress = patient.details.address[0];
+  const patientName = patient.details.name[0];
+  const firstName = sanitizeName(patientName.given);
+  const lastName = sanitizeName(patientName.family);
+  const uniquePatientStr = `${patientAddress.state},${patientAddress.zip},${firstName},${lastName},${patient.details.birthDate},${patient.details.gender.code}`;
+  const existingPatientId = dedupMap[uniquePatientStr];
+  if (existingPatientId) {
+    error(
+      `>>> Patient ${existingPatientId} and ${patientId} are duplicates... remove one from the DB`
+    );
+    return;
+  } else {
+    dedupMap[uniquePatientStr] = patientId;
+  }
+  const mimeTypeCnt: { [index: string]: number } = {};
+
+  log(`>>> Checking if the underlying CW person is new and was created by ${orgName}...`);
+  const personResp = await cwApi.searchPersonByPatientDemo(queryMeta, cwPatientId);
+  printAndSaveResponse(personResp, "person.json");
+  if (personResp._embedded.person[0].enrollmentSummary?.enroller === orgName) {
+    personCreatedByOrg = true;
+    warn(
+      `>>> Person was created by ${orgName} - meaning this person did not exist in CW prior to this customer onboarding`
+    );
+  } else {
+    log(`>>> Person already existed in CW`);
+  }
+
+  log(`>>> Checking links...`);
+  const links = await cwApi.getNetworkLinks(queryMeta, cwPatientId);
+  numLinks = links._embedded.networkLink?.length ?? 0;
+  printAndSaveResponse(links, "networkLinks.json");
+
+  if (numLinks < 1) {
+    warn(`>>> No network links found for patient, nothing to query...`);
+  } else {
+    for (const link of links._embedded.networkLink ?? []) {
+      if (parseInt(link?.assuranceLevel || "0") < 2) {
+        allLinksLOLA2 = false;
+        error(`>>> Patient has links less than LOLA 2... this should never happen`);
+        break;
+      }
+    }
+    log(`>>> Running DQ...`);
+    const curTime = new Date();
+    const docs = await cwApi.queryDocumentsFull(queryMeta, cwPatientId);
+    const afterDQTime = new Date();
+    docQueryResponseTimeMs = afterDQTime.getTime() - curTime.getTime();
+    printAndSaveResponse(docs, "docQuery.json");
+    log(`>>> DQ returned ${docs.entry?.length} results.`);
+
+    if (docs.entry && docs.entry.length >= 1) {
+      fs.mkdirSync(docDirName);
+      for (const item of docs.entry) {
+        cnt++;
+        if (item.content?.resourceType === "DocumentReference") {
+          const doc = item as Document;
+          if (doc.content?.location) {
+            if (doc.content.size === 0) {
+              warn(`>>> DQ returned 0 length document, might cause a DR 404"`);
+            }
+            docQueryCnt++;
+
+            let extension = "xml";
+            if (doc.content.mimeType) {
+              let curCnt = mimeTypeCnt[doc.content.mimeType] ?? 0;
+              mimeTypeCnt[doc.content.mimeType] = ++curCnt;
+              const imputedExtension = mime.extension(doc.content.mimeType);
+              extension = imputedExtension ? imputedExtension : extension;
+            }
+
+            if (downloadDocs) {
+              const fileName = `${docDirName}/${cnt}.${extension}`;
+              const outputStream = fs.createWriteStream(fileName, { encoding: undefined });
+              log(`>>> Downloading from ${doc.content.location}`);
+              try {
+                await cwApi.retrieveDocument(queryMeta, doc.content.location, outputStream);
+                log(`>>> File saved to "${fileName}"`);
+                docRetrieveCnt++;
+              } catch (err) {
+                error(`>>> DQ failed with error: ${err}"`);
+                docRetrieveErrCnt++;
+              }
+            } else {
+              log(`>>> Skipping doc download...`);
+            }
+          }
+        } else if (item.content?.resourceType === "OperationOutcome") {
+          const result = item as OperationOutcome;
+          console.log(`>>> DQ contained error: ${JSON.stringify(result.content?.issue, null, 2)}"`);
+          docQueryErrCnt++;
+        }
+      }
+    }
+  }
+
+  log(`>>> Results for patient ${patientId}:
+Total number of results returned: ${cnt}
+Doc refs: ${docQueryCnt}
+Doc refs with issues: ${docQueryErrCnt}
+Docs successfully downloaded: ${downloadDocs ? docRetrieveCnt : "skipped"}
+Docs downloaded but errored: ${downloadDocs ? docRetrieveErrCnt : "skipped"}
+  `);
+
+  // write line to results csv
+  fs.appendFileSync(
+    resultsCsvFileName,
+    `${patientId},${uniquePatientStr},${personCreatedByOrg},${numLinks},${allLinksLOLA2},${docQueryResponseTimeMs},${docQueryCnt},${docQueryErrCnt},${JSON.stringify(
+      mimeTypeCnt
+    ).replaceAll(",", " ")},${docRetrieveCnt},${docRetrieveErrCnt}\n`
+  );
+}
+
+async function main() {
+  // const { npi, orgName, orgOID } = await getCxData(apiKey, patientIds, includeAllPatients);
+  const { npi, orgName, orgOID } = await getCxData(apiKey, facilityId.trim());
+
+  const cwApi = new CommonWell(cert, privkey, orgName, "urn:oid:" + orgOID, cwApiMode);
+  const base = {
+    purposeOfUse: PurposeOfUse.TREATMENT,
+    role: "ict",
+    subjectId: `${orgName} System User`,
+  };
+  const queryMeta = {
+    subjectId: base.subjectId,
+    role: base.role,
+    purposeOfUse: base.purposeOfUse,
+    npi: npi,
+  };
+  const dirName = baseDir(orgName);
+  fs.mkdirSync(dirName);
+
+  // create results csv
+  const resultsCsvFileName = `${dirName}/${runName(orgName)}.csv`;
+  fs.writeFileSync(resultsCsvFileName, csvHeader);
+
+  // TODO review this logic, input 9 and got 8 results on the CSV - https://metriport.slack.com/archives/C04GEQ1GH9D/p1698700612408739?thread_ts=1698699585.390059&cid=C04GEQ1GH9D
+  // >> it might be a concurrency issue when trying to update the same file
+  // >> could return the results to the main Promise and write them synchronously
+  // TODO OSS has a function to run stuff in parallel/chunks
+  log(`>>> Checking coverage for total ${patientIds.length} patients...`);
+  for (let i = 0; i < patientIds.length; i += patientChunkSize) {
+    const chunk = patientIds.slice(i, i + patientChunkSize);
+    log(`>>> Now checking coverage for chunk of ${chunk.length} patients...`);
+    const coverageAssessments: Promise<void>[] = [];
+    for (const patientId of chunk) {
+      coverageAssessments.push(
+        assessCoverageForPatient(
+          orgName,
+          orgOID,
+          patientId,
+          queryMeta,
+          cwApi,
+          resultsCsvFileName
+        ).catch(error => {
+          error(`>>> Error assessing coverage for patient ${patientId}: ${error}`);
+        })
+      );
+    }
+    await Promise.allSettled(coverageAssessments);
+
+    log(`>>> Now sleeping for ${intraChunkSleepMs} ms to avoid rate limiting...`);
+    await new Promise(f => setTimeout(f, intraChunkSleepMs));
+  }
+}
+
+function log(...args: unknown[]) {
+  console.log(...args);
+}
+function warn(...args: unknown[]) {
+  console.log("WARN ", ...args);
+}
+function error(...args: unknown[]) {
+  console.log("ERROR ", ...args);
+}
+
+main();

--- a/packages/utils/src/commonwell/cq-org-builder.ts
+++ b/packages/utils/src/commonwell/cq-org-builder.ts
@@ -31,7 +31,7 @@ import { Gateway } from "./cq-org-types";
  */
 
 const resultFilename = `../../packages/core/src/external/commonwell/cq-bridge/cq-org-list.json`;
-const outputFailedFilename = `cq-org-builder.failed`;
+const outputFailedFilename = `./runs/cq-org-builder.failed`;
 
 const sequoiaApiKey = getEnvVarOrFail("SEQUOIA_API_KEY");
 const sequoiaQueryURL = `https://wpapi.sequoiaproject.org/fhir-stu3/1.0.0/Organization`;

--- a/packages/utils/src/commonwell/cq-org-grouper.ts
+++ b/packages/utils/src/commonwell/cq-org-grouper.ts
@@ -11,10 +11,10 @@ import originalPayloadFromCW from "./cq-org-list-original.json";
  */
 
 const orgsCSVHeader = "id\tname\t# of states\tgateway\n";
-const orgsCSVName = `./cq-orgs.csv`;
+const orgsCSVName = `./runs/cq-orgs.csv`;
 
 const gwCSVHeader = "id\tgateway\t# of orgs\n";
-const gwCSVName = `./cq-orgs-by-gateway.csv`;
+const gwCSVName = `./runs/cq-orgs-by-gateway.csv`;
 
 function initCSVs() {
   fs.writeFileSync(orgsCSVName, orgsCSVHeader);

--- a/packages/utils/src/commonwell/enhance-coverage.ts
+++ b/packages/utils/src/commonwell/enhance-coverage.ts
@@ -27,6 +27,7 @@ import { CookieManagerOnSecrets } from "@metriport/core/domain/auth/cookie-manag
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { sleep } from "@metriport/core/util/sleep";
 import { firefox as runtime } from "playwright";
+import { getCxData } from "../shared/get-cx-data";
 
 /**
  * Script to run on local environment the code that enhances coverage @ CommonWell.
@@ -43,13 +44,19 @@ import { firefox as runtime } from "playwright";
  * Try to limit the impact on the infrastructure by providing a list of patient IDs below.
  */
 
+/**
+ * Only need to provide the facilityId if the CX has more than one facility.
+ * Used to determine the NPI used to query CW.
+ */
+const facilityId: string = ""; // eslint-disable-line @typescript-eslint/no-inferrable-types
+/**
+ * List of patients to check coverage for.
+ */
 const patientIds: string[] = [];
-
 /**
  * Update this, each situation requires a diff value here.
  */
 const triggerWHNotificationsToCx = false;
-
 /**
  * During the execution, if the cookie gets outdated and the script errors, you'll need to set the index below
  * to the last one that was successful.
@@ -77,8 +84,9 @@ const cwUsername = getEnvVarOrFail("CW_USERNAME");
 const cwPassword = getEnvVarOrFail("CW_PASSWORD");
 
 const metriportApiBaseUrl = getEnvVarOrFail("API_URL");
+const apiKey = getEnvVarOrFail("API_KEY");
 const cxId = getEnvVarOrFail("CX_ID");
-const cxOrgOID = getEnvVarOrFail("ORG_OID");
+// const cxOrgOID = getEnvVarOrFail("ORG_OID");
 
 const WAIT_BETWEEN_LINKING_AND_DOC_QUERY = dayjs.duration({ seconds: 30 });
 const DOC_QUERIES_IN_PARALLEL = 25;
@@ -124,6 +132,8 @@ const coverageEnhancer = new CoverageEnhancerLocal(
 const triggerAndQueryDocRefs = new TriggerAndQueryDocRefsRemote(metriportApiBaseUrl);
 
 export async function main() {
+  const { orgOID: cxOrgOID } = await getCxData(apiKey, facilityId);
+
   console.log(`Running coverage enhancement... - started at ${new Date().toISOString()}`);
   const startedAt = Date.now();
 

--- a/packages/utils/src/customer-requests/get-exams.ts
+++ b/packages/utils/src/customer-requests/get-exams.ts
@@ -43,6 +43,7 @@ const examCode = "Z00";
 const patientIds: string[] = [];
 
 const apiUrl = getEnvVarOrFail("API_URL");
+// TODO update these to use `getCxData()` instead
 const apiKey = getEnvVarOrFail("API_KEY");
 const cxName = getEnvVarOrFail("CX_NAME");
 const facilityId = getEnvVarOrFail("FACILITY_ID");
@@ -50,8 +51,8 @@ const minJitterMillis = 100;
 const maxJitterMillis = 300;
 const numberOfParallelExecutions = parseInt(getEnvVar("PARALLEL_QUERIES") ?? "5");
 const curDateTime = new Date();
-const runName = `${cxName}`;
-const baseDir = `./${runName}`;
+const runName = `${cxName.replaceAll(" ", "-")}_Exams_${curDateTime.toISOString()}`;
+const baseDir = `./runs/${runName}`;
 const patientCsvHeader = "id,records,medications,exams\n";
 
 const metriportAPI = new MetriportMedicalApi(apiKey, {

--- a/packages/utils/src/get-medication-list.ts
+++ b/packages/utils/src/get-medication-list.ts
@@ -12,6 +12,7 @@ import fs from "fs";
 import { orderBy } from "lodash";
 
 const fromDate = "2022-10-12"; // TODO make this dynamic, maybe number of months, with a default of 6 months?
+// TODO update these to use `getCxData()` instead
 const apiUrl = getEnvVarOrFail("API_URL");
 const apiKey = getEnvVarOrFail("API_KEY");
 const cxName = getEnvVarOrFail("CX_NAME");
@@ -24,8 +25,8 @@ const dateFormat = "YYYY-MM-DD";
 const patientCsvHeader = "date,status,medication,dosage,quantity\n";
 const consolidatedCsvHeader = "id,firstName,lastName,dob,genderAtBirth," + patientCsvHeader;
 const curDateTime = new Date();
-const runName = `${cxName}-${curDateTime.toISOString()}`;
-const baseDir = `./${runName}`;
+const runName = `${cxName.replaceAll(" ", "-")}_Medications_${curDateTime.toISOString()}`;
+const baseDir = `./runs/${runName}`;
 
 const patientIds: string[] = [];
 

--- a/packages/utils/src/shared/get-cx-data.ts
+++ b/packages/utils/src/shared/get-cx-data.ts
@@ -1,0 +1,39 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// Keep dotenv import and config before everything else
+import { Facility, MetriportMedicalApi } from "@metriport/api-sdk";
+
+// Write a function to get the env vars from the customer data using the api sdk
+export async function getCxData(
+  apiKey: string,
+  facilityId?: string | undefined
+): Promise<{ npi: string; orgName: string; orgOID: string }> {
+  console.log(`>>> Getting customer data...`);
+
+  // get data from the api using the api-sdk
+  const api = new MetriportMedicalApi(apiKey);
+  const org = await api.getOrganization();
+  if (!org) throw new Error("No organization found");
+
+  const getFacility = async (): Promise<Facility> => {
+    const facilities = await api.listFacilities();
+    if (facilities.length < 1) throw new Error("No facility found");
+    if (facilityId) {
+      const facility = facilities.find(f => f.id === facilityId);
+      if (!facility) throw new Error("No facility matching the provided ID was found");
+      return facility;
+    }
+    if (facilities.length > 1) throw new Error("Got more than one facility");
+    return facilities[0];
+  };
+  const facility = await getFacility();
+
+  const res = {
+    npi: facility.npi,
+    orgName: org.name,
+    orgOID: org.oid,
+  };
+
+  console.log(`>>> Customer data retrieved.`, res);
+  return res;
+}

--- a/packages/utils/src/shared/get-cx-data.ts
+++ b/packages/utils/src/shared/get-cx-data.ts
@@ -7,7 +7,7 @@ import { Facility, MetriportMedicalApi } from "@metriport/api-sdk";
 export async function getCxData(
   apiKey: string,
   facilityId?: string | undefined
-): Promise<{ npi: string; orgName: string; orgOID: string }> {
+): Promise<{ facilityId: string; npi: string; orgName: string; orgOID: string }> {
   console.log(`>>> Getting customer data...`);
 
   // get data from the api using the api-sdk
@@ -29,6 +29,7 @@ export async function getCxData(
   const facility = await getFacility();
 
   const res = {
+    facilityId: facility.id,
     npi: facility.npi,
     orgName: org.name,
     orgOID: org.oid,


### PR DESCRIPTION
Ref: metriport/metriport#1040

### Dependencies

- related: https://github.com/metriport/metriport-internal/pull/1289
- downstream: https://github.com/metriport/metriport/pull/1233

### Description

- move coverage assessment from internal to here
- start getting env data from the API instead of env vars
- bulk insert more reliable to process phone
- add npm script for utils
- update a few API commands to return interface instead of model

### Release Plan

- nothing special