### PR TITLE
1040 get cx data for scripts from internal endpoint

### DIFF
--- a/packages/utils/src/commonwell/coverage-assessment.ts
+++ b/packages/utils/src/commonwell/coverage-assessment.ts
@@ -30,7 +30,7 @@ const pathToCerts = getEnvVarOrFail("ORG_CERTS_FOLDER");
 const cert = fs.readFileSync(`${pathToCerts}/cert1.pem`, "utf8");
 const privkey = fs.readFileSync(`${pathToCerts}/privkey1.pem`, "utf8");
 
-const apiKey = getEnvVarOrFail("API_KEY");
+const cxId = getEnvVarOrFail("CX_ID");
 
 /**
  * Only need to provide the facilityId if the CX has more than one facility.
@@ -218,8 +218,7 @@ Docs downloaded but errored: ${downloadDocs ? docRetrieveErrCnt : "skipped"}
 }
 
 async function main() {
-  // const { npi, orgName, orgOID } = await getCxData(apiKey, patientIds, includeAllPatients);
-  const { npi, orgName, orgOID } = await getCxData(apiKey, facilityId.trim());
+  const { npi, orgName, orgOID } = await getCxData(cxId, facilityId.trim());
 
   const cwApi = new CommonWell(cert, privkey, orgName, "urn:oid:" + orgOID, cwApiMode);
   const base = {

--- a/packages/utils/src/commonwell/enhance-coverage.ts
+++ b/packages/utils/src/commonwell/enhance-coverage.ts
@@ -84,9 +84,7 @@ const cwUsername = getEnvVarOrFail("CW_USERNAME");
 const cwPassword = getEnvVarOrFail("CW_PASSWORD");
 
 const metriportApiBaseUrl = getEnvVarOrFail("API_URL");
-const apiKey = getEnvVarOrFail("API_KEY");
 const cxId = getEnvVarOrFail("CX_ID");
-// const cxOrgOID = getEnvVarOrFail("ORG_OID");
 
 const WAIT_BETWEEN_LINKING_AND_DOC_QUERY = dayjs.duration({ seconds: 30 });
 const DOC_QUERIES_IN_PARALLEL = 25;
@@ -132,7 +130,7 @@ const coverageEnhancer = new CoverageEnhancerLocal(
 const triggerAndQueryDocRefs = new TriggerAndQueryDocRefsRemote(metriportApiBaseUrl);
 
 export async function main() {
-  const { orgOID: cxOrgOID } = await getCxData(apiKey, facilityId);
+  const { orgOID: cxOrgOID } = await getCxData(cxId, facilityId);
 
   console.log(`Running coverage enhancement... - started at ${new Date().toISOString()}`);
   const startedAt = Date.now();

--- a/packages/utils/src/shared/get-cx-data.ts
+++ b/packages/utils/src/shared/get-cx-data.ts
@@ -1,23 +1,34 @@
 import * as dotenv from "dotenv";
 dotenv.config();
 // Keep dotenv import and config before everything else
-import { Facility, MetriportMedicalApi } from "@metriport/api-sdk";
+import { Facility, Organization } from "@metriport/api-sdk";
+import { getEnvVarOrFail } from "@metriport/core/util/env-var";
+import axios from "axios";
+
+const apiUrl = getEnvVarOrFail("API_URL");
 
 // Write a function to get the env vars from the customer data using the api sdk
 export async function getCxData(
-  apiKey: string,
+  cxId: string,
   facilityId?: string | undefined
 ): Promise<{ facilityId: string; npi: string; orgName: string; orgOID: string }> {
   console.log(`>>> Getting customer data...`);
 
-  // get data from the api using the api-sdk
-  const api = new MetriportMedicalApi(apiKey);
-  const org = await api.getOrganization();
+  const respCxData = await axios.get(apiUrl + "/internal/cx-data", {
+    params: {
+      cxId,
+    },
+  });
+  console.log(`>>> Customer data retrieved:`, respCxData.data);
+
+  const org: Organization | undefined = respCxData.data.org;
+  const facilities: Facility[] | undefined = respCxData.data.facilities;
+
   if (!org) throw new Error("No organization found");
+  if (!facilities) throw new Error("No organization found");
 
   const getFacility = async (): Promise<Facility> => {
-    const facilities = await api.listFacilities();
-    if (facilities.length < 1) throw new Error("No facility found");
+    if (!facilities || facilities.length < 1) throw new Error("No facility found");
     if (facilityId) {
       const facility = facilities.find(f => f.id === facilityId);
       if (!facility) throw new Error("No facility matching the provided ID was found");
@@ -35,6 +46,5 @@ export async function getCxData(
     orgOID: org.oid,
   };
 
-  console.log(`>>> Customer data retrieved.`, res);
   return res;
 }


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport/issues/1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1232
- Downstream: none

### Description

Get cx data for scripts from internal endpoint instead of env vars

### Release Plan

- merge upstrem
- merge this