### PR TITLE
fix(cq): bug fix for sandbox

### DIFF
--- a/packages/api/src/external/carequality/api.ts
+++ b/packages/api/src/external/carequality/api.ts
@@ -6,7 +6,10 @@ import { Carequality } from "@metriport/carequality-sdk";
  * @param apiKey Optional, API key to use for authentication. If not used, the API key will be retrieved from the environment variables.
  * @returns Carequality API.
  */
-export function makeCarequalityAPI(apiKey?: string): Carequality {
+export function makeCarequalityAPI(apiKey?: string): Carequality | undefined {
+  if (Config.isSandbox()) {
+    return;
+  }
   const cqApiKey = apiKey ?? Config.getCQApiKey();
   return new Carequality(cqApiKey);
 }

--- a/packages/api/src/external/carequality/organization.ts
+++ b/packages/api/src/external/carequality/organization.ts
@@ -23,6 +23,10 @@ export type CQOrgDetails = {
 
 export async function createOrUpdateCQOrganization(): Promise<void> {
   const cqOrgDetailsString = Config.getCQOrgDetails();
+  if (!cq) {
+    const msg = "No CQ API key found. Skipping...";
+    throw new Error(msg);
+  }
   const cqOrgDetails = cqOrgDetailsString ? JSON.parse(cqOrgDetailsString) : undefined;
   if (!cqOrgDetails) {
     const msg = "No CQ Organization details found. Skipping...";
@@ -52,6 +56,10 @@ export async function createOrUpdateCQOrganization(): Promise<void> {
 
 async function updateCQOrganization(cqOrg: string, oid: string): Promise<void> {
   console.log(`Updating org in the CQ Directory...`);
+  if (!cq) {
+    const msg = "No CQ API key found. Skipping...";
+    throw new Error(msg);
+  }
   try {
     await cq.updateOrganization(cqOrg, oid);
   } catch (error) {

--- a/packages/api/src/external/carequality/organization.ts
+++ b/packages/api/src/external/carequality/organization.ts
@@ -24,8 +24,7 @@ export type CQOrgDetails = {
 export async function createOrUpdateCQOrganization(): Promise<void> {
   const cqOrgDetailsString = Config.getCQOrgDetails();
   if (!cq) {
-    const msg = "No CQ API key found. Skipping...";
-    throw new Error(msg);
+    throw new Error("CQ is not enabled in this environment");
   }
   const cqOrgDetails = cqOrgDetailsString ? JSON.parse(cqOrgDetailsString) : undefined;
   if (!cqOrgDetails) {
@@ -57,8 +56,7 @@ export async function createOrUpdateCQOrganization(): Promise<void> {
 async function updateCQOrganization(cqOrg: string, oid: string): Promise<void> {
   console.log(`Updating org in the CQ Directory...`);
   if (!cq) {
-    const msg = "No CQ API key found. Skipping...";
-    throw new Error(msg);
+    throw new Error("CQ is not enabled in this environment");
   }
   try {
     await cq.updateOrganization(cqOrg, oid);


### PR DESCRIPTION
refs. metriport/metriport-internal#1265
refs. https://github.com/metriport/metriport-internal/issues/1297

### Description

- Sandbox is failing to initiate Carequality SDK. This makes it so sandbox does not attempt to do so anymore.
- Document download signed url expiration time increased from 1 to 5 min

### Release Plan
- ⚠️ THIS IS POINTING TO MASTER
- ASAP