### PR TITLE
fix: bump fhir dependency

### DIFF
--- a/fern/dependencies.yml
+++ b/fern/dependencies.yml
@@ -3,4 +3,4 @@
 # https://github.com/fern-api/fern/tree/main/fern/fhir
 
 dependencies:
-  "@fern/fhir": "0.0.0" 
+  "@fern/fhir": "0.0.0-1" 


### PR DESCRIPTION
This PR depends the fhir dependency (in hopes of improving code generation speed). 