### PR TITLE
1154 allow API to access API GW and get usage plan info

### DIFF
--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -239,6 +239,7 @@ export function createAPIService(
             "appconfig:StartConfigurationSession",
             "appconfig:GetLatestConfiguration",
             "appconfig:GetConfiguration",
+            "apigateway:GET",
           ],
           resources: ["*"],
         }),


### PR DESCRIPTION
Ref: metriport/metriport#1154

### Dependencies

none

### Description

Allow API to access API GW and get usage plan info

Context: https://metriport.slack.com/archives/C04DMKE9DME/p1701189462131629

### Release Plan

- nothing special
- asap