### PR TITLE
1154 add API GW usage plan ID to env vars

### DIFF
--- a/packages/api/src/command/medical/admin/api.ts
+++ b/packages/api/src/command/medical/admin/api.ts
@@ -80,15 +80,11 @@ async function getOrgs(cxIds: string[]): Promise<Organization[]> {
 }
 
 async function getUsage(): Promise<Usage[]> {
+  const usagePlanId = Config.getApiGatewayUsagePlanId();
+  if (!usagePlanId) return [];
   const today = dayjs().format(ISO_DATE);
-  const usage = await apiGw
-    .getUsage({
-      usagePlanId: "vcoak3",
-      startDate: today,
-      endDate: today,
-    })
-    .promise();
 
+  const usage = await apiGw.getUsage({ usagePlanId, startDate: today, endDate: today }).promise();
   if (!usage.items) {
     console.log(`No usage items found for this run`);
     return [];

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -74,13 +74,16 @@ export class Config {
     if (this.isCloudEnv()) {
       return `${Config.getApiUrl()}/token/connect`;
     }
-
     // Garmin requires an internet accessible address - use a proxy like NGrok or similar
     return `${Config.getApiUrl()}/connect`;
   }
 
   static getApiUrl(): string {
     return getEnvVarOrFail("API_URL");
+  }
+
+  static getApiGatewayUsagePlanId(): string | undefined {
+    return getEnvVar("API_GW_USAGE_PLAN_ID");
   }
 
   static getCQApiKey(): string {

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -25,6 +25,7 @@ export type EnvConfig = {
   dbName: string;
   dbUsername: string;
   loadBalancerDnsName?: string;
+  apiGatewayUsagePlanId?: string; // optional since we need to create the stack first, then update this and redeploy
   usageReportUrl?: string;
   fhirServerUrl: string;
   fhirServerQueueUrl?: string;

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -108,6 +108,9 @@ export function createAPIService(
           AWS_REGION: props.config.region,
           TOKEN_TABLE_NAME: dynamoDBTokenTable.tableName,
           API_URL: `https://${props.config.subdomain}.${props.config.domain}`,
+          ...(props.config.apiGatewayUsagePlanId
+            ? { API_GW_USAGE_PLAN_ID: props.config.apiGatewayUsagePlanId }
+            : {}),
           CONNECT_WIDGET_URL: connectWidgetUrlEnvVar,
           SYSTEM_ROOT_OID: props.config.systemRootOID,
           ...props.config.commonwell.envVars,


### PR DESCRIPTION
Ref: metriport/metriport#1154

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1300
- Downstream: none

### Description

Add API GW usage plan ID to env vars

### Release Plan

- [x] merge upstream
- [x] merge this