### PR TITLE
1195 don't error when no CW data and EC is on

### DIFF
--- a/packages/api/src/external/commonwell/patient-external-data.ts
+++ b/packages/api/src/external/commonwell/patient-external-data.ts
@@ -20,7 +20,10 @@ export type PatientWithCWData = Patient & {
   data: { externalData: { COMMONWELL: PatientDataCommonwell } };
 };
 
-const getPatientWithCWDataOrFail = async ({ id, cxId }: Pick<Patient, "id" | "cxId">) => {
+const _getPatientWithCWData = async ({
+  id,
+  cxId,
+}: Pick<Patient, "id" | "cxId">): Promise<PatientWithCWData | undefined> => {
   const patientDB: Patient = await getPatientOrFail({
     id,
     cxId,
@@ -33,9 +36,11 @@ const getPatientWithCWDataOrFail = async ({ id, cxId }: Pick<Patient, "id" | "cx
   return patientDB as PatientWithCWData;
 };
 
-export async function getPatientWithCWData(patient: Patient): Promise<PatientWithCWData> {
+export async function getPatientWithCWData(
+  patient: Patient
+): Promise<PatientWithCWData | undefined> {
   return executeWithRetries(
-    () => getPatientWithCWDataOrFail(patient),
+    () => _getPatientWithCWData(patient),
     maxAttemptsToGetPatientCWData - 1,
     waitTimeBetweenAttemptsToGetPatientCWData.asMilliseconds()
   );

--- a/packages/api/src/shared/log.ts
+++ b/packages/api/src/shared/log.ts
@@ -18,8 +18,12 @@ export function debug(msg: string, ...optionalParams: any[]): void {
     console.log(msg);
   }
 }
+
 export type ErrorToStringOptions = { detailed: boolean };
 
+/**
+ * @deprecated Use @metriport/shared instead
+ */
 export function errorToString(
   err: unknown,
   options: ErrorToStringOptions = { detailed: true }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@metriport/core",
   "version": "1.6.7",
+  "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/src/common/__tests__/retry.test.ts
+++ b/packages/shared/src/common/__tests__/retry.test.ts
@@ -1,10 +1,10 @@
 import { faker } from "@faker-js/faker";
-import { executeWithRetries } from "../retry";
+import { executeWithRetriesOrFail } from "../retry";
 
 describe("executeWithRetries", () => {
   it("returns the first successful execution", async () => {
     const fn = jest.fn();
-    await executeWithRetries(fn, undefined, 1);
+    await executeWithRetriesOrFail(fn, undefined, 1);
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
@@ -14,7 +14,7 @@ describe("executeWithRetries", () => {
     fn.mockImplementationOnce(() => {
       throw new Error("test error");
     });
-    const resp = await executeWithRetries<string>(fn, undefined, 1);
+    const resp = await executeWithRetriesOrFail<string>(fn, undefined, 1);
     expect(resp).toBeTruthy();
     expect(resp).toEqual(expectedResponse);
     expect(fn).toHaveBeenCalledTimes(2);
@@ -26,6 +26,6 @@ describe("executeWithRetries", () => {
     fn.mockImplementation(() => {
       throw new Error(errorMsg);
     });
-    await expect(executeWithRetries<string>(fn, undefined, 1)).rejects.toThrow(errorMsg);
+    await expect(executeWithRetriesOrFail<string>(fn, undefined, 1)).rejects.toThrow(errorMsg);
   });
 });

--- a/packages/shared/src/common/error.ts
+++ b/packages/shared/src/common/error.ts
@@ -1,0 +1,28 @@
+export type ErrorToStringOptions = { detailed: boolean };
+
+export function errorToString(
+  err: unknown,
+  options: ErrorToStringOptions = { detailed: true }
+): string {
+  if (options.detailed) {
+    return detailedErrorToString(err);
+  }
+  return genericErrorToString(err);
+}
+
+export function genericErrorToString(err: unknown): string {
+  return (err as any)["message"] ?? String(err); // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function detailedErrorToString(error: any): string {
+  if (!error) return "undefined";
+  const thisErrorMessage = error.message ? error.message : error.toString();
+  const additionalInfo = error.additionalInfo ? JSON.stringify(error.additionalInfo) : undefined;
+  const causeMessage = error.cause ? detailedErrorToString(error.cause) : undefined;
+  return (
+    `${thisErrorMessage}` +
+    `${additionalInfo ? ` (${additionalInfo})` : ""}` +
+    `${causeMessage ? `; caused by ${causeMessage}` : ""}`
+  );
+}

--- a/packages/shared/src/common/retry.ts
+++ b/packages/shared/src/common/retry.ts
@@ -1,3 +1,4 @@
+import { errorToString } from "./error";
 import { sleep } from "./sleep";
 
 /**
@@ -10,9 +11,9 @@ import { sleep } from "./sleep";
  * @param maxRetries the maximum number of retries, defaults to 3
  * @param waitTime the time to wait between retries, defaults to 3000ms
  * @param log the logger to use, defaults to console.log
- * @returns
+ * @returns the result of calling the `fn` function
  */
-export async function executeWithRetries<K>(
+export async function executeWithRetriesOrFail<K>(
   fn: () => Promise<K>,
   maxRetries = 3,
   waitTime = 3000,
@@ -23,7 +24,7 @@ export async function executeWithRetries<K>(
     try {
       return await fn();
     } catch (e) {
-      const msg = `Error on executeWithRetries: ${e}, re`;
+      const msg = `Error on executeWithRetriesOrFail: ${e}, re`;
       if (count++ < maxRetries) {
         log(`${msg}, retrying...`);
         await sleep(waitTime);
@@ -34,4 +35,30 @@ export async function executeWithRetries<K>(
     }
   }
   throw new Error(`Should never get here`);
+}
+
+/**
+ * Executes a function with retries. If the function throws an error, it will retry
+ * up to maxRetries times, waiting waitTime between each retry.
+ * If the function throws an error on the last retry, it will return undefined.
+ * If the function succeeds, it will return the result.
+ *
+ * @param fn the function to be executed
+ * @param maxRetries the maximum number of retries, defaults to 3
+ * @param waitTime the time to wait between retries, defaults to 3000ms
+ * @param log the logger to use, defaults to console.log
+ * @returns the result of calling the `fn` function, or undefined if it fails
+ */
+export async function executeWithRetries<K>(
+  fn: () => Promise<K>,
+  maxRetries = 3,
+  waitTime = 3000,
+  log = console.log
+): Promise<K | undefined> {
+  try {
+    return await executeWithRetriesOrFail(fn, maxRetries, waitTime, log);
+  } catch (e) {
+    log(`Error calling executeWithRetriesOrFail, returning undefined: ${errorToString(e)}`);
+    return undefined;
+  }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,6 @@
 export { optionalDateSchema } from "./common/date";
 export { emptyFunction } from "./common/general";
 export { normalizeOid } from "./common/normalize-oid";
-export { executeWithRetries } from "./common/retry";
+export { executeWithRetries, executeWithRetriesOrFail } from "./common/retry";
 export { sleep } from "./common/sleep";
 export { validateNPI } from "./common/validate-npi";


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Dependencies

none

### Description

Don't error when no CW data and EC is on

Why: https://metriport.slack.com/archives/C04T256DQPQ/p1701453114033979?thread_ts=1701440231.797879&cid=C04T256DQPQ

### Release Plan

- nothing special