### PR TITLE
fix(api): when we upload docs to s3 if there is no doc type do not ap…

### DIFF
--- a/packages/core/src/external/commonwell/document/document-downloader-local.ts
+++ b/packages/core/src/external/commonwell/document/document-downloader-local.ts
@@ -215,7 +215,7 @@ export class DocumentDownloaderLocal extends DocumentDownloader {
           Bucket: s3FileLocation,
           Key: s3FileName,
           Body: pass,
-          ContentType: contentType ? contentType : "text/xml",
+          ...(contentType && { ContentType: contentType }),
         })
         .promise(),
     };


### PR DESCRIPTION
…pend one

Ref. metriport/metriport#799

Ref: https://metriport-inc.sentry.io/issues/4587371390/events/85d1c0e3a2244fd9b269c889b18bb7b6/?alert_rule_id=14442454&alert_type=issue&environment=production&notification_uuid=196c710f-c483-48f6-bf1a-e4cb5ecfed21&project=4505252341153792&referrer=previous-event

### Description

There is an issue wtih FHIR converter lambda where we are converting non-xml docs. The issue is because if the doc ref does not contain a a contentType we default to `text/xml` which we should not be doing. 

### Release Plan

nothing special

- [ ] Once aprpoved