### PR TITLE
1323 increase OS lambda memory

### DIFF
--- a/packages/infra/lib/api-stack/ccda-search-connector.ts
+++ b/packages/infra/lib/api-stack/ccda-search-connector.ts
@@ -59,7 +59,7 @@ export function settings(): {
     },
     connectorName: "CCDAOpenSearch",
     lambda: {
-      memory: isLarge ? 1024 : 512,
+      memory: isLarge ? 2048 : 512,
       // Number of messages the lambda pull from SQS at once
       batchSize: 1,
       // Max number of concurrent instances of the lambda that an Amazon SQS event source can invoke [2 - 1000].


### PR DESCRIPTION
Ref: metriport/metriport-internal#1323

### Dependencies

none

### Description

Increase memory of the OpenSearch ingestion lambda, CCDAOpenSearchLambda.

### Release Plan

- nothing special