### PR TITLE
Invalid patient Identifier Error on CDA conversion

### DIFF
--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -533,6 +533,7 @@ export async function downloadDocsAndUpsertFHIR({
                   facilityNPI,
                   cxId,
                   requestId,
+                  patientId: patient.id,
                 });
 
                 return newFile;
@@ -754,6 +755,7 @@ async function triggerDownloadDocument({
   facilityNPI,
   cxId,
   requestId,
+  patientId,
 }: {
   doc: DocumentWithLocation;
   fileInfo: S3Info;
@@ -761,6 +763,7 @@ async function triggerDownloadDocument({
   facilityNPI: string;
   cxId: string;
   requestId: string;
+  patientId: string;
 }): Promise<File> {
   const docDownloader = makeDocumentDownloader({
     orgName: organization.data.name,
@@ -778,7 +781,12 @@ async function triggerDownloadDocument({
   };
 
   try {
-    const result = await docDownloader.download({ document, fileInfo: adjustedFileInfo, cxId });
+    const result = await docDownloader.download({
+      document,
+      fileInfo: adjustedFileInfo,
+      cxId,
+      patientId,
+    });
     return {
       ...result,
       isNew: true,

--- a/packages/core/src/external/commonwell/document/__tests__/document-downloader-lambda.test.ts
+++ b/packages/core/src/external/commonwell/document/__tests__/document-downloader-lambda.test.ts
@@ -8,12 +8,14 @@ class DocumentDownloaderLambdaForTest extends DocumentDownloaderLambda {
     document,
     fileInfo,
     cxId,
+    patientId,
   }: {
     document: Document;
     fileInfo: FileInfo;
     cxId: string;
+    patientId: string;
   }): Promise<DownloadResult> {
-    return super.download({ document, fileInfo, cxId });
+    return super.download({ document, fileInfo, cxId, patientId });
   }
 }
 
@@ -59,6 +61,7 @@ describe.skip("document-downloader", () => {
           location: bucketName,
         },
         cxId,
+        patientId: "1234567890",
       })
     ).rejects.toThrowError(new MetriportError(`Error calling lambda ${lambdaName}`));
   });

--- a/packages/core/src/external/commonwell/document/document-downloader-lambda.ts
+++ b/packages/core/src/external/commonwell/document/document-downloader-lambda.ts
@@ -18,6 +18,7 @@ export type DocumentDownloaderLambdaRequest = {
   document: Document;
   fileInfo: FileInfo;
   cxId: string;
+  patientId: string;
 };
 
 export class DocumentDownloaderLambda extends DocumentDownloader {
@@ -40,10 +41,12 @@ export class DocumentDownloaderLambda extends DocumentDownloader {
     document,
     fileInfo,
     cxId,
+    patientId,
   }: {
     document: Document;
     fileInfo: FileInfo;
     cxId: string;
+    patientId: string;
   }): Promise<DownloadResult> {
     const payload: DocumentDownloaderLambdaRequest = {
       document,
@@ -52,6 +55,7 @@ export class DocumentDownloaderLambda extends DocumentDownloader {
       orgName: this.orgName,
       orgOid: this.orgOid,
       npi: this.npi,
+      patientId: patientId,
     };
 
     const lambdaResult = await this.lambdaClient

--- a/packages/core/src/external/commonwell/document/document-downloader.ts
+++ b/packages/core/src/external/commonwell/document/document-downloader.ts
@@ -32,9 +32,11 @@ export abstract class DocumentDownloader {
     document,
     fileInfo,
     cxId,
+    patientId,
   }: {
     document: Document;
     fileInfo: FileInfo;
     cxId: string;
+    patientId: string;
   }): Promise<DownloadResult>;
 }

--- a/packages/lambdas/src/document-downloader.ts
+++ b/packages/lambdas/src/document-downloader.ts
@@ -29,7 +29,7 @@ const apiMode = isProduction() ? APIMode.production : APIMode.integration;
 
 export const handler = Sentry.AWSLambda.wrapHandler(
   async (req: DocumentDownloaderLambdaRequest): Promise<DownloadResult> => {
-    const { orgName, orgOid, npi, cxId, fileInfo, document } = req;
+    const { orgName, orgOid, npi, cxId, fileInfo, document, patientId } = req;
     capture.setUser({ id: cxId });
     capture.setExtra({ lambdaName });
     console.log(
@@ -61,7 +61,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(
       },
       capture,
     });
-    const result = await docDownloader.download({ document, fileInfo });
+    const result = await docDownloader.download({ document, fileInfo, patientId });
 
     console.log(`Done - ${JSON.stringify(result)}`);
     return result;


### PR DESCRIPTION
Refs: #[1144](https://github.com/metriport/metriport-internal/issues/1144)

### Description

-  Some XMLs/CCDA have an empty patient ID, which leads to the sidechain converter to fail the conversion. This PR replaces those with a valid patient ID
- Conversion happening in download. This approach is WIP

### Release Plan

- [ ] release npm alpha for shared/core
- [ ] branch to staging - having trouble testing cda to fhir conversion on local
- [ ] merge 
- [ ] npm releases