### PR TITLE
PATCH: fix retry count to avoid recursion

### DIFF
--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -40,7 +40,7 @@ function settings() {
     // Number of times we want to retry a message, this includes throttles!
     maxReceiveCount: 5,
     // Number of times we want to retry a message that timed out when trying to be processed
-    maxTimeoutRetries: 99,
+    maxTimeoutRetries: 15,
     // How long messages should be invisible for other consumers, based on the lambda timeout
     // We don't care if the message gets reprocessed, so no need to have a huge visibility timeout that makes it harder to move messages to the DLQ
     visibilityTimeout: Duration.seconds(lambdaTimeout.toSeconds() * 2 + 1),

--- a/packages/infra/lib/api-stack/fhir-server-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-server-connector.ts
@@ -30,7 +30,7 @@ function settings() {
     // Number of times we want to retry a message, this includes throttles!
     maxReceiveCount: 5,
     // Number of times we want to retry a message that timed out when trying to be processed
-    maxTimeoutRetries: 99,
+    maxTimeoutRetries: 15,
     // How long messages should be invisible for other consumers, based on the lambda timeout
     // We don't care if the message gets reprocessed, so no need to have a huge visibility timeout that makes it harder to move messages to the DLQ
     visibilityTimeout: Duration.seconds(lambdaTimeout.toSeconds() * 2 + 1),

--- a/packages/infra/lib/api-stack/sidechain-fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/sidechain-fhir-converter-connector.ts
@@ -30,7 +30,7 @@ function settings() {
     // Number of times we want to retry a message, this includes throttles!
     maxReceiveCount: 5,
     // Number of times we want to retry a message that timed out when trying to be processed
-    maxTimeoutRetries: 99,
+    maxTimeoutRetries: 15,
     // How long messages should be invisible for other consumers, based on the lambda timeout
     // We don't care if the message gets reprocessed, so no need to have a huge visibility timeout that makes it harder to move messages to the DLQ
     visibilityTimeout: Duration.seconds(lambdaTimeout.toSeconds() * 2 + 1),


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Description

Fix issue with lambdas retying to many times and causing recursion errors - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1702067501378549)

### Testing

none

### Release Plan

nothing special

- [ ] :warning: Points to `master`
- [ ] Merge this
