### PR TITLE
799 publish API-SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38777,7 +38777,7 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.8.4",
+      "version": "7.8.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^4.9.8",
@@ -38985,13 +38985,13 @@
       }
     },
     "packages/connect-widget": {
-      "version": "1.7.12",
+      "version": "1.7.13-alpha.0",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.12",
         "@chakra-ui/react": "^2.4.1",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
-        "@metriport/api-sdk": "^7.8.4",
+        "@metriport/api-sdk": "^7.8.5-alpha.0",
         "@sentry/react": "^7.45.0",
         "@sentry/tracing": "^7.45.0",
         "@testing-library/jest-dom": "^5.16.5",
@@ -40242,10 +40242,10 @@
       "license": "MIT"
     },
     "packages/tester-node": {
-      "version": "1.1.12",
+      "version": "1.1.13-alpha.0",
       "license": "ISC",
       "dependencies": {
-        "@metriport/api-sdk": "^7.8.4",
+        "@metriport/api-sdk": "^7.8.5-alpha.0",
         "@metriport/core": "file:packages/core",
         "dotenv": "^16.0.3"
       },

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.8.4",
+  "version": "7.8.5-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/connect-widget/package.json
+++ b/packages/connect-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-widget",
-  "version": "1.7.12",
+  "version": "1.7.13-alpha.0",
   "private": true,
   "scripts": {
     "clean": "rimraf build && rimraf node_modules",
@@ -38,7 +38,7 @@
     "@chakra-ui/react": "^2.4.1",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@metriport/api-sdk": "^7.8.4",
+    "@metriport/api-sdk": "^7.8.5-alpha.0",
     "@sentry/react": "^7.45.0",
     "@sentry/tracing": "^7.45.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/packages/tester-node/package.json
+++ b/packages/tester-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tester-node",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "description": "",
   "private": true,
   "scripts": {
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@metriport/api-sdk": "^7.8.4",
+    "@metriport/api-sdk": "^7.8.5-alpha.0",
     "@metriport/core": "file:packages/core",
     "dotenv": "^16.0.3"
   },


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/799

### Dependencies

none

### Description

Publish API SDK after the fix sent by [yuanzhaoYZ](https://github.com/yuanzhaoYZ) [here](https://github.com/metriport/metriport/pull/1310).

### Release Plan

- [x] Release NPM packages