### PR TITLE
feat(infra): added sandbox and prod place index generation in cdk

### DIFF
--- a/.github/workflows/_deploy_cdk.yml
+++ b/.github/workflows/_deploy_cdk.yml
@@ -13,7 +13,7 @@ on:
         type: string
         description: "the environment we're deploying to, either 'staging', 'production', or 'sandbox'"
       location_services_cdk_stack:
-        required: true
+        required: false
         type: string
         description: "the name of the Location Services CDK stack we're deploying"
       cdk_stack:
@@ -182,6 +182,7 @@ jobs:
       # Location Stack DEPLOY
       - name: Deploy Location Services CDK stack
         uses: metriport/deploy-with-cdk@master
+        if: inputs.location_services_cdk_stack != null
         with:
           cdk_action: "deploy --verbose --require-approval never"
           cdk_version: "2.87.0"
@@ -197,6 +198,7 @@ jobs:
       # CDK DIFF
       - name: Diff CDK stack
         uses: metriport/deploy-with-cdk@master
+        if: inputs.location_services_cdk_stack != null
         with:
           cdk_action: "diff"
           cdk_version: "2.87.0"

--- a/.github/workflows/_deploy_cdk.yml
+++ b/.github/workflows/_deploy_cdk.yml
@@ -12,6 +12,10 @@ on:
         required: true
         type: string
         description: "the environment we're deploying to, either 'staging', 'production', or 'sandbox'"
+      location_services_cdk_stack:
+        required: true
+        type: string
+        description: "the name of the Location Services CDK stack we're deploying"
       cdk_stack:
         required: true
         type: string
@@ -160,6 +164,35 @@ jobs:
           ignore_empty: true
           sourcemaps: metriport/packages/lambdas/dist
           projects: lambdas-oss
+
+      # Location Stack CDK DIFF
+      - name: Diff Location Services CDK stack
+        uses: metriport/deploy-with-cdk@master
+        with:
+          cdk_action: "diff"
+          cdk_version: "2.87.0"
+          cdk_stack: "${{ inputs.location_services_cdk_stack }}"
+          cdk_env: "${{ inputs.deploy_env }}"
+        env:
+          INPUT_PATH: "metriport/packages/infra"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
+
+      # Location Stack DEPLOY
+      - name: Deploy Location Services CDK stack
+        uses: metriport/deploy-with-cdk@master
+        with:
+          cdk_action: "deploy --verbose --require-approval never"
+          cdk_version: "2.87.0"
+          cdk_stack: "${{ inputs.location_services_cdk_stack }}"
+          cdk_env: "${{ inputs.deploy_env }}"
+        env:
+          INPUT_PATH: "metriport/packages/infra"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
+          METRIPORT_VERSION: ${{ github.sha }}
 
       # CDK DIFF
       - name: Diff CDK stack

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -118,6 +118,7 @@ jobs:
     needs: files-changed
     with:
       deploy_env: "production"
+      location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_PRODUCTION }}
       cdk_stack: ${{ vars.API_STACK_NAME_PRODUCTION }}
       AWS_REGION: ${{ vars.API_REGION_PRODUCTION }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_PRODUCTION }}
@@ -135,6 +136,7 @@ jobs:
     if: ${{ !failure() && needs.infra-api-lambdas.result == 'success' }}
     with:
       deploy_env: "sandbox"
+      location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_SANDBOX }}
       cdk_stack: ${{ vars.API_STACK_NAME_SANDBOX }}
       AWS_REGION: ${{ vars.API_REGION_SANDBOX  }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_SANDBOX  }}
@@ -152,6 +154,7 @@ jobs:
     needs: files-changed
     with:
       deploy_env: "production"
+      location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_PRODUCTION }}
       cdk_stack: ${{ vars.WIDGET_STACK_NAME_PRODUCTION }}
       AWS_REGION: ${{ vars.WIDGET_REGION_PRODUCTION }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_PRODUCTION }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -154,7 +154,6 @@ jobs:
     needs: files-changed
     with:
       deploy_env: "production"
-      location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_PRODUCTION }}
       cdk_stack: ${{ vars.WIDGET_STACK_NAME_PRODUCTION }}
       AWS_REGION: ${{ vars.WIDGET_REGION_PRODUCTION }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_PRODUCTION }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -118,7 +118,6 @@ jobs:
     needs: files-changed
     with:
       deploy_env: "staging"
-      location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_STAGING }}
       cdk_stack: ${{ vars.WIDGET_STACK_NAME_STAGING }}
       AWS_REGION: ${{ vars.WIDGET_REGION_STAGING }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_STAGING }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -100,6 +100,7 @@ jobs:
     needs: files-changed
     with:
       deploy_env: "staging"
+      location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_STAGING }}
       cdk_stack: ${{ vars.API_STACK_NAME_STAGING }}
       AWS_REGION: ${{ vars.API_REGION_STAGING }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_STAGING }}
@@ -117,6 +118,7 @@ jobs:
     needs: files-changed
     with:
       deploy_env: "staging"
+      location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_STAGING }}
       cdk_stack: ${{ vars.WIDGET_STACK_NAME_STAGING }}
       AWS_REGION: ${{ vars.WIDGET_REGION_STAGING }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_STAGING }}

--- a/packages/api/src/external/aws/address.ts
+++ b/packages/api/src/external/aws/address.ts
@@ -8,8 +8,8 @@ import * as AWS from "aws-sdk";
 import { Coordinates } from "@metriport/core/external/aws/location";
 
 const indexName = Config.getPlaceIndexName();
-const awsRegion = Config.isProdEnv() ? Config.getPlaceIndexProdRegion() : Config.getAWSRegion();
-const client = makeLocationClient(awsRegion);
+const placeIndexRegion = Config.getPlaceIndexRegion();
+const client = makeLocationClient(placeIndexRegion);
 
 /**
  * Geocodes a list of addresses using Amazon Location Services.

--- a/packages/api/src/external/aws/address.ts
+++ b/packages/api/src/external/aws/address.ts
@@ -7,16 +7,16 @@ import { Config } from "../../shared/config";
 import * as AWS from "aws-sdk";
 import { Coordinates } from "@metriport/core/external/aws/location";
 
+const indexName = Config.getPlaceIndexName();
+const awsRegion = Config.isProdEnv() ? Config.getPlaceIndexProdRegion() : Config.getAWSRegion();
+const client = makeLocationClient(awsRegion);
+
 /**
  * Geocodes a list of addresses using Amazon Location Services.
  * @param addresses
  * @returns
  */
 export async function geocodeAddresses(addresses: Address[]): Promise<Coordinates[]> {
-  const indexName = Config.getPlaceIndexName();
-  const awsRegion = Config.isProdEnv() ? Config.getPlaceIndexProdRegion() : Config.getAWSRegion();
-  const client = makeLocationClient(awsRegion);
-
   const resultPromises = await Promise.allSettled(
     addresses.map(async address => {
       const addressText = `${address.addressLine1}, ${address.city}, ${address.state} ${address.zip}`;

--- a/packages/api/src/external/aws/address.ts
+++ b/packages/api/src/external/aws/address.ts
@@ -4,6 +4,7 @@ import {
   makeLocationClient,
 } from "@metriport/core/external/aws/location";
 import { Config } from "../../shared/config";
+import * as AWS from "aws-sdk";
 import { Coordinates } from "@metriport/core/external/aws/location";
 
 /**
@@ -13,7 +14,7 @@ import { Coordinates } from "@metriport/core/external/aws/location";
  */
 export async function geocodeAddresses(addresses: Address[]): Promise<Coordinates[]> {
   const indexName = Config.getPlaceIndexName();
-  const awsRegion = Config.getAWSRegion();
+  const awsRegion = Config.isProdEnv() ? Config.getPlaceIndexProdRegion() : Config.getAWSRegion();
   const client = makeLocationClient(awsRegion);
 
   const resultPromises = await Promise.allSettled(
@@ -21,7 +22,7 @@ export async function geocodeAddresses(addresses: Address[]): Promise<Coordinate
       const addressText = `${address.addressLine1}, ${address.city}, ${address.state} ${address.zip}`;
       const countryFilter = address.country ?? "USA";
 
-      const params = {
+      const params: AWS.Location.Types.SearchPlaceIndexForTextRequest = {
         Text: addressText,
         MaxResults: 1,
         Language: "en",

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -94,6 +94,10 @@ export class Config {
     return getEnvVarOrFail("PLACE_INDEX_NAME");
   }
 
+  static getPlaceIndexProdRegion(): string {
+    return getEnvVarOrFail("PLACE_INDEX_PROD_REGION");
+  }
+
   static getTokenTableName(): string {
     return getEnvVarOrFail("TOKEN_TABLE_NAME");
   }

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -94,8 +94,8 @@ export class Config {
     return getEnvVarOrFail("PLACE_INDEX_NAME");
   }
 
-  static getPlaceIndexProdRegion(): string {
-    return getEnvVarOrFail("PLACE_INDEX_PROD_REGION");
+  static getPlaceIndexRegion(): string {
+    return getEnvVarOrFail("PLACE_INDEX_REGION");
   }
 
   static getTokenTableName(): string {

--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -7,6 +7,7 @@ import { EnvConfig } from "../config/env-config";
 import { SecretsStack } from "../lib/secrets-stack";
 import { initConfig } from "../lib/shared/config";
 import { getEnvVar } from "../lib/shared/util";
+import { LocationServicesStack } from "../lib/location-services-stack";
 
 const app = new cdk.App();
 
@@ -28,6 +29,14 @@ async function deploy(config: EnvConfig) {
   //    Do this first, and then manually set the values in the AWS Secrets Manager.
   //---------------------------------------------------------------------------------
   new SecretsStack(app, config.secretsStackName, { env, config });
+
+  //---------------------------------------------------------------------------------
+  // 2. Deploy the location services stack to initialize all geo services.
+  //---------------------------------------------------------------------------------
+  new LocationServicesStack(app, config.locationService.stackName, {
+    env: { ...env, region: config.locationService.placeIndexRegion },
+    config,
+  });
 
   //---------------------------------------------------------------------------------
   // 2. Deploy the API stack once all secrets are defined.

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -38,8 +38,8 @@ export type EnvConfig = {
     POST_HOG_API_KEY: string;
   };
   locationService: {
+    stackName: string;
     placeIndexName: string;
-    placeIndexNameProd?: string;
     placeIndexRegion: string;
   };
   carequality?: {

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -37,9 +37,11 @@ export type EnvConfig = {
   analyticsSecretNames?: {
     POST_HOG_API_KEY: string;
   };
-  placeIndexName: string;
-  placeIndexNameProd?: string;
-  placeIndexProdRegion?: string;
+  locationService: {
+    placeIndexName: string;
+    placeIndexNameProd?: string;
+    placeIndexRegion: string;
+  };
   carequality?: {
     secretNames?: {
       CQ_API_KEY?: string;

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -37,6 +37,9 @@ export type EnvConfig = {
   analyticsSecretNames?: {
     POST_HOG_API_KEY: string;
   };
+  placeIndexName: string;
+  placeIndexNameProd?: string;
+  placeIndexProdRegion?: string;
   carequality?: {
     secretNames?: {
       CQ_API_KEY?: string;

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -52,7 +52,10 @@ export const config: EnvConfig = {
     domain: "myhealthapp.com",
     host: "myhealthapp.com",
   },
-  placeIndexName: "your_place_index_name",
+  locationService: {
+    placeIndexName: "your_place_index_name",
+    placeIndexRegion: "aws_region",
+  },
   carequality: {
     secretNames: {
       CQ_API_KEY: "CQ_API_KEY",

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -53,6 +53,7 @@ export const config: EnvConfig = {
     host: "myhealthapp.com",
   },
   locationService: {
+    stackName: "MetriportLocationServiceStack",
     placeIndexName: "your_place_index_name",
     placeIndexRegion: "aws_region",
   },

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -52,6 +52,7 @@ export const config: EnvConfig = {
     domain: "myhealthapp.com",
     host: "myhealthapp.com",
   },
+  placeIndexName: "your_place_index_name",
   carequality: {
     secretNames: {
       CQ_API_KEY: "CQ_API_KEY",

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -277,7 +277,7 @@ export class APIStack extends Stack {
     //-------------------------------------------
     // Amazon Location Service
     //-------------------------------------------
-    const indexName = props.config.placeIndexName;
+    const indexName = props.config.locationService.placeIndexName;
     const placeIndexStaging = isStaging(props.config)
       ? new ALS.CfnPlaceIndex(this, indexName, {
           dataSource: "Esri",
@@ -294,9 +294,8 @@ export class APIStack extends Stack {
         })
       : undefined;
 
-    const indexNameProd = props.config.placeIndexNameProd;
-
     // Production place index created on the sandbox env
+    const indexNameProd = props.config.locationService.placeIndexNameProd;
     const placeIndexProd =
       isSandbox(props.config) && indexNameProd
         ? new ALS.CfnPlaceIndex(this, indexNameProd, {

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -9,7 +9,6 @@ import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as ecs_patterns from "aws-cdk-lib/aws-ecs-patterns";
 import * as iam from "aws-cdk-lib/aws-iam";
 import { IFunction as ILambda } from "aws-cdk-lib/aws-lambda";
-import * as ALS from "aws-cdk-lib/aws-location";
 import * as r53 from "aws-cdk-lib/aws-route53";
 import * as r53_targets from "aws-cdk-lib/aws-route53-targets";
 import * as s3 from "aws-cdk-lib/aws-s3";
@@ -48,8 +47,6 @@ export function createAPIService(
   documentDownloaderLambda: ILambda,
   medicalDocumentsUploadBucket: s3.Bucket,
   fhirToMedicalRecordLambda: ILambda | undefined,
-  placeIndexStaging: ALS.CfnPlaceIndex | undefined,
-  placeIndexSandbox: ALS.CfnPlaceIndex | undefined,
   searchIngestionQueue: IQueue,
   searchEndpoint: string,
   searchAuth: { userName: string; secret: ISecret },
@@ -159,15 +156,7 @@ export function createAPIService(
           ...(props.config.carequality?.envVars?.CQ_ORG_DETAILS && {
             CQ_ORG_DETAILS: props.config.carequality.envVars.CQ_ORG_DETAILS,
           }),
-          ...((placeIndexStaging && {
-            PLACE_INDEX_NAME: placeIndexStaging.indexName,
-          }) ||
-            (placeIndexSandbox && {
-              PLACE_INDEX_NAME: placeIndexSandbox.indexName,
-            }) ||
-            (isProd(props.config) && {
-              PLACE_INDEX_NAME: props.config.locationService.placeIndexName,
-            })),
+          PLACE_INDEX_NAME: props.config.locationService.placeIndexName,
           PLACE_INDEX_REGION: props.config.locationService.placeIndexRegion,
           // app config
           APPCONFIG_APPLICATION_ID: appConfigEnvVars.appId,

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -166,11 +166,9 @@ export function createAPIService(
               PLACE_INDEX_NAME: placeIndexSandbox.indexName,
             }) ||
             (isProd(props.config) && {
-              PLACE_INDEX_NAME: props.config.placeIndexNameProd,
+              PLACE_INDEX_NAME: props.config.locationService.placeIndexName,
             })),
-          ...(props.config.placeIndexProdRegion && {
-            PLACE_INDEX_PROD_REGION: props.config.placeIndexProdRegion,
-          }),
+          PLACE_INDEX_REGION: props.config.locationService.placeIndexRegion,
           // app config
           APPCONFIG_APPLICATION_ID: appConfigEnvVars.appId,
           APPCONFIG_CONFIGURATION_ID: appConfigEnvVars.configId,

--- a/packages/infra/lib/location-services-stack.ts
+++ b/packages/infra/lib/location-services-stack.ts
@@ -1,0 +1,29 @@
+import { CfnOutput, Stack, StackProps } from "aws-cdk-lib";
+import * as ALS from "aws-cdk-lib/aws-location";
+import { Construct } from "constructs";
+import { EnvConfig } from "../config/env-config";
+
+interface LocationServicesStackProps extends StackProps {
+  config: EnvConfig;
+}
+
+export class LocationServicesStack extends Stack {
+  constructor(scope: Construct, id: string, props: LocationServicesStackProps) {
+    super(scope, id, props);
+    //-------------------------------------------
+    // API Gateway
+    //-------------------------------------------
+    const placeIndex = new ALS.CfnPlaceIndex(scope, props.config.locationService.placeIndexName, {
+      dataSource: "Esri",
+      indexName: props.config.locationService.placeIndexName,
+    });
+
+    //-------------------------------------------
+    // Output
+    //-------------------------------------------
+    new CfnOutput(this, "PlaceIndexName", {
+      description: "Place index name",
+      value: placeIndex.indexName,
+    });
+  }
+}


### PR DESCRIPTION
ticket: https://github.com/metriport/metriport-internal/issues/1302

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1347

### Description

- Infra update to allow sandbox to create the place index for prod 
- Prod can now use its own place index from the sandbox region

### Testing
- Local 
  - [x] Create another index on a different region and see if i can access it from the local setup 
- Staging 
  - [x] Test the new staging index and see if it works without an API key (thru IAM auth)
  - [ ] Test the location stack deployment in staging
- Production
  - [ ] Verify that the place index functions execute 

### Release Plan
- [ ] Upstream dependencies are met
- [ ] Merge this
