### PR TITLE
350 add doc entry about multi-user

### DIFF
--- a/docs/medical-api/getting-started/quickstart.mdx
+++ b/docs/medical-api/getting-started/quickstart.mdx
@@ -25,6 +25,7 @@ Getting started with our Medical API is pretty easy, you'll just need take the f
 7. [Get Patient Medical Documents](#7-get-patient-medical-documents).
 8. [Get Patient FHIR Resources](#8-get-patient-fhir-resources). 🎉🎉🎉
 9. [Share Medical Data with the Networks](#9-share-medical-data-with-the-networks). 🚀🚀🚀
+10. [Invite your team](#10-invite-your-team). 🤝
 
 Feel free to check this demo video out before getting started to get a high level overview of the platform:
 
@@ -253,6 +254,17 @@ Metriport makes it easy to share this data back with the networks - you can:
 
 - upload FHIR data using our [Create Patient's Consolidated Data](/medical-api/api-reference/fhir/create-patient-consolidated) endpoint.
 - upload binary documents using the [Upload Document](/medical-api/api-reference/document/post-upload-url) endpoint.
+
+## 10. Invite your team 🤝
+
+You can invite your team members to signup at https://dash.metriport.com/ and send us a list of the emails to be associated with your main account.
+
+By default, your account will be assigned the “admin” role and the new ones will be set as “contributor”:
+
+- Admin users can do everything on the Dashboard, and soon be able to invite/remove other users;
+- Contributors can manage Patients and Facilities, but not Organization, Billing, or Developer settings.
+
+Associating a team member's user to your account gives them access to your account’s “production” and “sandbox” data - meaning they will lose access to any data they might have created on “sandbox”.
 
 ## Wrapping up
 


### PR DESCRIPTION
Ref: metriport/metriport-internal#350

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1331
- Downstream: none

### Description

Add doc entry about multi-user, called "Invite your team"

<img width="853" alt="image" src="https://github.com/metriport/metriport/assets/2132564/85e20602-d70b-4bdc-b9ee-b4590b6d08e0">

<img width="780" alt="image" src="https://github.com/metriport/metriport/assets/2132564/461624ab-cfc4-4e31-8eec-fa37c671c0b2">

### Testing

- Local
  - [x] Tested the page local, including newly added links
- Staging
  - no docs on staging
- Production
  - [ ] Validate it displays properly

### Release Plan

- [ ] Added to monthly product update [here](https://www.notion.so/metriport/December-2023-7945176d59344e72a7c0e39f43c8d53f?pvs=4#e54a193b523040efa158cef4546b0bb8)
- [ ] Upstream dependencies are met
- [ ] Merge this
