### PR TITLE
PATCH RELEASE 2023-12-13

### DIFF
--- a/packages/api/src/external/commonwell/patient-conversion.ts
+++ b/packages/api/src/external/commonwell/patient-conversion.ts
@@ -95,7 +95,7 @@ export function patientToCommonwell({
         if (contact.phone) {
           contacts.push({
             system: ContactSystemCodes.phone,
-            value: contact.phone,
+            value: normalizePhoneNumber(contact.phone),
           });
         }
         return contacts;
@@ -115,4 +115,8 @@ function getStrongIdentifiers(data: PatientData): Identifier[] | undefined {
     period: id.period,
     ...(id.assigner ? { assigner: id.assigner } : undefined),
   }));
+}
+
+function normalizePhoneNumber(phone: string): string {
+  return phone.replace(/[^0-9]/g, "");
 }


### PR DESCRIPTION
refs. metriport/metriport-internal#1359

### Description

Removing everything besides numbers from phone number strings before sending them to CW

### Testing

- Local
  - [x] The function successfully removes the plus sign and dashes 

### Release Plan

- :warning: Points to `master`
- ASAP
