### PR TITLE
fix(mapi): phone num 10 digits long

### DIFF
--- a/packages/api/src/external/commonwell/patient-conversion.ts
+++ b/packages/api/src/external/commonwell/patient-conversion.ts
@@ -118,5 +118,9 @@ function getStrongIdentifiers(data: PatientData): Identifier[] | undefined {
 }
 
 function normalizePhoneNumber(phone: string): string {
-  return phone.replace(/[^0-9]/g, "");
+  const numericPhone = phone.replace(/[^0-9]/g, "");
+  if (numericPhone.length > 10) {
+    return numericPhone.slice(-10);
+  }
+  return numericPhone;
 }


### PR DESCRIPTION
refs. https://github.com/metriport/metriport-internal/issues/1359

### Description
- Removing everything besides numbers from phone number strings before sending them to CW

### Testing
- Local: The function takes the last 10 digits in longer phone numbers
- Production: Used `PUT /patient/:id` to make sure patients are matched to CW with these 10-digit strictly numeric phone numbers
### Release Plan
- ⚠️ Points to master
- ASAP