### PR TITLE
PATCH RELEASE 1195 run EC in parallel

### DIFF
--- a/packages/api/src/routes/helpers/request-logger.ts
+++ b/packages/api/src/routes/helpers/request-logger.ts
@@ -1,17 +1,33 @@
 import { NextFunction, Request, Response } from "express";
+import { nanoid } from "nanoid";
 import { analyzeRoute } from "./request-analytics";
 
 export const requestLogger = (req: Request, res: Response, next: NextFunction): void => {
+  const reqId = nanoid();
   const method = req.method;
   const url = req.baseUrl + req.path;
   const query = req.query && Object.keys(req.query).length ? req.query : undefined;
   const params = req.params && Object.keys(req.params).length ? req.params : undefined;
-  console.log("..........Begins %s %s %s %s", method, url, toString(params), toString(query));
+  console.log(
+    "%s ..........Begins %s %s %s %s",
+    reqId,
+    method,
+    url,
+    toString(params),
+    toString(query)
+  );
   const startHrTime = process.hrtime();
   res.on("close", () => {
     const elapsedHrTime = process.hrtime(startHrTime);
     const elapsedTimeInMs = elapsedHrTime[0] * 1000 + elapsedHrTime[1] / 1e6;
-    console.log("..........Done %s %s | %d | %fms", method, url, res.statusCode, elapsedTimeInMs);
+    console.log(
+      "%s ..........Done %s %s | %d | %fms",
+      reqId,
+      method,
+      url,
+      res.statusCode,
+      elapsedTimeInMs
+    );
 
     analyzeRoute({ req, method, url, duration: elapsedTimeInMs });
   });

--- a/packages/api/src/shared/notifications.ts
+++ b/packages/api/src/shared/notifications.ts
@@ -4,10 +4,8 @@ import {
   SlackMessage as CoreSlackMessage,
 } from "@metriport/core/external/slack/index";
 import { Capture } from "@metriport/core/util/capture";
+import { capture as captureFromCore } from "@metriport/core/util/notifications";
 import * as Sentry from "@sentry/node";
-import { Extras, ScopeContext } from "@sentry/types";
-import stringify from "json-stringify-safe";
-import { MetriportError } from "@metriport/core/util/error/metriport-error";
 
 /**
  * @deprecated Use core's instead
@@ -31,56 +29,7 @@ export type ApiCapture = Capture & {
   setExtra: (extra: Record<string, unknown>) => void;
 };
 
-export const capture: ApiCapture = {
-  setUser: (user: UserData): void => {
-    Sentry.setUser(user);
-  },
-
-  setExtra: (extra: Record<string, unknown>): void => {
-    Object.entries(extra).forEach(([key, value]) => {
-      Sentry.setExtra(key, value);
-    });
-  },
-
-  /**
-   * Captures an exception event and sends it to Sentry.
-   *
-   * @param error — An Error object.
-   * @param captureContext — Additional scope data to apply to exception event.
-   * @returns — The generated eventId.
-   */
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  error: (error: any, captureContext?: Partial<ScopeContext>): string => {
-    const extra = captureContext ? stringifyExtra(captureContext) : {};
-    return Sentry.captureException(error, {
-      ...captureContext,
-      extra,
-      ...(error instanceof MetriportError ? error.additionalInfo : {}),
-    });
-  },
-
-  /**
-   * Captures an exception event and sends it to Sentry.
-   *
-   * @param message The message to send to Sentry.
-   * @param captureContext — Additional scope data to apply to exception event.
-   * @returns — The generated eventId.
-   */
-  message: (message: string, captureContext?: Partial<ScopeContext>): string => {
-    const extra = captureContext ? stringifyExtra(captureContext) : {};
-    return Sentry.captureMessage(message, {
-      ...captureContext,
-      extra,
-    });
-  },
-};
-
-export function stringifyExtra(captureContext: Partial<ScopeContext>): Extras {
-  return Object.entries(captureContext.extra ?? {}).reduce(
-    (acc, [key, value]) => ({
-      ...acc,
-      [key]: typeof value === "string" ? value : stringify(value, null, 2),
-    }),
-    {}
-  );
-}
+/**
+ * @deprecated use Core's instead
+ */
+export const capture: ApiCapture = captureFromCore;

--- a/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer-local.ts
+++ b/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer-local.ts
@@ -75,10 +75,10 @@ export class CoverageEnhancerLocal extends CoverageEnhancer {
             level: "warning",
           });
           if (stopOnErrors) {
-            log(msg + " - interrupting...", error);
+            log(`${msg} - interrupting... ${JSON.stringify(error)}`);
             throw error;
           }
-          log(msg + " - continuing...", error);
+          log(`${msg} - continuing... ${JSON.stringify(error)}`);
         }
       }
 

--- a/packages/core/src/util/notifications.ts
+++ b/packages/core/src/util/notifications.ts
@@ -1,12 +1,12 @@
+import * as Sentry from "@sentry/node";
+import { Extras, ScopeContext } from "@sentry/types";
+import stringify from "json-stringify-safe";
 import {
   sendAlert as coreSendAlert,
   sendNotification as coreSendNotification,
   SlackMessage as CoreSlackMessage,
 } from "../external/slack/index";
 import { Capture } from "./capture";
-import * as Sentry from "@sentry/node";
-import { Extras, ScopeContext } from "@sentry/types";
-import stringify from "json-stringify-safe";
 import { MetriportError } from "./error/metriport-error";
 
 /**
@@ -51,6 +51,12 @@ export const capture: ApiCapture = {
    */
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: (error: any, captureContext?: Partial<ScopeContext>): string => {
+    if (typeof error === "string") {
+      return capture.message(error, {
+        ...captureContext,
+        level: captureContext?.level ?? "error",
+      });
+    }
     const extra = captureContext ? stringifyExtra(captureContext) : {};
     return Sentry.captureException(error, {
       ...captureContext,


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Description

- run EC in parallel
- add req ID to request-logger
- core's capture to allow string on `.error()`
- capture/notification from API to user core's

### Testing

- Local
   - [x] test capture w/ string works
   - [ ] EC triggered in parallel
- Staging
   - bypassing it
- Production
  - [ ] monitor an EC run

### Release Plan

- :warning: Points to `master`
- nothing special
