### PR TITLE
1354 enable EC upon patient update

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -13,6 +13,7 @@ import { initSentry, isSentryEnabled } from "./sentry";
 import { Config } from "./shared/config";
 import { isClientError } from "./shared/http";
 import { capture } from "./shared/notifications";
+import { initEvents } from "./event";
 
 const app: Application = express();
 const version = Config.getVersion();
@@ -54,6 +55,8 @@ if (isSentryEnabled()) {
   );
 }
 app.use(errorHandler);
+
+initEvents();
 
 const port = 8080;
 app.listen(port, "0.0.0.0", async () => {

--- a/packages/api/src/command/medical/patient/update-patient.ts
+++ b/packages/api/src/command/medical/patient/update-patient.ts
@@ -1,4 +1,5 @@
 import { Patient, PatientData } from "../../../domain/medical/patient";
+import { patientEvents } from "../../../event/medical/patient-event";
 import { PatientModel } from "../../../models/medical/patient";
 import { executeOnDBTx } from "../../../models/transaction-wrapper";
 import { validateVersionForUpdate } from "../../../models/_default";
@@ -19,7 +20,7 @@ export const updatePatient = async (patientUpdate: PatientUpdateCmd): Promise<Pa
   const sanitized = sanitize(patientUpdate);
   validate(sanitized);
 
-  return executeOnDBTx(PatientModel.prototype, async transaction => {
+  const result = await executeOnDBTx(PatientModel.prototype, async transaction => {
     const patient = await getPatientOrFail({
       id,
       cxId,
@@ -46,4 +47,8 @@ export const updatePatient = async (patientUpdate: PatientUpdateCmd): Promise<Pa
       { transaction }
     );
   });
+
+  patientEvents().emitUpdated(result);
+
+  return result;
 };

--- a/packages/api/src/event/index.ts
+++ b/packages/api/src/event/index.ts
@@ -1,0 +1,5 @@
+import initCWEvents from "../external/commonwell/cq-bridge/patient-event-listener";
+
+export function initEvents() {
+  initCWEvents();
+}

--- a/packages/api/src/event/medical/patient-event.ts
+++ b/packages/api/src/event/medical/patient-event.ts
@@ -1,0 +1,31 @@
+import EventEmitter from "events";
+import { Patient } from "../../domain/medical/patient";
+
+export type PatientEvent = Pick<Patient, "id" | "cxId">;
+
+let patientEventsInstance: PatientEvents;
+
+export const patientEvents = (): PatientEvents => {
+  if (!patientEventsInstance) {
+    patientEventsInstance = new PatientEvents();
+  }
+  return patientEventsInstance;
+};
+
+export class PatientEvents extends EventEmitter {
+  static readonly CREATED = "patient-created";
+  static readonly UPDATED = "patient-updated";
+  static readonly DELETED = "patient-deleted";
+
+  emitCreated(patient: PatientEvent) {
+    this.emit(PatientEvents.CREATED, { id: patient.id, cxId: patient.cxId });
+  }
+
+  emitUpdated(patient: PatientEvent) {
+    this.emit(PatientEvents.UPDATED, { id: patient.id, cxId: patient.cxId });
+  }
+
+  emitDeleted(patient: PatientEvent) {
+    this.emit(PatientEvents.DELETED, { id: patient.id, cxId: patient.cxId });
+  }
+}

--- a/packages/api/src/external/commonwell/cq-bridge/patient-event-listener.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/patient-event-listener.ts
@@ -1,0 +1,14 @@
+import { PatientEvents, patientEvents } from "../../../event/medical/patient-event";
+import { setCQLinkStatus } from "./cq-link-status";
+
+export default function () {
+  patientEvents().on(PatientEvents.UPDATED, async patient => {
+    const cqLinkStatus = "unlinked";
+    console.log(`[CQ-BRIDGE] Setting cqLinkStatus of patient ${patient.id} to ${cqLinkStatus}`);
+    await setCQLinkStatus({
+      cxId: patient.cxId,
+      patientId: patient.id,
+      cqLinkStatus,
+    });
+  });
+}

--- a/packages/api/src/external/commonwell/events.ts
+++ b/packages/api/src/external/commonwell/events.ts
@@ -1,0 +1,5 @@
+import initCQBridgeEvents from "./cq-bridge/patient-event-listener";
+
+export default function () {
+  initCQBridgeEvents();
+}

--- a/packages/api/src/routes/helpers/request-logger.ts
+++ b/packages/api/src/routes/helpers/request-logger.ts
@@ -1,17 +1,33 @@
 import { NextFunction, Request, Response } from "express";
+import { nanoid } from "nanoid";
 import { analyzeRoute } from "./request-analytics";
 
 export const requestLogger = (req: Request, res: Response, next: NextFunction): void => {
+  const reqId = nanoid();
   const method = req.method;
   const url = req.baseUrl + req.path;
   const query = req.query && Object.keys(req.query).length ? req.query : undefined;
   const params = req.params && Object.keys(req.params).length ? req.params : undefined;
-  console.log("..........Begins %s %s %s %s", method, url, toString(params), toString(query));
+  console.log(
+    "%s ..........Begins %s %s %s %s",
+    reqId,
+    method,
+    url,
+    toString(params),
+    toString(query)
+  );
   const startHrTime = process.hrtime();
   res.on("close", () => {
     const elapsedHrTime = process.hrtime(startHrTime);
     const elapsedTimeInMs = elapsedHrTime[0] * 1000 + elapsedHrTime[1] / 1e6;
-    console.log("..........Done %s %s | %d | %fms", method, url, res.statusCode, elapsedTimeInMs);
+    console.log(
+      "%s ..........Done %s %s | %d | %fms",
+      reqId,
+      method,
+      url,
+      res.statusCode,
+      elapsedTimeInMs
+    );
 
     analyzeRoute({ req, method, url, duration: elapsedTimeInMs });
   });

--- a/packages/api/src/shared/notifications.ts
+++ b/packages/api/src/shared/notifications.ts
@@ -4,10 +4,8 @@ import {
   SlackMessage as CoreSlackMessage,
 } from "@metriport/core/external/slack/index";
 import { Capture } from "@metriport/core/util/capture";
+import { capture as captureFromCore } from "@metriport/core/util/notifications";
 import * as Sentry from "@sentry/node";
-import { Extras, ScopeContext } from "@sentry/types";
-import stringify from "json-stringify-safe";
-import { MetriportError } from "@metriport/core/util/error/metriport-error";
 
 /**
  * @deprecated Use core's instead
@@ -31,56 +29,7 @@ export type ApiCapture = Capture & {
   setExtra: (extra: Record<string, unknown>) => void;
 };
 
-export const capture: ApiCapture = {
-  setUser: (user: UserData): void => {
-    Sentry.setUser(user);
-  },
-
-  setExtra: (extra: Record<string, unknown>): void => {
-    Object.entries(extra).forEach(([key, value]) => {
-      Sentry.setExtra(key, value);
-    });
-  },
-
-  /**
-   * Captures an exception event and sends it to Sentry.
-   *
-   * @param error — An Error object.
-   * @param captureContext — Additional scope data to apply to exception event.
-   * @returns — The generated eventId.
-   */
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  error: (error: any, captureContext?: Partial<ScopeContext>): string => {
-    const extra = captureContext ? stringifyExtra(captureContext) : {};
-    return Sentry.captureException(error, {
-      ...captureContext,
-      extra,
-      ...(error instanceof MetriportError ? error.additionalInfo : {}),
-    });
-  },
-
-  /**
-   * Captures an exception event and sends it to Sentry.
-   *
-   * @param message The message to send to Sentry.
-   * @param captureContext — Additional scope data to apply to exception event.
-   * @returns — The generated eventId.
-   */
-  message: (message: string, captureContext?: Partial<ScopeContext>): string => {
-    const extra = captureContext ? stringifyExtra(captureContext) : {};
-    return Sentry.captureMessage(message, {
-      ...captureContext,
-      extra,
-    });
-  },
-};
-
-export function stringifyExtra(captureContext: Partial<ScopeContext>): Extras {
-  return Object.entries(captureContext.extra ?? {}).reduce(
-    (acc, [key, value]) => ({
-      ...acc,
-      [key]: typeof value === "string" ? value : stringify(value, null, 2),
-    }),
-    {}
-  );
-}
+/**
+ * @deprecated use Core's instead
+ */
+export const capture: ApiCapture = captureFromCore;

--- a/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer-local.ts
+++ b/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer-local.ts
@@ -75,10 +75,10 @@ export class CoverageEnhancerLocal extends CoverageEnhancer {
             level: "warning",
           });
           if (stopOnErrors) {
-            log(msg + " - interrupting...", error);
+            log(`${msg} - interrupting... ${JSON.stringify(error)}`);
             throw error;
           }
-          log(msg + " - continuing...", error);
+          log(`${msg} - continuing... ${JSON.stringify(error)}`);
         }
       }
 

--- a/packages/core/src/util/concurrency.ts
+++ b/packages/core/src/util/concurrency.ts
@@ -3,7 +3,7 @@ import { sleep } from "./sleep";
 
 export type ExecuteInChunksOptions = {
   /**
-   * How many promises should execute at the same time.
+   * How many promises should execute at the same time. Defaults to `collection.length` (all promises to run at the same time).
    */
   numberOfParallelExecutions?: number;
   /**

--- a/packages/core/src/util/notifications.ts
+++ b/packages/core/src/util/notifications.ts
@@ -1,12 +1,12 @@
+import * as Sentry from "@sentry/node";
+import { Extras, ScopeContext } from "@sentry/types";
+import stringify from "json-stringify-safe";
 import {
   sendAlert as coreSendAlert,
   sendNotification as coreSendNotification,
   SlackMessage as CoreSlackMessage,
 } from "../external/slack/index";
 import { Capture } from "./capture";
-import * as Sentry from "@sentry/node";
-import { Extras, ScopeContext } from "@sentry/types";
-import stringify from "json-stringify-safe";
 import { MetriportError } from "./error/metriport-error";
 
 /**
@@ -51,6 +51,12 @@ export const capture: ApiCapture = {
    */
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: (error: any, captureContext?: Partial<ScopeContext>): string => {
+    if (typeof error === "string") {
+      return capture.message(error, {
+        ...captureContext,
+        level: captureContext?.level ?? "error",
+      });
+    }
     const extra = captureContext ? stringifyExtra(captureContext) : {};
     return Sentry.captureException(error, {
       ...captureContext,


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1354

### Dependencies

none

### Description

- Enable EC upon patient update
- Introduce NodeJS events 🎉 
- Some goodies from a [PR put on hold](https://github.com/metriport/metriport/pull/1344)
   - Include req ID on request logger
   - Allow `capture.error()` to be passed a string
   - Reuse core's capture/notif on API

### Testing

- Local
  - [x] Update patient changed the status from `linked` to `unlinked`
  - [x] Requests still get logged
- Staging
  - [ ] Update patient changed the status from `linked` to `unlinked`
  - [ ] Requests still get logged
- Production
  - [ ] Update patient changed the status from `linked` to `unlinked`
  - [ ] Requests still get logged

### Release Plan

- nothing special