### PR TITLE
1040 fix FreeStorageSpace alarm on OpenSearchConstruct

### DIFF
--- a/packages/infra/lib/shared/open-search-construct.ts
+++ b/packages/infra/lib/shared/open-search-construct.ts
@@ -1,5 +1,5 @@
 import { CfnOutput, RemovalPolicy } from "aws-cdk-lib";
-import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { ComparisonOperator, Metric } from "aws-cdk-lib/aws-cloudwatch";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as iam from "aws-cdk-lib/aws-iam";
 import {
@@ -147,16 +147,19 @@ export default class OpenSearchConstruct extends Construct {
       name,
       threshold,
       evaluationPeriods,
+      comparisonOperator,
     }: {
       metric: Metric;
       name: string;
       threshold: number;
       evaluationPeriods: number;
+      comparisonOperator?: ComparisonOperator;
     }) => {
       metric.createAlarm(this, `${id}${name}`, {
         threshold,
         evaluationPeriods,
         alarmName: `${id}${name}`,
+        comparisonOperator,
       });
     };
 
@@ -180,6 +183,7 @@ export default class OpenSearchConstruct extends Construct {
       name: "FreeStorage",
       threshold: freeStorageMB ?? 5_000,
       evaluationPeriods: 1,
+      comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
     });
 
     createAlarm({


### PR DESCRIPTION
Ref: metriport/metriport-internal#1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1352
- Downstream: none

### Description

Fix FreeStorageSpace alarm on OpenSearchConstruct, adjust the comparison to "lower than".

### Testing

- Local
  - none
- Staging
  - [ ] OpenSearch `CCDAOpenSearchFreeStorage ` alarm update and not "in alarm"
- Production
  - [ ] OpenSearch `CCDAOpenSearchFreeStorage ` alarm not "in alarm"

### Release Plan

- nothing special