### PR TITLE
1040 add action to ACU RDS alarm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13047,9 +13047,10 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.80.0",
+      "version": "2.115.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.115.0.tgz",
+      "integrity": "sha512-jf+5j+ygk/DqxLzYyjFnCOOlRgvL/fwcYhyanhpb1OEQEe1FF6NGUb1TYsnQc3Ly67qLOKkQgdeyeXgzkKoSOQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -39204,7 +39205,7 @@
         "@types/prettier": "2.7.1",
         "@typescript-eslint/eslint-plugin": "^5.48.2",
         "@typescript-eslint/parser": "^5.48.2",
-        "aws-cdk": "^2.80.0",
+        "aws-cdk": "^2.87.0",
         "esbuild": "^0.15.12",
         "eslint": "^8.32.0",
         "eslint-config-prettier": "^8.6.0",

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -56,7 +56,6 @@ export function createAPIService(
     configId: string;
     cxsWithEnhancedCoverageFeatureFlag: string;
   },
-  // cqLinkPatientQueue: IQueue | undefined
   cookieStore: secret.ISecret | undefined
 ): {
   cluster: ecs.Cluster;
@@ -163,9 +162,6 @@ export function createAPIService(
           APPCONFIG_CONFIGURATION_ID: appConfigEnvVars.configId,
           CXS_WITH_ENHANCED_COVERAGE_FEATURE_FLAG:
             appConfigEnvVars.cxsWithEnhancedCoverageFeatureFlag,
-          // ...(cqLinkPatientQueue && {
-          //   CW_CQ_PATIENT_LINK_QUEUE_URL: cqLinkPatientQueue.queueUrl,
-          // }),
           ...(coverageEnhancementConfig && {
             CW_MANAGEMENT_URL: coverageEnhancementConfig.managementUrl,
           }),
@@ -216,12 +212,6 @@ export function createAPIService(
       queue: sidechainFHIRConverterDLQ,
       resource: fargateService.service.taskDefinition.taskRole,
     });
-  // cqLinkPatientQueue &&
-  //   provideAccessToQueue({
-  //     accessType: "send",
-  //     queue: cqLinkPatientQueue,
-  //     resource: fargateService.service.taskDefinition.taskRole,
-  //   });
   if (cookieStore) {
     cookieStore.grantRead(fargateService.service.taskDefinition.taskRole);
     cookieStore.grantWrite(fargateService.service.taskDefinition.taskRole);

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -24,7 +24,7 @@
     "@types/prettier": "2.7.1",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",
-    "aws-cdk": "^2.80.0",
+    "aws-cdk": "^2.87.0",
     "esbuild": "^0.15.12",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",


### PR DESCRIPTION
Ref: metriport/metriport-internal#1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1350
- Downstream: none

### Description

Fix ACU alarm, it was missing the action when the alarm triggers.

To prevent this from happening again, I created a function to create DB alarms that always adds actions to each alarm created.

While I was there, removed some left-over comments from stuff we were going to do but decided not to.

### Testing

- Local
  - none
- Staging
  - [ ] existing alarms are not modified
  - [ ] RDS ACU alarm has action
- Production
  - [ ] existing alarms are not modified
  - [ ] RDS ACU alarm has action

### Release Plan

- nothing special