### PR TITLE
1195 store EC stats per patient

### DIFF
--- a/packages/api/src/domain/base-domain.ts
+++ b/packages/api/src/domain/base-domain.ts
@@ -2,9 +2,12 @@ export interface BaseDomainCreate {
   id: string;
 }
 
-export interface BaseDomain extends BaseDomainCreate {
+export interface BaseDomainNoId {
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface BaseDomain extends BaseDomainCreate, BaseDomainNoId {
   eTag: string;
 }
 

--- a/packages/api/src/domain/medical/coverage-enhancement.ts
+++ b/packages/api/src/domain/medical/coverage-enhancement.ts
@@ -1,0 +1,21 @@
+import { BaseDomainCreate } from "../base-domain";
+
+type Base = Omit<BaseDomainCreate, "id">;
+
+export type CoverageEnhancementData = {
+  cqOrgIds: string[];
+  docsFound?: number;
+};
+
+export interface CoverageEnhancementCreate extends Base {
+  ecId: string;
+  cxId: string;
+  patientId: string;
+  data: CoverageEnhancementData;
+}
+
+//eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CoverageEnhancementUpdate extends CoverageEnhancementCreate {}
+
+//eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CoverageEnhancement extends Base, CoverageEnhancementCreate {}

--- a/packages/api/src/external/commonwell/__tests__/organization.test.ts
+++ b/packages/api/src/external/commonwell/__tests__/organization.test.ts
@@ -4,7 +4,7 @@ import { CookieManagerInMemory } from "@metriport/core/domain/auth/cookie-manage
 import * as orgs from "@metriport/core/external/commonwell/cq-bridge/get-orgs";
 import { CQOrgHydrated } from "@metriport/core/external/commonwell/cq-bridge/get-orgs";
 import { makeSimpleOrg } from "@metriport/core/external/commonwell/cq-bridge/__tests__/cq-orgs";
-import { CommonWellManagementAPI } from "@metriport/core/external/commonwell/management/api";
+import { CommonWellManagementAPIImpl } from "@metriport/core/external/commonwell/management/api-impl";
 import * as api from "../api";
 import { initCQOrgIncludeList } from "../organization";
 jest.mock("@metriport/core/external/commonwell/management/api");
@@ -15,12 +15,12 @@ let getOrgsByPrio_mock: jest.SpyInstance;
 let makeCommonWellManagementAPI_mock: jest.SpyInstance;
 beforeEach(() => {
   jest.restoreAllMocks();
-  updateIncludeList_mock = jest.spyOn(CommonWellManagementAPI.prototype, "updateIncludeList");
+  updateIncludeList_mock = jest.spyOn(CommonWellManagementAPIImpl.prototype, "updateIncludeList");
   getOrgsByPrio_mock = jest.spyOn(orgs, "getOrgsByPrio");
   makeCommonWellManagementAPI_mock = jest
     .spyOn(api, "makeCommonWellManagementAPI")
     .mockImplementation(() => {
-      return new CommonWellManagementAPI({
+      return new CommonWellManagementAPIImpl({
         cookieManager: new CookieManagerInMemory(),
         baseUrl: "",
       });

--- a/packages/api/src/external/commonwell/api.ts
+++ b/packages/api/src/external/commonwell/api.ts
@@ -8,6 +8,7 @@ import {
 } from "@metriport/commonwell-sdk";
 import { CookieManagerOnSecrets } from "@metriport/core/domain/auth/cookie-management/cookie-manager-on-secrets";
 import { CommonWellManagementAPI } from "@metriport/core/external/commonwell/management/api";
+import { makeApi } from "@metriport/core/external/commonwell/management/api-factory";
 import { X509Certificate } from "crypto";
 import dayjs from "dayjs";
 import { Config } from "../../shared/config";
@@ -28,10 +29,8 @@ export function makeCommonWellManagementAPI(): CommonWellManagementAPI | undefin
   if (!cwManagementBaseUrl) return undefined;
 
   const cookieManager = new CookieManagerOnSecrets(cookieArn, Config.getAWSRegion());
-  return new CommonWellManagementAPI({
-    cookieManager,
-    baseUrl: cwManagementBaseUrl,
-  });
+
+  return makeApi({ cookieManager, baseUrl: cwManagementBaseUrl });
 }
 
 /**

--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancement-init.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancement-init.ts
@@ -25,6 +25,8 @@ export async function initEnhancedCoverage(
     return;
   }
 
+  const ecId = coverageEnhancer.makeId();
+
   const getPatientsToProcess = async () => {
     if (patientIds && patientIds.length > 0) {
       const cxId = cxIds[0];
@@ -58,6 +60,7 @@ export async function initEnhancedCoverage(
 
     const patientIds = patients.map(p => p.id);
     await coverageEnhancer.enhanceCoverage({
+      ecId,
       cxId,
       orgOID: org.oid,
       patientIds,

--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancement-storage.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancement-storage.ts
@@ -1,0 +1,17 @@
+import { Transaction } from "sequelize";
+import { CoverageEnhancementUpdate } from "../../../domain/medical/coverage-enhancement";
+import { CoverageEnhancementModel } from "../../../models/medical/coverage-enhancement";
+
+export type CreateOrUpdateCmd = CoverageEnhancementUpdate[];
+
+export const createOrUpdateCoverageEnhancements = async (
+  ecList: CreateOrUpdateCmd,
+  transaction?: Transaction
+): Promise<void> => {
+  // create or update
+  await CoverageEnhancementModel.bulkCreate(ecList, {
+    returning: false,
+    updateOnDuplicate: ["data"],
+    transaction,
+  });
+};

--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-api-local.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-api-local.ts
@@ -9,6 +9,7 @@ import { capture } from "../../../shared/notifications";
 import { PatientLoaderLocal } from "../patient-loader-local";
 import { PatientUpdaterCommonWell } from "../patient-updater-commonwell";
 import { completeEnhancedCoverage } from "./coverage-enhancement-complete";
+import { ECUpdaterLocal } from "./ec-updater-local";
 
 dayjs.extend(duration);
 
@@ -24,6 +25,7 @@ export class CoverageEnhancerApiLocal extends CoverageEnhancerLocal {
       cwManagementApi,
       new PatientLoaderLocal(),
       new PatientUpdaterCommonWell(),
+      new ECUpdaterLocal(),
       capture,
       prefix
     );
@@ -36,20 +38,23 @@ export class CoverageEnhancerApiLocal extends CoverageEnhancerLocal {
   }: CoverageEnhancementParams & {
     waitBetweenLinkingAndDocQuery: duration.Duration;
     startedAt?: number;
-  }) {
+  }): Promise<string> {
     const { cxId, patientIds } = params;
-    const { log } = out(`EC - MAIN - cx ${cxId}`);
 
-    await super.enhanceCoverage(params);
+    const ecId = await super.enhanceCoverage(params);
+
+    const { log } = out(`EC ${ecId} - cx ${cxId}`);
 
     const waitTime = waitBetweenLinkingAndDocQuery.asMilliseconds();
     log(`Giving some time for patients to be updated @ CW... (${waitTime} ms)`);
     await sleep(waitTime);
 
-    await completeEnhancedCoverage({ cxId, patientIds, cqLinkStatus: "linked" });
+    await completeEnhancedCoverage({ ecId, cxId, patientIds, cqLinkStatus: "linked" });
 
     const duration = Date.now() - startedAt;
     const durationMin = dayjs.duration(duration).asMinutes();
     log(`Done, total time: ${duration} ms / ${durationMin} min`);
+
+    return ecId;
   }
 }

--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-factory.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-factory.ts
@@ -1,20 +1,10 @@
 import { CookieManagerOnSecrets } from "@metriport/core/domain/auth/cookie-management/cookie-manager-on-secrets";
 import { CoverageEnhancer } from "@metriport/core/external/commonwell/cq-bridge/coverage-enhancer";
-// import { CoverageEnhancerCloud } from "@metriport/core/external/commonwell/cq-bridge/coverage-enhancer-cloud";
-import { CommonWellManagementAPI } from "@metriport/core/external/commonwell/management/api";
+import { makeApi } from "@metriport/core/external/commonwell/management/api-factory";
 import { Config } from "../../../shared/config";
 import { CoverageEnhancerApiLocal } from "./coverage-enhancer-api-local";
 
 export function makeCoverageEnhancer(): CoverageEnhancer | undefined {
-  // if (Config.isCloudEnv()) {
-  //   const cwPatientLinkQueueUrl = Config.getCWPatientLinkQueueUrl();
-  //   if (!cwPatientLinkQueueUrl) {
-  //     console.log(`Could not return a CoverageEnhancer, mising cwPatientLinkQueueUrl`);
-  //     return undefined;
-  //   }
-  //   return new CoverageEnhancerCloud(Config.getAWSRegion(), cwPatientLinkQueueUrl);
-  // }
-
   const cwManagementUrl = Config.getCWManagementUrl();
   if (!cwManagementUrl) {
     console.log(`WARNING: Could not return a CoverageEnhancer, mising cwManagementUrl`);
@@ -26,9 +16,6 @@ export function makeCoverageEnhancer(): CoverageEnhancer | undefined {
     return undefined;
   }
   const cookieManager = new CookieManagerOnSecrets(cookieArn, Config.getAWSRegion());
-  const cwManagementApi = new CommonWellManagementAPI({
-    cookieManager,
-    baseUrl: cwManagementUrl,
-  });
+  const cwManagementApi = makeApi({ cookieManager, baseUrl: cwManagementUrl });
   return new CoverageEnhancerApiLocal(cwManagementApi);
 }

--- a/packages/api/src/external/commonwell/cq-bridge/ec-updater-local.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/ec-updater-local.ts
@@ -1,0 +1,101 @@
+import {
+  ECUpdater,
+  StoreECAfterDocQueryCmd,
+  StoreECAfterIncludeListCmd,
+} from "@metriport/core/external/commonwell/cq-bridge/ec-updater";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
+import { MetriportError } from "@metriport/core/util/error/metriport-error";
+import NotFoundError from "@metriport/core/util/error/not-found";
+import { CoverageEnhancementModel } from "../../../models/medical/coverage-enhancement";
+import { executeOnDBTx } from "../../../models/transaction-wrapper";
+import { createOrUpdateCoverageEnhancements } from "./coverage-enhancement-storage";
+
+export class ECUpdaterLocal extends ECUpdater {
+  async storeECAfterIncludeList({
+    ecId,
+    cxId,
+    patientIds,
+    cqOrgIds,
+  }: StoreECAfterIncludeListCmd): Promise<void> {
+    await executeAsynchronously(
+      patientIds,
+      async patientId => {
+        await executeOnDBTx(CoverageEnhancementModel.prototype, async transaction => {
+          const existing = await CoverageEnhancementModel.findOne({
+            where: {
+              ecId,
+              patientId,
+            },
+            transaction,
+          });
+          if (existing && existing.cxId !== cxId) {
+            throw new MetriportError(`CxId mismatch`, undefined, {
+              paramCxId: cxId,
+              loadedCxId: existing.cxId,
+              patientId,
+              cqOrgIds: cqOrgIds.join(","),
+            });
+          }
+          const updatedCQList = [...(existing?.data.cqOrgIds ?? []), ...cqOrgIds];
+          const ecList = patientIds.map(patientId => ({
+            ecId,
+            cxId,
+            patientId,
+            data: {
+              ...(existing?.data ?? {}),
+              cqOrgIds: updatedCQList,
+            },
+          }));
+          await createOrUpdateCoverageEnhancements(ecList, transaction);
+        });
+      },
+      { numberOfParallelExecutions: 20 }
+    );
+  }
+
+  async storeECAfterDocQuery({
+    ecId,
+    cxId,
+    patientId,
+    docsFound,
+  }: StoreECAfterDocQueryCmd): Promise<void> {
+    await executeOnDBTx(CoverageEnhancementModel.prototype, async transaction => {
+      const existing = await CoverageEnhancementModel.findOne({
+        where: {
+          ecId,
+          patientId,
+        },
+        transaction,
+      });
+      if (!existing) {
+        throw new NotFoundError(`Coverage enhancement not found`, undefined, {
+          cxId,
+          patientId,
+          docsFound,
+        });
+      }
+      if (existing.cxId !== cxId) {
+        throw new MetriportError(`CxId mismatch`, undefined, {
+          paramCxId: cxId,
+          loadedCxId: existing.cxId,
+          patientId,
+          docsFound,
+        });
+      }
+      await createOrUpdateCoverageEnhancements(
+        [
+          {
+            ecId,
+            cxId,
+            patientId,
+            data: {
+              ...existing.data,
+              docsFound,
+            },
+          },
+        ],
+        transaction
+      );
+    });
+  }
+}

--- a/packages/api/src/models/db.ts
+++ b/packages/api/src/models/db.ts
@@ -4,18 +4,19 @@ import { FacilityModel } from "../models/medical/facility";
 import { OrganizationModel } from "../models/medical/organization";
 import updateDB from "../sequelize";
 import { Config } from "../shared/config";
-import { ModelSetup } from "./_default";
 import { ConnectedUser } from "./connected-user";
 import { initDDBDev, initLocalCxAccount } from "./db-dev";
 import { CQDirectoryEntryModel } from "./medical/cq-directory";
 import { DocRefMappingModel } from "./medical/docref-mapping";
 import { DocumentQueryResultModel } from "./medical/document-query-result";
 import { DocumentRetrievalResultModel } from "./medical/document-retrieval-result";
+import { CoverageEnhancementModel } from "./medical/coverage-enhancement";
 import { MAPIAccess } from "./medical/mapi-access";
-import { PatientDiscoveryResultModel } from "./medical/patient-discovery-result";
 import { PatientModel } from "./medical/patient";
+import { PatientDiscoveryResultModel } from "./medical/patient-discovery-result";
 import { Settings } from "./settings";
 import { WebhookRequest } from "./webhook-request";
+import { ModelSetup } from "./_default";
 
 // models to setup with sequelize
 const models: ModelSetup[] = [
@@ -31,6 +32,7 @@ const models: ModelSetup[] = [
   PatientDiscoveryResultModel.setup,
   DocumentQueryResultModel.setup,
   DocumentRetrievalResultModel.setup,
+  CoverageEnhancementModel.setup,
 ];
 
 export type MetriportDB = {

--- a/packages/api/src/models/medical/coverage-enhancement.ts
+++ b/packages/api/src/models/medical/coverage-enhancement.ts
@@ -1,0 +1,43 @@
+import { DataTypes, Sequelize } from "sequelize";
+import {
+  CoverageEnhancement,
+  CoverageEnhancementData,
+} from "../../domain/medical/coverage-enhancement";
+import { BaseModelNoId, ModelSetup } from "../_default";
+
+export class CoverageEnhancementModel
+  extends BaseModelNoId<CoverageEnhancementModel>
+  implements CoverageEnhancement
+{
+  static NAME = "coverage-enhancement";
+  declare ecId: string;
+  declare patientId: string;
+  declare cxId: string;
+  declare data: CoverageEnhancementData;
+
+  static setup: ModelSetup = (sequelize: Sequelize) => {
+    CoverageEnhancementModel.init(
+      {
+        ...BaseModelNoId.attributes(),
+        ecId: {
+          type: DataTypes.UUID,
+          primaryKey: true,
+        },
+        patientId: {
+          type: DataTypes.UUID,
+          primaryKey: true,
+        },
+        cxId: {
+          type: DataTypes.UUID,
+        },
+        data: {
+          type: DataTypes.JSONB,
+        },
+      },
+      {
+        ...BaseModelNoId.modelOptions(sequelize),
+        tableName: CoverageEnhancementModel.NAME,
+      }
+    );
+  };
+}

--- a/packages/api/src/models/transaction-starter.ts
+++ b/packages/api/src/models/transaction-starter.ts
@@ -1,9 +1,9 @@
 import { Model, Transaction } from "sequelize";
-import { BaseModel } from "./_default";
+import { BaseModelNoId } from "./_default";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function startTransaction<T extends Model<any, any>>(
-  model: BaseModel<T>
+  model: BaseModelNoId<T>
 ): Promise<Transaction> {
   const sequelize = model.sequelize;
   if (!sequelize) throw new Error("Missing sequelize");

--- a/packages/api/src/models/transaction-wrapper.ts
+++ b/packages/api/src/models/transaction-wrapper.ts
@@ -1,6 +1,6 @@
 import { Model, Transaction } from "sequelize";
 import { startTransaction } from "./transaction-starter";
-import { BaseModel } from "./_default";
+import { BaseModelNoId } from "./_default";
 
 // TODO Add unit tests
 
@@ -16,7 +16,7 @@ import { BaseModel } from "./_default";
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function executeOnDBTx<T extends Model<any, any>, X>(
-  model: BaseModel<T>,
+  model: BaseModelNoId<T>,
   callback: (tx: Transaction) => Promise<X>
 ): Promise<X> {
   let transaction: Transaction | undefined = await startTransaction(model);

--- a/packages/api/src/routes/schemas/shared.ts
+++ b/packages/api/src/routes/schemas/shared.ts
@@ -1,3 +1,4 @@
+import BadRequestError from "@metriport/core/util/error/bad-request";
 import { z } from "zod";
 
 export const stringListSchema = z.string().array();
@@ -5,6 +6,20 @@ export const stringListSchema = z.string().array();
 export const stringListFromQuerySchema = z.union([z.string(), stringListSchema]).transform(v => {
   return Array.isArray(v) ? v : v.split(",").map(v => v.trim());
 });
+
+export const nonEmptyStringListFromQuerySchema = z
+  .union([z.string(), stringListSchema])
+  .transform(v => {
+    return Array.isArray(v) ? v : v.split(",").map(v => v.trim());
+  })
+  .transform(arr => {
+    arr.forEach((item: string) => {
+      if (!item || item.trim().length === 0) {
+        throw new BadRequestError("Invalid empty string");
+      }
+    });
+    return arr;
+  });
 
 export const stringIntegerSchema = z
   .string()

--- a/packages/api/src/sequelize/migrations/2023-12-18_00_create-coverage-enhancement.ts
+++ b/packages/api/src/sequelize/migrations/2023-12-18_00_create-coverage-enhancement.ts
@@ -1,0 +1,51 @@
+import { DataTypes, literal } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "coverage-enhancement";
+
+// Use 'Promise.all' when changes are independent of each other
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.createTable(
+      tableName,
+      {
+        patientId: {
+          type: DataTypes.UUID,
+          field: "patient_id",
+          primaryKey: true,
+        },
+        ecId: {
+          type: DataTypes.UUID,
+          field: "ec_id",
+          primaryKey: true,
+        },
+        cxId: {
+          type: DataTypes.UUID,
+          field: "cx_id",
+        },
+        data: {
+          type: DataTypes.JSONB,
+        },
+        createdAt: {
+          field: "created_at",
+          type: DataTypes.DATE(6),
+          allowNull: false,
+          defaultValue: literal("CURRENT_TIMESTAMP(6)"),
+        },
+        updatedAt: {
+          field: "updated_at",
+          type: DataTypes.DATE(6),
+          allowNull: false,
+          defaultValue: literal("CURRENT_TIMESTAMP(6)"),
+        },
+      },
+      { transaction }
+    );
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.dropTable(tableName, { transaction });
+  });
+};

--- a/packages/core/src/external/commonwell/cq-bridge/__tests__/coverate-enhancer.test.ts
+++ b/packages/core/src/external/commonwell/cq-bridge/__tests__/coverate-enhancer.test.ts
@@ -10,7 +10,7 @@ class CoverageEnhancerLocal extends CoverageEnhancer {
   constructor(params: ConstructorParameters<typeof CoverageEnhancer>[0]) {
     super(params);
   }
-  public enhanceCoverage(): Promise<void> {
+  public enhanceCoverage(): Promise<string> {
     throw new Error("Method not implemented.");
   }
   override async getOrgsForPatients(cxId: string, patientIds: string[]): Promise<CQOrgHydrated[]> {

--- a/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer-cloud.ts
+++ b/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer-cloud.ts
@@ -20,16 +20,20 @@ export class CoverageEnhancerCloud extends CoverageEnhancer {
   }
 
   public override async enhanceCoverage({
+    ecId: ecIdParam,
     cxId,
     orgOID,
     patientIds,
     fromOrgChunkPos = 0,
-  }: CoverageEnhancementParams) {
+  }: CoverageEnhancementParams): Promise<string> {
+    const ecId = ecIdParam ?? super.makeId();
+
     const { chunks } = await this.getCarequalityOrgs({ cxId, patientIds, fromOrgChunkPos });
 
     // Each chunk of CQ orgs
     for (const cqOrgList of chunks) {
       await this.sendEnhancedCoverageByCxAndChunk({
+        ecId,
         cxId,
         orgOID,
         patientIds,
@@ -37,21 +41,26 @@ export class CoverageEnhancerCloud extends CoverageEnhancer {
       });
     }
     await this.sendEnhancedCoverageDone(cxId, patientIds);
+
+    return ecId;
   }
 
   // for each patientId, send a message to SQS with the patientId and the orgChunks
   private async sendEnhancedCoverageByCxAndChunk({
+    ecId,
     cxId,
     orgOID,
     patientIds,
     cqOrgIds,
   }: {
+    ecId: string;
     cxId: string;
     orgOID: string;
     patientIds: string[];
     cqOrgIds: string[];
   }) {
     const payload: Input = {
+      ecId,
       cxId,
       cxOrgOID: orgOID,
       patientIds,

--- a/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer.ts
+++ b/packages/core/src/external/commonwell/cq-bridge/coverage-enhancer.ts
@@ -1,10 +1,12 @@
 import { PatientLoader } from "../../../domain/patient/patient-loader";
+import { uuidv7 } from "../../../util/uuid-v7";
 import { CQOrgHydrated, getOrgChunksFromPos, getOrgsByPrio, OrgPrio } from "./get-orgs";
 
 // Try to keep it even to make testing easier
 export const defaultMaxOrgsToProcess = 350;
 
 export type CoverageEnhancementParams = {
+  ecId?: string | undefined;
   cxId: string;
   orgOID: string;
   patientIds: string[];
@@ -31,20 +33,27 @@ export abstract class CoverageEnhancer {
     this.maxOrgsToProcess = maxOrgsToProcess;
   }
 
+  public makeId(): string {
+    return uuidv7();
+  }
+
   /**
    * Execute the Enhanced Coverage flow using CW's CQ bridge.
    *
+   * @param ecId The ID of this EC run, optional (created if not provided)
    * @param cxId The customer ID
    * @param orgOID The OID of the customer's Org
    * @param patientIds The IDs of the patients to have coverage enhanced
    * @param fromOrgChunkPos The initial chunk of CQ orgs to start from (defaults to 0)
+   * @returns The ID of the EC run
    */
   public abstract enhanceCoverage({
+    ecId,
     cxId,
     orgOID,
     patientIds,
     fromOrgChunkPos,
-  }: CoverageEnhancementParams): Promise<void>;
+  }: CoverageEnhancementParams): Promise<string>;
 
   protected async getCarequalityOrgs({
     cxId,

--- a/packages/core/src/external/commonwell/cq-bridge/ec-updater-api.ts
+++ b/packages/core/src/external/commonwell/cq-bridge/ec-updater-api.ts
@@ -1,0 +1,56 @@
+import axios from "axios";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import { ECUpdater, StoreECAfterDocQueryCmd, StoreECAfterIncludeListCmd } from "./ec-updater";
+
+dayjs.extend(duration);
+
+const UPDATE_TIMEOUT = dayjs.duration({ minutes: 2 });
+
+export class ECUpdaterAPI extends ECUpdater {
+  constructor(private readonly apiUrl: string) {
+    super();
+  }
+
+  async storeECAfterIncludeList({
+    ecId,
+    cxId,
+    patientIds,
+    cqOrgIds,
+  }: StoreECAfterIncludeListCmd): Promise<void> {
+    const endpoint = "/internal/patient/enhance-coverage/after-include-list";
+    console.log(
+      `Calling API ${endpoint} w/ ${patientIds.length} patients and ${cqOrgIds.length} orgs.`
+    );
+    const params = new URLSearchParams({
+      ecId,
+      cxId,
+      patientIds: patientIds.join(","),
+      cqOrgIds: cqOrgIds.join(","),
+    });
+    await axios.post(
+      `${this.apiUrl}/internal/patient/enhance-coverage/after-include-list?${params.toString()}`,
+      undefined,
+      { timeout: UPDATE_TIMEOUT.asMilliseconds() }
+    );
+  }
+
+  async storeECAfterDocQuery({
+    ecId,
+    cxId,
+    patientId,
+    docsFound,
+  }: StoreECAfterDocQueryCmd): Promise<void> {
+    const endpoint = "/internal/patient/enhance-coverage/after-doc-query";
+    console.log(`Calling API ${endpoint} w/ patient ${patientId}, found ${docsFound} docs.`);
+    const params = new URLSearchParams({
+      ecId,
+      cxId,
+      patientId,
+      docsFound: docsFound.toString(),
+    });
+    await axios.post(`${this.apiUrl}${endpoint}?${params.toString()}`, undefined, {
+      timeout: UPDATE_TIMEOUT.asMilliseconds(),
+    });
+  }
+}

--- a/packages/core/src/external/commonwell/cq-bridge/ec-updater.ts
+++ b/packages/core/src/external/commonwell/cq-bridge/ec-updater.ts
@@ -1,0 +1,18 @@
+export type StoreECAfterIncludeListCmd = {
+  ecId: string;
+  cxId: string;
+  patientIds: string[];
+  cqOrgIds: string[];
+};
+
+export type StoreECAfterDocQueryCmd = {
+  ecId: string;
+  cxId: string;
+  patientId: string;
+  docsFound: number;
+};
+
+export abstract class ECUpdater {
+  public abstract storeECAfterIncludeList(params: StoreECAfterIncludeListCmd): Promise<void>;
+  public abstract storeECAfterDocQuery(params: StoreECAfterDocQueryCmd): Promise<void>;
+}

--- a/packages/core/src/external/commonwell/management/api-factory.ts
+++ b/packages/core/src/external/commonwell/management/api-factory.ts
@@ -1,0 +1,17 @@
+import { CookieManager } from "../../../domain/auth/cookie-management/cookie-manager";
+import { Config } from "../../../util/config";
+import { CommonWellManagementAPI } from "./api";
+import { CommonWellManagementAPIImpl } from "./api-impl";
+import { CommonWellManagementAPIMock } from "./api-mock";
+
+export function makeApi({
+  cookieManager,
+  baseUrl,
+}: {
+  cookieManager: CookieManager;
+  baseUrl: string;
+}): CommonWellManagementAPI {
+  return Config.isDev()
+    ? new CommonWellManagementAPIMock({ baseUrl })
+    : new CommonWellManagementAPIImpl({ cookieManager, baseUrl });
+}

--- a/packages/core/src/external/commonwell/management/api-impl.ts
+++ b/packages/core/src/external/commonwell/management/api-impl.ts
@@ -1,0 +1,214 @@
+import { emptyFunction } from "@metriport/shared";
+import axios, { AxiosResponse } from "axios";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import {
+  Cookie,
+  cookieFromString,
+  CookieManager,
+  cookiesToString,
+} from "../../../domain/auth/cookie-management/cookie-manager";
+import { MetriportError } from "../../../util/error/metriport-error";
+import { safeStringify } from "../../../util/string";
+import { CommonWellManagementAPI, Member } from "./api";
+
+dayjs.extend(duration);
+
+const DEFAULT_TIMEOUT_GET_MEMBER = dayjs.duration({ seconds: 20 });
+const DEFAULT_TIMEOUT_INCLUDE_LIST = dayjs.duration({ minutes: 5 });
+
+export const userAgent =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36";
+
+export const baseHeaders = {
+  "User-Agent": userAgent,
+  Accept: "application/json, text/plain, */*",
+};
+
+export class CommonWellManagementAPIImpl implements CommonWellManagementAPI {
+  private readonly cookieManager: CookieManager;
+  private readonly baseUrl: string;
+
+  constructor(params: { cookieManager: CookieManager; baseUrl: string }) {
+    this.cookieManager = params.cookieManager;
+    this.baseUrl = params.baseUrl.endsWith("/") ? params.baseUrl.slice(0, -1) : params.baseUrl;
+  }
+
+  public getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  public async getMember({
+    timeout = DEFAULT_TIMEOUT_GET_MEMBER.asMilliseconds(),
+    log = console.log,
+  }: {
+    timeout?: number;
+    log?: typeof console.log;
+  } = {}): Promise<Member | undefined> {
+    const cookies = await this.cookieManager.getCookies();
+
+    const resp = await axios.get(`${this.baseUrl}/Organization/GetMembers`, {
+      timeout,
+      withCredentials: true,
+      headers: {
+        ...baseHeaders,
+        Cookie: cookiesToString(cookies),
+        Origin: `${this.baseUrl}`,
+        Referer: `${this.baseUrl}/Organization/List`,
+      },
+    });
+    log(`Responded w/ ${resp.status} - ${resp.statusText}`);
+    if (Array.isArray(resp.data) && resp.data.length > 0) {
+      const member = resp.data[0];
+
+      await this.updateCookiesFromResponse(cookies, resp, log);
+
+      return { id: member.Id, name: member.Name };
+    }
+    log(`No member array available, returning 'undefined'`);
+    return undefined;
+  }
+
+  private getIncludeListUrl(oid: string): string {
+    return `${this.baseUrl}/Organization/${oid}/IncludeList`;
+  }
+
+  public async getIncludeList({
+    oid,
+    timeout = DEFAULT_TIMEOUT_INCLUDE_LIST.asMilliseconds(),
+    log = console.log,
+  }: {
+    oid: string;
+    timeout?: number;
+    log?: typeof console.log;
+  }): Promise<string[]> {
+    const cookies = await this.cookieManager.getCookies();
+
+    log(`Get from /IncludeList...`);
+    const before = Date.now();
+    const resp = await axios.get(this.getIncludeListUrl(oid), {
+      timeout,
+      withCredentials: true,
+      headers: {
+        Cookie: cookiesToString(cookies),
+        ...baseHeaders,
+        Origin: `${this.baseUrl}`,
+        Referer: `${this.baseUrl}/Organization/${oid}/IncludeList/Edit`,
+      },
+    });
+    log(`Responded w/ ${resp.status} - ${resp.statusText} - took ${Date.now() - before}ms`);
+
+    const result = resp.data["IncludedOrganizationIdList"] as string[] | undefined;
+    if (!result) {
+      const msg = `Bad response from CommonWell`;
+      const additionalData = {
+        status: resp.status,
+        statusText: resp.statusText,
+        data: safeStringify(resp.data),
+      };
+      log(msg, additionalData);
+      throw new MetriportError(msg, undefined, additionalData);
+    }
+    log("Response", result.join(", "));
+
+    await this.updateCookiesFromResponse(cookies, resp, log);
+
+    return result;
+  }
+
+  public async updateIncludeList({
+    oid,
+    careQualityOrgIds,
+    timeout = DEFAULT_TIMEOUT_INCLUDE_LIST.asMilliseconds(),
+    log = console.log,
+    debug = emptyFunction,
+  }: {
+    oid: string;
+    careQualityOrgIds: string[];
+    timeout?: number;
+    log?: typeof console.log | undefined;
+    debug?: typeof console.log | undefined;
+  }): Promise<void> {
+    const cookies = await this.cookieManager.getCookies();
+    if (cookies.length < 1) {
+      log(`No cookies to support auth, skipping...`);
+      return;
+    }
+
+    log(`Posting to /IncludeList...`);
+    const before = Date.now();
+    const resp = await axios.post(
+      this.getIncludeListUrl(oid),
+      {
+        LocalOrganizationid: oid,
+        IncludedOrganizationIdList: careQualityOrgIds,
+      },
+      {
+        timeout,
+        withCredentials: true,
+        headers: {
+          Cookie: cookiesToString(cookies),
+          ...baseHeaders,
+          Origin: `${this.baseUrl}`,
+          Referer: `${this.baseUrl}/Organization/${oid}/IncludeList/Edit`,
+        },
+      }
+    );
+    log(`Responded w/ ${resp.status} - ${resp.statusText} - took ${Date.now() - before}ms`);
+    const result = resp.data["SelectedOrganizationList"];
+    if (!result) {
+      const msg = `Bad response from CommonWell`;
+      const additionalData = {
+        status: resp.status,
+        statusText: resp.statusText,
+        data: safeStringify(resp.data),
+      };
+      log(msg, additionalData);
+      throw new MetriportError(msg, undefined, additionalData);
+    }
+    debug(
+      "Response",
+      JSON.stringify(
+        //eslint-disable-next-line @typescript-eslint/no-explicit-any
+        result.map((item: any) => ({
+          Id: item.Id,
+          Name: item.Name,
+          AllSelected: item.AllSelected,
+          //eslint-disable-next-line @typescript-eslint/no-explicit-any
+          Organizations: item.Organizations?.map((o: any) => o.Id).join(", "),
+        }))
+      )
+    );
+
+    await this.updateCookiesFromResponse(cookies, resp, log);
+  }
+
+  /**
+   * Check if cookies were updated and update them if so.
+   */
+  private async updateCookiesFromResponse<T extends AxiosResponse>(
+    cookies: Cookie[],
+    resp: T,
+    log = console.log
+  ): Promise<void> {
+    const respCookies = resp.headers["set-cookie"];
+    if (respCookies) {
+      log(`Received cookies, added/updated!`);
+      await this.updateCookies(cookies, respCookies);
+    }
+  }
+
+  private async updateCookies(actualCookies: Cookie[], newCookies: string[]): Promise<void> {
+    const newCookiesParsed = newCookies.flatMap(c => cookieFromString(c) ?? []);
+    for (const newCookie of newCookiesParsed) {
+      const existingCookieIndex = actualCookies.findIndex(c => c.name.startsWith(newCookie.name));
+      if (existingCookieIndex >= 0) {
+        actualCookies[existingCookieIndex] = newCookie;
+      } else {
+        actualCookies.push(newCookie);
+      }
+    }
+
+    await this.cookieManager.updateCookies(actualCookies);
+  }
+}

--- a/packages/core/src/external/commonwell/management/api-mock.ts
+++ b/packages/core/src/external/commonwell/management/api-mock.ts
@@ -1,0 +1,31 @@
+import { CommonWellManagementAPI, Member } from "./api";
+
+export class CommonWellManagementAPIMock implements CommonWellManagementAPI {
+  private readonly baseUrl: string;
+
+  constructor(params: { baseUrl: string }) {
+    this.baseUrl = params.baseUrl.endsWith("/") ? params.baseUrl.slice(0, -1) : params.baseUrl;
+  }
+
+  public getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  public async getMember(): Promise<Member | undefined> {
+    console.log(`[CommonWellManagementAPIMock] Would be calling CW's GET member endpoint now...`);
+    return undefined;
+  }
+
+  public async getIncludeList(): Promise<string[]> {
+    console.log(
+      `[CommonWellManagementAPIMock] Would be calling CW's GET include list endpoint now...`
+    );
+    return [];
+  }
+
+  public async updateIncludeList(): Promise<void> {
+    console.log(
+      `[CommonWellManagementAPIMock] Would be calling CW's POST include list endpoint now...`
+    );
+  }
+}

--- a/packages/core/src/external/commonwell/management/api.ts
+++ b/packages/core/src/external/commonwell/management/api.ts
@@ -1,218 +1,29 @@
-import { emptyFunction } from "@metriport/shared";
-import axios, { AxiosResponse } from "axios";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
-import {
-  Cookie,
-  cookieFromString,
-  CookieManager,
-  cookiesToString,
-} from "../../../domain/auth/cookie-management/cookie-manager";
-import { MetriportError } from "../../../util/error/metriport-error";
-import { safeStringify } from "../../../util/string";
 
 dayjs.extend(duration);
-
-const DEFAULT_TIMEOUT_GET_MEMBER = dayjs.duration({ seconds: 20 });
-const DEFAULT_TIMEOUT_INCLUDE_LIST = dayjs.duration({ minutes: 5 });
-
-export const userAgent =
-  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36";
-
-export const baseHeaders = {
-  "User-Agent": userAgent,
-  Accept: "application/json, text/plain, */*",
-};
 
 export type Member = {
   id: string;
   name: string;
 };
 
-export class CommonWellManagementAPI {
-  private readonly cookieManager: CookieManager;
-  private readonly baseUrl: string;
+export interface CommonWellManagementAPI {
+  getBaseUrl(): string;
 
-  constructor(params: { cookieManager: CookieManager; baseUrl: string }) {
-    this.cookieManager = params.cookieManager;
-    this.baseUrl = params.baseUrl.endsWith("/") ? params.baseUrl.slice(0, -1) : params.baseUrl;
-  }
+  getMember(params?: { timeout?: number; log?: typeof console.log }): Promise<Member | undefined>;
 
-  public getBaseUrl(): string {
-    return this.baseUrl;
-  }
-
-  public async getMember({
-    timeout = DEFAULT_TIMEOUT_GET_MEMBER.asMilliseconds(),
-    log = console.log,
-  }: {
-    timeout?: number;
-    log?: typeof console.log;
-  } = {}): Promise<Member | undefined> {
-    const cookies = await this.cookieManager.getCookies();
-
-    const resp = await axios.get(`${this.baseUrl}/Organization/GetMembers`, {
-      timeout,
-      withCredentials: true,
-      headers: {
-        ...baseHeaders,
-        Cookie: cookiesToString(cookies),
-        Origin: `${this.baseUrl}`,
-        Referer: `${this.baseUrl}/Organization/List`,
-      },
-    });
-    log(`Responded w/ ${resp.status} - ${resp.statusText}`);
-    if (Array.isArray(resp.data) && resp.data.length > 0) {
-      const member = resp.data[0];
-
-      await this.updateCookiesFromResponse(cookies, resp, log);
-
-      return { id: member.Id, name: member.Name };
-    }
-    log(`No member array available, returning 'undefined'`);
-    return undefined;
-  }
-
-  private getIncludeListUrl(oid: string): string {
-    return `${this.baseUrl}/Organization/${oid}/IncludeList`;
-  }
-
-  public async getIncludeList({
-    oid,
-    timeout = DEFAULT_TIMEOUT_INCLUDE_LIST.asMilliseconds(),
-    log = console.log,
-  }: {
+  getIncludeList(params: {
     oid: string;
     timeout?: number;
     log?: typeof console.log;
-  }): Promise<string[]> {
-    const cookies = await this.cookieManager.getCookies();
+  }): Promise<string[]>;
 
-    log(`Get from /IncludeList...`);
-    const before = Date.now();
-    const resp = await axios.get(this.getIncludeListUrl(oid), {
-      timeout,
-      withCredentials: true,
-      headers: {
-        Cookie: cookiesToString(cookies),
-        ...baseHeaders,
-        Origin: `${this.baseUrl}`,
-        Referer: `${this.baseUrl}/Organization/${oid}/IncludeList/Edit`,
-      },
-    });
-    log(`Responded w/ ${resp.status} - ${resp.statusText} - took ${Date.now() - before}ms`);
-
-    const result = resp.data["IncludedOrganizationIdList"] as string[] | undefined;
-    if (!result) {
-      const msg = `Bad response from CommonWell`;
-      const additionalData = {
-        status: resp.status,
-        statusText: resp.statusText,
-        data: safeStringify(resp.data),
-      };
-      log(msg, additionalData);
-      throw new MetriportError(msg, undefined, additionalData);
-    }
-    log("Response", result.join(", "));
-
-    await this.updateCookiesFromResponse(cookies, resp, log);
-
-    return result;
-  }
-
-  public async updateIncludeList({
-    oid,
-    careQualityOrgIds,
-    timeout = DEFAULT_TIMEOUT_INCLUDE_LIST.asMilliseconds(),
-    log = console.log,
-    debug = emptyFunction,
-  }: {
+  updateIncludeList(params: {
     oid: string;
     careQualityOrgIds: string[];
     timeout?: number;
     log?: typeof console.log | undefined;
     debug?: typeof console.log | undefined;
-  }): Promise<void> {
-    const cookies = await this.cookieManager.getCookies();
-    if (cookies.length < 1) {
-      log(`No cookies to support auth, skipping...`);
-      return;
-    }
-
-    log(`Posting to /IncludeList...`);
-    const before = Date.now();
-    const resp = await axios.post(
-      this.getIncludeListUrl(oid),
-      {
-        LocalOrganizationid: oid,
-        IncludedOrganizationIdList: careQualityOrgIds,
-      },
-      {
-        timeout,
-        withCredentials: true,
-        headers: {
-          Cookie: cookiesToString(cookies),
-          ...baseHeaders,
-          Origin: `${this.baseUrl}`,
-          Referer: `${this.baseUrl}/Organization/${oid}/IncludeList/Edit`,
-        },
-      }
-    );
-    log(`Responded w/ ${resp.status} - ${resp.statusText} - took ${Date.now() - before}ms`);
-    const result = resp.data["SelectedOrganizationList"];
-    if (!result) {
-      const msg = `Bad response from CommonWell`;
-      const additionalData = {
-        status: resp.status,
-        statusText: resp.statusText,
-        data: safeStringify(resp.data),
-      };
-      log(msg, additionalData);
-      throw new MetriportError(msg, undefined, additionalData);
-    }
-    debug(
-      "Response",
-      JSON.stringify(
-        //eslint-disable-next-line @typescript-eslint/no-explicit-any
-        result.map((item: any) => ({
-          Id: item.Id,
-          Name: item.Name,
-          AllSelected: item.AllSelected,
-          //eslint-disable-next-line @typescript-eslint/no-explicit-any
-          Organizations: item.Organizations?.map((o: any) => o.Id).join(", "),
-        }))
-      )
-    );
-
-    await this.updateCookiesFromResponse(cookies, resp, log);
-  }
-
-  /**
-   * Check if cookies were updated and update them if so.
-   */
-  private async updateCookiesFromResponse<T extends AxiosResponse>(
-    cookies: Cookie[],
-    resp: T,
-    log = console.log
-  ): Promise<void> {
-    const respCookies = resp.headers["set-cookie"];
-    if (respCookies) {
-      log(`Received cookies, added/updated!`);
-      await this.updateCookies(cookies, respCookies);
-    }
-  }
-
-  private async updateCookies(actualCookies: Cookie[], newCookies: string[]): Promise<void> {
-    const newCookiesParsed = newCookies.flatMap(c => cookieFromString(c) ?? []);
-    for (const newCookie of newCookiesParsed) {
-      const existingCookieIndex = actualCookies.findIndex(c => c.name.startsWith(newCookie.name));
-      if (existingCookieIndex >= 0) {
-        actualCookies[existingCookieIndex] = newCookie;
-      } else {
-        actualCookies.push(newCookie);
-      }
-    }
-
-    await this.cookieManager.updateCookies(actualCookies);
-  }
+  }): Promise<void>;
 }

--- a/packages/core/src/external/commonwell/management/link-patients.ts
+++ b/packages/core/src/external/commonwell/management/link-patients.ts
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import { PatientUpdater } from "../../../domain/patient/patient-updater";
 import { sleep } from "../../../util/sleep";
+import { ECUpdater } from "../cq-bridge/ec-updater";
 import { CommonWellManagementAPI } from "./api";
 
 dayjs.extend(duration);
@@ -9,6 +10,7 @@ dayjs.extend(duration);
 const TIME_BETWEEN_INCLUDE_LIST_AND_UPDATE_ALL = dayjs.duration({ seconds: 2 });
 
 export type LinkPatientsCommand = {
+  ecId: string;
   cxId: string;
   cxOrgOID: string;
   patientIds: string[];
@@ -22,10 +24,12 @@ export type LinkPatientsCommand = {
 export class LinkPatients {
   constructor(
     private readonly cwManagementApi: CommonWellManagementAPI,
-    private readonly patientsUpdater: PatientUpdater
+    private readonly patientsUpdater: PatientUpdater,
+    private readonly ecUpdater: ECUpdater
   ) {}
 
   async linkPatientsToOrgs({
+    ecId,
     cxId,
     cxOrgOID,
     patientIds,
@@ -42,5 +46,13 @@ export class LinkPatients {
     await sleep(TIME_BETWEEN_INCLUDE_LIST_AND_UPDATE_ALL.asMilliseconds());
 
     await this.patientsUpdater.updateAll(cxId, patientIds);
+
+    // intentionally not in parallel with updteAll so we only update this if updateAll works
+    await this.ecUpdater.storeECAfterIncludeList({
+      ecId,
+      cxId,
+      patientIds,
+      cqOrgIds,
+    });
   }
 }

--- a/packages/core/src/external/commonwell/management/session.ts
+++ b/packages/core/src/external/commonwell/management/session.ts
@@ -8,7 +8,8 @@ import {
 } from "../../../domain/auth/cookie-management/cookie-manager";
 import { MetriportError } from "../../../util/error/metriport-error";
 import { sleep } from "../../../util/sleep";
-import { CommonWellManagementAPI, userAgent } from "./api";
+import { CommonWellManagementAPI } from "./api";
+import { userAgent } from "./api-impl";
 
 // This file relies heavily on Playwright: https://playwright.dev/docs/library
 

--- a/packages/core/src/util/error/not-found.ts
+++ b/packages/core/src/util/error/not-found.ts
@@ -1,5 +1,5 @@
 import httpStatus from "http-status";
-import { MetriportError } from "./metriport-error";
+import { AdditionalInfo, MetriportError } from "./metriport-error";
 
 const numericStatus = httpStatus.NOT_FOUND;
 
@@ -7,7 +7,7 @@ export default class NotFoundError extends MetriportError {
   constructor(
     message = "Could not find the requested resource",
     cause?: unknown,
-    additionalInfo?: Record<string, string | undefined | null>
+    additionalInfo?: AdditionalInfo
   ) {
     super(message, cause, additionalInfo);
     this.status = numericStatus;

--- a/packages/lambdas/src/cw-enhanced-coverage-link-patients.ts
+++ b/packages/lambdas/src/cw-enhanced-coverage-link-patients.ts
@@ -1,7 +1,8 @@
 import { CookieManagerOnSecrets } from "@metriport/core/domain/auth/cookie-management/cookie-manager-on-secrets";
 import { PatientUpdaterMetriportAPI } from "@metriport/core/domain/patient/patient-updater-metriport-api";
 import { Input } from "@metriport/core/external/commonwell/cq-bridge/cq-link-patients";
-import { CommonWellManagementAPI } from "@metriport/core/external/commonwell/management/api";
+import { ECUpdaterAPI } from "@metriport/core/external/commonwell/cq-bridge/ec-updater-api";
+import { CommonWellManagementAPIImpl } from "@metriport/core/external/commonwell/management/api-impl";
 import { LinkPatients } from "@metriport/core/external/commonwell/management/link-patients";
 import { MetriportError } from "@metriport/core/util/error/metriport-error";
 import { sleep } from "@metriport/core/util/sleep";
@@ -38,12 +39,13 @@ const cookieSecretArn = getEnvOrFail("COOKIE_SECRET_ARN");
 const metriportBaseUrl = getEnvOrFail("API_URL");
 
 const cookieManager = new CookieManagerOnSecrets(cookieSecretArn, region);
-const cwManagementApi = new CommonWellManagementAPI({
+const cwManagementApi = new CommonWellManagementAPIImpl({
   cookieManager,
   baseUrl: cwManagementBaseUrl,
 });
 const patientUpdater = new PatientUpdaterMetriportAPI(metriportBaseUrl);
-const linkPatients = new LinkPatients(cwManagementApi, patientUpdater);
+const ecUpdater = new ECUpdaterAPI(metriportBaseUrl);
+const linkPatients = new LinkPatients(cwManagementApi, patientUpdater, ecUpdater);
 
 /**
  * Lambda that processes each "chunk" of CQ orgs received as param, updating CW's include list

--- a/packages/lambdas/src/cw-session-management.ts
+++ b/packages/lambdas/src/cw-session-management.ts
@@ -2,7 +2,7 @@ import { getSecret } from "@aws-lambda-powertools/parameters/secrets";
 import { CodeChallengeFromSecretManager } from "@metriport/core/domain/auth/code-challenge/code-challenge-on-secrets";
 import { CookieManagerOnSecrets } from "@metriport/core/domain/auth/cookie-management/cookie-manager-on-secrets";
 import { makeS3Client } from "@metriport/core/external/aws/s3";
-import { CommonWellManagementAPI } from "@metriport/core/external/commonwell/management/api";
+import { CommonWellManagementAPIImpl } from "@metriport/core/external/commonwell/management/api-impl";
 import {
   SessionManagement,
   SessionManagementConfig,
@@ -32,7 +32,7 @@ const errorBucketName = getEnvOrFail("ERROR_BUCKET_NAME");
 
 const s3Client = makeS3Client(region);
 const cookieManager = new CookieManagerOnSecrets(cookieSecretArn, region);
-const cwManagementApi = new CommonWellManagementAPI({ cookieManager, baseUrl });
+const cwManagementApi = new CommonWellManagementAPIImpl({ cookieManager, baseUrl });
 // TODO 1195 move this to an email based code challenge, so it can be fully automated.
 // Could use AWS SES for that, it can send the email to a SNS topic, which could trigger
 // a lambda and update the secret: https://docs.aws.amazon.com/ses/latest/dg/receiving-email-concepts.html

--- a/packages/utils/src/commonwell/session-manager.ts
+++ b/packages/utils/src/commonwell/session-manager.ts
@@ -6,7 +6,6 @@ import { CodeChallengeFromSecretManager } from "@metriport/core/domain/auth/code
 import { cookieFromString } from "@metriport/core/domain/auth/cookie-management/cookie-manager";
 import { CookieManagerInMemory } from "@metriport/core/domain/auth/cookie-management/cookie-manager-in-memory";
 import { CookieManagerOnSecrets } from "@metriport/core/domain/auth/cookie-management/cookie-manager-on-secrets";
-import { CommonWellManagementAPI } from "@metriport/core/external/commonwell/management/api";
 import {
   SessionManagement,
   SessionManagementConfig,
@@ -18,6 +17,7 @@ require("aws-sdk/lib/maintenance_mode_message").suppress = true; // eslint-disab
 
 // Leaving this separated from the rest as we might need to switch browsers if it fails to get the cookie
 // import { chromium as runtime } from "playwright";
+import { makeApi } from "@metriport/core/external/commonwell/management/api-factory";
 import { firefox as runtime } from "playwright";
 
 /**
@@ -81,7 +81,7 @@ const buildStores = () => {
 };
 const { codeChallenge, cookieManager } = buildStores();
 
-const cwManagementApi = new CommonWellManagementAPI({ cookieManager, baseUrl: cwBaseUrl });
+const cwManagementApi = makeApi({ cookieManager, baseUrl: cwBaseUrl });
 
 export async function main() {
   console.log(`Runnning at ${new Date().toISOString()}`);


### PR DESCRIPTION
Ref: metriport/metriport-internal#1195

### Dependencies

none

### Description

Store EC stats per patient - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1702918625965569?thread_ts=1702918105.967629&cid=C0616FCPAKZ).

This is the data we'll have available on EC runs (the amount of items on `data.cqOrgIds` can go from 400 - regular runs - to 2,400 - full runs):

<img width="1533" alt="image" src="https://github.com/metriport/metriport/assets/2132564/2a6107fe-c977-4222-9df4-828c63ebf81d">

### Testing

- Local
  - [x] Run EC thru API
  - [x] Run EC thru script
- Staging
  - can't run EC in `staging`
- Production
  - [ ] Run EC thru API
  - [ ] Run EC thru script

### Release Plan

- release this off hours to test EC manually