### PR TITLE
1040 add defaultHandler to lambdas

### DIFF
--- a/packages/core/src/external/commonwell/document/document-downloader-local.ts
+++ b/packages/core/src/external/commonwell/document/document-downloader-local.ts
@@ -4,6 +4,8 @@ import path from "path";
 import * as stream from "stream";
 import { DOMParser } from "xmldom";
 import { MetriportError } from "../../../util/error/metriport-error";
+import NotFoundError from "../../../util/error/not-found";
+import { detectFileType, isContentTypeAccepted } from "../../../util/file-type";
 import { isMimeTypeXML } from "../../../util/mime";
 import { makeS3Client, S3Utils } from "../../aws/s3";
 import {
@@ -13,8 +15,6 @@ import {
   DownloadResult,
   FileInfo,
 } from "./document-downloader";
-import NotFoundError from "../../../util/error/not-found";
-import { detectFileType, isContentTypeAccepted } from "../../../util/file-type";
 
 export type DocumentDownloaderLocalConfig = DocumentDownloaderConfig & {
   commonWell: {
@@ -292,12 +292,9 @@ export class DocumentDownloaderLocal extends DocumentDownloader {
       if (error instanceof CommonwellError && error.cause?.response?.status === 404) {
         const msg = "CW - Document not found";
         console.log(`${msg} - ${JSON.stringify(additionalInfo)}`);
-        throw new NotFoundError(msg, undefined, additionalInfo);
+        throw new NotFoundError(msg, error, additionalInfo);
       }
-      const msg = `CW - Error downloading document`;
-      this.config.capture &&
-        this.config.capture.message(msg, { extra: { ...additionalInfo, error }, level: "error" });
-      throw new MetriportError(msg, error, additionalInfo);
+      throw new MetriportError(`CW - Error downloading document`, error, additionalInfo);
     }
   }
 }

--- a/packages/core/src/util/capture.ts
+++ b/packages/core/src/util/capture.ts
@@ -1,5 +1,7 @@
 import { ScopeContext } from "@sentry/types";
 
+export type AdditionalInfo = Record<string, string | number | boolean | undefined | null>;
+
 export type Capture = {
   /**
    * Captures an exception event and sends it to Sentry.

--- a/packages/core/src/util/error/bad-request.ts
+++ b/packages/core/src/util/error/bad-request.ts
@@ -1,4 +1,5 @@
 import httpStatus from "http-status";
+import { AdditionalInfo } from "../capture";
 import { MetriportError } from "./metriport-error";
 
 const numericStatus = httpStatus.BAD_REQUEST;
@@ -7,7 +8,7 @@ export default class BadRequestError extends MetriportError {
   constructor(
     message = "Unexpected issue with the request - check inputs and try again",
     cause?: unknown,
-    additionalInfo?: Record<string, string | number | undefined | null>
+    additionalInfo?: AdditionalInfo
   ) {
     super(message, cause, additionalInfo);
     this.status = numericStatus;

--- a/packages/core/src/util/error/metriport-error.ts
+++ b/packages/core/src/util/error/metriport-error.ts
@@ -1,6 +1,5 @@
 import status from "http-status";
-
-export type AdditionalInfo = Record<string, string | number | undefined | null>;
+import { AdditionalInfo } from "../capture";
 
 export class MetriportError extends Error {
   status: number = status.INTERNAL_SERVER_ERROR;

--- a/packages/core/src/util/error/not-found.ts
+++ b/packages/core/src/util/error/not-found.ts
@@ -1,4 +1,5 @@
 import httpStatus from "http-status";
+import { AdditionalInfo } from "../capture";
 import { MetriportError } from "./metriport-error";
 
 const numericStatus = httpStatus.NOT_FOUND;
@@ -7,7 +8,7 @@ export default class NotFoundError extends MetriportError {
   constructor(
     message = "Could not find the requested resource",
     cause?: unknown,
-    additionalInfo?: Record<string, string | undefined | null>
+    additionalInfo?: AdditionalInfo
   ) {
     super(message, cause, additionalInfo);
     this.status = numericStatus;

--- a/packages/lambdas/src/cw-session-management.ts
+++ b/packages/lambdas/src/cw-session-management.ts
@@ -8,7 +8,8 @@ import {
   SessionManagementConfig,
 } from "@metriport/core/external/commonwell/management/session";
 import { base64ToBuffer } from "@metriport/core/util/base64";
-import { AdditionalInfo, MetriportError } from "@metriport/core/util/error/metriport-error";
+import { AdditionalInfo } from "@metriport/core/util/capture";
+import { MetriportError } from "@metriport/core/util/error/metriport-error";
 import * as Sentry from "@sentry/serverless";
 
 import * as playwright from "playwright-aws-lambda";

--- a/packages/lambdas/src/document-downloader.ts
+++ b/packages/lambdas/src/document-downloader.ts
@@ -10,9 +10,9 @@ import { DownloadResult } from "@metriport/core/external/commonwell/document/doc
 import { DocumentDownloaderLambdaRequest } from "@metriport/core/external/commonwell/document/document-downloader-lambda";
 import { DocumentDownloaderLocal } from "@metriport/core/external/commonwell/document/document-downloader-local";
 import { getEnvType } from "@metriport/core/util/env-var";
-import * as Sentry from "@sentry/serverless";
 import { capture } from "./shared/capture";
 import { getEnv, getEnvOrFail, isProduction } from "./shared/env";
+import { defaultHandler } from "./shared/handler";
 
 // Keep this as early on the file as possible
 capture.init();
@@ -27,7 +27,7 @@ const cwOrgPrivateKeySecret = getEnvOrFail("CW_ORG_PRIVATE_KEY");
 
 const apiMode = isProduction() ? APIMode.production : APIMode.integration;
 
-export const handler = Sentry.AWSLambda.wrapHandler(
+export const handler = defaultHandler(
   async (req: DocumentDownloaderLambdaRequest): Promise<DownloadResult> => {
     const { orgName, orgOid, npi, cxId, fileInfo, document } = req;
     capture.setUser({ id: cxId });

--- a/packages/lambdas/src/shared/capture.ts
+++ b/packages/lambdas/src/shared/capture.ts
@@ -1,4 +1,4 @@
-import { Capture } from "@metriport/core/util/capture";
+import { AdditionalInfo } from "@metriport/core/util/capture";
 import { getEnvType, getEnvVar } from "@metriport/core/util/env-var";
 import * as Sentry from "@sentry/serverless";
 import { Extras } from "@sentry/types";
@@ -7,11 +7,6 @@ import { ScopeContext } from "@sentry/types/types/scope";
 const sentryDsn = getEnvVar("SENTRY_DSN");
 
 export type UserData = Pick<Sentry.AWSLambda.User, "id" | "email">;
-
-export type LambdaCapture = Capture & {
-  setUser: (user: UserData) => void;
-  setExtra: (extra: Record<string, unknown>) => void;
-};
 
 export const capture = {
   // TODO #499 Review 'tracesSampleRate' based on the load on our app and Sentry's quotas
@@ -35,7 +30,7 @@ export const capture = {
     Sentry.setUser(user);
   },
 
-  setExtra: (extra: Record<string, unknown>): void => {
+  setExtra: (extra: AdditionalInfo): void => {
     Object.entries(extra).forEach(([key, value]) => {
       Sentry.setExtra(key, value);
     });

--- a/packages/lambdas/src/shared/handler.ts
+++ b/packages/lambdas/src/shared/handler.ts
@@ -1,0 +1,52 @@
+/**
+ * Borrowed from @sentry/serverless:
+ * https://github.com/getsentry/sentry-javascript/blob/develop/packages/serverless/src/awslambda.ts
+ */
+import { MetriportError } from "@metriport/core/util/error/metriport-error";
+import { AsyncHandler } from "@sentry/serverless/types/awslambda";
+import { Handler } from "aws-lambda";
+import { types } from "util";
+import { capture } from "./capture";
+
+type SyncHandler<T extends Handler> = (
+  event: Parameters<T>[0],
+  context: Parameters<T>[1],
+  callback: Parameters<T>[2]
+) => void;
+
+const { isPromise } = types;
+
+export function defaultHandler<TEvent, TResult>(
+  handler: Handler<TEvent, TResult>
+): Handler<TEvent, TResult> {
+  const asyncHandler: AsyncHandler<typeof handler> =
+    handler.length > 2
+      ? (event, context) =>
+          new Promise((resolve, reject) => {
+            const rv = (handler as SyncHandler<typeof handler>)(event, context, (error, result) => {
+              if (error === null || error === undefined) {
+                resolve(result!); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+              } else {
+                reject(error);
+              }
+            }) as unknown;
+
+            // This should never happen, but still can if someone writes a handler as
+            // `async (event, context, callback) => {}`
+            if (isPromise(rv)) {
+              void (rv as Promise<NonNullable<TResult>>).then(resolve, reject);
+            }
+          })
+      : (handler as AsyncHandler<typeof handler>);
+
+  return async (event, context) => {
+    try {
+      return await asyncHandler(event, context);
+    } catch (error) {
+      if (error instanceof MetriportError && error.additionalInfo) {
+        capture.setExtra(error.additionalInfo);
+      }
+      throw error;
+    }
+  };
+}


### PR DESCRIPTION
Ref: metriport/metriport-internal#1040

### Dependencies

none

### Description

Add `defaultHandler()` to lambdas so we can let error/exceptions "bubble up" all the way to the default handler and it will make sure the additional info from `MetriportError`-like errors will be included on the Sentry event.

### Testing

- Local
  - [ ] Branch to staging, try to download an invalid file, see if the error gets the additional context (`cwReferenceHeader` and `documentLocation`)
- Staging
  - none
- Production
  - none

### Release Plan

- nothing special