### PR TITLE
1040 core's notif to use unknown instead of any on error()

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint-fix": "npm run lint-fix --workspaces --if-present",
     "lint-staged": "npx lint-staged",
     "prettier-fix": "npm run prettier-fix --workspaces --if-present",
-    "test": "if npm run test --workspaces --if-present && SCRIPT='test' npm run lambdas; then echo 'Tests passed'; else echo '\n\\033[1;31m>>> Tests failed <<<\\033[0m' && exit 1; fi",
+    "test": "if npm run test --workspaces --if-present && SCRIPT='test' npm run lambdas; then echo '\n\\033[1;32mTests passed\\033[0m'; else echo '\n\\033[1;31m>>> Tests failed <<<\\033[0m' && exit 1; fi",
     "test:e2e": "npm run test:e2e --workspaces --if-present",
     "lambdas:no-run": "cd packages/lambdas && npm $SCRIPT && cd ../..",
     "lambdas": "cd packages/lambdas && npm run $SCRIPT && cd ../..",

--- a/packages/core/src/util/capture.ts
+++ b/packages/core/src/util/capture.ts
@@ -8,8 +8,7 @@ export type Capture = {
    * @param captureContext — Additional scope data to apply to exception event.
    * @returns — The generated eventId.
    */
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  error: (error: any, captureContext?: Partial<ScopeContext>) => string;
+  error: (error: unknown, captureContext?: Partial<ScopeContext>) => string;
 
   /**
    * Captures an exception event and sends it to Sentry.

--- a/packages/core/src/util/notifications.ts
+++ b/packages/core/src/util/notifications.ts
@@ -49,8 +49,7 @@ export const capture: ApiCapture = {
    * @param captureContext — Additional scope data to apply to exception event.
    * @returns — The generated eventId.
    */
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  error: (error: any, captureContext?: Partial<ScopeContext>): string => {
+  error: (error: unknown, captureContext?: Partial<ScopeContext>): string => {
     if (typeof error === "string") {
       return capture.message(error, {
         ...captureContext,


### PR DESCRIPTION
Ref: metriport/metriport-internal#1040

### Dependencies

none

### Description

Core's notif to use unknown instead of any on `error()`.

Also adjust the color of `Tests passed` to stand out more.

### Testing

nothing, just expect a new deploy on `staging` to mark the release w/ successful as such

### Release Plan

- nothing special