### PR TITLE
1040 include ConnectWidget's infra on branch to staging

### DIFF
--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -56,3 +56,20 @@ jobs:
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  infra-widget:
+    uses: ./.github/workflows/_deploy_cdk.yml
+    with:
+      deploy_env: "staging"
+      is-branch-to-staging: true
+      cdk_stack: ${{ vars.WIDGET_STACK_NAME_STAGING }}
+      AWS_REGION: ${{ vars.WIDGET_REGION_STAGING }}
+      INFRA_CONFIG: ${{ vars.INFRA_CONFIG_STAGING }}
+    secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Ref: metriport/metriport-internal#1040

### Dependencies

none

### Description

Include ConnectWidget's infra on branch to staging.

Noticed it was not being included when debugging [this run](https://github.com/metriport/metriport/actions/runs/7304072823).

### Testing

- Local
  - [x] branch to staging works w/ ConnectWidget's infra being deployed as well - [job](https://github.com/metriport/metriport/actions/runs/7304334784)
- Staging
  - none
- Production
  - none

### Release Plan

- nothing special