### PR TITLE
1392 re-convert doc refs

### DIFF
--- a/packages/api/src/command/medical/docref-mapping/get-docref-mapping.ts
+++ b/packages/api/src/command/medical/docref-mapping/get-docref-mapping.ts
@@ -1,7 +1,8 @@
+import { uuidv7 } from "@metriport/core/util/uuid-v7";
+import { Op } from "sequelize";
 import { DocRefMapping } from "../../../domain/medical/docref-mapping";
 import { MedicalDataSource } from "../../../external";
 import { DocRefMappingModel } from "../../../models/medical/docref-mapping";
-import { uuidv7 } from "@metriport/core/util/uuid-v7";
 
 export const getDocRefMapping = async (id: string): Promise<DocRefMapping | undefined> => {
   const docRef = await DocRefMappingModel.findByPk(id);
@@ -25,6 +26,37 @@ export const getOrCreateDocRefMapping = async ({
     defaults: {
       id: uuidv7(),
       ...docRef,
+    },
+  });
+  return res;
+};
+
+export const getDocRefMappings = async ({
+  cxId,
+  ids = [],
+  patientId: patientIdParam = [],
+  externalId,
+  source,
+  createdAtRange: { from, to } = {},
+}: {
+  cxId: string;
+  ids?: string[];
+  patientId?: string[] | string;
+  externalId?: string;
+  source?: MedicalDataSource;
+  createdAtRange?: { from?: Date; to?: Date };
+}): Promise<DocRefMapping[]> => {
+  const patientIds = Array.isArray(patientIdParam) ? patientIdParam : [patientIdParam];
+  const res = await DocRefMappingModel.findAll({
+    where: {
+      cxId,
+      ...(ids && ids.length ? { id: { [Op.in]: ids } } : {}),
+      ...(patientIds.length ? { patientId: { [Op.in]: patientIds } } : {}),
+      ...(externalId ? { externalId } : {}),
+      ...(source ? { source } : {}),
+      ...(from || to
+        ? { createdAt: { ...(from && { [Op.gte]: from }), ...(to && { [Op.lte]: to }) } }
+        : {}),
     },
   });
   return res;

--- a/packages/api/src/command/medical/document/document-query-storage-info.ts
+++ b/packages/api/src/command/medical/document/document-query-storage-info.ts
@@ -23,7 +23,6 @@ export type S3Info = {
   fileContentType: string | undefined;
 };
 
-// TODO we need to overhaul this whole file
 export type SimplerFile = {
   fileName: string;
   fileLocation: string;
@@ -47,20 +46,16 @@ export function getDocToFileFunction(patient: Pick<Patient, "cxId" | "id">) {
     };
   };
 }
-export function makeDocRefContentToFileFunction(patient: Pick<Patient, "cxId" | "id">) {
-  return (content: DocumentReferenceContent): SimplerFile | undefined => {
-    const attachment = content.attachment;
-    if (!attachment) return undefined;
-    const mimeType = attachment.contentType;
-    const extension = getFileExtension(mimeType);
-    const docName = `${content.id}${extension}`;
-    const fileName = createS3FileName(patient.cxId, patient.id, docName);
-    return {
-      fileName,
-      fileLocation: s3BucketName,
-      fileContentType: mimeType,
-    };
-  };
+export function docRefContentToFileFunction(
+  content: DocumentReferenceContent
+): SimplerFile | undefined {
+  const attachment = content.attachment;
+  if (!attachment) return undefined;
+  const fileLocation = s3BucketName;
+  const fileContentType = attachment.contentType;
+  const fileName = attachment.title;
+  if (!fileName) return undefined;
+  return { fileName, fileLocation, fileContentType };
 }
 
 // TODO convert this to: 1. list files on patient's folder on S3; 2. match to docs and retrieve info

--- a/packages/api/src/command/medical/document/document-reconvert.ts
+++ b/packages/api/src/command/medical/document/document-reconvert.ts
@@ -71,8 +71,6 @@ export const reConvertDocuments = async (params: ReConvertDocumentsCommand): Pro
       await logConsolidatedCount({
         cxId,
         patientIds,
-        dateFrom,
-        dateTo,
       });
     }
 
@@ -105,8 +103,6 @@ export const reConvertDocuments = async (params: ReConvertDocumentsCommand): Pro
       await logConsolidatedCount({
         cxId,
         patientIds,
-        dateFrom,
-        dateTo,
       });
     }
   } finally {
@@ -283,24 +279,18 @@ async function reConvertDocument({
 async function logConsolidatedCount({
   cxId,
   patientIds = [],
-  dateFrom,
-  dateTo,
 }: {
   cxId: string;
   patientIds?: string[];
-  dateFrom?: string;
-  dateTo?: string;
 }): Promise<void> {
-  const consolidatedBeforeMap = new Map<string, number>();
+  const consolidatedBeforeMap: Record<string, number> = {};
   for (const patientId of patientIds) {
     const patient = await getPatientOrFail({ id: patientId, cxId });
-    const consolidatedBefore = await getConsolidated({
+    const consolidated = await getConsolidated({
       patient,
       resources: resourcesToDelete,
-      dateFrom,
-      dateTo,
     });
-    consolidatedBeforeMap.set(patientId, (consolidatedBefore.bundle.entry ?? []).length);
+    consolidatedBeforeMap[patientId] = (consolidated.bundle.entry ?? []).length;
   }
   console.log(`Consolidated count by patient: ${JSON.stringify(consolidatedBeforeMap)}`);
 }

--- a/packages/api/src/command/medical/document/document-reconvert.ts
+++ b/packages/api/src/command/medical/document/document-reconvert.ts
@@ -1,0 +1,328 @@
+import { DocumentReference } from "@medplum/fhirtypes";
+import { resourceTypeForConsolidation } from "@metriport/api-sdk";
+import { S3Utils } from "@metriport/core/external/aws/s3";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
+import { out } from "@metriport/core/util/log";
+import { capture } from "@metriport/core/util/notifications";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import { groupBy } from "lodash";
+import { DocRefMapping } from "../../../domain/medical/docref-mapping";
+import { convertCDAToFHIR } from "../../../external/fhir-converter/converter";
+import { getDocuments as getDocumentsFromFHIRServer } from "../../../external/fhir/document/get-documents";
+import { downloadedFromHIEs } from "../../../external/fhir/shared";
+import { getMetriportContent } from "../../../external/fhir/shared/extensions/metriport";
+import { PatientModel as Patient } from "../../../models/medical/patient";
+import { Config } from "../../../shared/config";
+import { errorToString } from "../../../shared/log";
+import { formatNumber } from "../../../shared/numbers";
+import { getDocRefMappings } from "../docref-mapping/get-docref-mapping";
+import { deleteConsolidated as deleteConsolidatedOnFHIRServer } from "../patient/consolidated-delete";
+import { getConsolidated } from "../patient/consolidated-get";
+import { getPatientOrFail } from "../patient/get-patient";
+import { makeDocRefContentToFileFunction, SimplerFile } from "./document-query-storage-info";
+
+dayjs.extend(duration);
+
+// TODO review this
+const patientsToProcessInParallel = 1;
+
+const resourcesToDelete = resourceTypeForConsolidation.filter(r => r !== "DocumentReference");
+const s3Utils = new S3Utils(Config.getAWSRegion());
+
+export type ReConvertDocumentsCommand = {
+  cxId: string;
+  patientIds?: string[];
+  documentIds?: string[];
+  dateFrom?: string;
+  dateTo?: string;
+  requestId: string;
+  logConsolidatedCountBeforeAndAfter?: boolean;
+};
+
+type DocumentReferenceWithId = DocumentReference & { id: string };
+
+type DocRefWithS3Info = {
+  docRef: DocumentReferenceWithId;
+  file: SimplerFile;
+};
+
+export const reConvertDocuments = async (params: ReConvertDocumentsCommand): Promise<void> => {
+  const startedAt = Date.now();
+  const {
+    cxId,
+    patientIds = [],
+    documentIds = [],
+    dateFrom,
+    dateTo,
+    requestId,
+    logConsolidatedCountBeforeAndAfter = false,
+  } = params;
+  const { log } = out(`reConvertDocuments - cxId ${cxId}`);
+  log(
+    `Re-converting documents: ${documentIds.length ?? "all"}, ` +
+      `patients: ${patientIds.length ?? "all"}, ` +
+      `dateFrom: ${dateFrom}, dateTo: ${dateTo} - ` +
+      `docs: ${documentIds.join(", ")}; ` +
+      `patients: ${patientIds.join(", ")}`
+  );
+  try {
+    if (logConsolidatedCountBeforeAndAfter) {
+      await logConsolidatedCount({
+        cxId,
+        patientIds,
+        dateFrom,
+        dateTo,
+      });
+    }
+
+    const docRefs = await getDocRefsByCreatedAt(params);
+    if (docRefs.length <= 0) {
+      log(`No DocumentReferenceMappings found, exiting...`);
+      return;
+    }
+
+    const docsByPatientId = groupBy(docRefs, d => d.patientId);
+
+    const patientPromise = async ([patientId, docs]: [string, DocRefMapping[]]) => {
+      try {
+        const documentIds = docs.map(d => d.id);
+        const patient = await getPatientOrFail({ id: patientId, cxId });
+        await reConvertByPatient({ patient, documentIds, requestId });
+      } catch (error) {
+        const msg = `Error re-converting documents for patient`;
+        const extra = { error, patientId, documentIds };
+        log(`${msg} - ${JSON.stringify(extra)} - ${errorToString(error)}`);
+        capture.error(`Error re-converting documents for patient`, { extra });
+      }
+    };
+
+    await executeAsynchronously(Object.entries(docsByPatientId), patientPromise, {
+      numberOfParallelExecutions: patientsToProcessInParallel,
+    });
+
+    if (logConsolidatedCountBeforeAndAfter) {
+      await logConsolidatedCount({
+        cxId,
+        patientIds,
+        dateFrom,
+        dateTo,
+      });
+    }
+  } finally {
+    const duration = Date.now() - startedAt;
+    const durationMin = formatNumber(dayjs.duration(duration).asMinutes());
+
+    log(`Done in ${duration} ms / ${durationMin} min`);
+  }
+};
+
+async function reConvertByPatient({
+  patient,
+  documentIds,
+  requestId,
+}: {
+  patient: Patient;
+  documentIds: string[];
+  requestId: string;
+}): Promise<void> {
+  const { log } = out(`reConvertDocuments - patient ${patient.id}`);
+
+  const documentsFromFHIR = await getDocumentsFromFHIRServer({
+    cxId: patient.cxId,
+    documentIds,
+  });
+  // Only use use those we got from HIEs
+  const documentsFromHIEs = documentsFromFHIR.filter(downloadedFromHIEs);
+
+  const contentToFile = makeDocRefContentToFileFunction(patient);
+
+  const docRefWithS3InfoRaw = await Promise.all(
+    documentsFromHIEs.map(addS3InfoToDocRef(contentToFile, log))
+  );
+  const docRefWithS3Info = docRefWithS3InfoRaw.flatMap(d => d ?? []);
+
+  const documents = docRefWithS3Info;
+  log(
+    `Got ${documentsFromFHIR.length} documentsFromFHIR, ` +
+      `${documentsFromHIEs.length} documentsFromHIEs, ` +
+      `${documents.length} to process`
+  );
+  if (documents.length <= 0) {
+    log(`No documents to process, exiting...`);
+    return;
+  }
+
+  await reConvertFHIRResources({
+    patient,
+    documents,
+    requestId,
+    log,
+  });
+
+  log(`Done for patient`);
+}
+
+function addS3InfoToDocRef(
+  contentToFile: ReturnType<typeof makeDocRefContentToFileFunction>,
+  log = console.log
+) {
+  return async (doc: DocumentReference): Promise<DocRefWithS3Info | undefined> => {
+    const docId = doc.id;
+    if (!docId) {
+      log(`No id found for docRef, skipping it`);
+      return undefined;
+    }
+    const docRefWithId = { ...doc, id: docId };
+    const content = getMetriportContent(docRefWithId);
+    if (!content) {
+      log(`No Metriport content found for docRef, skipping it - ${docId}`);
+      return undefined;
+    }
+    const file = contentToFile(content);
+    if (!file) {
+      log(`Could not determine file info for docRef, skipping it - ${docId}`);
+      return undefined;
+    }
+    const s3Info = await s3Utils.getFileInfoFromS3(file.fileName, file.fileLocation);
+    if (s3Info.contentType !== "application/xml") {
+      log(`DocRef's content is not XML, skipping it - ${docId}`);
+      return undefined;
+    }
+    return {
+      docRef: docRefWithId,
+      file,
+    };
+  };
+}
+
+async function reConvertFHIRResources({
+  patient,
+  documents,
+  requestId,
+  log = console.log,
+}: {
+  patient: Patient;
+  documents: DocRefWithS3Info[];
+  requestId: string;
+  log?: typeof console.log;
+}): Promise<void> {
+  const docIds = documents.map(d => d.docRef.id);
+
+  log(`Deleting consolidated data...`);
+  await deleteConsolidatedOnFHIRServer({
+    patient,
+    resources: resourcesToDelete,
+    docIds,
+  });
+
+  await reConvertDocumentsInternal({
+    patient,
+    documents,
+    requestId,
+    log,
+  });
+}
+
+async function reConvertDocumentsInternal({
+  patient,
+  documents,
+  requestId,
+  log = console.log,
+}: {
+  patient: Patient;
+  documents: DocRefWithS3Info[];
+  requestId: string;
+  log?: typeof console.log;
+}): Promise<void> {
+  const { id: patientId } = patient;
+
+  try {
+    log(`Triggering re-conversion of ${documents.length} doc refs...`);
+
+    await executeAsynchronously(documents, async docWithS3Info =>
+      reConvertDocument({
+        patient,
+        docWithS3Info,
+        requestId,
+      })
+    );
+  } catch (error) {
+    log(`Error processing docs: ${errorToString(error)}`);
+    capture.error(error, {
+      extra: { context: `processDocsOfPatient`, error, patientId },
+    });
+  }
+}
+
+async function reConvertDocument({
+  patient,
+  docWithS3Info,
+  requestId,
+}: {
+  patient: Patient;
+  docWithS3Info: DocRefWithS3Info;
+  requestId: string;
+}) {
+  const { docRef, file } = docWithS3Info;
+  const doc = {
+    id: docRef.id,
+    content: {
+      mimeType: file.fileContentType,
+    },
+  };
+  await convertCDAToFHIR({
+    patient,
+    document: doc,
+    s3FileName: file.fileName,
+    s3BucketName: file.fileLocation,
+    requestId,
+  });
+}
+
+async function logConsolidatedCount({
+  cxId,
+  patientIds = [],
+  dateFrom,
+  dateTo,
+}: {
+  cxId: string;
+  patientIds?: string[];
+  dateFrom?: string;
+  dateTo?: string;
+}): Promise<void> {
+  const consolidatedBeforeMap = new Map<string, number>();
+  for (const patientId of patientIds) {
+    const patient = await getPatientOrFail({ id: patientId, cxId });
+    const consolidatedBefore = await getConsolidated({
+      patient,
+      resources: resourcesToDelete,
+      dateFrom,
+      dateTo,
+    });
+    consolidatedBeforeMap.set(patientId, (consolidatedBefore.bundle.entry ?? []).length);
+  }
+  console.log(`Consolidated count by patient: ${JSON.stringify(consolidatedBeforeMap)}`);
+}
+
+async function getDocRefsByCreatedAt({
+  cxId,
+  documentIds = [],
+  patientIds = [],
+  dateFrom,
+  dateTo,
+}: ReConvertDocumentsCommand) {
+  const createdAtRange =
+    dateFrom || dateTo
+      ? {
+          ...(dateFrom ? { from: new Date(dateFrom) } : undefined),
+          ...(dateTo ? { to: new Date(dateTo) } : undefined),
+        }
+      : undefined;
+  return getDocRefMappings({
+    cxId,
+    ids: documentIds,
+    patientId: patientIds,
+    createdAtRange,
+  });
+}

--- a/packages/api/src/command/medical/document/document-redownload.ts
+++ b/packages/api/src/command/medical/document/document-redownload.ts
@@ -14,6 +14,7 @@ import {
 } from "@metriport/commonwell-sdk";
 import { difference, groupBy } from "lodash";
 import { DeepRequired } from "ts-essentials";
+import { getFacilityIdOrFail } from "../../../domain/medical/patient-facility";
 import {
   downloadDocsAndUpsertFHIR,
   queryAndProcessDocuments,
@@ -142,10 +143,8 @@ async function downloadDocsAndUpsertFHIRWithDocRefs({
     }
     const patient = await getPatientOrFail({ id: patientId, cxId });
 
-    const facilityId = patient.facilityIds[0];
-    if (!facilityId) throw new Error(`Patient ${patientId} is missing facilityId`);
-
     if (isReQuery(options)) {
+      const facilityId = getFacilityIdOrFail(patient);
       await appendDocQueryProgress({
         patient: { id: patient.id, cxId: patient.cxId },
         downloadProgress: { status: "processing" },
@@ -204,8 +203,7 @@ async function processDocuments({
   }
   if (docsAsCW.length === 0) return;
 
-  const facilityId = patient.facilityIds[0];
-  if (!facilityId) throw new Error(`Patient ${patientId} is missing facilityId`);
+  const facilityId = getFacilityIdOrFail(patient);
 
   try {
     log(`Processing ${docs.length} documents for patient ${patientId}...`);

--- a/packages/api/src/command/medical/patient/consolidated-delete.ts
+++ b/packages/api/src/command/medical/patient/consolidated-delete.ts
@@ -1,0 +1,112 @@
+import { OperationOutcomeError } from "@medplum/core";
+import { BundleEntry, OperationOutcomeIssue, Resource } from "@medplum/fhirtypes";
+import { ResourceTypeForConsolidation } from "@metriport/api-sdk";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
+import { Patient } from "../../../domain/medical/patient";
+import { makeFhirApi } from "../../../external/fhir/api/api-factory";
+import { isResourceDerivedFromDocRef } from "../../../external/fhir/shared";
+import { capture } from "../../../shared/notifications";
+import { Util } from "../../../shared/util";
+import { getConsolidated } from "./consolidated-get";
+
+const numberOfParallelExecutions = 10;
+
+export type DeleteConsolidatedFilters = {
+  resources?: ResourceTypeForConsolidation[];
+  docIds: string[];
+};
+
+export type DeleteConsolidatedParams = {
+  patient: Pick<Patient, "id" | "cxId" | "data">;
+} & DeleteConsolidatedFilters;
+
+export async function deleteConsolidated(params: DeleteConsolidatedParams): Promise<void> {
+  const { patient, resources, docIds } = params;
+  const { log } = Util.out(`deleteConsolidated - cxId ${patient.cxId}, patientId ${patient.id}`);
+  const fhir = makeFhirApi(patient.cxId);
+
+  const getResourcesToDelete = async () => {
+    try {
+      const bundle = await getConsolidated({
+        patient,
+        resources,
+      });
+      const resourcesFromFHIRServer = bundle.bundle.entry;
+      if (!resourcesFromFHIRServer || resourcesFromFHIRServer.length <= 0) {
+        log(`No resources to delete`);
+        return;
+      }
+
+      const isDerivedFromDocRefs = (r: Resource) =>
+        docIds.some(id => isResourceDerivedFromDocRef(r, id));
+
+      const resourcesToDelete = resourcesFromFHIRServer.filter(r => {
+        const resource = r.resource;
+        if (!resource) return false;
+        return resource.resourceType !== "DocumentReference" && isDerivedFromDocRefs(resource);
+      });
+      return resourcesToDelete;
+    } catch (error) {
+      const msg = `Failed to get consolidated FHIR resources ;`;
+      log(`${msg}: ${JSON.stringify(params)}`);
+      throw error;
+    }
+  };
+
+  const resourcesToDelete = await getResourcesToDelete();
+  if (!resourcesToDelete || resourcesToDelete.length <= 0) return;
+
+  const errorsToReport: Record<string, string> = {};
+
+  const deleteResource = async (entry: BundleEntry<Resource>) => {
+    const resource = entry.resource;
+    if (!resource) return;
+    const resourceType = resource.resourceType;
+    if (!resourceType) {
+      log(`No resourceType found for entry ${JSON.stringify(entry)}`);
+      return;
+    }
+    const resourceId = resource.id;
+    if (!resourceId) {
+      log(`No resourceId found for entry ${JSON.stringify(entry)}`);
+      return;
+    }
+    try {
+      await fhir.deleteResource(resourceType, resourceId);
+    } catch (err) {
+      if (err instanceof OperationOutcomeError) errorsToReport[resourceType] = getMessage(err);
+      else errorsToReport[resourceType] = String(err);
+      throw err;
+    }
+  };
+
+  await executeAsynchronously(resourcesToDelete, async r => deleteResource(r), {
+    numberOfParallelExecutions,
+  });
+
+  const failuresAmount = Object.keys(errorsToReport).length;
+  if (failuresAmount > 0) {
+    const msg = `Failed to delete FHIR resources`;
+    log(`${msg} (${failuresAmount} failures): ${JSON.stringify(errorsToReport)}`);
+    capture.error(msg, {
+      extra: {
+        context: `getConsolidatedPatientData`,
+        patientId: patient.id,
+        errorAmount: failuresAmount,
+        errorsToReport,
+      },
+    });
+  }
+}
+
+function getMessage(err: OperationOutcomeError): string {
+  return err.outcome.issue ? err.outcome.issue.map(issueToString).join(",") : "";
+}
+
+function issueToString(issue: OperationOutcomeIssue): string {
+  return (
+    issue.details?.text ??
+    (issue.diagnostics ? issue.diagnostics.slice(0, 100) + "..." : null) ??
+    JSON.stringify(issue)
+  );
+}

--- a/packages/api/src/command/medical/patient/consolidated-delete.ts
+++ b/packages/api/src/command/medical/patient/consolidated-delete.ts
@@ -47,7 +47,7 @@ export async function deleteConsolidated(params: DeleteConsolidatedParams): Prom
       });
       return resourcesToDelete;
     } catch (error) {
-      const msg = `Failed to get consolidated FHIR resources ;`;
+      const msg = `Failed to get consolidated FHIR resources`;
       log(`${msg}: ${JSON.stringify(params)}`);
       throw error;
     }

--- a/packages/api/src/command/medical/patient/convert-fhir-bundle.ts
+++ b/packages/api/src/command/medical/patient/convert-fhir-bundle.ts
@@ -47,9 +47,9 @@ export async function handleBundleToMedicalRecord({
   conversionType: ConsolidationConversionType;
 }): Promise<Bundle<Resource>> {
   const isSandbox = Config.isSandbox();
-  const patientMatch = getSandboxSeedData(patient.data.firstName);
 
   if (isSandbox) {
+    const patientMatch = getSandboxSeedData(patient.data.firstName);
     const url = await processSandboxSeed({
       firstName: patientMatch ? patient.data.firstName : "jane",
       conversionType,

--- a/packages/api/src/external/fhir/document/__tests__/get-documents.test.ts
+++ b/packages/api/src/external/fhir/document/__tests__/get-documents.test.ts
@@ -37,7 +37,7 @@ describe("getDocuments", () => {
     it("returns document IDs when only `documentIds` is set", async () => {
       const documentIds = [uuidv4(), uuidv4()];
       const res = getFilters({ documentIds });
-      expect(res).toEqual("_ids=" + documentIds.join(encodeURIComponent(",")));
+      expect(res).toEqual("_id=" + documentIds.join(encodeURIComponent(",")));
     });
 
     it("groups patientId and documentIds when both are set", async () => {
@@ -45,7 +45,7 @@ describe("getDocuments", () => {
       const documentIds = [uuidv4(), uuidv4()];
       const res = getFilters({ patientId: patient.id, documentIds });
       expect(res).toEqual(
-        "patient=" + patient.id + "&_ids=" + documentIds.join(encodeURIComponent(","))
+        "patient=" + patient.id + "&_id=" + documentIds.join(encodeURIComponent(","))
       );
     });
 
@@ -63,7 +63,7 @@ describe("getDocuments", () => {
       const to = dayjs(faker.date.past()).format(ISO_DATE);
       const res = getFilters({ documentIds, from, to });
       expect(res).toEqual(
-        "_ids=" + documentIds.join(encodeURIComponent(",")) + "&date=ge" + from + "&date=le" + to
+        "_id=" + documentIds.join(encodeURIComponent(",")) + "&date=ge" + from + "&date=le" + to
       );
     });
 
@@ -76,7 +76,7 @@ describe("getDocuments", () => {
       expect(res).toEqual(
         "patient=" +
           patient.id +
-          "&_ids=" +
+          "&_id=" +
           documentIds.join(encodeURIComponent(",")) +
           "&date=ge" +
           from +

--- a/packages/api/src/external/fhir/document/get-documents.ts
+++ b/packages/api/src/external/fhir/document/get-documents.ts
@@ -11,7 +11,7 @@ export async function getDocuments({
   documentIds,
 }: {
   cxId: string;
-  patientId: string;
+  patientId?: string;
   from?: string;
   to?: string;
   documentIds?: string[];
@@ -45,7 +45,7 @@ export function getFilters({
 } = {}) {
   const filters = new URLSearchParams();
   patientId && filters.append("patient", patientId);
-  documentIds.length && filters.append(`_ids`, documentIds.join(","));
+  documentIds.length && filters.append(`_id`, documentIds.join(","));
   from && filters.append("date", isoDateToFHIRDateQueryFrom(from));
   to && filters.append("date", isoDateToFHIRDateQueryTo(to));
   const filtersAsStr = filters.toString();

--- a/packages/api/src/external/fhir/shared/extensions/doc-id-extension.ts
+++ b/packages/api/src/external/fhir/shared/extensions/doc-id-extension.ts
@@ -2,7 +2,7 @@ import { Extension } from "@medplum/fhirtypes";
 import { BASE_EXTENSION_URL } from "./base-extension";
 
 // TODO #712: create this extension
-const DOC_ID_EXTENSION_URL = `${BASE_EXTENSION_URL}/doc-id-extension.json`;
+export const DOC_ID_EXTENSION_URL = `${BASE_EXTENSION_URL}/doc-id-extension.json`;
 
 export type DocIdExtension = Required<Pick<Extension, "url" | "valueString">>;
 

--- a/packages/api/src/external/fhir/shared/index.ts
+++ b/packages/api/src/external/fhir/shared/index.ts
@@ -1,10 +1,13 @@
 import { Operator } from "@medplum/core";
 import {
   DocumentReference,
+  Extension,
   OperationOutcomeIssue,
+  Resource,
   ResourceType as MedplumResourceType,
 } from "@medplum/fhirtypes";
 import { isCommonwellExtension } from "../../commonwell/extension";
+import { DOC_ID_EXTENSION_URL } from "./extensions/doc-id-extension";
 
 export function operationOutcomeIssueToString(i: OperationOutcomeIssue): string {
   return i.diagnostics ?? i.details?.text ?? i.code ?? "Unknown error";
@@ -78,4 +81,13 @@ const resourcesSupportingDateQueriesMap: { [k in MedplumResourceType]?: boolean 
 
 export function resourceSupportsDateQuery(resourceType: MedplumResourceType): boolean {
   return Object.keys(resourcesSupportingDateQueriesMap).includes(resourceType);
+}
+
+export function isResourceDerivedFromDocRef(resource: Resource, docId: string): boolean {
+  if (!("extension" in resource)) return false;
+  return (resource.extension ?? [])?.some(e => isExtensionDerivedFromDocRef(e, docId));
+}
+
+export function isExtensionDerivedFromDocRef(e: Extension, docId: string): boolean {
+  return e.url === DOC_ID_EXTENSION_URL && (e.valueString ?? "")?.includes(docId);
 }

--- a/packages/api/src/external/sidechain-fhir-converter/connector-factory.ts
+++ b/packages/api/src/external/sidechain-fhir-converter/connector-factory.ts
@@ -1,6 +1,18 @@
-import { SidechainFHIRConverterConnector } from "./connector";
+import { Config } from "../../shared/config";
+import { SidechainFHIRConverterConnector, SidechainFHIRConverterRequest } from "./connector";
 import { SidechainFHIRConverterConnectorSQS } from "./connector-sqs";
 
 export function makeSidechainFHIRConverterConnector(): SidechainFHIRConverterConnector {
+  if (!Config.isCloudEnv()) return new SidechainFHIRConverterVoid();
   return new SidechainFHIRConverterConnectorSQS();
+}
+
+class SidechainFHIRConverterVoid implements SidechainFHIRConverterConnector {
+  async requestConvert(params: SidechainFHIRConverterRequest): Promise<void> {
+    console.log(
+      `SidechainFHIRConverterVoid - Would be sending a message to SQS to convert document ${params.documentId}`,
+      params
+    );
+    return;
+  }
 }

--- a/packages/api/src/providers/withings.ts
+++ b/packages/api/src/providers/withings.ts
@@ -10,6 +10,7 @@ import {
   bodyCategory,
   sleepCategory,
 } from "../command/webhook/withings";
+import MetriportError from "../errors/metriport-error";
 import { mapToActivity } from "../mappings/withings/activity";
 import { mapToBiometrics } from "../mappings/withings/biometrics";
 import { mapToBody } from "../mappings/withings/body";
@@ -31,9 +32,9 @@ import { Config } from "../shared/config";
 import { PROVIDER_WITHINGS } from "../shared/constants";
 import { capture } from "../shared/notifications";
 import { Util } from "../shared/util";
-import { OAuth2, OAuth2DefaultImpl } from "./shared/oauth2";
 import Provider, { ConsumerHealthDataType } from "./provider";
 import { getHttpClient } from "./shared/http";
+import { OAuth2, OAuth2DefaultImpl } from "./shared/oauth2";
 
 const api = getHttpClient();
 
@@ -305,10 +306,20 @@ export class Withings extends Provider implements OAuth2 {
     });
 
     if (response.data?.status !== Withings.STATUS_OK) {
-      capture.error(response.data, {
-        extra: { context: `withings.fetch.measurements` },
+      const msg = `Error fetching measure data from Withings`;
+      console.log(`${msg} - response: ${JSON.stringify(response.data)}`);
+      capture.error(msg, {
+        extra: {
+          context: `withings.fetch.measurements`,
+          status: response.status,
+          statusText: response.statusText,
+          response: response.data,
+        },
       });
-      throw new Error(response.data.error);
+      throw new MetriportError(msg, undefined, {
+        status: response.status,
+        statusText: response.statusText,
+      });
     }
 
     return withingsMeasurementResp.parse(response.data.body);

--- a/packages/api/src/routes/medical/dtos/documentDTO.ts
+++ b/packages/api/src/routes/medical/dtos/documentDTO.ts
@@ -1,6 +1,5 @@
 import { DocumentReference } from "@medplum/fhirtypes";
-import { isMetriportContent } from "../../../external/fhir/shared/extensions/metriport";
-import { capture } from "../../../shared/notifications";
+import { getMetriportContent } from "../../../external/fhir/shared/extensions/metriport";
 import { CodeableConceptDTO, toDTO as codeableToDTO } from "./codeableDTO";
 
 export type DocumentReferenceDTO = {
@@ -15,35 +14,23 @@ export type DocumentReferenceDTO = {
 };
 
 export function toDTO(docs: DocumentReference[] | undefined): DocumentReferenceDTO[] {
-  if (docs) {
-    return docs.flatMap(doc => {
-      if (doc && doc.id && doc.content) {
-        const contents = doc.content.filter(isMetriportContent);
-        if (contents.length > 1) {
-          capture.message("Doc contains more than one Metriport content item", {
-            extra: {
-              id: doc.id,
-              content_length: contents.length,
-            },
-          });
-        }
-        const content = contents[0];
-        if (content && content.attachment && content.attachment.title && content.attachment.url) {
-          return {
-            id: doc.id,
-            description: doc.description,
-            fileName: content.attachment.title,
-            type: codeableToDTO(doc.type),
-            status: doc.status,
-            indexed: content.attachment.creation,
-            mimeType: content.attachment.contentType,
-            size: content.attachment.size,
-          };
-        }
-        return [];
+  if (!docs) return [];
+  return docs.flatMap(doc => {
+    if (doc && doc.id) {
+      const content = getMetriportContent(doc);
+      if (content && content.attachment && content.attachment.title && content.attachment.url) {
+        return {
+          id: doc.id,
+          description: doc.description,
+          fileName: content.attachment.title,
+          type: codeableToDTO(doc.type),
+          status: doc.status,
+          indexed: content.attachment.creation,
+          mimeType: content.attachment.contentType,
+          size: content.attachment.size,
+        };
       }
-      return [];
-    });
-  }
-  return [];
+    }
+    return [];
+  });
 }

--- a/packages/api/src/routes/medical/internal-docs.ts
+++ b/packages/api/src/routes/medical/internal-docs.ts
@@ -20,7 +20,9 @@ import {
   MAPIWebhookStatus,
   processPatientDocumentRequest,
 } from "../../command/medical/document/document-webhook";
+import { appendBulkGetDocUrlProgress } from "../../command/medical/patient/bulk-get-doc-url-progress";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
+import { BulkGetDocUrlStatus } from "../../domain/medical/bulk-get-document-url";
 import { convertResult } from "../../domain/medical/document-query";
 import BadRequestError from "../../errors/bad-request";
 import { Config } from "../../shared/config";
@@ -32,13 +34,14 @@ import { getUUIDFrom } from "../schemas/uuid";
 import { asyncHandler, getFrom, getFromQueryAsArray } from "../util";
 import { getFromQueryOrFail } from "./../util";
 import { cxRequestMetadataSchema } from "./schemas/request-metadata";
-import { appendBulkGetDocUrlProgress } from "../../command/medical/patient/bulk-get-doc-url-progress";
-import { BulkGetDocUrlStatus } from "../../domain/medical/bulk-get-document-url";
 
 import {
   DocumentBulkSignerLambdaResponse,
   DocumentBulkSignerLambdaResponseArraySchema,
 } from "@metriport/core/domain/document-bulk-signer-response";
+import { reConvertDocuments } from "../../command/medical/document/document-reconvert";
+import { parseISODate } from "../../shared/date";
+import { errorToString } from "../../shared/log";
 
 const router = Router();
 const upload = multer();
@@ -67,7 +70,7 @@ const reprocessOptionsSchema = z.enum(options).array().optional();
  *     - force-download: whether we should re-download the documents from CommonWell, if not
  *       present the API will not download them again if already present on S3.
  *     - ignore-fhir-conversion-and-upsert: whether we should not-convert the documents to FHIR and store the reference, if not
- *      present the API will convert and store the new reference.
+ *       present the API will convert and store the new reference.
  * @return 200
  */
 router.post(
@@ -92,6 +95,55 @@ router.post(
       capture.error(err);
     });
     return res.json({ processing: true, options, documentIds, cxId });
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * POST /internal/docs/re-convert
+ *
+ * WARNING: This will remove all non-DocumentReferences from the FHIR server!
+ *
+ * Use the document references we have on FHIR server and the respective CDA on S3
+ * to re-convert them to FHIR and insert on the FHIR server.
+ *
+ * WARNING: This will remove all non-DocumentReferences from the FHIR server!
+ *
+ * Asychronous operation, returns 200 immediately.
+ *
+ * @param req.query.cxId - The customer's ID.
+ * @param req.query.patientIds - Optional comma-separated list of Patient IDs to filter document
+ *     references for; if not set all patients of the customer will be re-converted;
+ * @param req.query.documentIds - Optional comma-separated list of metriport document
+ *     IDs to re-convert; if not set all documents of the customer will be re-converted;
+ * @param req.query.dateFrom Start date that doc refs will be filtered by (inclusive, required).
+ * @param req.query.dateTo Optional end date that doc refs will be filtered by (inclusive).
+ * @return 200
+ */
+router.post(
+  "/re-convert",
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").orFail();
+    const patientIds = getFromQueryAsArray("patientIds", req) ?? [];
+    const documentIds = getFromQueryAsArray("documentIds", req) ?? [];
+    const dateFrom = parseISODate(getFrom("query").orFail("dateFrom", req));
+    const dateTo = parseISODate(getFrom("query").optional("dateTo", req));
+    const requestId = uuidv7();
+
+    reConvertDocuments({
+      cxId,
+      patientIds,
+      documentIds,
+      dateFrom,
+      dateTo,
+      requestId,
+      logConsolidatedCountBeforeAndAfter: true,
+    }).catch(err => {
+      console.log(`Error re-converting documents for cxId ${cxId}: ${errorToString(err)}`);
+      capture.error(err);
+    });
+    return res
+      .status(httpStatus.OK)
+      .json({ processing: true, cxId, patientIds, documentIds, dateFrom, dateTo, requestId });
   })
 );
 

--- a/packages/api/src/routes/medical/internal-docs.ts
+++ b/packages/api/src/routes/medical/internal-docs.ts
@@ -31,13 +31,7 @@ import { Util } from "../../shared/util";
 import { documentQueryProgressSchema } from "../schemas/internal";
 import { stringListSchema } from "../schemas/shared";
 import { getUUIDFrom } from "../schemas/uuid";
-import {
-  asyncHandler,
-  getFrom,
-  getFromQueryAsArray,
-  getFromQueryAsArrayOrFail,
-  getFromQueryAsBoolean,
-} from "../util";
+import { asyncHandler, getFrom, getFromQueryAsArray, getFromQueryAsBoolean } from "../util";
 import { getFromQueryOrFail } from "./../util";
 import { cxRequestMetadataSchema } from "./schemas/request-metadata";
 
@@ -131,7 +125,7 @@ router.post(
   "/re-convert",
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
-    const patientIdsRaw = getFromQueryAsArrayOrFail("patientIds", req);
+    const patientIds = getFromQueryAsArray("patientIds", req) ?? [];
     const documentIds = getFromQueryAsArray("documentIds", req) ?? [];
     const dateFrom = parseISODate(getFrom("query").orFail("dateFrom", req));
     const dateTo = parseISODate(getFrom("query").optional("dateTo", req));
@@ -140,9 +134,6 @@ router.post(
       req
     );
     const requestId = uuidv7();
-
-    const patientIds = patientIdsRaw.flatMap(id => (id && id.trim().length > 0 ? id : []));
-    if (patientIds.length <= 0) throw new BadRequestError(`patientIds must have at least one item`);
 
     reConvertDocuments({
       cxId,

--- a/packages/api/src/routes/medical/internal-docs.ts
+++ b/packages/api/src/routes/medical/internal-docs.ts
@@ -31,7 +31,7 @@ import { Util } from "../../shared/util";
 import { documentQueryProgressSchema } from "../schemas/internal";
 import { stringListSchema } from "../schemas/shared";
 import { getUUIDFrom } from "../schemas/uuid";
-import { asyncHandler, getFrom, getFromQueryAsArray } from "../util";
+import { asyncHandler, getFrom, getFromQueryAsArray, getFromQueryAsBoolean } from "../util";
 import { getFromQueryOrFail } from "./../util";
 import { cxRequestMetadataSchema } from "./schemas/request-metadata";
 
@@ -117,6 +117,8 @@ router.post(
  *     IDs to re-convert; if not set all documents of the customer will be re-converted;
  * @param req.query.dateFrom Start date that doc refs will be filtered by (inclusive, required).
  * @param req.query.dateTo Optional end date that doc refs will be filtered by (inclusive).
+ * @param req.query.logConsolidatedCountBeforeAndAfter Optional whether to log consolidated data
+ *     count before and after the conversion (defaults false).
  * @return 200
  */
 router.post(
@@ -127,6 +129,10 @@ router.post(
     const documentIds = getFromQueryAsArray("documentIds", req) ?? [];
     const dateFrom = parseISODate(getFrom("query").orFail("dateFrom", req));
     const dateTo = parseISODate(getFrom("query").optional("dateTo", req));
+    const logConsolidatedCountBeforeAndAfter = getFromQueryAsBoolean(
+      "logConsolidatedCountBeforeAndAfter",
+      req
+    );
     const requestId = uuidv7();
 
     reConvertDocuments({
@@ -136,7 +142,7 @@ router.post(
       dateFrom,
       dateTo,
       requestId,
-      logConsolidatedCountBeforeAndAfter: true,
+      logConsolidatedCountBeforeAndAfter,
     }).catch(err => {
       console.log(`Error re-converting documents for cxId ${cxId}: ${errorToString(err)}`);
       capture.error(err);

--- a/packages/api/src/routes/util.ts
+++ b/packages/api/src/routes/util.ts
@@ -3,6 +3,7 @@ import BadRequestError from "../errors/bad-request";
 import { Config } from "../shared/config";
 import { errorToString } from "../shared/log";
 import { capture } from "../shared/notifications";
+import { stringToBoolean } from "../shared/types";
 
 export const asyncHandler =
   (
@@ -71,6 +72,14 @@ export const getFromQueryAsArray = (prop: string, req: Request): string[] | unde
 export const getFromQueryAsArrayOrFail = (prop: string, req: Request) => {
   const value = getFromQueryAsArray(prop, req);
   if (!value) throw new BadRequestError(`Missing ${prop} query param`);
+  return value;
+};
+export const getFromQueryAsBoolean = (prop: string, req: Request): boolean | undefined => {
+  return stringToBoolean(getFrom("query").optional(prop, req));
+};
+export const getFromQueryAsBooleanOrFail = (prop: string, req: Request): boolean => {
+  const value = getFromQueryAsBoolean(prop, req);
+  if (value == undefined) throw new BadRequestError(`Missing ${prop} query param`);
   return value;
 };
 

--- a/packages/api/src/shared/types.ts
+++ b/packages/api/src/shared/types.ts
@@ -3,5 +3,9 @@ export type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> & U[k
 
 export function stringToBoolean(value?: string): boolean | undefined {
   if (!value) return undefined;
+  return stringToBooleanRequired(value);
+}
+
+export function stringToBooleanRequired(value: string): boolean {
   return value.toLowerCase().trim() === "true";
 }

--- a/packages/core/src/util/concurrency.ts
+++ b/packages/core/src/util/concurrency.ts
@@ -31,7 +31,8 @@ export type FunctionType<T> = (
 ) => Promise<void>;
 
 /**
- * Process an array or items asynchronously.
+ * Process an array or items asynchronously. It doesn't throw if one of the promises fails
+ * (error handling should be done within the promise/function).
  *
  * For example, with an array of 19 elements and 4 parallel executions,
  * we would have something like this being executed, where:

--- a/packages/utils/src/open-search/re-populate.ts
+++ b/packages/utils/src/open-search/re-populate.ts
@@ -86,6 +86,7 @@ async function getDocRefsFromCx(cxId: string): Promise<DocumentReference[]> {
   try {
     const fhirApi = makeFhirApi(cxId, fhirBaseUrl);
     const docs: DocumentReference[] = [];
+    // TODO use getDocuments() instead - see src/external/fhir/document/get-documents.ts
     for await (const page of fhirApi.searchResourcePages("DocumentReference", filters)) {
       docs.push(...page);
     }


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1392

### Dependencies

none

### Description

- re-convert doc refs 
- fix issue on Withings - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1703911302362379?thread_ts=1703905699.236099&cid=C04T256DQPQ)
- docRef toDTO use new `getMetriportContent`

### Testing

- Local
  - [x] removes existing resources from FHIR server
  - [x] triggers re-conversion of doc ref
- Staging
  - [ ] removes existing resources from FHIR server
  - [ ] triggers re-conversion of doc ref
- Production
  - [ ] removes existing resources from FHIR server
  - [ ] triggers re-conversion of doc ref

### Release Plan

- nothing special