### PR TITLE
1392 add dryRun + adjust consolidated log

### DIFF
--- a/packages/api/src/routes/medical/internal-docs.ts
+++ b/packages/api/src/routes/medical/internal-docs.ts
@@ -117,8 +117,10 @@ router.post(
  *     IDs to re-convert; if not set all documents of the customer will be re-converted;
  * @param req.query.dateFrom Start date that doc refs will be filtered by (inclusive, required).
  * @param req.query.dateTo Optional end date that doc refs will be filtered by (inclusive).
- * @param req.query.logConsolidatedCountBeforeAndAfter Optional whether to log consolidated data
- *     count before and after the conversion (defaults false).
+ * @param req.query.logConsolidatedCountBefore Optional whether to log consolidated data count
+ *     before the re-conversion (defaults false).
+ * @param req.query.dry-run Optional whether just simulate the execution of the endpoint, no
+ *     change is expected in the repositories (defaults false).
  * @return 200
  */
 router.post(
@@ -129,10 +131,8 @@ router.post(
     const documentIds = getFromQueryAsArray("documentIds", req) ?? [];
     const dateFrom = parseISODate(getFrom("query").orFail("dateFrom", req));
     const dateTo = parseISODate(getFrom("query").optional("dateTo", req));
-    const logConsolidatedCountBeforeAndAfter = getFromQueryAsBoolean(
-      "logConsolidatedCountBeforeAndAfter",
-      req
-    );
+    const dryRun = getFromQueryAsBoolean("dry-run", req);
+    const logConsolidatedCountBefore = getFromQueryAsBoolean("logConsolidatedCountBefore", req);
     const requestId = uuidv7();
 
     reConvertDocuments({
@@ -142,7 +142,8 @@ router.post(
       dateFrom,
       dateTo,
       requestId,
-      logConsolidatedCountBeforeAndAfter,
+      dryRun,
+      logConsolidatedCountBefore,
     }).catch(err => {
       console.log(`Error re-converting documents for cxId ${cxId}: ${errorToString(err)}`);
       capture.error(err);


### PR DESCRIPTION
Ref: metriport/metriport-internal#1392

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1379
- Downstream: none

### Description

- Add dryRun
- Don't log consolidated after
- Consolidated by doc's patientId (so it logs even if no patient ID is sent)

### Testing

- Local
  - [x] dry-run doesn't delete or convert
  - [x] consolidated log is updated
- Staging
  - upstream
- Production
  - upstream

### Release Plan

- nothing special