### PR TITLE
1392 do not log dryRun for each resource

### DIFF
--- a/packages/api/src/command/medical/patient/consolidated-delete.ts
+++ b/packages/api/src/command/medical/patient/consolidated-delete.ts
@@ -73,11 +73,7 @@ export async function deleteConsolidated(params: DeleteConsolidatedParams): Prom
       return;
     }
     try {
-      if (dryRun) {
-        log(`[DRY-RUN] Would delete ${resourceType}/${resourceId} from FHRIR server`);
-      } else {
-        await fhir.deleteResource(resourceType, resourceId);
-      }
+      await fhir.deleteResource(resourceType, resourceId);
     } catch (err) {
       if (err instanceof OperationOutcomeError) errorsToReport[resourceType] = getMessage(err);
       else errorsToReport[resourceType] = String(err);
@@ -85,6 +81,10 @@ export async function deleteConsolidated(params: DeleteConsolidatedParams): Prom
     }
   };
 
+  if (dryRun) {
+    log(`[DRY-RUN] Would delete ${resourcesToDelete.length} resources from FHRIR server`);
+    return;
+  }
   await executeAsynchronously(resourcesToDelete, async r => deleteResource(r), {
     numberOfParallelExecutions,
   });


### PR DESCRIPTION
Ref: metriport/metriport-internal#1392

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1381
- Downstream: none

### Description

- Do not log dryRun for each resource
- Allow to filter resources on getConsolidated by document ID

### Testing

- Local
  - [x] do not log dryRun for each resource
- Staging
  - none
- Production
  - none

### Release Plan

- nothing special