### PR TITLE
fix(api): fix null flavor regex

### DIFF
--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -549,6 +549,6 @@ function removeCDUNK(payloadRaw: string): string {
 
 function removeNullFlavor(payloadRaw: string): string {
   const stringToReplace = /<id\s*nullFlavor\s*=\s*".*?"\s*\/>/g;
-  const replacement = `<id extension="1" root="1"`;
+  const replacement = `<id extension="1" root="1"/>`;
   return payloadRaw.replace(stringToReplace, replacement);
 }

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -548,7 +548,7 @@ function removeCDUNK(payloadRaw: string): string {
 }
 
 function removeNullFlavor(payloadRaw: string): string {
-  const stringToReplace = /<id nullFlavor=".*?"/g;
+  const stringToReplace = /<id\s*nullFlavor\s*=\s*".*?"\s*\/>/g;
   const replacement = `<id extension="1" root="1"`;
   return payloadRaw.replace(stringToReplace, replacement);
 }


### PR DESCRIPTION
refs. metriport/metriport-internal#1392

### Dependencies

N/A

### Description

make null flavor regex match on only `<id nullFlavor="NA" />` with any permutation of spaces between elements and NA characters

### Testing

- Local
  - [x] tested on offending files
  
### Release Plan


- :warning: Points to `master`
- [ ] Merge this
