### PR TITLE
build: disable WH on re-convert + query docs from FHIR server

### DIFF
--- a/packages/api/src/command/medical/document/document-redownload.ts
+++ b/packages/api/src/command/medical/document/document-redownload.ts
@@ -3,7 +3,6 @@ import {
   DocumentReference,
   DocumentReferenceContent,
   Identifier,
-  Reference,
   Resource,
 } from "@medplum/fhirtypes";
 import {
@@ -21,6 +20,7 @@ import {
 } from "../../../external/commonwell/document/document-query";
 import { hasCommonwellContent, isCommonwellContent } from "../../../external/commonwell/extension";
 import { makeFhirApi } from "../../../external/fhir/api/api-factory";
+import { getPatientId } from "../../../external/fhir/patient";
 import { downloadedFromHIEs } from "../../../external/fhir/shared";
 import { isMetriportContent } from "../../../external/fhir/shared/extensions/metriport";
 import { getAllPages } from "../../../external/fhir/shared/paginated";
@@ -103,21 +103,6 @@ export const reprocessDocuments = async ({
 };
 
 const MISSING_ID = "missing-id";
-
-const getIdFromSubjectId = (subject: Reference | undefined): string | undefined => subject?.id;
-
-function getIdFromSubjectRef(subject: Reference | undefined): string | undefined {
-  if (subject?.reference) {
-    const reference = subject.reference;
-    if (reference.includes("/")) return subject.reference.split("/")[1];
-    if (reference.includes("#")) return subject.reference.split("#")[1];
-  }
-  return undefined;
-}
-
-function getPatientId(doc: DocumentReference): string | undefined {
-  return getIdFromSubjectId(doc.subject) ?? getIdFromSubjectRef(doc.subject);
-}
 
 async function downloadDocsAndUpsertFHIRWithDocRefs({
   cxId,

--- a/packages/api/src/command/medical/document/document-webhook.ts
+++ b/packages/api/src/command/medical/document/document-webhook.ts
@@ -77,6 +77,7 @@ export const processPatientDocumentRequest = async (
         patient.data.cxDocumentRequestMetadata
       );
     } else {
+      // TODO 858 indicate this was not really sent to the customer
       await createWebhookRequest({
         cxId,
         type: whType,

--- a/packages/api/src/command/medical/patient/webhook.ts
+++ b/packages/api/src/command/medical/patient/webhook.ts
@@ -1,0 +1,62 @@
+import { webhookDisableFlagName } from "@metriport/core/domain/webhook/index";
+import { Patient } from "../../../domain/medical/patient";
+import { PatientModel } from "../../../models/medical/patient";
+import { executeOnDBTx } from "../../../models/transaction-wrapper";
+import { getPatientOrFail } from "./get-patient";
+
+export type DisableWHMeta = {
+  [webhookDisableFlagName]: boolean;
+};
+export type DisableWH = {
+  meta: DisableWHMeta;
+};
+
+export type DisableWHCommand = {
+  patient: Pick<Patient, "id" | "cxId">;
+  field: "cxDocumentRequestMetadata" | "cxConsolidatedRequestMetadata";
+  isDisableWH: boolean;
+};
+
+async function setDisableWHFlag(cmd: DisableWHCommand): Promise<void> {
+  const {
+    patient: { id, cxId },
+    field,
+    isDisableWH,
+  } = cmd;
+
+  await executeOnDBTx(PatientModel.prototype, async transaction => {
+    const patient = await getPatientOrFail({
+      id,
+      cxId,
+      lock: true,
+      transaction,
+    });
+    const existingField = patient.data[field];
+    patient.data = {
+      ...patient.data,
+      [field]: {
+        ...(existingField ? existingField : {}),
+        [webhookDisableFlagName]: isDisableWH,
+      },
+    };
+    await patient.save({ transaction });
+  });
+}
+
+export async function setDisableDocumentRequestWHFlag(
+  cmd: Omit<DisableWHCommand, "field">
+): Promise<void> {
+  return setDisableWHFlag({
+    ...cmd,
+    field: "cxDocumentRequestMetadata",
+  });
+}
+
+export async function setDisableConsolidatedRequestWHFlag(
+  cmd: Omit<DisableWHCommand, "field">
+): Promise<void> {
+  return setDisableWHFlag({
+    ...cmd,
+    field: "cxConsolidatedRequestMetadata",
+  });
+}

--- a/packages/api/src/command/medical/patient/webhook.ts
+++ b/packages/api/src/command/medical/patient/webhook.ts
@@ -17,14 +17,14 @@ export type DisableWHCommand = {
   isDisableWH: boolean;
 };
 
-async function setDisableWHFlag(cmd: DisableWHCommand): Promise<void> {
+async function setDisableWHFlag(cmd: DisableWHCommand): Promise<Patient> {
   const {
     patient: { id, cxId },
     field,
     isDisableWH,
   } = cmd;
 
-  await executeOnDBTx(PatientModel.prototype, async transaction => {
+  return executeOnDBTx(PatientModel.prototype, async transaction => {
     const patient = await getPatientOrFail({
       id,
       cxId,
@@ -39,13 +39,13 @@ async function setDisableWHFlag(cmd: DisableWHCommand): Promise<void> {
         [webhookDisableFlagName]: isDisableWH,
       },
     };
-    await patient.save({ transaction });
+    return patient.save({ transaction });
   });
 }
 
 export async function setDisableDocumentRequestWHFlag(
   cmd: Omit<DisableWHCommand, "field">
-): Promise<void> {
+): Promise<Patient> {
   return setDisableWHFlag({
     ...cmd,
     field: "cxDocumentRequestMetadata",
@@ -54,7 +54,7 @@ export async function setDisableDocumentRequestWHFlag(
 
 export async function setDisableConsolidatedRequestWHFlag(
   cmd: Omit<DisableWHCommand, "field">
-): Promise<void> {
+): Promise<Patient> {
   return setDisableWHFlag({
     ...cmd,
     field: "cxConsolidatedRequestMetadata",

--- a/packages/api/src/external/fhir/document/get-documents.ts
+++ b/packages/api/src/external/fhir/document/get-documents.ts
@@ -44,8 +44,11 @@ export function getFilters({
   to?: string;
 } = {}) {
   const filters = new URLSearchParams();
-  const patientId = Array.isArray(patientIdParam) ? patientIdParam : [patientIdParam];
-  patientId.length && filters.append("patient", patientId.join(","));
+  const patientIds = Array.isArray(patientIdParam) ? patientIdParam : [patientIdParam];
+  const patientIdsFiltered = patientIds.flatMap(id =>
+    id && id.trim().length > 0 ? id.trim() : []
+  );
+  patientIdsFiltered.length && filters.append("patient", patientIdsFiltered.join(","));
   documentIds.length && filters.append(`_id`, documentIds.join(","));
   from && filters.append("date", isoDateToFHIRDateQueryFrom(from));
   to && filters.append("date", isoDateToFHIRDateQueryTo(to));

--- a/packages/api/src/external/fhir/document/get-documents.ts
+++ b/packages/api/src/external/fhir/document/get-documents.ts
@@ -11,7 +11,7 @@ export async function getDocuments({
   documentIds,
 }: {
   cxId: string;
-  patientId?: string;
+  patientId?: string | string[];
   from?: string;
   to?: string;
   documentIds?: string[];
@@ -33,18 +33,19 @@ export async function getDocuments({
 }
 
 export function getFilters({
-  patientId,
+  patientId: patientIdParam,
   documentIds = [],
   from,
   to,
 }: {
-  patientId?: string;
+  patientId?: string | string[];
   documentIds?: string[];
   from?: string;
   to?: string;
 } = {}) {
   const filters = new URLSearchParams();
-  patientId && filters.append("patient", patientId);
+  const patientId = Array.isArray(patientIdParam) ? patientIdParam : [patientIdParam];
+  patientId.length && filters.append("patient", patientId.join(","));
   documentIds.length && filters.append(`_id`, documentIds.join(","));
   from && filters.append("date", isoDateToFHIRDateQueryFrom(from));
   to && filters.append("date", isoDateToFHIRDateQueryTo(to));

--- a/packages/api/src/external/fhir/patient/index.ts
+++ b/packages/api/src/external/fhir/patient/index.ts
@@ -1,4 +1,10 @@
-import { Identifier, Patient as FHIRPatient, Reference } from "@medplum/fhirtypes";
+import {
+  DocumentReference,
+  Identifier,
+  Patient as FHIRPatient,
+  Reference,
+} from "@medplum/fhirtypes";
+import { driversLicenseURIs } from "@metriport/core/domain/oid";
 import { ContactTypes } from "../../../domain/medical/contact";
 import {
   GenderAtBirth,
@@ -6,7 +12,7 @@ import {
   PersonalIdentifier,
   splitName,
 } from "../../../domain/medical/patient";
-import { driversLicenseURIs } from "@metriport/core/domain/oid";
+import { getIdFromSubjectId, getIdFromSubjectRef } from "../shared";
 
 export const genderMapping: { [k in GenderAtBirth]: "female" | "male" } = {
   F: "female",
@@ -72,4 +78,8 @@ export function toFHIRSubject(patientId: string): Reference<FHIRPatient> {
     type: "Patient",
   };
   return subject;
+}
+
+export function getPatientId(doc: DocumentReference): string | undefined {
+  return getIdFromSubjectId(doc.subject) ?? getIdFromSubjectRef(doc.subject);
 }

--- a/packages/api/src/external/fhir/shared/index.ts
+++ b/packages/api/src/external/fhir/shared/index.ts
@@ -3,6 +3,7 @@ import {
   DocumentReference,
   Extension,
   OperationOutcomeIssue,
+  Reference,
   Resource,
   ResourceType as MedplumResourceType,
 } from "@medplum/fhirtypes";
@@ -90,4 +91,22 @@ export function isResourceDerivedFromDocRef(resource: Resource, docId: string): 
 
 export function isExtensionDerivedFromDocRef(e: Extension, docId: string): boolean {
   return e.url === DOC_ID_EXTENSION_URL && (e.valueString ?? "")?.includes(docId);
+}
+
+/**
+ * @see getPatientId() to get the patient ID from a DocumentReference
+ */
+export function getIdFromSubjectId(subject: Reference | undefined): string | undefined {
+  return subject?.id;
+}
+/**
+ * @see getPatientId() to get the patient ID from a DocumentReference
+ */
+export function getIdFromSubjectRef(subject: Reference | undefined): string | undefined {
+  if (subject?.reference) {
+    const reference = subject.reference;
+    if (reference.includes("/")) return subject.reference.split("/")[1];
+    if (reference.includes("#")) return subject.reference.split("#")[1];
+  }
+  return undefined;
 }

--- a/packages/api/src/external/fhir/shared/index.ts
+++ b/packages/api/src/external/fhir/shared/index.ts
@@ -10,6 +10,9 @@ import {
 import { isCommonwellExtension } from "../../commonwell/extension";
 import { DOC_ID_EXTENSION_URL } from "./extensions/doc-id-extension";
 
+export const SEPARATOR_ID = "/";
+export const SEPARATOR_REF = "#";
+
 export function operationOutcomeIssueToString(i: OperationOutcomeIssue): string {
   return i.diagnostics ?? i.details?.text ?? i.code ?? "Unknown error";
 }
@@ -105,8 +108,8 @@ export function getIdFromSubjectId(subject: Reference | undefined): string | und
 export function getIdFromSubjectRef(subject: Reference | undefined): string | undefined {
   if (subject?.reference) {
     const reference = subject.reference;
-    if (reference.includes("/")) return subject.reference.split("/")[1];
-    if (reference.includes("#")) return subject.reference.split("#")[1];
+    if (reference.includes(SEPARATOR_ID)) return subject.reference.split(SEPARATOR_ID)[1];
+    if (reference.includes(SEPARATOR_REF)) return subject.reference.split(SEPARATOR_REF)[1];
   }
   return undefined;
 }

--- a/packages/api/src/routes/medical/internal-docs.ts
+++ b/packages/api/src/routes/medical/internal-docs.ts
@@ -119,7 +119,9 @@ router.post(
  * @param req.query.dateTo Optional end date that doc refs will be filtered by (inclusive).
  * @param req.query.logConsolidatedCountBefore Optional whether to log consolidated data count
  *     before the re-conversion (defaults false).
- * @param req.query.dry-run Optional whether just simulate the execution of the endpoint, no
+ * @param req.query.isDisableWH Optional whether to disable sending WH notifications after the
+ *     re-conversion is done (defaults true).
+ * @param req.query.dryRun Optional whether just simulate the execution of the endpoint, no
  *     change is expected in the repositories (defaults false).
  * @return 200
  */
@@ -131,7 +133,8 @@ router.post(
     const documentIds = getFromQueryAsArray("documentIds", req) ?? [];
     const dateFrom = parseISODate(getFrom("query").orFail("dateFrom", req));
     const dateTo = parseISODate(getFrom("query").optional("dateTo", req));
-    const dryRun = getFromQueryAsBoolean("dry-run", req);
+    const isDisableWH = getFromQueryAsBoolean("isDisableWH", req);
+    const dryRun = getFromQueryAsBoolean("dryRun", req);
     const logConsolidatedCountBefore = getFromQueryAsBoolean("logConsolidatedCountBefore", req);
     const requestId = uuidv7();
 
@@ -142,15 +145,24 @@ router.post(
       dateFrom,
       dateTo,
       requestId,
+      isDisableWH,
       dryRun,
       logConsolidatedCountBefore,
     }).catch(err => {
       console.log(`Error re-converting documents for cxId ${cxId}: ${errorToString(err)}`);
       capture.error(err);
     });
-    return res
-      .status(httpStatus.OK)
-      .json({ processing: true, cxId, patientIds, documentIds, dateFrom, dateTo, requestId });
+    return res.status(httpStatus.OK).json({
+      processing: true,
+      cxId,
+      patientIds,
+      documentIds,
+      dateFrom,
+      dateTo,
+      requestId,
+      isDisableWH,
+      dryRun,
+    });
   })
 );
 


### PR DESCRIPTION
Ref: metriport/metriport-internal#1392

### Dependencies

none

### Description

- disable WH on re-convert
- query docs from FHIR server instead of docRefMappings

### Testing

- Local
  - [x] trigger re-convert
  - [x] update WH flag according to request param
  - [x] query doc refs from multiple patient IDs from FHIR server
- Staging
  - [ ] trigger re-convert
  - [ ] update WH flag according to request param
  - [ ] query doc refs from multiple patient IDs from FHIR server
- Production
  - [ ] execute [release plan](https://metriport.slack.com/archives/C04GEQ1GH9D/p1704061018033979?thread_ts=1703894243.751199&cid=C04GEQ1GH9D)

### Release Plan

- nothing special