### PR TITLE
1406 require apiType when sending analytics/posthog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13451,11 +13451,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -18354,14 +18354,15 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -31475,21 +31476,15 @@
       }
     },
     "node_modules/posthog-node": {
-      "version": "2.6.0",
-      "license": "MIT",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-3.3.0.tgz",
+      "integrity": "sha512-C6IkW1UWPWCVbLQBUwY34QJZq/zYCvjwsZejP+CUwuXU3/Vrsf3knmIVXelcjQq4oTAiLiYBAA03s143+T1Glg==",
       "dependencies": {
-        "axios": "^0.27.0"
+        "axios": "^1.6.2",
+        "rusha": "^0.8.14"
       },
       "engines": {
         "node": ">=15.0.0"
-      }
-    },
-    "node_modules/posthog-node/node_modules/axios": {
-      "version": "0.27.2",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -34243,6 +34238,11 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rusha": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.14.tgz",
+      "integrity": "sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA=="
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
@@ -38753,7 +38753,7 @@
         "oauth-signature": "^1.5.0",
         "pg": "^8.8.0",
         "pg-hstore": "^2.3.4",
-        "posthog-node": "^2.6.0",
+        "posthog-node": "^3.3.0",
         "reflect-metadata": "^0.1.13",
         "sequelize": "^6.31.0",
         "simple-oauth2": "^5.0.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -61,7 +61,7 @@
     "oauth-signature": "^1.5.0",
     "pg": "^8.8.0",
     "pg-hstore": "^2.3.4",
-    "posthog-node": "^2.6.0",
+    "posthog-node": "^3.3.0",
     "reflect-metadata": "^0.1.13",
     "sequelize": "^6.31.0",
     "simple-oauth2": "^5.0.0",

--- a/packages/api/src/command/webhook/fitbit.ts
+++ b/packages/api/src/command/webhook/fitbit.ts
@@ -201,8 +201,8 @@ async function createAndSendCustomerPayloads(dataByCustomer: Dictionary<Entry[]>
           properties: {
             method: "POST",
             url: "/webhook/fitbit",
-            apiType: Product.devices,
           },
+          apiType: Product.devices,
         });
         const webhookRequest = await createWebhookRequest({
           cxId,

--- a/packages/api/src/command/webhook/garmin.ts
+++ b/packages/api/src/command/webhook/garmin.ts
@@ -113,8 +113,8 @@ export const processData = async <T extends MetriportData>(data: UserData<T>[]):
             properties: {
               method: "POST",
               url: "/webhook/garmin",
-              apiType: Product.devices,
             },
+            apiType: Product.devices,
           });
           await processOneCustomer(cxId, settings, payloads);
           reportDevicesUsage(

--- a/packages/api/src/command/webhook/tenovi.ts
+++ b/packages/api/src/command/webhook/tenovi.ts
@@ -1,4 +1,5 @@
 import { Biometrics, Body, ProviderSource, SourceType } from "@metriport/api-sdk";
+import { formatNumber, getFloatValue } from "@metriport/shared/common/numbers";
 import convert from "convert-units";
 import { Product } from "../../domain/product";
 import { TenoviMeasurement } from "../../mappings/tenovi";
@@ -17,7 +18,6 @@ import { ConnectedUser } from "../../models/connected-user";
 import { analytics, EventTypes } from "../../shared/analytics";
 import { errorToString } from "../../shared/log";
 import { capture } from "../../shared/notifications";
-import { formatNumber, getFloatValue } from "@metriport/shared/common/numbers";
 import { getConnectedUsersByDeviceId } from "../connected-user/get-connected-user";
 import { getSettingsOrFail } from "../settings/getSettings";
 import {
@@ -141,8 +141,8 @@ async function createAndSendPayload(
           properties: {
             method: "POST",
             url: "/webhook/tenovi",
-            apiType: Product.devices,
           },
+          apiType: Product.devices,
         });
         reportDevicesUsage(cxId, [userId]);
       } catch (error) {

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -80,11 +80,11 @@ export const processRequest = async (
       distinctId: webhookRequest.cxId,
       event: EventTypes.webhook,
       properties: {
-        apiType: getProductFromWebhookRequest(webhookRequest),
         whType: webhookRequest.type,
         whStatus: status,
         ...(additionalWHRequestMeta ? additionalWHRequestMeta : {}),
       },
+      apiType: getProductFromWebhookRequest(webhookRequest),
     });
   };
 

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -1,24 +1,24 @@
 import { sleep } from "@metriport/shared";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
-import { searchNearbyCQOrganizations } from "./command/cq-directory/search-cq-directory";
-import { createOrUpdateCQPatientData } from "./command/cq-patient-data/create-cq-data";
-import { deleteCQPatientData } from "./command/cq-patient-data/delete-cq-data";
 import { getOrganizationOrFail } from "../../command/medical/organization/get-organization";
-import {
-  getPatientDiscoveryResultCount,
-  getPatientDiscoveryResults,
-} from "./command/patient-discovery-result/get-patient-discovery-result";
-import { CQLink } from "./domain/cq-patient-data";
 import { Patient } from "../../domain/medical/patient";
-import { PatientDiscoveryResult } from "./domain/patient-discovery-result";
 import { Product } from "../../domain/product";
-import { EventTypes, analytics } from "../../shared/analytics";
+import { analytics, EventTypes } from "../../shared/analytics";
 import { capture } from "../../shared/notifications";
 import { Util } from "../../shared/util";
 import { toFHIR } from "../fhir/patient";
 import { makeIheGatewayAPI } from "./api";
+import { searchNearbyCQOrganizations } from "./command/cq-directory/search-cq-directory";
+import { createOrUpdateCQPatientData } from "./command/cq-patient-data/create-cq-data";
+import { deleteCQPatientData } from "./command/cq-patient-data/delete-cq-data";
+import {
+  getPatientDiscoveryResultCount,
+  getPatientDiscoveryResults,
+} from "./command/patient-discovery-result/get-patient-discovery-result";
 import { createPatientDiscoveryRequest } from "./create-pd-request";
+import { CQLink } from "./domain/cq-patient-data";
+import { PatientDiscoveryResult } from "./domain/patient-discovery-result";
 import { cqOrgsToXCPDGateways } from "./organization-conversion";
 
 dayjs.extend(duration);
@@ -76,10 +76,10 @@ export async function discover(patient: Patient, facilityNPI: string): Promise<v
       distinctId: cxId,
       event: EventTypes.patientDiscovery,
       properties: {
-        apiType: Product.medical,
         numberGateways: numGateways,
         numberLinkedGateways: pdResults.length,
       },
+      apiType: Product.medical,
     });
 
     if (pdResults.length === 0) {

--- a/packages/api/src/providers/fitbit.ts
+++ b/packages/api/src/providers/fitbit.ts
@@ -15,6 +15,7 @@ import {
   getProviderTokenFromConnectedUserOrFail,
 } from "../command/connected-user/get-connected-user";
 import { sendProviderDisconnected } from "../command/webhook/devices";
+import { Product } from "../domain/product";
 import MetriportError from "../errors/metriport-error";
 import { FitbitWebhookSubscriptions, fitbitWebhookSubscriptionsSchema } from "../mappings/fitbit";
 import { mapToActivity } from "../mappings/fitbit/activity";
@@ -743,6 +744,7 @@ export async function executeWithoutConnectedUser<R>(
       duration: durationInMs,
       ...additionalAnalyticsData,
     },
+    apiType: Product.devices,
   });
   return resp;
 }

--- a/packages/api/src/providers/shared/analytics.ts
+++ b/packages/api/src/providers/shared/analytics.ts
@@ -1,10 +1,16 @@
 import { ProviderSource } from "@metriport/api-sdk";
+import { Product } from "../../domain/product";
 import { ConnectedUser } from "../../models/connected-user";
 import { analytics, EventTypes } from "../../shared/analytics";
 import Provider from "../provider";
 
-export type ExtraType = Record<string, string | undefined> & { action: keyof Provider };
+export type ExtraType = Record<string, string | undefined> & {
+  action: keyof Provider;
+};
 
+/**
+ * DAPI only!
+ */
 export async function executeAndReportAnalytics<R>(
   fnToExecute: () => Promise<R>,
   connectedUser: ConnectedUser,
@@ -25,6 +31,7 @@ export async function executeAndReportAnalytics<R>(
       duration: durationInMs,
       ...(extra ? extra : {}),
     },
+    apiType: Product.devices,
   });
   return resp;
 }

--- a/packages/api/src/routes/helpers/request-analytics.ts
+++ b/packages/api/src/routes/helpers/request-analytics.ts
@@ -1,6 +1,6 @@
 import { Request } from "express";
 import { Product } from "../../domain/product";
-import { EventTypes, analytics } from "../../shared/analytics";
+import { analytics, EventTypes } from "../../shared/analytics";
 import { getCxId, getCxIdFromHeaders } from "../util";
 
 const medicalRoutes = ["medical", "fhir"];
@@ -44,12 +44,12 @@ export const analyzeRoute = ({
     properties: {
       method,
       url,
-      ...(isMedical
-        ? { apiType: Product.medical }
-        : isDevices
-        ? { apiType: Product.devices }
-        : { apiType: "internal" }),
       duration,
     },
+    ...(isMedical
+      ? { apiType: Product.medical }
+      : isDevices
+      ? { apiType: Product.devices }
+      : { apiType: "internal" }),
   });
 };

--- a/packages/api/src/routes/webhook/apple.ts
+++ b/packages/api/src/routes/webhook/apple.ts
@@ -5,6 +5,7 @@ import { appleSchema, mapData } from "../../mappings/apple";
 import { asyncHandler, getCxIdOrFail } from "../util";
 import { capture } from "../../shared/notifications";
 import { analytics, EventTypes } from "../../shared/analytics";
+import { Product } from "../../domain/product";
 
 const routes = Router();
 /** ---------------------------------------------------------------------------
@@ -34,6 +35,7 @@ routes.post(
         type: key,
         payload,
       },
+      apiType: Product.devices,
     });
 
     if (payload.error) {

--- a/packages/api/src/shared/analytics.ts
+++ b/packages/api/src/shared/analytics.ts
@@ -1,11 +1,12 @@
 import { PostHog } from "posthog-node";
-// import { EventMessageV1 } from "posthog-node/src/types";
+import { Product } from "../domain/product";
 import { Config } from "./config";
 
+// TEMPORARY FIX - CANT EXPORT THE TYPE FROM MODULE
 export interface IdentifyMessageV1 {
   distinctId: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  properties?: Record<string | number, any>;
+  properties?: Record<string | number, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  disableGeoip?: boolean;
 }
 
 // TEMPORARY FIX - CANT EXPORT THE TYPE FROM MODULE
@@ -18,14 +19,15 @@ export interface EventMessageV1 extends IdentifyMessageV1 {
 
 const postApiKey = Config.getPostHogApiKey();
 
-export const analytics = (params: EventMessageV1) => {
+export const analytics = (params: EventMessageV1 & { apiType: Product | "internal" }) => {
   if (postApiKey) {
     const posthog = new PostHog(postApiKey);
 
     params.properties = {
-      ...params.properties,
+      ...(params.properties ? { ...params.properties } : undefined),
       environment: Config.getEnvType(),
       platform: "oss-api",
+      apiType: params.apiType,
     };
 
     posthog.capture(params);


### PR DESCRIPTION
Ref: metriport/metriport-internal#1406

### Dependencies

- related: https://github.com/metriport/metriport-internal/pull/1407

### Description

Require apiType when sending analytics/posthog.

While working on [this PR](https://github.com/metriport/metriport-internal/pull/1407) and [this escalation](https://metriport.slack.com/archives/C04GEQ1GH9D/p1704761110968329) I checked Posthog and noticed lots of events coming from the API were missing the API Type.

### Testing

- Local
  - [x] Event submitted to Posthog
- Staging
  - [ ] Event submitted to Posthog
- Production
  - [ ] Event submitted to Posthog

### Release Plan

- nothing special