### PR TITLE
1377 keep IHE GW Stack separated from API Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,21 @@ $ ./packages/scripts/deploy-infra.sh -e "production" -s "<config.stackName>"
 This will create the infrastructure to run the API, including the ECR repository where the API will be deployed at. Take note of that to populate
 the environment variable `ECR_REPO_URI`.
 
-4. To deploy the API on ECR and restart the ECS service to make use of it:
+4. To provision the IHE Gateway:
+
+Update the `packages/infra/config/production.ts` configuration file, populating the properties under
+`iheGateway` with the information from the respective resources created on the previous step
+(API Stack).
+
+Execute:
+
+```shell
+$ ./packages/scripts/deploy-infra.sh -e "production" -s "IHEStack"
+```
+
+This will create the infrastructure to run the IHE Gateway.
+
+5. To deploy the API on ECR and restart the ECS service to make use of it:
 
 ```shell
 $ AWS_REGION=xxx ECR_REPO_URI=xxx ECS_CLUSTER=xxx ECS_SERVICE=xxx ./packages/scripts/deploy-api.sh"

--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -40,23 +40,22 @@ async function deploy(config: EnvConfig) {
   });
 
   //---------------------------------------------------------------------------------
-  // 2. Deploy the API stack once all secrets are defined.
+  // 3. Deploy the API stack once all secrets are defined.
   //---------------------------------------------------------------------------------
-  const apiStack = new APIStack(app, config.stackName, { env, config, version });
+  new APIStack(app, config.stackName, { env, config, version });
 
   //---------------------------------------------------------------------------------
-  // 3. Deploy the IHE stack. Contains Mirth, Lambdas for IHE Inbound, and IHE API Gateway.
+  // 4. Deploy the IHE stack. Contains Mirth, Lambdas for IHE Inbound, and IHE API Gateway.
   //---------------------------------------------------------------------------------
   if (config.iheGateway) {
     new IHEStack(app, "IHEStack", {
       env,
       config: config,
-      vpc: apiStack.vpc,
-      alarmAction: apiStack.alarmAction,
+      version,
     });
   }
   //---------------------------------------------------------------------------------
-  // 3. Deploy the Connect widget stack.
+  // 5. Deploy the Connect widget stack.
   //---------------------------------------------------------------------------------
   if (config.connectWidget) {
     new ConnectWidgetStack(app, config.connectWidget.stackName, {

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -96,8 +96,10 @@ export type EnvConfig = {
     CW_GATEWAY_AUTHORIZATION_CLIENT_SECRET: string;
   };
   iheGateway?: {
+    vpcId: string;
     certArn: string;
     subdomain: string; // Subdomain for IHE integrations
+    snsTopicArn?: string;
   };
   sentryDSN?: string; // API's Sentry DSN
   lambdasSentryDSN?: string;

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -42,8 +42,10 @@ export const config: EnvConfig = {
     CW_GATEWAY_AUTHORIZATION_CLIENT_SECRET: "CW_GATEWAY_AUTHORIZATION_CLIENT_SECRET",
   },
   iheGateway: {
-    certArn: "<your_cert_arn>",
+    vpcId: "<your-vpc-id>",
+    certArn: "<your-cert-arn>",
     subdomain: "ihe",
+    snsTopicArn: "<your-sns-topic-arn>",
   },
   connectWidget: {
     stackName: "MetriportConnectInfraStack",

--- a/packages/infra/lib/ihe-stack.ts
+++ b/packages/infra/lib/ihe-stack.ts
@@ -5,20 +5,27 @@ import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as r53 from "aws-cdk-lib/aws-route53";
 import * as r53_targets from "aws-cdk-lib/aws-route53-targets";
+import * as sns from "aws-cdk-lib/aws-sns";
 import { Construct } from "constructs";
 import { EnvConfig } from "../config/env-config";
 import { createLambda } from "./shared/lambda";
-import { setupLambdasLayers, LambdaLayers } from "./shared/lambda-layers";
+import { LambdaLayers, setupLambdasLayers } from "./shared/lambda-layers";
 
 interface IHEStackProps extends StackProps {
   config: EnvConfig;
-  vpc: ec2.IVpc;
-  alarmAction: SnsAction | undefined;
+  version: string | undefined;
 }
 
 export class IHEStack extends Stack {
   constructor(scope: Construct, id: string, props: IHEStackProps) {
     super(scope, id, props);
+
+    const vpcId = props.config.iheGateway?.vpcId;
+    if (!vpcId) throw new Error("Missing VPC ID for IHE stack");
+    const vpc = ec2.Vpc.fromLookup(this, "APIVpc", { vpcId });
+
+    const alarmSnsAction = setupSlackNotifSnsTopic(this, props.config);
+
     //-------------------------------------------
     // API Gateway
     //-------------------------------------------
@@ -71,8 +78,8 @@ export class IHEStack extends Stack {
       envVars: {
         ...(props.config.lambdasSentryDSN ? { SENTRY_DSN: props.config.lambdasSentryDSN } : {}),
       },
-      vpc: props.vpc,
-      alarmSnsAction: props.alarmAction,
+      vpc,
+      alarmSnsAction,
     });
 
     const proxy = new apig.ProxyResource(this, `IHE/Proxy`, {
@@ -88,10 +95,12 @@ export class IHEStack extends Stack {
 
     // Create lambdas
     const xcaResource = api.root.addResource("xca");
+    const xcpdResource = api.root.addResource("xcpd");
 
-    this.setupDocumentQueryLambda(props, lambdaLayers, xcaResource);
-    this.setupDocumentRetrievalLambda(props, lambdaLayers, xcaResource);
-    this.setupPatientDiscoveryLambda(props, lambdaLayers, api);
+    // TODO 1377 When we have the IHE GW infra in place, let's update these so lambdas get triggered by the IHE GW instead of API GW
+    this.setupDocumentQueryLambda(props, lambdaLayers, xcaResource, vpc, alarmSnsAction);
+    this.setupDocumentRetrievalLambda(props, lambdaLayers, xcaResource, vpc, alarmSnsAction);
+    this.setupPatientDiscoveryLambda(props, lambdaLayers, xcpdResource, vpc, alarmSnsAction);
 
     //-------------------------------------------
     // Output
@@ -113,7 +122,9 @@ export class IHEStack extends Stack {
   private setupDocumentQueryLambda(
     props: IHEStackProps,
     lambdaLayers: LambdaLayers,
-    xcaResource: apig.Resource
+    xcaResource: apig.Resource,
+    vpc: ec2.IVpc,
+    alarmSnsAction?: SnsAction | undefined
   ) {
     const documentQueryLambda = createLambda({
       stack: this,
@@ -124,8 +135,9 @@ export class IHEStack extends Stack {
       envVars: {
         ...(props.config.lambdasSentryDSN ? { SENTRY_DSN: props.config.lambdasSentryDSN } : {}),
       },
-      vpc: props.vpc,
-      alarmSnsAction: props.alarmAction,
+      vpc,
+      alarmSnsAction,
+      version: props.version,
     });
 
     const documentQueryResource = xcaResource.addResource("document-query");
@@ -135,7 +147,9 @@ export class IHEStack extends Stack {
   private setupDocumentRetrievalLambda(
     props: IHEStackProps,
     lambdaLayers: LambdaLayers,
-    xcaResource: apig.Resource
+    xcaResource: apig.Resource,
+    vpc: ec2.IVpc,
+    alarmSnsAction?: SnsAction | undefined
   ) {
     const documentRetrievalLambda = createLambda({
       stack: this,
@@ -146,8 +160,9 @@ export class IHEStack extends Stack {
       envVars: {
         ...(props.config.lambdasSentryDSN ? { SENTRY_DSN: props.config.lambdasSentryDSN } : {}),
       },
-      vpc: props.vpc,
-      alarmSnsAction: props.alarmAction,
+      vpc,
+      alarmSnsAction,
+      version: props.version,
     });
 
     const documentRetrievalResource = xcaResource.addResource("document-retrieve");
@@ -157,7 +172,9 @@ export class IHEStack extends Stack {
   private setupPatientDiscoveryLambda(
     props: IHEStackProps,
     lambdaLayers: LambdaLayers,
-    api: apig.RestApi
+    apiResource: apig.Resource,
+    vpc: ec2.IVpc,
+    alarmSnsAction?: SnsAction | undefined
   ) {
     const patientDiscoveryLambda = createLambda({
       stack: this,
@@ -168,11 +185,21 @@ export class IHEStack extends Stack {
       envVars: {
         ...(props.config.lambdasSentryDSN ? { SENTRY_DSN: props.config.lambdasSentryDSN } : {}),
       },
-      vpc: props.vpc,
-      alarmSnsAction: props.alarmAction,
+      vpc,
+      alarmSnsAction,
+      version: props.version,
     });
 
-    const xcpdResource = api.root.addResource("xcpd");
-    xcpdResource.addMethod("ANY", new apig.LambdaIntegration(patientDiscoveryLambda));
+    apiResource.addMethod("ANY", new apig.LambdaIntegration(patientDiscoveryLambda));
   }
+}
+
+function setupSlackNotifSnsTopic(stack: Stack, config: EnvConfig): SnsAction | undefined {
+  if (!config.slack) return undefined;
+  const topicArn = config.iheGateway?.snsTopicArn;
+  if (!topicArn) throw new Error("Missing SNS topic ARN for IHE stack");
+
+  const slackNotifSnsTopic = sns.Topic.fromTopicArn(stack, "SlackSnsTopic", topicArn);
+  const alarmAction = new SnsAction(slackNotifSnsTopic);
+  return alarmAction;
 }

--- a/packages/infra/lib/shared/lambda.ts
+++ b/packages/infra/lib/shared/lambda.ts
@@ -55,6 +55,7 @@ export interface LambdaProps extends StackProps {
   readonly runtime?: Runtime;
   readonly architecture?: Architecture;
   readonly layers: ILayerVersion[];
+  readonly version?: string | undefined;
 }
 
 export function createLambda(props: LambdaProps): Lambda {
@@ -79,6 +80,7 @@ export function createLambda(props: LambdaProps): Lambda {
     environment: {
       ...props.envVars,
       ENV_TYPE: props.envType,
+      ...(props.version ? { METRIPORT_VERSION: props.version } : undefined),
     },
     retryAttempts: props.retryAttempts ?? 0,
     maxEventAge: props.maxEventAge ?? undefined,

--- a/packages/lambdas/src/document-query.ts
+++ b/packages/lambdas/src/document-query.ts
@@ -1,10 +1,13 @@
-import * as Sentry from "@sentry/serverless";
+import { getEnvVar } from "@metriport/core/util/env-var";
 import {
-  DocumentQueryResponseOutgoing,
-  documentQueryRequestIncomingSchema,
   DocumentQueryRequestIncoming,
+  documentQueryRequestIncomingSchema,
+  DocumentQueryResponseOutgoing,
   DocumentReference,
 } from "@metriport/ihe-gateway-sdk";
+import * as Sentry from "@sentry/serverless";
+
+const version = getEnvVar(`METRIPORT_VERSION`);
 
 export const handler = Sentry.AWSLambda.wrapHandler(processRequest);
 
@@ -12,6 +15,8 @@ export const handler = Sentry.AWSLambda.wrapHandler(processRequest);
 async function processRequest(
   payload: DocumentQueryRequestIncoming
 ): Promise<DocumentQueryResponseOutgoing> {
+  console.log(`Running with payload: ${JSON.stringify(payload)}; version: ${version}`);
+
   // Randomly return error or success response
   const xca = documentQueryRequestIncomingSchema.parse(payload);
   if (Math.random() > 0.5) {

--- a/packages/lambdas/src/document-retrieval.ts
+++ b/packages/lambdas/src/document-retrieval.ts
@@ -1,10 +1,13 @@
-import * as Sentry from "@sentry/serverless";
+import { getEnvVar } from "@metriport/core/util/env-var";
 import {
-  DocumentRetrievalResponseOutgoing,
-  DocumentRetrievalRequestIncoming,
   DocumentReference,
+  DocumentRetrievalRequestIncoming,
   documentRetrievalRequestIncomingSchema,
+  DocumentRetrievalResponseOutgoing,
 } from "@metriport/ihe-gateway-sdk";
+import * as Sentry from "@sentry/serverless";
+
+const version = getEnvVar(`METRIPORT_VERSION`);
 
 export const handler = Sentry.AWSLambda.wrapHandler(processRequest);
 
@@ -12,6 +15,8 @@ export const handler = Sentry.AWSLambda.wrapHandler(processRequest);
 async function processRequest(
   payload: DocumentRetrievalRequestIncoming
 ): Promise<DocumentRetrievalResponseOutgoing> {
+  console.log(`Running with patientId: ${payload.patientId}; version: ${version}`);
+
   // validate with zod schema
   const xca = documentRetrievalRequestIncomingSchema.parse(payload);
   if (Math.random() > 0.5) {

--- a/packages/lambdas/src/patient-discovery.ts
+++ b/packages/lambdas/src/patient-discovery.ts
@@ -5,6 +5,9 @@ import {
   baseRequestSchema,
 } from "@metriport/ihe-gateway-sdk";
 import { Patient } from "@medplum/fhirtypes";
+import { getEnvVar } from "@metriport/core/util/env-var";
+
+const version = getEnvVar(`METRIPORT_VERSION`);
 
 export const handler = Sentry.AWSLambda.wrapHandler(processRequest);
 
@@ -12,6 +15,8 @@ export const handler = Sentry.AWSLambda.wrapHandler(processRequest);
 async function processRequest(
   payload: PatientDiscoveryRequestIncoming
 ): Promise<PatientDiscoveryResponseOutgoing> {
+  console.log(`Running with patientId: ${payload.patientId}; version: ${version}`);
+
   // validate with zod schema
   const baseRequest = baseRequestSchema.parse({
     id: payload.id,


### PR DESCRIPTION
Ref: metriport/metriport-internal#1377

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1415
- Downstream: TBD

### Description

- Keep IHE GW Stack separated from API Stack
- Update docs for IHE GW
- Support surfacing Metriport version to lambdas

### Testing

- Local
  - none
- Staging
  - [ ] infra deployed
- Production
  - none

### Release Plan

- [ ] manually remove the IHE GW Stack
- [ ] merge upstream
- [ ] deploy this