### PR TITLE
fix(api): provision lambda to avoid cold starts

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -33,7 +33,12 @@ import * as fhirServerConnector from "./api-stack/fhir-server-connector";
 import * as sidechainFHIRConverterConnector from "./api-stack/sidechain-fhir-converter-connector";
 import { createAppConfigStack } from "./app-config-stack";
 import { EnvType } from "./env-type";
-import { addErrorAlarmToLambdaFunc, createLambda, MAXIMUM_LAMBDA_TIMEOUT } from "./shared/lambda";
+import {
+  addErrorAlarmToLambdaFunc,
+  createLambda,
+  MAXIMUM_LAMBDA_TIMEOUT,
+  addProvisionedConcurrencyToLambda,
+} from "./shared/lambda";
 import { LambdaLayers, setupLambdasLayers } from "./shared/lambda-layers";
 import { getSecrets, Secrets } from "./shared/secrets";
 import { provideAccessToQueue } from "./shared/sqs";
@@ -1014,9 +1019,11 @@ export class APIStack extends Stack {
       sandboxSeedDataBucket,
     } = ownProps;
 
+    const name = "CdaToVisualization";
+
     const cdaToVisualizationLambda = createLambda({
       stack: this,
-      name: "CdaToVisualization",
+      name: name,
       runtime: lambda.Runtime.NODEJS_16_X,
       entry: "cda-to-visualization",
       envType,
@@ -1030,6 +1037,8 @@ export class APIStack extends Stack {
       vpc,
       alarmSnsAction: alarmAction,
     });
+
+    addProvisionedConcurrencyToLambda(this, cdaToVisualizationLambda, name, 1);
 
     medicalDocumentsBucket.grantReadWrite(cdaToVisualizationLambda);
 

--- a/packages/infra/lib/shared/lambda.ts
+++ b/packages/infra/lib/shared/lambda.ts
@@ -13,6 +13,7 @@ import {
   Runtime,
   SingletonFunction,
 } from "aws-cdk-lib/aws-lambda";
+import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as lambda_node from "aws-cdk-lib/aws-lambda-nodejs";
 import { FilterPattern } from "aws-cdk-lib/aws-logs";
 import { IQueue } from "aws-cdk-lib/aws-sqs";
@@ -175,4 +176,18 @@ export function addErrorAlarmToLambdaFunc(
     treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
   });
   alarmAction && alarm.addAlarmAction(alarmAction);
+}
+
+export function addProvisionedConcurrencyToLambda(
+  stack: Construct,
+  theLambda: lambda.Function,
+  lambdaName: string,
+  provisionedConcurrentExecutions: number
+): lambda.IAlias {
+  const options = {
+    aliasName: `${lambdaName}Alias`,
+    version: theLambda.currentVersion,
+    provisionedConcurrentExecutions,
+  };
+  return new lambda.Alias(stack, `${options.aliasName}Resource`, options);
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#1430

Ticket:[1430](https://github.com/metriport/metriport-internal/issues/1430)

### Dependencies

- Upstream: none
- Downstream: none

### Description

We had an issue that when the lambda would cold start we have an issue where it would err because certain files were too big and so it would timeout. 

### Testing

- Local
  - none
- Staging
  - [ ] CDAVisualizationLambda has provisioned concurrency of 1
- Production
  - [ ] CDAVisualizationLambda has provisioned concurrency of 1

_[Release PRs:]_

Check each PR.

### Release Plan

nothing special