### PR TITLE
PATCH - 799 chunk fhir url length

### DIFF
--- a/packages/core/src/external/fhir/document/get-documents.ts
+++ b/packages/core/src/external/fhir/document/get-documents.ts
@@ -1,4 +1,5 @@
 import { DocumentReference } from "@medplum/fhirtypes";
+import { chunk } from "lodash";
 import { capture } from "../../../util/notifications";
 import { makeFhirApi } from "../api/api-factory";
 import { isoDateToFHIRDateQueryFrom, isoDateToFHIRDateQueryTo } from "../shared";
@@ -19,10 +20,14 @@ export async function getDocuments({
 }): Promise<DocumentReference[]> {
   try {
     const api = makeFhirApi(cxId, Config.getFHIRServerUrl());
-    const filtersAsStr = getFilters({ patientId, documentIds, from, to });
     const docs: DocumentReference[] = [];
-    for await (const page of api.searchResourcePages("DocumentReference", filtersAsStr)) {
-      docs.push(...page);
+    const chunksDocIds = chunk(documentIds, 10);
+
+    for (const docIds of chunksDocIds) {
+      const filtersAsStr = getFilters({ patientId, documentIds: docIds, from, to });
+      for await (const page of api.searchResourcePages("DocumentReference", filtersAsStr)) {
+        docs.push(...page);
+      }
     }
     return docs;
   } catch (error) {

--- a/packages/core/src/external/fhir/document/get-documents.ts
+++ b/packages/core/src/external/fhir/document/get-documents.ts
@@ -21,7 +21,7 @@ export async function getDocuments({
   try {
     const api = makeFhirApi(cxId, Config.getFHIRServerUrl());
     const docs: DocumentReference[] = [];
-    const chunksDocIds = chunk(documentIds, 10);
+    const chunksDocIds = chunk(documentIds, 200);
 
     for (const docIds of chunksDocIds) {
       const filtersAsStr = getFilters({ patientId, documentIds: docIds, from, to });


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ticket: 799

### Description

Issue where the doc ids where too  many and so the url to search ended up being too large

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
