### PR TITLE
PATCH fix(api): chunk the doc ids by 200

### DIFF
--- a/packages/core/src/external/fhir/document/get-documents.ts
+++ b/packages/core/src/external/fhir/document/get-documents.ts
@@ -21,7 +21,7 @@ export async function getDocuments({
   try {
     const api = makeFhirApi(cxId, Config.getFHIRServerUrl());
     const docs: DocumentReference[] = [];
-    const chunksDocIds = chunk(documentIds, 150);
+    const chunksDocIds = chunk(documentIds, 200);
 
     for (const docIds of chunksDocIds) {
       const filtersAsStr = getFilters({ patientId, documentIds: docIds, from, to });


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ticket: 799

### Description

Issue where the doc ids where too  many and so the url to search ended up being too large

### Release Plan

- :warning: Points to `master`
- [ ] Merge this