### PR TITLE
PATCH: update the fhir get docs with defaults

### DIFF
--- a/packages/api/src/external/fhir/document/get-documents.ts
+++ b/packages/api/src/external/fhir/document/get-documents.ts
@@ -32,7 +32,7 @@ export async function getDocuments({
     };
 
     if (documentIds && documentIds.length > 1) {
-      const chunksDocIds = chunk(documentIds, 200);
+      const chunksDocIds = chunk(documentIds, 150);
 
       for (const docIds of chunksDocIds) {
         const filtersAsStr = getFilters({ ...defaultFilters, documentIds: docIds });

--- a/packages/core/src/external/fhir/document/get-documents.ts
+++ b/packages/core/src/external/fhir/document/get-documents.ts
@@ -30,7 +30,7 @@ export async function getDocuments({
     };
 
     if (documentIds && documentIds.length > 1) {
-      const chunksDocIds = chunk(documentIds, 200);
+      const chunksDocIds = chunk(documentIds, 150);
 
       for (const docIds of chunksDocIds) {
         const filtersAsStr = getFilters({ ...defaultFilters, documentIds: docIds });

--- a/packages/core/src/external/fhir/document/get-documents.ts
+++ b/packages/core/src/external/fhir/document/get-documents.ts
@@ -21,14 +21,31 @@ export async function getDocuments({
   try {
     const api = makeFhirApi(cxId, Config.getFHIRServerUrl());
     const docs: DocumentReference[] = [];
-    const chunksDocIds = chunk(documentIds, 200);
 
-    for (const docIds of chunksDocIds) {
-      const filtersAsStr = getFilters({ patientId, documentIds: docIds, from, to });
+    const defaultFilters = {
+      patientId,
+      from,
+      to,
+      documentIds,
+    };
+
+    if (documentIds && documentIds.length > 1) {
+      const chunksDocIds = chunk(documentIds, 200);
+
+      for (const docIds of chunksDocIds) {
+        const filtersAsStr = getFilters({ ...defaultFilters, documentIds: docIds });
+        for await (const page of api.searchResourcePages("DocumentReference", filtersAsStr)) {
+          docs.push(...page);
+        }
+      }
+    } else {
+      const filtersAsStr = getFilters(defaultFilters);
+
       for await (const page of api.searchResourcePages("DocumentReference", filtersAsStr)) {
         docs.push(...page);
       }
     }
+
     return docs;
   } catch (error) {
     const msg = `Error getting documents from FHIR server`;

--- a/packages/core/src/external/fhir/document/get-documents.ts
+++ b/packages/core/src/external/fhir/document/get-documents.ts
@@ -21,31 +21,14 @@ export async function getDocuments({
   try {
     const api = makeFhirApi(cxId, Config.getFHIRServerUrl());
     const docs: DocumentReference[] = [];
+    const chunksDocIds = documentIds && documentIds.length > 0 ? chunk(documentIds, 150) : [[]];
 
-    const defaultFilters = {
-      patientId,
-      from,
-      to,
-      documentIds,
-    };
-
-    if (documentIds && documentIds.length > 1) {
-      const chunksDocIds = chunk(documentIds, 150);
-
-      for (const docIds of chunksDocIds) {
-        const filtersAsStr = getFilters({ ...defaultFilters, documentIds: docIds });
-        for await (const page of api.searchResourcePages("DocumentReference", filtersAsStr)) {
-          docs.push(...page);
-        }
-      }
-    } else {
-      const filtersAsStr = getFilters(defaultFilters);
-
+    for (const docIds of chunksDocIds) {
+      const filtersAsStr = getFilters({ patientId, documentIds: docIds, from, to });
       for await (const page of api.searchResourcePages("DocumentReference", filtersAsStr)) {
         docs.push(...page);
       }
     }
-
     return docs;
   } catch (error) {
     const msg = `Error getting documents from FHIR server`;


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ticket: 799

### Description

Issue where the FHIR docs werent getting queried because we didnt pass doc ids

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
