### PR TITLE
fix(api): update the doc query to reset hies when startign

### DIFF
--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -1,5 +1,6 @@
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { emptyFunction } from "@metriport/shared";
+import { MedicalDataSource } from "@metriport/core/external/index";
 import { calculateConversionProgress } from "../../../domain/medical/conversion-progress";
 import {
   ConvertResult,
@@ -75,6 +76,7 @@ export async function queryDocumentsAcrossHIEs({
   });
 
   await appendDocQueryProgressWithSource({
+    source: MedicalDataSource.ALL,
     patient: updatedPatient,
     requestId,
     reset: true,

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -18,6 +18,7 @@ import { getPatientOrFail } from "../patient/get-patient";
 import { storeQueryInit } from "../patient/query-init";
 import { areDocumentsProcessing } from "./document-status";
 import { getDocumentsFromCQ } from "../../../external/carequality/document/query-documents";
+import { appendDocQueryProgressWithSource } from "../../../external/hie/append-doc-query-progress-with-source";
 
 export function isProgressEqual(a?: Progress, b?: Progress): boolean {
   return (
@@ -71,6 +72,12 @@ export async function queryDocumentsAcrossHIEs({
     documentQueryProgress: { download: { status: "processing" } },
     requestId,
     cxDocumentRequestMetadata,
+  });
+
+  await appendDocQueryProgressWithSource({
+    patient: updatedPatient,
+    requestId,
+    reset: true,
   });
 
   getDocumentsFromCW({

--- a/packages/api/src/command/medical/patient/append-doc-query-progress.ts
+++ b/packages/api/src/command/medical/patient/append-doc-query-progress.ts
@@ -8,23 +8,26 @@ import { PatientModel } from "../../../models/medical/patient";
 import { executeOnDBTx } from "../../../models/transaction-wrapper";
 import { getPatientOrFail } from "./get-patient";
 
-export type SetDocQueryProgress = {
+export type SetDocQueryProgressBase = {
   patient: Pick<Patient, "id" | "cxId">;
   convertibleDownloadErrors?: number;
   increaseCountConvertible?: number;
   requestId: string;
-} & (
-  | {
-      downloadProgress?: Progress | undefined | null;
-      convertProgress?: Progress | undefined | null;
-      reset?: false | undefined;
-    }
-  | {
-      downloadProgress: Progress;
-      convertProgress?: never;
-      reset?: true;
-    }
-);
+};
+
+export type SetDocQueryProgress = SetDocQueryProgressBase &
+  (
+    | {
+        downloadProgress?: Progress | undefined | null;
+        convertProgress?: Progress | undefined | null;
+        reset?: false | undefined;
+      }
+    | {
+        downloadProgress: Progress;
+        convertProgress?: never;
+        reset?: true;
+      }
+  );
 
 /**
  * Appends the given properties of a patient's document query progress.

--- a/packages/api/src/external/hie/append-doc-query-progress-with-source.ts
+++ b/packages/api/src/external/hie/append-doc-query-progress-with-source.ts
@@ -20,7 +20,7 @@ import { getCQData } from "../carequality/patient";
 export type HIEPatientData = PatientDataCommonwell | PatientDataCarequality;
 
 export type SetDocQueryProgressWithSource = {
-  source?: MedicalDataSource;
+  source: MedicalDataSource;
 } & SetDocQueryProgressBase &
   (
     | {
@@ -176,7 +176,7 @@ export function setExternalData(
   patient: PatientModel,
   downloadProgress: Progress | undefined | null,
   convertProgress: Progress | undefined | null,
-  source: MedicalDataSource | undefined,
+  source: MedicalDataSource,
   convertibleDownloadErrors?: number,
   increaseCountConvertible?: number
 ): PatientExternalData {
@@ -195,8 +195,6 @@ export function setExternalData(
       },
     };
   }
-
-  if (!source) return externalData;
 
   const sourceData = externalData[source] as HIEPatientData;
 

--- a/packages/api/src/external/hie/append-doc-query-progress-with-source.ts
+++ b/packages/api/src/external/hie/append-doc-query-progress-with-source.ts
@@ -7,7 +7,7 @@ import { Patient } from "@metriport/core/domain/patient";
 import { PatientModel } from "../../models/medical/patient";
 import { executeOnDBTx } from "../../models/transaction-wrapper";
 import {
-  SetDocQueryProgress,
+  SetDocQueryProgressBase,
   setDocQueryProgress,
 } from "../../command/medical/patient/append-doc-query-progress";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
@@ -19,9 +19,21 @@ import { getCQData } from "../carequality/patient";
 
 export type HIEPatientData = PatientDataCommonwell | PatientDataCarequality;
 
-type SetDocQueryProgressWithSource = SetDocQueryProgress & {
-  source: MedicalDataSource;
-};
+export type SetDocQueryProgressWithSource = {
+  source?: MedicalDataSource;
+} & SetDocQueryProgressBase &
+  (
+    | {
+        downloadProgress?: Progress | undefined | null;
+        convertProgress?: Progress | undefined | null;
+        reset?: false | undefined;
+      }
+    | {
+        downloadProgress?: never;
+        convertProgress?: never;
+        reset?: true;
+      }
+  );
 
 /**
  * Appends the given properties of a patient's document query progress.
@@ -31,12 +43,12 @@ type SetDocQueryProgressWithSource = SetDocQueryProgress & {
  */
 export async function appendDocQueryProgressWithSource({
   patient,
+  requestId,
   downloadProgress,
   convertProgress,
   convertibleDownloadErrors,
   increaseCountConvertible,
   reset,
-  requestId,
   source,
 }: SetDocQueryProgressWithSource): Promise<Patient> {
   const patientFilter = {
@@ -51,10 +63,9 @@ export async function appendDocQueryProgressWithSource({
       transaction,
     });
 
-    const documentQueryProgress =
-      reset || !existingPatient.data.documentQueryProgress
-        ? {}
-        : existingPatient.data.documentQueryProgress;
+    const documentQueryProgress = !existingPatient.data.documentQueryProgress
+      ? {}
+      : existingPatient.data.documentQueryProgress;
 
     // Set the doc query progress for the given hie
     const externalData = setExternalData(
@@ -165,7 +176,7 @@ export function setExternalData(
   patient: PatientModel,
   downloadProgress: Progress | undefined | null,
   convertProgress: Progress | undefined | null,
-  source: MedicalDataSource,
+  source: MedicalDataSource | undefined,
   convertibleDownloadErrors?: number,
   increaseCountConvertible?: number
 ): PatientExternalData {
@@ -184,6 +195,8 @@ export function setExternalData(
       },
     };
   }
+
+  if (!source) return externalData;
 
   const sourceData = externalData[source] as HIEPatientData;
 

--- a/packages/core/src/external/index.ts
+++ b/packages/core/src/external/index.ts
@@ -9,14 +9,3 @@ export function isMedicalDataSource(s?: string | null): s is MedicalDataSource {
   const list = Object.values(MedicalDataSource) as string[];
   return list.includes(s);
 }
-
-export const HL7OID = "2.16.840.1.113883";
-
-type ValidMedicalDataSourceOid = Exclude<
-  MedicalDataSource,
-  MedicalDataSource.ALL | MedicalDataSource.CAREQUALITY
->;
-
-export const MedicalDataSourceOid: Record<ValidMedicalDataSourceOid, string> = {
-  [MedicalDataSource.COMMONWELL]: `${HL7OID}.3.3330`,
-};

--- a/packages/core/src/external/index.ts
+++ b/packages/core/src/external/index.ts
@@ -1,4 +1,5 @@
 export enum MedicalDataSource {
+  ALL = "ALL",
   COMMONWELL = "COMMONWELL",
   CAREQUALITY = "CAREQUALITY",
 }
@@ -11,7 +12,10 @@ export function isMedicalDataSource(s?: string | null): s is MedicalDataSource {
 
 export const HL7OID = "2.16.840.1.113883";
 
-type ValidMedicalDataSourceOid = Exclude<MedicalDataSource, MedicalDataSource.CAREQUALITY>;
+type ValidMedicalDataSourceOid = Exclude<
+  MedicalDataSource,
+  MedicalDataSource.ALL | MedicalDataSource.CAREQUALITY
+>;
 
 export const MedicalDataSourceOid: Record<ValidMedicalDataSourceOid, string> = {
   [MedicalDataSource.COMMONWELL]: `${HL7OID}.3.3330`,

--- a/packages/core/src/external/index.ts
+++ b/packages/core/src/external/index.ts
@@ -9,3 +9,14 @@ export function isMedicalDataSource(s?: string | null): s is MedicalDataSource {
   const list = Object.values(MedicalDataSource) as string[];
   return list.includes(s);
 }
+
+export const HL7OID = "2.16.840.1.113883";
+
+type ValidMedicalDataSourceOid = Exclude<
+  MedicalDataSource,
+  MedicalDataSource.ALL | MedicalDataSource.CAREQUALITY
+>;
+
+export const MedicalDataSourceOid: Record<ValidMedicalDataSourceOid, string> = {
+  [MedicalDataSource.COMMONWELL]: `${HL7OID}.3.3330`,
+};


### PR DESCRIPTION
Ref:metriport/metriport-internal#799

Ticket: #799

### Dependencies

- Upstream: None
- Downstream: None

### Description

Bug where the doc query progress within the hies wasnt being reset resulting in subsequent queries counting the aggregate total wrong.

### Testing

- Local
  - [x] Manually updated doc query for patient to simulate it already had and then checked after if it reset
- Staging
  - [ ] Run a doc query and then run again to make sure previous one was reset
- Sandbox
  - [x] This isnt an issue here because sandbox has a separate
- Production
  - [ ] Run a doc query under one of cx's broken patients and see if it resets


### Release Plan

Nothing special

- [ ] Merge this
