### PR TITLE
chore: add support for template reload in converter

### DIFF
--- a/packages/fhir-converter/docker-compose.yml
+++ b/packages/fhir-converter/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - "8777:8080"
       - "9277:9229"
-    # volumes:
-    #   - ./src:/usr/src/app/src
+    volumes:
+      - ./src:/app/src
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Ticket:  metriport/metriport-internal#1441

### Dependencies

n/a

### Description

add support for template reload in converter

### Testing


- Local
  - [x] volume mounts


### Release Plan


- :warning: Points to `master`
- [ ] Merge this
