### PR TITLE
Fix Pydantic Deprecations

### DIFF
--- a/samples/python-fast-api/create_patient_trigger_webhook.py
+++ b/samples/python-fast-api/create_patient_trigger_webhook.py
@@ -58,7 +58,7 @@ class Address(pydantic.BaseModel):
     state: str = pydantic.Field(min_length=1)
     zip: str = pydantic.Field(min_length=5, max_length=5)
 
-    @pydantic.validator("zip", always=True)
+    @pydantic.validator("zip")
     def check_zip_alphanumeric(cls, v):  # pylint: disable=no-self-argument
         int(v)
         return v
@@ -87,7 +87,7 @@ async def upload_new_patient(
     result = await client.post(
         "/medical/v1/patient",
         params={"facilityId": metriport_facility_id},
-        content=patient.json(exclude_none=True),
+        content=patient.model_dump_json(exclude_none=True),
         headers={"Content-Type": "application/json"},
     )
     return result

--- a/samples/python-fast-api/create_patient_trigger_webhook.py
+++ b/samples/python-fast-api/create_patient_trigger_webhook.py
@@ -58,7 +58,7 @@ class Address(pydantic.BaseModel):
     state: str = pydantic.Field(min_length=1)
     zip: str = pydantic.Field(min_length=5, max_length=5)
 
-    @pydantic.validator("zip")
+    @pydantic.field_validator("zip")
     def check_zip_alphanumeric(cls, v):  # pylint: disable=no-self-argument
         int(v)
         return v


### PR DESCRIPTION
```
PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.5/migration/
  @pydantic.validator("zip", always=True)
PydanticDeprecatedSince20: The `json` method is deprecated; use `model_dump_json` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.5/migration/
  content=patient.json(exclude_none=True),
```

A few small fixes for Pydantic warning messages.