### PR TITLE
PATCH RELEASE 2024-01-23

### DIFF
--- a/packages/api/src/command/medical/document/document-download.ts
+++ b/packages/api/src/command/medical/document/document-download.ts
@@ -36,7 +36,7 @@ export const downloadDocument = async ({
   if (conversionType && validConversionTypes.includes(conversionType) && bucketName) {
     return getConversionUrl({ fileName, conversionType, bucketName });
   }
-  return getSignedURL({ fileName });
+  return getSignedURL({ fileName, bucketName });
 };
 
 const getConversionUrl = async ({
@@ -134,10 +134,11 @@ export const getSignedURL = async ({
   const url = s3client.getSignedUrl("getObject", {
     // TODO 760 Fix this
     Bucket:
-      bucketName ?? Config.isSandbox()
+      bucketName ??
+      (Config.isSandbox()
         ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           Config.getSandboxSeedBucketName()!
-        : Config.getMedicalDocumentsBucketName(),
+        : Config.getMedicalDocumentsBucketName()),
     Key: fileName,
     Expires: urlExpirationSeconds,
   });

--- a/packages/api/src/command/medical/document/document-download.ts
+++ b/packages/api/src/command/medical/document/document-download.ts
@@ -130,15 +130,15 @@ export const getSignedURL = async ({
   bucketName?: string;
 }): Promise<string> => {
   const urlExpirationSeconds = URL_EXPIRATION_TIME.asSeconds();
+  const bucket =
+    bucketName ??
+    (Config.isSandbox()
+      ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        Config.getSandboxSeedBucketName()!
+      : Config.getMedicalDocumentsBucketName());
 
   const url = s3client.getSignedUrl("getObject", {
-    // TODO 760 Fix this
-    Bucket:
-      bucketName ??
-      (Config.isSandbox()
-        ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          Config.getSandboxSeedBucketName()!
-        : Config.getMedicalDocumentsBucketName()),
+    Bucket: bucket,
     Key: fileName,
     Expires: urlExpirationSeconds,
   });


### PR DESCRIPTION
refs. metriport/metriport-internal#760

Ticket: #_[ticket-number]_760

### Description

- CX uploaded docs will now pick the correct sandbox med docs bucket

### Testing

- Local
  - [x] Created a local script and rigged the API to behave in sandbox mode. The logic works well. 
- Sandbox
  - [ ] Create a sandbox patient, upload a document for them, and see if it downloads from the dashboard
- Production 
  - [ ] Make sure doc download still works for a prod patient

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
- [ ] Test prod doc download immediately
- [ ] Test sandbox doc upload functionality
