### PR TITLE
feat(patch): fhir validation bug patch

### DIFF
--- a/packages/api/src/external/fhir/shared/json-validator.ts
+++ b/packages/api/src/external/fhir/shared/json-validator.ts
@@ -7,7 +7,7 @@ import BadRequestError from "../../../errors/bad-request";
 
 type Error = {
   resourceType: string;
-  errors: ErrorObject[] | null | undefined;
+  errors: ErrorObject[] | null | undefined | string[];
 };
 
 const ajv = new Ajv({
@@ -25,6 +25,9 @@ export const validateFhirEntries = (bundle: Bundle): Bundle => {
   const errors: Error[] = [];
 
   for (const entry of bundle.entry) {
+    if (!entry.resource) {
+      throw new BadRequestError(`Missing FHIR resource top level object`);
+    }
     const resourceType = entry.resource.resourceType;
 
     const isValid = validate(entry.resource);

--- a/packages/api/src/external/fhir/shared/json-validator.ts
+++ b/packages/api/src/external/fhir/shared/json-validator.ts
@@ -25,10 +25,12 @@ export const validateFhirEntries = (bundle: Bundle): Bundle => {
   const errors: Error[] = [];
 
   for (const entry of bundle.entry) {
-    if (!entry.resource) {
-      throw new BadRequestError(`Missing FHIR resource top level object`);
-    }
     const resourceType = entry.resource.resourceType;
+    if (typeof resourceType !== "string") {
+      throw new BadRequestError("Resource type must be a string", undefined, {
+        actualType: typeof resourceType,
+      });
+    }
 
     const isValid = validate(entry.resource);
 

--- a/packages/api/src/external/fhir/shared/json-validator.ts
+++ b/packages/api/src/external/fhir/shared/json-validator.ts
@@ -7,7 +7,7 @@ import BadRequestError from "../../../errors/bad-request";
 
 type Error = {
   resourceType: string;
-  errors: ErrorObject[] | null | undefined | string[];
+  errors: ErrorObject[] | null | undefined;
 };
 
 const ajv = new Ajv({

--- a/packages/api/src/routes/medical/schemas/fhir.ts
+++ b/packages/api/src/routes/medical/schemas/fhir.ts
@@ -9,7 +9,7 @@ const typeSchema = z.enum(["collection"]);
 
 const bundleEntrySchema = z.array(
   z.object({
-    resource: z.object({}).nonstrict(),
+    resource: z.any().refine(value => value !== undefined, { message: "Resource is required" }),
   })
 );
 

--- a/packages/api/src/routes/medical/schemas/fhir.ts
+++ b/packages/api/src/routes/medical/schemas/fhir.ts
@@ -9,7 +9,7 @@ const typeSchema = z.enum(["collection"]);
 
 const bundleEntrySchema = z.array(
   z.object({
-    resource: z.any(),
+    resource: z.object({}).nonstrict(),
   })
 );
 


### PR DESCRIPTION
Refs: #443

### Description

- customers were getting 500 errors when sending fhir bundles on PUT requests that were missing the resource object. 

### Testing

- Local
  - [x] tested on local with fhir bundles, valid, and invalid

### Release Plan

- [x] Merge this
- [ ] test on staging
- [ ] release
