### PR TITLE
1443 additional fixes

### DIFF
--- a/packages/api/src/external/fhir/references/get-references.ts
+++ b/packages/api/src/external/fhir/references/get-references.ts
@@ -17,7 +17,7 @@ export async function getReferencesFromFHIR(
   const chunks = Object.values(refByType).flatMap(r => chunk(r, MAX_IDS_PER_REQUEST));
   // transform the chunks into array of resource type and ids for each chunk
   const consolidated: { type: ResourceType; ids: string[] }[] = chunks.flatMap(chunk => {
-    const type = chunk[0].type as ResourceType | undefined;
+    const type = chunk[0]?.type as ResourceType | undefined;
     const ids = chunk.flatMap(c => c.id ?? []);
     if (!type || ids.length <= 0) return [];
     return { type, ids };

--- a/packages/infra/lib/shared/sqs.ts
+++ b/packages/infra/lib/shared/sqs.ts
@@ -7,7 +7,7 @@ import { ILayerVersion } from "aws-cdk-lib/aws-lambda";
 import { IQueue, Queue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs/lib/construct";
 import { EnvType } from "../env-type";
-import { DEFAULT_LAMBDA_TIMEOUT, createRetryLambda } from "./lambda";
+import { createRetryLambda, DEFAULT_LAMBDA_TIMEOUT } from "./lambda";
 
 /**
  * ...set the source queue's visibility timeout to at least six times the timeout that
@@ -21,6 +21,8 @@ import { DEFAULT_LAMBDA_TIMEOUT, createRetryLambda } from "./lambda";
  * throttled lambda is about to keep processing it after its unthrottled.
  */
 const DEFAULT_VISIBILITY_TIMEOUT_MULTIPLIER = 6;
+
+const DEFAULT_MAX_RECEIVE_COUNT = 5;
 
 export type QueueProps = (StandardQueueProps | FifoQueueProps) & {
   dlq?: never;
@@ -105,7 +107,9 @@ function createStandardQueue(props: StandardQueueProps): Queue {
     deadLetterQueue: props.dlq
       ? {
           maxReceiveCount:
-            props.maxReceiveCount && props.maxReceiveCount > 0 ? props.maxReceiveCount : 1,
+            props.maxReceiveCount && props.maxReceiveCount > 0
+              ? props.maxReceiveCount
+              : DEFAULT_MAX_RECEIVE_COUNT,
           queue: props.dlq,
         }
       : undefined,
@@ -133,7 +137,9 @@ function createFifoQueue(props: FifoQueueProps): Queue {
     deadLetterQueue: props.dlq
       ? {
           maxReceiveCount:
-            props.maxReceiveCount && props.maxReceiveCount > 0 ? props.maxReceiveCount : 1,
+            props.maxReceiveCount && props.maxReceiveCount > 0
+              ? props.maxReceiveCount
+              : DEFAULT_MAX_RECEIVE_COUNT,
           queue: props.dlq,
         }
       : undefined,


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1143

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1518
- Downstream: https://github.com/metriport/metriport/pull/1522

### Description

- SQS' default `maxReceiveCount` from 1 to 5 - [why](https://docs.aws.amazon.com/lambda/latest/operatorguide/sqs-retries.html#:~:text=Set%20the%20maxReceiveCount%20on%20the%20source%20queue%E2%80%99s%20redrive%20policy%20to%20at%20least%205.%20This%20improves%20the%20chances%20of%20messages%20being%20processed%20before%20reaching%20the%20DLQ.)
   - we override this in all queues we create, so there shouldn't be any impact
- couple small warning fixes 

### Testing

- Local
  - none
- Staging
  - [ ] test the flow with messages going through SQS
- Production
  - [ ] monitor SQS/app flow for a few minutes w/ messages being processed

### Release Plan

- nothing special