### PR TITLE
feat(api): add waf

### DIFF
--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -13,7 +13,6 @@ import * as r53 from "aws-cdk-lib/aws-route53";
 import * as r53_targets from "aws-cdk-lib/aws-route53-targets";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
-import { aws_wafv2 as wafv2 } from "aws-cdk-lib";
 import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
 import { IQueue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
@@ -22,7 +21,6 @@ import { DnsZones } from "../shared/dns";
 import { Secrets, secretsToECS } from "../shared/secrets";
 import { provideAccessToQueue } from "../shared/sqs";
 import { isProd } from "../shared/util";
-import { wafRules } from "../shared/waf-rules";
 
 interface ApiServiceProps extends StackProps {
   config: EnvConfig;
@@ -77,19 +75,6 @@ export function createAPIService(
   new CfnOutput(stack, "APIECRRepoURI", {
     description: "API ECR repository URI",
     value: ecrRepo.repositoryUri,
-  });
-
-  // Web application firewall for enhanced security
-  const waf = new wafv2.CfnWebACL(stack, "APIWAF", {
-    defaultAction: { allow: {} },
-    scope: "REGIONAL",
-    name: `APIWAF`,
-    rules: wafRules,
-    visibilityConfig: {
-      cloudWatchMetricsEnabled: true,
-      metricName: `APIWAF-Metric`,
-      sampledRequestsEnabled: false,
-    },
   });
 
   const connectWidgetUrlEnvVar =
@@ -202,12 +187,6 @@ export function createAPIService(
     target: r53.RecordTarget.fromAlias(
       new r53_targets.LoadBalancerTarget(fargateService.loadBalancer)
     ),
-  });
-
-  // Hookup the LB to the WAF
-  new wafv2.CfnWebACLAssociation(stack, "APIWAFLBAssociation", {
-    resourceArn: fargateService.loadBalancer.loadBalancerArn,
-    webAclArn: waf.attrArn,
   });
 
   // Access grant for Aurora DB's secret

--- a/packages/infra/lib/shared/waf-rules.ts
+++ b/packages/infra/lib/shared/waf-rules.ts
@@ -1,71 +1,19 @@
-// Based on https://gist.github.com/statik/f1ac9d6227d98d30c7a7cec0c83f4e64
-
 import { aws_wafv2 as wafv2 } from "aws-cdk-lib";
 
 export const wafRules: wafv2.CfnWebACL.RuleProperty[] = [
-  // Common Rule Set aligns with major portions of OWASP Core Rule Set
-  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html
+  // AWS IP Reputation list includes known malicious actors/bots and is regularly updated.
+  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-ip-rep.html#aws-managed-rule-groups-ip-rep-amazon
   {
-    name: "AWS-AWSManagedRulesCommonRuleSet",
+    name: "AWS-AWSManagedRulesAmazonIpReputationList",
     priority: 10,
     statement: {
       managedRuleGroupStatement: {
         vendorName: "AWS",
-        name: "AWSManagedRulesCommonRuleSet",
-        // Excluding generic RFI body rule for sns notifications
-        // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html
-        excludedRules: [
-          { name: "NoUserAgent_HEADER" },
-          { name: "UserAgent_BadBots_HEADER" },
-          { name: "SizeRestrictions_QUERYSTRING" },
-          { name: "SizeRestrictions_Cookie_HEADER" },
-          { name: "SizeRestrictions_BODY" },
-          { name: "SizeRestrictions_URIPATH" },
-          { name: "EC2MetaDataSSRF_BODY" },
-          { name: "EC2MetaDataSSRF_COOKIE" },
-          { name: "EC2MetaDataSSRF_URIPATH" },
-          { name: "EC2MetaDataSSRF_QUERYARGUMENTS" },
-          { name: "GenericLFI_QUERYARGUMENTS" },
-          { name: "GenericLFI_URIPATH" },
-          { name: "GenericLFI_BODY" },
-          { name: "RestrictedExtensions_URIPATH" },
-          { name: "RestrictedExtensions_QUERYARGUMENTS" },
-          { name: "GenericRFI_QUERYARGUMENTS" },
-          { name: "GenericRFI_BODY" },
-          { name: "GenericRFI_URIPATH" },
-          { name: "CrossSiteScripting_COOKIE" },
-          { name: "CrossSiteScripting_QUERYARGUMENTS" },
-          { name: "CrossSiteScripting_BODY" },
-          { name: "CrossSiteScripting_URIPATH" },
-        ],
-      },
-    },
-    overrideAction: {
-      count: {},
-    },
-    visibilityConfig: {
-      sampledRequestsEnabled: true,
-      cloudWatchMetricsEnabled: true,
-      metricName: "AWS-AWSManagedRulesCommonRuleSet",
-    },
-  },
-  // AWS IP Reputation list includes known malicious actors/bots and is regularly updated
-  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-ip-rep.html
-  {
-    name: "AWS-AWSManagedRulesAmazonIpReputationList",
-    priority: 20,
-    statement: {
-      managedRuleGroupStatement: {
-        vendorName: "AWS",
         name: "AWSManagedRulesAmazonIpReputationList",
-        excludedRules: [
-          { name: "AWSManagedIPReputationList" },
-          { name: "AWSManagedReconnaissanceList" },
-        ],
       },
     },
     overrideAction: {
-      count: {},
+      none: {},
     },
     visibilityConfig: {
       sampledRequestsEnabled: true,
@@ -73,56 +21,156 @@ export const wafRules: wafv2.CfnWebACL.RuleProperty[] = [
       metricName: "AWSManagedRulesAmazonIpReputationList",
     },
   },
+  // Blocks requests from services that permit the obfuscation of viewer identity. These include requests from VPNs, proxies, Tor nodes, and web hosting providers.
+  {
+    name: "AWS-AWSManagedRulesAnonymousIpList",
+    priority: 15,
+    statement: {
+      managedRuleGroupStatement: {
+        vendorName: "AWS",
+        name: "AWSManagedRulesAnonymousIpList",
+        excludedRules: [
+          { name: "HostingProviderIPList" }, // Excluding block of IP addresses from web hosting and cloud providers - as we traffic could come from hosted solutions.
+        ],
+      },
+    },
+    overrideAction: {
+      none: {},
+    },
+    visibilityConfig: {
+      sampledRequestsEnabled: true,
+      cloudWatchMetricsEnabled: true,
+      metricName: "AWS-AWSManagedRulesAnonymousIpList",
+    },
+  },
+  // Common Rule Set aligns with major portions of OWASP Core Rule Set
+  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html
+  {
+    name: "AWS-AWSManagedRulesCommonRuleSet",
+    priority: 20,
+    statement: {
+      managedRuleGroupStatement: {
+        vendorName: "AWS",
+        name: "AWSManagedRulesCommonRuleSet",
+        excludedRules: [
+          { name: "GenericRFI_BODY" }, // Excluding generic RFI body rule for things like webhook URLs - SSRF handled internally
+          { name: "SizeRestrictions_BODY" }, // Excluding generic size body rule for lar - limits handled internally
+          { name: "NoUserAgent_HEADER" }, // Excluding the block for the HTTP User-Agent header missing - TODO: alert customers before putting this block in
+        ],
+      },
+    },
+    overrideAction: {
+      none: {},
+    },
+    visibilityConfig: {
+      sampledRequestsEnabled: true,
+      cloudWatchMetricsEnabled: true,
+      metricName: "AWS-AWSManagedRulesCommonRuleSet",
+    },
+  },
+  // Blocks external access to exposed administrative pages.
+  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-admin
+  {
+    name: "AWS-AWSManagedRulesAdminProtectionRuleSet",
+    priority: 30,
+    statement: {
+      managedRuleGroupStatement: {
+        vendorName: "AWS",
+        name: "AWSManagedRulesAdminProtectionRuleSet",
+        excludedRules: [],
+      },
+    },
+    overrideAction: {
+      none: {},
+    },
+    visibilityConfig: {
+      sampledRequestsEnabled: true,
+      cloudWatchMetricsEnabled: true,
+      metricName: "AWS-AWSManagedRulesAdminProtectionRuleSet",
+    },
+  },
+  // Blocks request patterns that are known to be invalid and are associated with exploitation or discovery of vulnerabilities.
+  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-admin
+  {
+    name: "AWS-AWSManagedRulesKnownBadInputsRuleSet",
+    priority: 40,
+    statement: {
+      managedRuleGroupStatement: {
+        vendorName: "AWS",
+        name: "AWSManagedRulesKnownBadInputsRuleSet",
+        excludedRules: [],
+      },
+    },
+    overrideAction: {
+      none: {},
+    },
+    visibilityConfig: {
+      sampledRequestsEnabled: true,
+      cloudWatchMetricsEnabled: true,
+      metricName: "AWS-AWSManagedRulesKnownBadInputsRuleSet",
+    },
+  },
   // Blocks common SQL Injection
   // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   {
-    name: "AWSManagedRulesSQLiRuleSet",
-    priority: 30,
+    name: "AWS-AWSManagedRulesSQLiRuleSet",
+    priority: 50,
     visibilityConfig: {
       sampledRequestsEnabled: true,
       cloudWatchMetricsEnabled: true,
       metricName: "AWSManagedRulesSQLiRuleSet",
     },
     overrideAction: {
-      count: {},
+      none: {},
     },
     statement: {
       managedRuleGroupStatement: {
         vendorName: "AWS",
-        name: "AWSManagedRulesSQLiRuleSet",
-        excludedRules: [
-          { name: "SQLi_QUERYARGUMENTS" },
-          { name: "SQLiExtendedPatterns_QUERYARGUMENTS" },
-          { name: "SQLi_BODY" },
-          { name: "SQLiExtendedPatterns_BODY" },
-          { name: "SQLi_COOKIE" },
-          { name: "SQLi_URIPATH" },
-        ],
+        name: "AWS-AWSManagedRulesSQLiRuleSet",
+        excludedRules: [],
       },
     },
   },
-  // Blocks attacks targeting LFI(Local File Injection) for linux systems
+  // Blocks attacks targeting LFI (Local File Injection) for Linux systems.
   // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-linux-os
   {
-    name: "AWSManagedRuleLinux",
-    priority: 40,
+    name: "AWS-AWSManagedRuleLinux",
+    priority: 60,
     visibilityConfig: {
       sampledRequestsEnabled: true,
       cloudWatchMetricsEnabled: true,
       metricName: "AWSManagedRuleLinux",
     },
     overrideAction: {
-      count: {},
+      none: {},
     },
     statement: {
       managedRuleGroupStatement: {
         vendorName: "AWS",
-        name: "AWSManagedRulesLinuxRuleSet",
-        excludedRules: [
-          { name: "LFI_URIPATH" },
-          { name: "LFI_QUERYSTRING" },
-          { name: "LFI_COOKIE" },
-        ],
+        name: "AWS-AWSManagedRulesLinuxRuleSet",
+        excludedRules: [],
+      },
+    },
+  },
+  // Blocks request patterns associated with the exploitation of vulnerabilities specific to POSIX and POSIX-like operating systems;
+  // including, but not limited to: Linux, AIX, HP-UX, macOS, Solaris, FreeBSD, and OpenBSD.
+  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-linux-os
+  {
+    name: "AWS-AWSManagedRulesUnixRuleSet",
+    priority: 70,
+    visibilityConfig: {
+      sampledRequestsEnabled: true,
+      cloudWatchMetricsEnabled: true,
+      metricName: "AWSManagedRulesUnixRuleSet",
+    },
+    overrideAction: {
+      none: {},
+    },
+    statement: {
+      managedRuleGroupStatement: {
+        vendorName: "AWS",
+        name: "AWS-AWSManagedRulesUnixRulesSet",
+        excludedRules: [],
       },
     },
   },

--- a/packages/infra/lib/shared/waf-rules.ts
+++ b/packages/infra/lib/shared/waf-rules.ts
@@ -116,20 +116,20 @@ export const wafRules: wafv2.CfnWebACL.RuleProperty[] = [
   {
     name: "AWS-AWSManagedRulesSQLiRuleSet",
     priority: 50,
-    visibilityConfig: {
-      sampledRequestsEnabled: true,
-      cloudWatchMetricsEnabled: true,
-      metricName: "AWSManagedRulesSQLiRuleSet",
+    statement: {
+      managedRuleGroupStatement: {
+        vendorName: "AWS",
+        name: "AWSManagedRulesSQLiRuleSet",
+        excludedRules: [],
+      },
     },
     overrideAction: {
       none: {},
     },
-    statement: {
-      managedRuleGroupStatement: {
-        vendorName: "AWS",
-        name: "AWS-AWSManagedRulesSQLiRuleSet",
-        excludedRules: [],
-      },
+    visibilityConfig: {
+      sampledRequestsEnabled: true,
+      cloudWatchMetricsEnabled: true,
+      metricName: "AWS-AWSManagedRulesSQLiRuleSet",
     },
   },
   // Blocks attacks targeting LFI (Local File Injection) for Linux systems.
@@ -137,20 +137,20 @@ export const wafRules: wafv2.CfnWebACL.RuleProperty[] = [
   {
     name: "AWS-AWSManagedRulesLinuxRuleSet",
     priority: 60,
-    visibilityConfig: {
-      sampledRequestsEnabled: true,
-      cloudWatchMetricsEnabled: true,
-      metricName: "AWSManagedRulesLinuxRuleSet",
+    statement: {
+      managedRuleGroupStatement: {
+        vendorName: "AWS",
+        name: "AWSManagedRulesLinuxRuleSet",
+        excludedRules: [],
+      },
     },
     overrideAction: {
       none: {},
     },
-    statement: {
-      managedRuleGroupStatement: {
-        vendorName: "AWS",
-        name: "AWS-AWSManagedRulesLinuxRuleSet",
-        excludedRules: [],
-      },
+    visibilityConfig: {
+      sampledRequestsEnabled: true,
+      cloudWatchMetricsEnabled: true,
+      metricName: "AWS-AWSManagedRulesLinuxRuleSet",
     },
   },
   // Blocks request patterns associated with the exploitation of vulnerabilities specific to POSIX and POSIX-like operating systems;
@@ -159,20 +159,20 @@ export const wafRules: wafv2.CfnWebACL.RuleProperty[] = [
   {
     name: "AWS-AWSManagedRulesUnixRuleSet",
     priority: 70,
-    visibilityConfig: {
-      sampledRequestsEnabled: true,
-      cloudWatchMetricsEnabled: true,
-      metricName: "AWSManagedRulesUnixRuleSet",
+    statement: {
+      managedRuleGroupStatement: {
+        vendorName: "AWS",
+        name: "AWSManagedRulesUnixRuleSet",
+        excludedRules: [],
+      },
     },
     overrideAction: {
       none: {},
     },
-    statement: {
-      managedRuleGroupStatement: {
-        vendorName: "AWS",
-        name: "AWS-AWSManagedRulesUnixRulesSet",
-        excludedRules: [],
-      },
+    visibilityConfig: {
+      sampledRequestsEnabled: true,
+      cloudWatchMetricsEnabled: true,
+      metricName: "AWS-AWSManagedRulesUnixRuleSet",
     },
   },
 ];

--- a/packages/infra/lib/shared/waf-rules.ts
+++ b/packages/infra/lib/shared/waf-rules.ts
@@ -1,0 +1,129 @@
+// Based on https://gist.github.com/statik/f1ac9d6227d98d30c7a7cec0c83f4e64
+
+import { aws_wafv2 as wafv2 } from "aws-cdk-lib";
+
+export const wafRules: wafv2.CfnWebACL.RuleProperty[] = [
+  // Common Rule Set aligns with major portions of OWASP Core Rule Set
+  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html
+  {
+    name: "AWS-AWSManagedRulesCommonRuleSet",
+    priority: 10,
+    statement: {
+      managedRuleGroupStatement: {
+        vendorName: "AWS",
+        name: "AWSManagedRulesCommonRuleSet",
+        // Excluding generic RFI body rule for sns notifications
+        // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html
+        excludedRules: [
+          { name: "NoUserAgent_HEADER" },
+          { name: "UserAgent_BadBots_HEADER" },
+          { name: "SizeRestrictions_QUERYSTRING" },
+          { name: "SizeRestrictions_Cookie_HEADER" },
+          { name: "SizeRestrictions_BODY" },
+          { name: "SizeRestrictions_URIPATH" },
+          { name: "EC2MetaDataSSRF_BODY" },
+          { name: "EC2MetaDataSSRF_COOKIE" },
+          { name: "EC2MetaDataSSRF_URIPATH" },
+          { name: "EC2MetaDataSSRF_QUERYARGUMENTS" },
+          { name: "GenericLFI_QUERYARGUMENTS" },
+          { name: "GenericLFI_URIPATH" },
+          { name: "GenericLFI_BODY" },
+          { name: "RestrictedExtensions_URIPATH" },
+          { name: "RestrictedExtensions_QUERYARGUMENTS" },
+          { name: "GenericRFI_QUERYARGUMENTS" },
+          { name: "GenericRFI_BODY" },
+          { name: "GenericRFI_URIPATH" },
+          { name: "CrossSiteScripting_COOKIE" },
+          { name: "CrossSiteScripting_QUERYARGUMENTS" },
+          { name: "CrossSiteScripting_BODY" },
+          { name: "CrossSiteScripting_URIPATH" },
+        ],
+      },
+    },
+    overrideAction: {
+      count: {},
+    },
+    visibilityConfig: {
+      sampledRequestsEnabled: true,
+      cloudWatchMetricsEnabled: true,
+      metricName: "AWS-AWSManagedRulesCommonRuleSet",
+    },
+  },
+  // AWS IP Reputation list includes known malicious actors/bots and is regularly updated
+  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-ip-rep.html
+  {
+    name: "AWS-AWSManagedRulesAmazonIpReputationList",
+    priority: 20,
+    statement: {
+      managedRuleGroupStatement: {
+        vendorName: "AWS",
+        name: "AWSManagedRulesAmazonIpReputationList",
+        excludedRules: [
+          { name: "AWSManagedIPReputationList" },
+          { name: "AWSManagedReconnaissanceList" },
+        ],
+      },
+    },
+    overrideAction: {
+      count: {},
+    },
+    visibilityConfig: {
+      sampledRequestsEnabled: true,
+      cloudWatchMetricsEnabled: true,
+      metricName: "AWSManagedRulesAmazonIpReputationList",
+    },
+  },
+  // Blocks common SQL Injection
+  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
+  {
+    name: "AWSManagedRulesSQLiRuleSet",
+    priority: 30,
+    visibilityConfig: {
+      sampledRequestsEnabled: true,
+      cloudWatchMetricsEnabled: true,
+      metricName: "AWSManagedRulesSQLiRuleSet",
+    },
+    overrideAction: {
+      count: {},
+    },
+    statement: {
+      managedRuleGroupStatement: {
+        vendorName: "AWS",
+        name: "AWSManagedRulesSQLiRuleSet",
+        excludedRules: [
+          { name: "SQLi_QUERYARGUMENTS" },
+          { name: "SQLiExtendedPatterns_QUERYARGUMENTS" },
+          { name: "SQLi_BODY" },
+          { name: "SQLiExtendedPatterns_BODY" },
+          { name: "SQLi_COOKIE" },
+          { name: "SQLi_URIPATH" },
+        ],
+      },
+    },
+  },
+  // Blocks attacks targeting LFI(Local File Injection) for linux systems
+  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-linux-os
+  {
+    name: "AWSManagedRuleLinux",
+    priority: 40,
+    visibilityConfig: {
+      sampledRequestsEnabled: true,
+      cloudWatchMetricsEnabled: true,
+      metricName: "AWSManagedRuleLinux",
+    },
+    overrideAction: {
+      count: {},
+    },
+    statement: {
+      managedRuleGroupStatement: {
+        vendorName: "AWS",
+        name: "AWSManagedRulesLinuxRuleSet",
+        excludedRules: [
+          { name: "LFI_URIPATH" },
+          { name: "LFI_QUERYSTRING" },
+          { name: "LFI_COOKIE" },
+        ],
+      },
+    },
+  },
+];

--- a/packages/infra/lib/shared/waf-rules.ts
+++ b/packages/infra/lib/shared/waf-rules.ts
@@ -22,6 +22,7 @@ export const wafRules: wafv2.CfnWebACL.RuleProperty[] = [
     },
   },
   // Blocks requests from services that permit the obfuscation of viewer identity. These include requests from VPNs, proxies, Tor nodes, and web hosting providers.
+  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-ip-rep.html#aws-managed-rule-groups-ip-rep-anonymous
   {
     name: "AWS-AWSManagedRulesAnonymousIpList",
     priority: 15,
@@ -134,12 +135,12 @@ export const wafRules: wafv2.CfnWebACL.RuleProperty[] = [
   // Blocks attacks targeting LFI (Local File Injection) for Linux systems.
   // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-linux-os
   {
-    name: "AWS-AWSManagedRuleLinux",
+    name: "AWS-AWSManagedRulesLinuxRuleSet",
     priority: 60,
     visibilityConfig: {
       sampledRequestsEnabled: true,
       cloudWatchMetricsEnabled: true,
-      metricName: "AWSManagedRuleLinux",
+      metricName: "AWSManagedRulesLinuxRuleSet",
     },
     overrideAction: {
       none: {},


### PR DESCRIPTION
refs. metriport/metriport#1525


### Dependencies

N/A

### Description

Adds a WAF to the API for enhanced security.

### Testing


- Staging
  - [x] deploy and validate that we can still make API calls
- Sandbox
  - [ ] deploy and validate that we can still make API calls
- Production
  - [ ] deploy and validate that we can still make API calls


### Release Plan

- [ ] Merge this
