### PR TITLE
1040 Miscellaneous improvements/fixes

### DIFF
--- a/packages/api/src/command/medical/docref-mapping/remove-docref-mapping.ts
+++ b/packages/api/src/command/medical/docref-mapping/remove-docref-mapping.ts
@@ -1,0 +1,13 @@
+import { DocRefMappingModel } from "../../../models/medical/docref-mapping";
+
+export const removeDocRefMapping = async ({
+  cxId,
+  docRefMappingId,
+}: {
+  cxId: string;
+  docRefMappingId: string;
+}): Promise<number> => {
+  const docRef = { cxId, id: docRefMappingId };
+  const res = await DocRefMappingModel.destroy({ where: docRef });
+  return res;
+};

--- a/packages/api/src/command/medical/document/__tests__/document-query.test.ts
+++ b/packages/api/src/command/medical/document/__tests__/document-query.test.ts
@@ -1,30 +1,17 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import * as uuidv7_file from "@metriport/core/util/uuid-v7";
 import { makeDocumentQueryProgress } from "../../../../domain/medical/__tests__/document-query";
-import { makePatient } from "../../../../domain/medical/__tests__/patient";
 import { PatientModel } from "../../../../models/medical/patient";
-import { makePatientModel } from "../../../../models/medical/__tests__/patient";
 import { mockStartTransaction } from "../../../../models/__tests__/transaction";
-import * as docQueryProgress from "../../patient/append-doc-query-progress";
-import * as docQuery from "../document-query";
-import { getOrGenerateRequestId, updateDocQuery } from "../document-query";
+import { getOrGenerateRequestId } from "../document-query";
 import * as whMedical from "../document-webhook";
 
-const patientModel = makePatientModel();
-let docQuery_updateConversionProgress: jest.SpyInstance;
-let appendDocQueryProgress_mock: jest.SpyInstance;
 let uuidv7_mock: jest.SpyInstance;
 
 beforeEach(() => {
   jest.restoreAllMocks();
   mockStartTransaction();
   jest.spyOn(PatientModel, "findOne");
-  docQuery_updateConversionProgress = jest
-    .spyOn(docQuery, "updateConversionProgress")
-    .mockImplementation(async () => patientModel);
-  appendDocQueryProgress_mock = jest
-    .spyOn(docQueryProgress, "appendDocQueryProgress")
-    .mockImplementation(async () => patientModel);
   jest.spyOn(whMedical, "processPatientDocumentRequest").mockImplementation(async () => {});
   uuidv7_mock = jest.spyOn(uuidv7_file, "uuidv7");
 });
@@ -35,39 +22,7 @@ describe("document-query", () => {
       // TODO 785 IMPLEMENT IT
     });
   });
-  describe("updateDocQuery", () => {
-    describe("updateConversionProgress", () => {
-      it(`Calls updateConversionProgress when convertResult is present`, async () => {
-        const patient = makePatient();
-        await updateDocQuery({ patient, convertResult: "success" });
-        expect(docQuery_updateConversionProgress).toHaveBeenCalled();
-      });
-      // TODO check params are passed to updateConversionProgress
-      it(`return result of updateConversionProgress`, async () => {
-        const patient = makePatient();
-        const res = await updateDocQuery({ patient, convertResult: "success" });
-        expect(res).toEqual(patientModel);
-      });
-    });
-    describe("appendDocQueryProgress", () => {
-      const requestId = uuidv7_file.uuidv4();
 
-      it(`Calls appendDocQueryProgress when convertResult is not present`, async () => {
-        const patient = makePatient();
-        await updateDocQuery({ patient, requestId, convertProgress: { status: "processing" } });
-        expect(appendDocQueryProgress_mock).toHaveBeenCalled();
-      });
-      it(`return result of appendDocQueryProgress`, async () => {
-        const patient = makePatient();
-        const res = await updateDocQuery({
-          patient,
-          requestId,
-          convertProgress: { status: "processing" },
-        });
-        expect(res).toEqual(patientModel);
-      });
-    });
-  });
   describe("getOrGenerateRequestId", () => {
     afterEach(() => {
       uuidv7_mock.mockRestore();

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -1,7 +1,3 @@
-import { uuidv7 } from "@metriport/core/util/uuid-v7";
-import { emptyFunction } from "@metriport/shared";
-import { MedicalDataSource } from "@metriport/core/external/index";
-import { calculateConversionProgress } from "../../../domain/medical/conversion-progress";
 import {
   ConvertResult,
   DocumentQueryProgress,
@@ -9,17 +5,20 @@ import {
   Progress,
 } from "@metriport/core/domain/document-query";
 import { Patient } from "@metriport/core/domain/patient";
+import { MedicalDataSource } from "@metriport/core/external/index";
+import { uuidv7 } from "@metriport/core/util/uuid-v7";
+import { emptyFunction } from "@metriport/shared";
+import { calculateConversionProgress } from "../../../domain/medical/conversion-progress";
 import { validateOptionalFacilityId } from "../../../domain/medical/patient-facility";
+import { getDocumentsFromCQ } from "../../../external/carequality/document/query-documents";
 import { queryAndProcessDocuments as getDocumentsFromCW } from "../../../external/commonwell/document/document-query";
+import { appendDocQueryProgressWithSource } from "../../../external/hie/append-doc-query-progress-with-source";
 import { PatientModel } from "../../../models/medical/patient";
 import { executeOnDBTx } from "../../../models/transaction-wrapper";
 import { Util } from "../../../shared/util";
-import { appendDocQueryProgress, SetDocQueryProgress } from "../patient/append-doc-query-progress";
 import { getPatientOrFail } from "../patient/get-patient";
 import { storeQueryInit } from "../patient/query-init";
 import { areDocumentsProcessing } from "./document-status";
-import { getDocumentsFromCQ } from "../../../external/carequality/document/query-documents";
-import { appendDocQueryProgressWithSource } from "../../../external/hie/append-doc-query-progress-with-source";
 
 export function isProgressEqual(a?: Progress, b?: Progress): boolean {
   return (
@@ -115,24 +114,6 @@ type UpdateResult = {
   patient: Pick<Patient, "id" | "cxId">;
   convertResult: ConvertResult;
 };
-
-type UpdateDocQueryParams =
-  | (SetDocQueryProgress & { convertResult?: never })
-  | (UpdateResult & {
-      downloadProgress?: never;
-      convertProgress?: never;
-      reset?: never;
-    });
-
-/**
- * @deprecated - call appendDocQueryProgress or updateConversionProgress directly
- */
-export async function updateDocQuery(params: UpdateDocQueryParams): Promise<Patient> {
-  if (params.convertResult) {
-    return updateConversionProgress(params);
-  }
-  return appendDocQueryProgress(params);
-}
 
 export const updateConversionProgress = async ({
   patient,

--- a/packages/api/src/external/commonwell/cw-fhir-proxy.ts
+++ b/packages/api/src/external/commonwell/cw-fhir-proxy.ts
@@ -111,7 +111,7 @@ export async function userResDecorator(
       payload.total = payload.entry?.length != null ? payload.entry.length : undefined;
     }
     const response = JSON.stringify(payload);
-    log(`Responing to CW (cxPatientId ${cxPatientId}): ${response}`);
+    log(`Responding to CW (cxPatientId ${cxPatientId}): ${response}`);
     return response;
   } catch (err) {
     log(`Error parsing/transforming response: `, err);

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -414,7 +414,7 @@ function addMetriportDocRefId({
  * CW for them (optional) - defaults to `false`
  * @returns Document References as they were stored on the FHIR server
  */
-export async function downloadDocsAndUpsertFHIR({
+async function downloadDocsAndUpsertFHIR({
   patient,
   facilityId,
   documents,

--- a/packages/api/src/external/fhir/connector/connector-sqs.ts
+++ b/packages/api/src/external/fhir/connector/connector-sqs.ts
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { Config } from "../../../shared/config";
 import { sendMessageToQueue } from "../../aws/sqs";
-import { FHIRServerConnector, FHIRServerRequest } from "./connector";
+import { FHIRServerConnector, FHIRServerRequest, makeJobId } from "./connector";
 
 dayjs.extend(utc);
 
@@ -20,7 +20,7 @@ export class FHIRServerConnectorSQS implements FHIRServerConnector {
       messageAttributes: {
         cxId,
         patientId,
-        jobId: `${requestId}_${documentId}`,
+        jobId: makeJobId(requestId, documentId),
         startedAt: dayjs.utc().toISOString(),
       },
     });

--- a/packages/api/src/external/fhir/connector/connector-sqs.ts
+++ b/packages/api/src/external/fhir/connector/connector-sqs.ts
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { Config } from "../../../shared/config";
 import { sendMessageToQueue } from "../../aws/sqs";
-import { FHIRServerConnector, FHIRServerRequest, makeJobId } from "./connector";
+import { FHIRServerConnector, FHIRServerRequest, createJobId } from "./connector";
 
 dayjs.extend(utc);
 
@@ -20,7 +20,7 @@ export class FHIRServerConnectorSQS implements FHIRServerConnector {
       messageAttributes: {
         cxId,
         patientId,
-        jobId: makeJobId(requestId, documentId),
+        jobId: createJobId(requestId, documentId),
         startedAt: dayjs.utc().toISOString(),
       },
     });

--- a/packages/api/src/external/fhir/connector/connector.ts
+++ b/packages/api/src/external/fhir/connector/connector.ts
@@ -9,3 +9,16 @@ export type FHIRServerRequest = {
 export interface FHIRServerConnector {
   upsertBatch(req: FHIRServerRequest): Promise<void>;
 }
+
+// TODO try to make `requestId` required
+export function makeJobId(requestId: string | undefined, documentId: string): string {
+  return `${requestId}_${documentId}`;
+}
+
+export function decomposeJobId(
+  jobId?: string
+): { requestId?: string; documentId?: string } | undefined {
+  if (!jobId) return undefined;
+  const [requestId, documentId] = jobId.split("_");
+  return { requestId, documentId };
+}

--- a/packages/api/src/external/fhir/connector/connector.ts
+++ b/packages/api/src/external/fhir/connector/connector.ts
@@ -11,11 +11,11 @@ export interface FHIRServerConnector {
 }
 
 // TODO try to make `requestId` required
-export function makeJobId(requestId: string | undefined, documentId: string): string {
+export function createJobId(requestId: string | undefined, documentId: string): string {
   return `${requestId}_${documentId}`;
 }
 
-export function decomposeJobId(
+export function parseJobId(
   jobId?: string
 ): { requestId?: string; documentId?: string } | undefined {
   if (!jobId) return undefined;

--- a/packages/api/src/routes/helpers/request-logger.ts
+++ b/packages/api/src/routes/helpers/request-logger.ts
@@ -1,37 +1,42 @@
 import { NextFunction, Request, Response } from "express";
 import { nanoid } from "nanoid";
+import { getLocalStorage } from "@metriport/core/util/local-storage";
 import { analyzeRoute } from "./request-analytics";
+
+const asyncLocalStorage = getLocalStorage("reqId");
 
 export const requestLogger = (req: Request, res: Response, next: NextFunction): void => {
   const reqId = nanoid();
-  const method = req.method;
-  const url = req.baseUrl + req.path;
-  const query = req.query && Object.keys(req.query).length ? req.query : undefined;
-  const params = req.params && Object.keys(req.params).length ? req.params : undefined;
-  console.log(
-    "%s ..........Begins %s %s %s %s",
-    reqId,
-    method,
-    url,
-    toString(params),
-    toString(query)
-  );
-  const startHrTime = process.hrtime();
-  res.on("close", () => {
-    const elapsedHrTime = process.hrtime(startHrTime);
-    const elapsedTimeInMs = elapsedHrTime[0] * 1000 + elapsedHrTime[1] / 1e6;
+  asyncLocalStorage.run(reqId, () => {
+    const method = req.method;
+    const url = req.baseUrl + req.path;
+    const query = req.query && Object.keys(req.query).length ? req.query : undefined;
+    const params = req.params && Object.keys(req.params).length ? req.params : undefined;
     console.log(
-      "%s ..........Done %s %s | %d | %fms",
+      "%s ..........Begins %s %s %s %s",
       reqId,
       method,
       url,
-      res.statusCode,
-      elapsedTimeInMs
+      toString(params),
+      toString(query)
     );
+    const startHrTime = process.hrtime();
+    res.on("close", () => {
+      const elapsedHrTime = process.hrtime(startHrTime);
+      const elapsedTimeInMs = elapsedHrTime[0] * 1000 + elapsedHrTime[1] / 1e6;
+      console.log(
+        "%s ..........Done %s %s | %d | %fms",
+        reqId,
+        method,
+        url,
+        res.statusCode,
+        elapsedTimeInMs
+      );
 
-    analyzeRoute({ req, method, url, duration: elapsedTimeInMs });
+      analyzeRoute({ req, method, url, duration: elapsedTimeInMs });
+    });
+    next();
   });
-  next();
 };
 
 function toString(obj: unknown): string {

--- a/packages/api/src/routes/medical/internal-docs.ts
+++ b/packages/api/src/routes/medical/internal-docs.ts
@@ -31,7 +31,7 @@ import { appendDocQueryProgress } from "../../command/medical/patient/append-doc
 import { appendBulkGetDocUrlProgress } from "../../command/medical/patient/bulk-get-doc-url-progress";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
 import BadRequestError from "../../errors/bad-request";
-import { decomposeJobId } from "../../external/fhir/connector/connector";
+import { parseJobId } from "../../external/fhir/connector/connector";
 import { appendDocQueryProgressWithSource } from "../../external/hie/append-doc-query-progress-with-source";
 import { updateSourceConversionProgress } from "../../external/hie/update-source-conversion-progress";
 import { Config } from "../../shared/config";
@@ -140,7 +140,7 @@ router.post(
 
     // keeping the old logic for now, but we should avoid having these optional parameters that can
     // lead to empty string or `undefined` being used as IDs
-    const decomposed = jobId ? decomposeJobId(jobId) : { requestId: "", documentId: "" };
+    const decomposed = jobId ? parseJobId(jobId) : { requestId: "", documentId: "" };
     const requestId = decomposed?.requestId ?? "";
     const docId = decomposed?.documentId ?? "";
     const hasSource = isMedicalDataSource(source);

--- a/packages/api/src/routes/medical/internal-patient.ts
+++ b/packages/api/src/routes/medical/internal-patient.ts
@@ -17,8 +17,8 @@ import { deletePatient } from "../../command/medical/patient/delete-patient";
 import {
   getPatientIds,
   getPatientOrFail,
-  getPatientStates,
   getPatients,
+  getPatientStates,
 } from "../../command/medical/patient/get-patient";
 import { PatientUpdateCmd, updatePatient } from "../../command/medical/patient/update-patient";
 import { getFacilityIdOrFail } from "../../domain/medical/patient-facility";
@@ -51,7 +51,7 @@ import {
   getFromQueryAsArray,
   getFromQueryAsArrayOrFail,
 } from "../util";
-import { PatientLinksDTO, dtoFromCW } from "./dtos/linkDTO";
+import { dtoFromCW, PatientLinksDTO } from "./dtos/linkDTO";
 import { dtoFromModel } from "./dtos/patientDTO";
 import { getResourcesQueryParam } from "./schemas/fhir";
 import { linkCreateSchema } from "./schemas/link";
@@ -402,10 +402,10 @@ router.post(
       const filteredCxIds = cxIds.filter(cxId => !cqDirectCxIds.includes(cxId));
 
       if (filteredCxIds.length < 1 && cxIds.length == 1) {
-        console.log(`Customer ${cxIds[0]} has CQ Direct enabled, skipping...`);
+        log(`Customer ${cxIds[0]} has CQ Direct enabled, skipping...`);
         return res.status(status.OK).json({ patientIds: [] });
       } else if (filteredCxIds.length < 1) {
-        console.log(`No customers to Enhanced Coverage, skipping...`);
+        log(`No customers to Enhanced Coverage, skipping...`);
         return res.status(status.OK).json({ patientIds: [] });
       }
       log(`Using these cxIds: ${cxIds.join(", ")}`);

--- a/packages/api/src/shared/log.ts
+++ b/packages/api/src/shared/log.ts
@@ -1,23 +1,8 @@
 import { inspect } from "node:util";
 import { ZodError } from "zod";
-import { Config } from "./config";
 
-/**
- * @deprecated Use @metriport/core instead
- */
-//eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function debug(msg: string, ...optionalParams: any[]): void {
-  if (Config.isCloudEnv()) return;
-  if (optionalParams) {
-    if (typeof optionalParams[0] === typeof Function) {
-      console.log(msg, optionalParams[0](), ...optionalParams.slice(1));
-    } else {
-      console.log(msg, ...optionalParams);
-    }
-  } else {
-    console.log(msg);
-  }
-}
+type LogParamBasic = string | number | boolean | unknown | null | undefined;
+export type LogParam = LogParamBasic | (() => LogParamBasic);
 
 export type ErrorToStringOptions = { detailed: boolean };
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,10 @@
 # Metriport Core package
 
-A package to share common code across other [Metriport](https://metriport.com/) packages.
+A package to share common SERVER-SIDE code across other [Metriport](https://metriport.com/) packages.
 
 If you're looking for Metriport's API SDK, check this one out: https://www.npmjs.com/package/@metriport/api-sdk
+
+If you're looking for a package to share common code that can be used across the stack, check out the `packages/shared` one.
 
 [Metriport](https://metriport.com/) is a universal and open-source API for healthcare data.
 

--- a/packages/core/src/external/aws/lambda-logic/document-uploader.ts
+++ b/packages/core/src/external/aws/lambda-logic/document-uploader.ts
@@ -116,7 +116,7 @@ async function forwardCallToServer(
 
   const resp = await api.post(encodedUrl, fileData);
   console.log(`Server response - status: ${resp.status}`);
-  console.log(`Server response - body: ${resp.data}`);
+  console.log(`Server response - body: ${JSON.stringify(resp.data)}`);
   return resp.data;
 }
 

--- a/packages/core/src/util/local-storage.ts
+++ b/packages/core/src/util/local-storage.ts
@@ -1,0 +1,17 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+type LocalStorage = "reqId";
+
+const reqIdAsyncLocalStorage = new AsyncLocalStorage<string>();
+
+/**
+ * Returns a context to be used in async functions while processing a request.
+ * See: https://nodejs.org/api/async_context.html
+ *
+ * To add more information on the request, like cx/user id, create a new storage
+ * and return the correct one based on the param to `getLocalStorage()`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function getLocalStorage(_: LocalStorage): AsyncLocalStorage<string> {
+  return reqIdAsyncLocalStorage;
+}

--- a/packages/core/src/util/log.ts
+++ b/packages/core/src/util/log.ts
@@ -1,14 +1,22 @@
 import { emptyFunction } from "@metriport/shared";
 import { Config } from "./config";
+import { getLocalStorage } from "./local-storage";
 
 type LogParamBasic = string | number | boolean | unknown | null | undefined;
 export type LogParam = LogParamBasic | (() => LogParamBasic);
 
+const asyncLocalStorage = getLocalStorage("reqId");
+
 export function log(prefix?: string, suffix?: string) {
   return (msg: string, ...optionalParams: LogParam[]): void => {
+    const actualPrefix = prefix ? `[${prefix}] ` : ``;
+
+    const reqId = asyncLocalStorage.getStore();
+    const reqPrefix = reqId ? `${reqId} ` : "";
+
     const actualParams = (optionalParams ?? []).map(p => (typeof p === "function" ? p() : p));
     return console.log(
-      `${prefix ? `[${prefix}] ` : ``}${msg}`,
+      `${reqPrefix}${actualPrefix}${msg}`,
       ...[...actualParams, ...(suffix ? [suffix] : [])]
     );
   };


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport/pull/1532

### Description

I was hoping to fix https://github.com/metriport/metriport-internal/issues/1455. While debugging I ended up doing some improvements:

- add AsyncLocalStorage and update logs to include the request ID 🤓 
- remove docRefMapping if fails to download docRef
- remove deprecated `updateDocQuery`:tada:
- move jobId create/decompose to single place

https://github.com/metriport/metriport-internal/issues/1455 will be done on another PR, the changes are larger than expected.

### Testing

- Local
  - [x] same as staging
- Staging
  - [ ] If it fails to DQ/DR, the entry on docRefMapping is removed
  - [ ] DQ progress (download / conversion) is updated accordingly
  - [ ] CW request to FHIR proxy is logged w/ body of response to CW
  - [ ] Request logger works
  - [ ] Logs include reqId as prefix
- Sandbox
  - none
- Production
  - none

### Release Plan

- nothing special