### PR TITLE
1040 Add DB maintenance daily job

### DIFF
--- a/packages/api/src/command/medical/admin/db-maintenance.ts
+++ b/packages/api/src/command/medical/admin/db-maintenance.ts
@@ -1,0 +1,24 @@
+import dayjs from "dayjs";
+import { Op } from "sequelize";
+import { WebhookRequest } from "../../../models/webhook-request";
+
+const DAYS_TO_KEEP_WEBHOOK_REQUESTS = 30;
+
+/**
+ * ADMIN ONLY, NOT TO BE CALLED BY REGULAR CODE/USERS.
+ */
+export async function dbMaintenance() {
+  const whRequestsRemoved = await WebhookRequest.destroy({
+    where: {
+      createdAt: {
+        [Op.lt]: dayjs().subtract(DAYS_TO_KEEP_WEBHOOK_REQUESTS, "days").toDate(),
+      },
+    },
+  });
+  const whRequestsRemaining = await WebhookRequest.count();
+
+  return {
+    whRequestsRemoved,
+    whRequestsRemaining,
+  };
+}

--- a/packages/api/src/command/medical/admin/db-maintenance.ts
+++ b/packages/api/src/command/medical/admin/db-maintenance.ts
@@ -4,21 +4,30 @@ import { WebhookRequest } from "../../../models/webhook-request";
 
 const DAYS_TO_KEEP_WEBHOOK_REQUESTS = 30;
 
+export type WHRequestsCleanupResult = {
+  removed: number;
+  remaining: number;
+};
+
 /**
  * ADMIN ONLY, NOT TO BE CALLED BY REGULAR CODE/USERS.
  */
-export async function dbMaintenance() {
-  const whRequestsRemoved = await WebhookRequest.destroy({
+export async function dbMaintenance(): Promise<{ webhookRequests: WHRequestsCleanupResult }> {
+  const webhookRequests = await cleanupWHRequests();
+  return { webhookRequests };
+}
+
+async function cleanupWHRequests(): Promise<WHRequestsCleanupResult> {
+  const removed = await WebhookRequest.destroy({
     where: {
       createdAt: {
         [Op.lt]: dayjs().subtract(DAYS_TO_KEEP_WEBHOOK_REQUESTS, "days").toDate(),
       },
     },
   });
-  const whRequestsRemaining = await WebhookRequest.count();
-
+  const remaining = await WebhookRequest.count();
   return {
-    whRequestsRemoved,
-    whRequestsRemaining,
+    removed,
+    remaining,
   };
 }

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -3,6 +3,7 @@ import { getReferencesFromResources } from "@metriport/core/external/fhir/shared
 import { Request, Response, Router } from "express";
 import httpStatus from "http-status";
 import { checkApiQuota } from "../command/medical/admin/api";
+import { dbMaintenance } from "../command/medical/admin/db-maintenance";
 import {
   populateFhirServer,
   PopulateFhirServerResponse,
@@ -197,6 +198,19 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const cxsWithLowQuota = await checkApiQuota();
     return res.status(httpStatus.OK).json({ cxsWithLowQuota });
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * POST /internal/db-maintenance
+ *
+ * Perform regular DB Maintenance.
+ */
+router.post(
+  "/db-maintenance",
+  asyncHandler(async (req: Request, res: Response) => {
+    const result = await dbMaintenance();
+    return res.status(httpStatus.OK).json(result);
   })
 );
 

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1,4 +1,12 @@
-import { Aspects, CfnOutput, Duration, RemovalPolicy, Stack, StackProps } from "aws-cdk-lib";
+import {
+  Aspects,
+  aws_wafv2 as wafv2,
+  CfnOutput,
+  Duration,
+  RemovalPolicy,
+  Stack,
+  StackProps,
+} from "aws-cdk-lib";
 import * as apig from "aws-cdk-lib/aws-apigateway";
 import * as cert from "aws-cdk-lib/aws-certificatemanager";
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
@@ -17,7 +25,6 @@ import * as r53_targets from "aws-cdk-lib/aws-route53-targets";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import * as sns from "aws-cdk-lib/aws-sns";
-import { aws_wafv2 as wafv2 } from "aws-cdk-lib";
 import { ITopic } from "aws-cdk-lib/aws-sns";
 import { Construct } from "constructs";
 import { EnvConfig } from "../config/env-config";
@@ -26,6 +33,7 @@ import { createScheduledAPIQuotaChecker } from "./api-stack/api-quota-checker";
 import { createAPIService } from "./api-stack/api-service";
 import * as ccdaSearch from "./api-stack/ccda-search-connector";
 import * as cwEnhancedCoverageConnector from "./api-stack/cw-enhanced-coverage-connector";
+import { createScheduledDBMaintenance } from "./api-stack/db-maintenance";
 import { createDocQueryChecker } from "./api-stack/doc-query-checker";
 import * as documentUploader from "./api-stack/document-upload";
 import * as fhirConverterConnector from "./api-stack/fhir-converter-connector";
@@ -686,6 +694,12 @@ export class APIStack extends Stack {
     });
 
     createScheduledAPIQuotaChecker({
+      stack: this,
+      lambdaLayers,
+      vpc: this.vpc,
+      apiAddress: apiLoadBalancerAddress,
+    });
+    createScheduledDBMaintenance({
       stack: this,
       lambdaLayers,
       vpc: this.vpc,

--- a/packages/infra/lib/api-stack/db-maintenance.ts
+++ b/packages/infra/lib/api-stack/db-maintenance.ts
@@ -1,0 +1,51 @@
+import { Duration } from "aws-cdk-lib";
+import { IVpc } from "aws-cdk-lib/aws-ec2";
+import { IFunction } from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+import { getConfig } from "../shared/config";
+import { LambdaLayers } from "../shared/lambda-layers";
+import { createScheduledLambda } from "../shared/lambda-scheduled";
+
+export type EnhancedCoverageConnectorProps = {
+  stack: Construct;
+  lambdaLayers: LambdaLayers;
+  vpc: IVpc;
+  apiAddress: string;
+};
+
+function getSettings(props: EnhancedCoverageConnectorProps) {
+  return {
+    ...props,
+    name: "ScheduledDBMaintenance",
+    /**
+     * UTC-based: "Minutes Hours Day-of-month Month Day-of-week Year"
+     * @see: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html
+     * @see: https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html
+     */
+    scheduleExpression: ["23 9 * * ? *"], // Every day at 9:23am UTC (1:23am PST)
+    url: `http://${props.apiAddress}/internal/db-maintenance`,
+    lambdaTimeout: Duration.minutes(5), // How long can the lambda run for, max is 900 seconds (15 minutes)
+  };
+}
+
+export function createScheduledDBMaintenance(props: EnhancedCoverageConnectorProps): IFunction {
+  const config = getConfig();
+  const { stack, lambdaLayers, vpc, name, lambdaTimeout, scheduleExpression, url } =
+    getSettings(props);
+
+  const lambda = createScheduledLambda({
+    stack,
+    layers: [lambdaLayers.shared],
+    name,
+    vpc,
+    scheduleExpression,
+    url,
+    timeout: lambdaTimeout,
+    envType: config.environmentType,
+    envVars: {
+      ...(config.lambdasSentryDSN ? { SENTRY_DSN: config.lambdasSentryDSN } : {}),
+    },
+  });
+
+  return lambda;
+}


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1531
- Downstream: none

### Description

Add DB maintenance daily job - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1706403600770069).

### Testing

- Local
  - [x] manual execution logs proper SQL
- Staging
  - [ ] manual execution removes older records
  - [ ] scheduled lambda created properly (w/ schedule)
- Sandbox
  - [ ] manual execution removes older records
  - [ ] scheduled lambda created properly (w/ schedule)
- Production
  - [ ] manual execution removes older records
  - [ ] scheduled lambda created properly (w/ schedule)

### Release Plan

- nothing special