### PR TITLE
fix(docs): no location service in sandbox

### DIFF
--- a/packages/api/src/command/medical/patient/add-coordinates.ts
+++ b/packages/api/src/command/medical/patient/add-coordinates.ts
@@ -4,6 +4,7 @@ import { capture } from "@metriport/core/util/notifications";
 import { Product } from "../../../domain/product";
 import { AddressGeocodingResult, geocodeAddress } from "../../../external/aws/address";
 import { EventTypes, analytics } from "../../../shared/analytics";
+import { Config } from "../../../shared/config";
 
 const ADDRESS_MATCH_RELEVANCE_THRESHOLD = 0.9;
 
@@ -29,7 +30,8 @@ export async function addCoordinatesToAddresses({
   addresses: Address[];
   patient: Pick<Patient, "id" | "cxId">;
   reportRelevance?: boolean;
-}): Promise<Address[]> {
+}): Promise<Address[] | undefined> {
+  if (Config.isSandbox()) return;
   const updatedAddresses = await addGeographicCoordinates(addresses, patient, reportRelevance);
   const addressesWithCoordinates = combineAddresses(updatedAddresses, addresses);
   return addressesWithCoordinates;

--- a/packages/api/src/command/medical/patient/create-patient.ts
+++ b/packages/api/src/command/medical/patient/create-patient.ts
@@ -37,11 +37,13 @@ export const createPatient = async (patient: PatientCreateCmd): Promise<Patient>
     externalId,
     data: { firstName, lastName, dob, genderAtBirth, personalIdentifiers, address, contact },
   };
-  patientCreate.data.address = await addCoordinatesToAddresses({
+  const addressWithCoordinates = await addCoordinatesToAddresses({
     addresses: patientCreate.data.address,
     patient: patientCreate,
     reportRelevance: true,
   });
+  if (addressWithCoordinates) patientCreate.data.address = addressWithCoordinates;
+
   const newPatient = await PatientModel.create(patientCreate);
 
   // TODO: #393 declarative, event-based integration

--- a/packages/api/src/command/medical/patient/update-patient.ts
+++ b/packages/api/src/command/medical/patient/update-patient.ts
@@ -31,11 +31,14 @@ export const updatePatient = async (
       lock: true,
       transaction,
     });
-    patientUpdate.address = await addCoordinatesToAddresses({
+
+    const addressWithCoordinates = await addCoordinatesToAddresses({
       addresses: patientUpdate.address,
       patient: patientUpdate,
       reportRelevance: true,
     });
+
+    if (addressWithCoordinates) patientUpdate.address = addressWithCoordinates;
 
     validateVersionForUpdate(patient, eTag);
 

--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -34,10 +34,12 @@ async function deploy(config: EnvConfig) {
   //---------------------------------------------------------------------------------
   // 2. Deploy the location services stack to initialize all geo services.
   //---------------------------------------------------------------------------------
-  new LocationServicesStack(app, config.locationService.stackName, {
-    env: { ...env, region: config.locationService.placeIndexRegion },
-    config,
-  });
+  if (config.locationService) {
+    new LocationServicesStack(app, config.locationService.stackName, {
+      env: { ...env, region: config.locationService.placeIndexRegion },
+      config,
+    });
+  }
 
   //---------------------------------------------------------------------------------
   // 3. Deploy the API stack once all secrets are defined.

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -37,7 +37,7 @@ export type EnvConfig = {
   analyticsSecretNames?: {
     POST_HOG_API_KEY: string;
   };
-  locationService: {
+  locationService?: {
     stackName: string;
     placeIndexName: string;
     placeIndexRegion: string;

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -158,8 +158,10 @@ export function createAPIService(
           ...(props.config.carequality?.envVars?.CQ_ORG_DETAILS && {
             CQ_ORG_DETAILS: props.config.carequality.envVars.CQ_ORG_DETAILS,
           }),
-          PLACE_INDEX_NAME: props.config.locationService.placeIndexName,
-          PLACE_INDEX_REGION: props.config.locationService.placeIndexRegion,
+          ...(props.config.locationService && {
+            PLACE_INDEX_NAME: props.config.locationService.placeIndexName,
+            PLACE_INDEX_REGION: props.config.locationService.placeIndexRegion,
+          }),
           // app config
           APPCONFIG_APPLICATION_ID: appConfigEnvVars.appId,
           APPCONFIG_CONFIGURATION_ID: appConfigEnvVars.configId,

--- a/packages/infra/lib/location-services-stack.ts
+++ b/packages/infra/lib/location-services-stack.ts
@@ -13,6 +13,9 @@ export class LocationServicesStack extends Stack {
     //-------------------------------------------
     // API Gateway
     //-------------------------------------------
+    if (!props.config.locationService) {
+      return;
+    }
     const placeIndex = new ALS.CfnPlaceIndex(this, props.config.locationService.placeIndexName, {
       dataSource: "Esri",
       indexName: props.config.locationService.placeIndexName,


### PR DESCRIPTION
refs. metriport/metriport-internal#1447

### Dependencies
- Upstream: https://github.com/metriport/metriport-internal/pull/1462

### Description

- Removed the AWS location service from sandbox
- Adjusted patient create and update to not try to add address coordinates on sandbox

### Testing

- Local
  - [x] Faked using sandbox locally and created/updated some patients to make sure it works as expected

### Release Plan
- [ ] Upstream dependencies met
- [ ] Merge this
