### PR TITLE
feat(api): added feature flags to configure sandbox patient limits

### DIFF
--- a/packages/api/src/domain/medical/get-patient-limit.ts
+++ b/packages/api/src/domain/medical/get-patient-limit.ts
@@ -1,0 +1,23 @@
+import { getCxsWithIncreasedSandboxLimitFeatureFlagValue } from "../../external/aws/appConfig";
+import { Config } from "../../shared/config";
+
+export async function getPatientLimitForCx(cxId: string): Promise<number> {
+  const cxIdsWithIncreasedSandboxPatientVolumeEnabled =
+    await getCxsWithIncreasedSandboxLimitFeatureFlagValue();
+  const cxIdAndLimit = cxIdsWithIncreasedSandboxPatientVolumeEnabled.find(i => i.includes(cxId));
+  const limit = cxIdAndLimit ? parseCxIdAndLimit(cxIdAndLimit)?.patientLimit : undefined;
+  return limit ?? Config.SANDBOX_PATIENT_LIMIT;
+}
+
+function parseCxIdAndLimit(increasedPatientLimitFeatureFlagValue: string):
+  | {
+      cxId: string;
+      patientLimit: number;
+    }
+  | undefined {
+  const cxIdsAndLimits = increasedPatientLimitFeatureFlagValue.split(":");
+
+  if (cxIdsAndLimits[0] && cxIdsAndLimits[1])
+    return { cxId: cxIdsAndLimits[0], patientLimit: parseInt(cxIdsAndLimits[1]) };
+  return;
+}

--- a/packages/api/src/external/aws/appConfig.ts
+++ b/packages/api/src/external/aws/appConfig.ts
@@ -45,8 +45,12 @@ export async function getCxsWithCQDirectFeatureFlagValue(): Promise<string[]> {
   return getCxsWithFeatureFlagValue(Config.getCxsWithCQDirectFeatureFlagName());
 }
 
-export async function getCxsWithIncreasedSandboxLimitFeatureFlagValue(): Promise<string[]> {
-  return getCxsWithFeatureFlagValue(Config.getCxsWithIncreasedSandboxLimitFeatureFlagValue());
+export async function getCxsWithIncreasedSandboxLimitFeatureFlagValue(): Promise<
+  string[] | undefined
+> {
+  const featureFlagValue = Config.getCxsWithIncreasedSandboxLimitFeatureFlagValue();
+  if (!featureFlagValue) return;
+  return getCxsWithFeatureFlagValue(featureFlagValue);
 }
 
 export async function isEnhancedCoverageEnabledForCx(cxId: string): Promise<boolean> {

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -42,6 +42,7 @@ import {
   schemaUpdateToPatient,
 } from "./schemas/patient";
 import { cxRequestMetadataSchema } from "./schemas/request-metadata";
+import { getPatientLimitForCx } from "../../external/aws/appConfig";
 
 const router = Router();
 const MAX_RESOURCE_POST_COUNT = 50;
@@ -67,7 +68,8 @@ router.post(
     if (Config.isSandbox()) {
       // limit the amount of patients that can be created in sandbox mode
       const numPatients = await Patient.count({ where: { cxId } });
-      if (numPatients >= Config.SANDBOX_PATIENT_LIMIT) {
+      const patientLimit = await getPatientLimitForCx(cxId);
+      if (numPatients >= patientLimit) {
         return res.status(status.BAD_REQUEST).json({
           message: `Cannot create more than ${Config.SANDBOX_PATIENT_LIMIT} patients in Sandbox mode!`,
         });

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -42,7 +42,7 @@ import {
   schemaUpdateToPatient,
 } from "./schemas/patient";
 import { cxRequestMetadataSchema } from "./schemas/request-metadata";
-import { getPatientLimitForCx } from "../../external/aws/appConfig";
+import { getPatientLimitForCx } from "../../domain/medical/get-patient-limit";
 
 const router = Router();
 const MAX_RESOURCE_POST_COUNT = 50;

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -295,7 +295,7 @@ export class Config {
   static getCxsWithCQDirectFeatureFlagName(): string {
     return getEnvVarOrFail("CXS_WITH_CQ_DIRECT_FEATURE_FLAG");
   }
-  static getCxsWithIncreasedSandboxLimitFeatureFlagValue(): string {
-    return getEnvVarOrFail("CXS_WITH_INCREASED_SANDBOX_LIMIT_FEATURE_FLAG");
+  static getCxsWithIncreasedSandboxLimitFeatureFlagValue(): string | undefined {
+    return getEnvVar("CXS_WITH_INCREASED_SANDBOX_LIMIT_FEATURE_FLAG");
   }
 }

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -295,7 +295,7 @@ export class Config {
   static getCxsWithCQDirectFeatureFlagName(): string {
     return getEnvVarOrFail("CXS_WITH_CQ_DIRECT_FEATURE_FLAG");
   }
-  static getCxsWithIncreasedPatientLimitFeatureFlagValue(): string {
-    return getEnvVarOrFail("CXS_WITH_INCREASED_PATIENT_LIMIT_FEATURE_FLAG");
+  static getCxsWithIncreasedSandboxLimitFeatureFlagValue(): string {
+    return getEnvVarOrFail("CXS_WITH_INCREASED_SANDBOX_LIMIT_FEATURE_FLAG");
   }
 }

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -295,4 +295,7 @@ export class Config {
   static getCxsWithCQDirectFeatureFlagName(): string {
     return getEnvVarOrFail("CXS_WITH_CQ_DIRECT_FEATURE_FLAG");
   }
+  static getCxsWithIncreasedPatientLimitFeatureFlagValue(): string {
+    return getEnvVarOrFail("CXS_WITH_INCREASED_PATIENT_LIMIT_FEATURE_FLAG");
+  }
 }

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -135,7 +135,8 @@ export class APIStack extends Stack {
       appConfigConfigId,
       cxsWithEnhancedCoverageFeatureFlag,
       cxsWithCQDirectFeatureFlag,
-    } = createAppConfigStack(this, { config: props.config });
+      cxsWithIncreasedSandboxLimitFeatureFlag,
+    } = createAppConfigStack({ stack: this, props: { config: props.config } });
 
     //-------------------------------------------
     // Aurora Database for backend data
@@ -399,6 +400,7 @@ export class APIStack extends Stack {
         configId: appConfigConfigId,
         cxsWithEnhancedCoverageFeatureFlag,
         cxsWithCQDirectFeatureFlag,
+        cxsWithIncreasedSandboxLimitFeatureFlag,
       },
       cookieStore,
     });

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -183,7 +183,7 @@ export function createAPIService({
           CXS_WITH_CQ_DIRECT_FEATURE_FLAG: appConfigEnvVars.cxsWithCQDirectFeatureFlag,
           CXS_WITH_ENHANCED_COVERAGE_FEATURE_FLAG:
             appConfigEnvVars.cxsWithEnhancedCoverageFeatureFlag,
-          CXS_WITH_INCREASED_PATIENT_LIMIT_FEATURE_FLAG:
+          CXS_WITH_INCREASED_SANDBOX_LIMIT_FEATURE_FLAG:
             appConfigEnvVars.cxsWithIncreasedSandboxLimitFeatureFlag,
           ...(coverageEnhancementConfig && {
             CW_MANAGEMENT_URL: coverageEnhancementConfig.managementUrl,

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -79,6 +79,7 @@ export function createAPIService({
     configId: string;
     cxsWithEnhancedCoverageFeatureFlag: string;
     cxsWithCQDirectFeatureFlag: string;
+    cxsWithIncreasedSandboxLimitFeatureFlag: string;
   };
   cookieStore: secret.ISecret | undefined;
 }): {
@@ -182,6 +183,8 @@ export function createAPIService({
           CXS_WITH_CQ_DIRECT_FEATURE_FLAG: appConfigEnvVars.cxsWithCQDirectFeatureFlag,
           CXS_WITH_ENHANCED_COVERAGE_FEATURE_FLAG:
             appConfigEnvVars.cxsWithEnhancedCoverageFeatureFlag,
+          CXS_WITH_INCREASED_PATIENT_LIMIT_FEATURE_FLAG:
+            appConfigEnvVars.cxsWithIncreasedSandboxLimitFeatureFlag,
           ...(coverageEnhancementConfig && {
             CW_MANAGEMENT_URL: coverageEnhancementConfig.managementUrl,
           }),

--- a/packages/infra/lib/app-config-stack.ts
+++ b/packages/infra/lib/app-config-stack.ts
@@ -7,15 +7,18 @@ interface AppConfigStackProps extends StackProps {
   config: EnvConfig;
 }
 
-// TODO move these parameters to object properties
-export function createAppConfigStack(
-  stack: Construct,
-  props: AppConfigStackProps
-): {
+export function createAppConfigStack({
+  stack,
+  props,
+}: {
+  stack: Construct;
+  props: AppConfigStackProps;
+}): {
   appConfigAppId: string;
   appConfigConfigId: string;
   cxsWithEnhancedCoverageFeatureFlag: string;
   cxsWithCQDirectFeatureFlag: string;
+  cxsWithIncreasedSandboxLimitFeatureFlag: string;
 } {
   const appConfigOSSApp = new appConfig.CfnApplication(stack, "OSSAPIConfig", {
     name: "OSSAPIConfig",
@@ -30,6 +33,7 @@ export function createAppConfigStack(
 
   const cxsWithEnhancedCoverageFeatureFlag = "cxsWithEnhancedCoverage";
   const cxsWithCQDirectFeatureFlag = "cxsWithCQDirect";
+  const cxsWithIncreasedSandboxLimitFeatureFlag = "cxsWithIncreasedSandboxLimit";
   const appConfigOSSVersion = new appConfig.CfnHostedConfigurationVersion(
     stack,
     "OSSAPIConfigVersion",
@@ -55,6 +59,14 @@ export function createAppConfigStack(
               },
             },
           },
+          [cxsWithIncreasedSandboxLimitFeatureFlag]: {
+            name: cxsWithIncreasedSandboxLimitFeatureFlag,
+            attributes: {
+              cxIdsAndLimits: {
+                type: "string[]",
+              },
+            },
+          },
         },
         values: {
           [cxsWithEnhancedCoverageFeatureFlag]: {
@@ -64,6 +76,10 @@ export function createAppConfigStack(
           [cxsWithCQDirectFeatureFlag]: {
             enabled: true,
             cxIds: [],
+          },
+          [cxsWithIncreasedSandboxLimitFeatureFlag]: {
+            enabled: true,
+            cxWithIncreasedLimits: [],
           },
         },
       }),
@@ -100,5 +116,6 @@ export function createAppConfigStack(
     appConfigConfigId: appConfigOSSProfile.ref,
     cxsWithEnhancedCoverageFeatureFlag,
     cxsWithCQDirectFeatureFlag,
+    cxsWithIncreasedSandboxLimitFeatureFlag,
   };
 }

--- a/packages/infra/lib/app-config-stack.ts
+++ b/packages/infra/lib/app-config-stack.ts
@@ -62,7 +62,7 @@ export function createAppConfigStack({
           [cxsWithIncreasedSandboxLimitFeatureFlag]: {
             name: cxsWithIncreasedSandboxLimitFeatureFlag,
             attributes: {
-              cxIdsAndLimits: {
+              cxIds: {
                 type: "string[]",
               },
             },
@@ -79,7 +79,7 @@ export function createAppConfigStack({
           },
           [cxsWithIncreasedSandboxLimitFeatureFlag]: {
             enabled: true,
-            cxWithIncreasedLimits: [],
+            cxIds: [],
           },
         },
       }),

--- a/packages/infra/lib/app-config-stack.ts
+++ b/packages/infra/lib/app-config-stack.ts
@@ -79,7 +79,7 @@ export function createAppConfigStack({
           },
           [cxsWithIncreasedSandboxLimitFeatureFlag]: {
             enabled: true,
-            cxIds: [],
+            cxIdsAndLimits: [],
           },
         },
       }),


### PR DESCRIPTION
refs. metriport/metriport#1116

### Description
- Added feature flags to configure the limits for the number of sandbox patients per cx

### Testing

- Local
  - [x] Functionality tested in a local script
- Staging
  - [x] Test feature flag creation
  - [x] Rigged the local environment to retrieve the feature flag from staging, and check the logic for patient limits
- Sandbox
  - [ ] Create a feature flag to increase the limit and create >20 patients on sandbox 

### Release Plan
- [x] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (introduce a feature that would be useful customers)
- [ ] Merge this
