### PR TITLE
1040 CW FHIR proxy include other resources

### DIFF
--- a/packages/lambdas/src/cw-doc-contribution.ts
+++ b/packages/lambdas/src/cw-doc-contribution.ts
@@ -17,12 +17,13 @@ const SIGNED_URL_DURATION_SECONDS = 60;
 
 export const handler = Sentry.AWSLambda.wrapHandler(
   async (event: lambda.APIGatewayRequestAuthorizerEvent) => {
-    const fileName = event.queryStringParameters?.[docContributionFileParam];
+    const fileName = event.queryStringParameters?.[docContributionFileParam] ?? "";
+    const key = fileName.startsWith("/") ? fileName.slice(1) : fileName;
 
     if (fileName) {
-      const url = await s3Utils.s3.getSignedUrl("getObject", {
+      const url = s3Utils.s3.getSignedUrl("getObject", {
         Bucket: bucketName,
-        Key: fileName,
+        Key: key,
         Expires: SIGNED_URL_DURATION_SECONDS,
       });
 


### PR DESCRIPTION
Ref: metriport/metriport-internal#1040

### Dependencies

none

### Description

- CW FHIR proxy include other resources
- CW contrib lambda removes leading forward slash for S3 key

### Testing

- Local
  - [x] test CW FHIR proxy endpoint
- Staging
  - [ ] downloads docs from other orgs
  - [ ] include the Patient on the response to CW
- Sandbox
  - none
- Production
  - none
 
### Release Plan

- nothing special