### PR TITLE
1040 Make timeout optional on scheduled lambda

### DIFF
--- a/packages/lambdas/src/scheduled.ts
+++ b/packages/lambdas/src/scheduled.ts
@@ -12,7 +12,8 @@ capture.init();
 const lambdaName = getEnv("AWS_LAMBDA_FUNCTION_NAME");
 // Set by us
 const url = getEnvOrFail("URL");
-const timeoutMillis = Number(getEnvOrFail("TIMEOUT_MILLIS"));
+const timeoutRaw = getEnv("TIMEOUT_MILLIS");
+const timeoutMillis = timeoutRaw != undefined ? Number(timeoutRaw) : undefined;
 
 /**
  * Lambda that just triggers an endpoint, it doesn't wait for the response.


### PR DESCRIPTION
Ref: metriport/metriport-internal#1040

### Dependencies

none

### Description

Make timeout optional on scheduled lambda - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1706644039383199?thread_ts=1706591878.808909&cid=C04DMKE9DME)

### Testing

- Staging
  - [ ] DB maintenance lambda runs successfully
- Sandbox
  - none
- Production
  - none

### Release Plan

- nothing special