### PR TITLE
1467 Fix Doc Contribution

### DIFF
--- a/packages/api/src/command/medical/admin/upload-doc.ts
+++ b/packages/api/src/command/medical/admin/upload-doc.ts
@@ -1,5 +1,6 @@
 import { DocumentReference } from "@medplum/fhirtypes";
 import { FileData } from "@metriport/core/external/aws/lambda-logic/document-uploader";
+import { IETF_URL } from "@metriport/core/external/fhir/shared/namespaces";
 import { errorToString } from "@metriport/core/util/error/shared";
 import { capture } from "@metriport/core/util/notifications";
 import { randomInt } from "@metriport/shared/common/numbers";
@@ -78,13 +79,13 @@ export async function createAndUploadDocReference({
       },
     ],
     masterIdentifier: {
-      system: "urn:ietf:rfc:3986",
+      system: IETF_URL,
       value: docId,
     },
     identifier: [
       {
         use: "official",
-        system: "urn:ietf:rfc:3986",
+        system: IETF_URL,
         value: docId,
       },
     ],

--- a/packages/api/src/command/medical/admin/upload-doc.ts
+++ b/packages/api/src/command/medical/admin/upload-doc.ts
@@ -1,6 +1,6 @@
 import { DocumentReference } from "@medplum/fhirtypes";
 import { FileData } from "@metriport/core/external/aws/lambda-logic/document-uploader";
-import { IETF_URL } from "@metriport/core/external/fhir/shared/namespaces";
+import { IETF_URI } from "@metriport/core/external/fhir/shared/namespaces";
 import { errorToString } from "@metriport/core/util/error/shared";
 import { capture } from "@metriport/core/util/notifications";
 import { randomInt } from "@metriport/shared/common/numbers";
@@ -79,13 +79,13 @@ export async function createAndUploadDocReference({
       },
     ],
     masterIdentifier: {
-      system: IETF_URL,
+      system: IETF_URI,
       value: docId,
     },
     identifier: [
       {
         use: "official",
-        system: IETF_URL,
+        system: IETF_URI,
         value: docId,
       },
     ],

--- a/packages/api/src/command/medical/document/document-query-storage-info.ts
+++ b/packages/api/src/command/medical/document/document-query-storage-info.ts
@@ -1,14 +1,11 @@
 import { DocumentReferenceContent } from "@medplum/fhirtypes";
 import { Document } from "@metriport/commonwell-sdk";
-import { S3Utils } from "@metriport/core/external/aws/s3";
 import { Patient } from "@metriport/core/domain/patient";
-import {
-  DocumentWithMetriportId,
-  getFileExtension,
-} from "../../../external/commonwell/document/shared";
+import { S3Utils } from "@metriport/core/external/aws/s3";
+import { capture } from "@metriport/core/util/notifications";
+import { DocumentWithMetriportId } from "../../../external/commonwell/document/shared";
 import { Config } from "../../../shared/config";
 import { createS3FileName } from "../../../shared/external";
-import { capture } from "../../../shared/notifications";
 import { Util } from "../../../shared/util";
 
 const s3Utils = new S3Utils(Config.getAWSRegion());
@@ -35,8 +32,7 @@ type SimpleFile = {
 export function getDocToFileFunction(patient: Pick<Patient, "cxId" | "id">) {
   // TODO convert the input from CW Document to a Metriport shape
   return async (doc: Document): Promise<SimpleFile> => {
-    const extension = getFileExtension(doc.content?.mimeType);
-    const docName = extension ? `${doc.id}${extension}` : doc.id;
+    const docName = doc.id;
     const fileName = createS3FileName(patient.cxId, patient.id, docName);
     return {
       docId: doc.id,
@@ -100,7 +96,7 @@ export async function getS3Info(
     const msg = `Errors getting info from S3`;
     const extra = { errors, patientId: patient.id };
     log(msg, extra);
-    capture.message(msg, { extra });
+    capture.error(msg, { extra });
   }
   const successful: S3Info[] = s3Info.flatMap(ref =>
     ref.status === "fulfilled" && ref.value ? ref.value : []

--- a/packages/api/src/command/medical/document/document-query-storage-info.ts
+++ b/packages/api/src/command/medical/document/document-query-storage-info.ts
@@ -1,11 +1,11 @@
 import { DocumentReferenceContent } from "@medplum/fhirtypes";
 import { Document } from "@metriport/commonwell-sdk";
+import { createDocumentFilePath } from "@metriport/core/domain/document/filename";
 import { Patient } from "@metriport/core/domain/patient";
 import { S3Utils } from "@metriport/core/external/aws/s3";
 import { capture } from "@metriport/core/util/notifications";
 import { DocumentWithMetriportId } from "../../../external/commonwell/document/shared";
 import { Config } from "../../../shared/config";
-import { createS3FileName } from "../../../shared/external";
 import { Util } from "../../../shared/util";
 
 const s3Utils = new S3Utils(Config.getAWSRegion());
@@ -32,8 +32,12 @@ type SimpleFile = {
 export function getDocToFileFunction(patient: Pick<Patient, "cxId" | "id">) {
   // TODO convert the input from CW Document to a Metriport shape
   return async (doc: Document): Promise<SimpleFile> => {
-    const docName = doc.id;
-    const fileName = createS3FileName(patient.cxId, patient.id, docName);
+    const fileName = createDocumentFilePath(
+      patient.cxId,
+      patient.id,
+      doc.id,
+      doc.content?.mimeType
+    );
     return {
       docId: doc.id,
       fileName,

--- a/packages/api/src/external/carequality/document/process-document-query-results.ts
+++ b/packages/api/src/external/carequality/document/process-document-query-results.ts
@@ -1,16 +1,17 @@
-import { S3Utils, createS3FileName } from "@metriport/core/external/aws/s3";
-import { out } from "@metriport/core/util/log";
+import { DocumentReference as FHIRDocumentReference } from "@medplum/fhirtypes";
+import { createDocumentFilePath } from "@metriport/core/domain/document/filename";
+import { S3Utils } from "@metriport/core/external/aws/s3";
+import { MedicalDataSource } from "@metriport/core/external/index";
 import { errorToString } from "@metriport/core/util/error/shared";
+import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import { DocumentReference } from "@metriport/ihe-gateway-sdk";
-import { DocumentReference as FHIRDocumentReference } from "@medplum/fhirtypes";
-import { DocumentQueryResult } from "../document-query-result";
 import { Config } from "../../../shared/config";
+import { isConvertible } from "../../fhir-converter/converter";
 import { makeFhirApi } from "../../fhir/api/api-factory";
 import { getAllPages } from "../../fhir/shared/paginated";
-import { isConvertible } from "../../fhir-converter/converter";
-import { MedicalDataSource } from "@metriport/core/external/index";
 import { appendDocQueryProgressWithSource } from "../../hie/append-doc-query-progress-with-source";
+import { DocumentQueryResult } from "../document-query-result";
 
 const region = Config.getAWSRegion();
 const s3Utils = new S3Utils(region);
@@ -121,7 +122,12 @@ const filterOutExistingDocRefsS3 = async (
 ): Promise<ExistentialDocRefs> => {
   const docIdWithExist = await Promise.allSettled(
     documents.map(async (doc): Promise<{ docId: string; exists: boolean }> => {
-      const fileName = createS3FileName(cxId, patientId, doc.docUniqueId);
+      const fileName = createDocumentFilePath(
+        cxId,
+        patientId,
+        doc.docUniqueId,
+        doc.contentType ?? undefined
+      );
 
       const { exists } = await s3Utils.getFileInfoFromS3(fileName, s3BucketName);
 

--- a/packages/api/src/external/commonwell/document/document-query-sandbox.ts
+++ b/packages/api/src/external/commonwell/document/document-query-sandbox.ts
@@ -1,20 +1,21 @@
 import { DocumentReference } from "@medplum/fhirtypes";
+import { Organization } from "@metriport/core/domain/organization";
+import { Patient } from "@metriport/core/domain/patient";
+import { getFileExtension } from "@metriport/core/util/mime";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import {
   MAPIWebhookStatus,
   processPatientDocumentRequest,
 } from "../../../command/medical/document/document-webhook";
 import { appendDocQueryProgress } from "../../../command/medical/patient/append-doc-query-progress";
-import { Organization } from "@metriport/core/domain/organization";
-import { Patient } from "@metriport/core/domain/patient";
 import { toDTO } from "../../../routes/medical/dtos/documentDTO";
 import { getSandboxSeedData } from "../../../shared/sandbox/sandbox-seed-data";
 import { Util } from "../../../shared/util";
 import { convertCDAToFHIR, isConvertible } from "../../fhir-converter/converter";
-import { upsertDocumentToFHIRServer } from "../../fhir/document/save-document-reference";
-import { getFileExtension, sandboxSleepTime } from "./shared";
 import { getDocuments } from "../../fhir/document/get-documents";
+import { upsertDocumentToFHIRServer } from "../../fhir/document/save-document-reference";
 import { metriportDataSourceExtension } from "../../fhir/shared/extensions/metriport";
+import { sandboxSleepTime } from "./shared";
 
 const randomDates = [
   "2023-06-15",

--- a/packages/api/src/external/commonwell/document/shared.ts
+++ b/packages/api/src/external/commonwell/document/shared.ts
@@ -1,6 +1,6 @@
 import { Document } from "@metriport/commonwell-sdk";
-import { contentType, extension } from "mime-types";
 import { Patient } from "@metriport/core/domain/patient";
+import { getFileExtension } from "@metriport/core/util/mime";
 
 export const sandboxSleepTime = 5000;
 
@@ -33,10 +33,4 @@ export function getFileName(patient: Patient, doc: Document): string {
 function getSuffix(id: string | undefined): string {
   if (!id) return "";
   return id.replace("urn:uuid:", "");
-}
-
-export function getFileExtension(value: string | undefined): string {
-  if (!value || !contentType(value)) return "";
-  const fileExtension = extension(value);
-  return fileExtension ? `.${fileExtension}` : "";
 }

--- a/packages/api/src/external/fhir/document/draft-update-document-reference.ts
+++ b/packages/api/src/external/fhir/document/draft-update-document-reference.ts
@@ -8,7 +8,7 @@ import {
 } from "@medplum/fhirtypes";
 import { S3Utils } from "@metriport/core/external/aws/s3";
 import { toFHIRSubject } from "@metriport/core/external/fhir/patient/index";
-import { IETF_URL } from "@metriport/core/external/fhir/shared/namespaces";
+import { IETF_URI } from "@metriport/core/external/fhir/shared/namespaces";
 import BadRequestError from "@metriport/core/util/error/bad-request";
 import { cloneDeep } from "lodash";
 import { OrganizationModel } from "../../../models/medical/organization";
@@ -77,7 +77,7 @@ export function composeDocumentReference({
 
 function getMasterIdentifier(docRefId: string): Identifier {
   return {
-    system: IETF_URL,
+    system: IETF_URI,
     value: docRefId,
   };
 }

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -210,6 +210,7 @@ router.post(
   "/db-maintenance",
   asyncHandler(async (req: Request, res: Response) => {
     const result = await dbMaintenance();
+    console.log(`DB Maintenance Result: ${JSON.stringify(result)}`);
     return res.status(httpStatus.OK).json(result);
   })
 );

--- a/packages/api/src/routes/medical/document.ts
+++ b/packages/api/src/routes/medical/document.ts
@@ -90,7 +90,7 @@ router.get(
     const cxId = getCxIdOrFail(req);
     const patientId = getFromQueryOrFail("patientId", req);
     const patient = await getPatientOrFail({ cxId, id: patientId });
-    return res.status(OK).json(patient.data.documentQueryProgress);
+    return res.status(OK).json(patient.data.documentQueryProgress ?? {});
   })
 );
 

--- a/packages/api/src/shared/external.ts
+++ b/packages/api/src/shared/external.ts
@@ -1,13 +1,6 @@
 import { Document } from "@metriport/commonwell-sdk";
-import { getOrCreateDocRefMapping } from "../command/medical/docref-mapping/get-docref-mapping";
 import { MedicalDataSource } from "@metriport/core/external/index";
-
-/**
- * @deprecated Use @metriport/core instead
- */
-export const createS3FileName = (cxId: string, patientId: string, fileName: string): string => {
-  return `${cxId}/${patientId}/${cxId}_${patientId}_${fileName}`;
-};
+import { getOrCreateDocRefMapping } from "../command/medical/docref-mapping/get-docref-mapping";
 
 export const mapDocRefToMetriport = async ({
   cxId,

--- a/packages/core/src/domain/document/filename.ts
+++ b/packages/core/src/domain/document/filename.ts
@@ -1,0 +1,17 @@
+import { getFileExtension } from "../../util/mime";
+import { createFilePath } from "../filename";
+
+export function createDocumentFileName(docId: string, mimeType?: string | undefined): string {
+  const extension = getFileExtension(mimeType);
+  const docName = extension ? `${docId}${extension}` : docId;
+  return docName;
+}
+
+export function createDocumentFilePath(
+  cxId: string,
+  patientId: string,
+  docId: string,
+  mimeType?: string | undefined
+): string {
+  return createFilePath(cxId, patientId, createDocumentFileName(docId, mimeType));
+}

--- a/packages/core/src/domain/document/upload.ts
+++ b/packages/core/src/domain/document/upload.ts
@@ -1,0 +1,18 @@
+import { createFileName, createFolderName } from "../filename";
+
+const UPLOADS_FOLDER = "uploads";
+
+export function createUploadFilePath(cxId: string, patientId: string, docName: string): string {
+  const folderName = createFolderName(cxId, patientId);
+  const fileName = createFileName(cxId, patientId, docName);
+  return `${folderName}/${UPLOADS_FOLDER}/${fileName}`;
+}
+
+export function createUploadMetadataFilePath(
+  cxId: string,
+  patientId: string,
+  docName: string
+): string {
+  const uploadFilePath = createUploadFilePath(cxId, patientId, docName);
+  return `${uploadFilePath}_metadata.xml`;
+}

--- a/packages/core/src/domain/filename.ts
+++ b/packages/core/src/domain/filename.ts
@@ -1,0 +1,31 @@
+export function createFileName(cxId: string, patientId: string, fileId: string): string {
+  return `${cxId}_${patientId}_${fileId}`;
+}
+export function createFolderName(cxId: string, patientId: string): string {
+  return `${cxId}/${patientId}`;
+}
+export function createFilePath(cxId: string, patientId: string, fileId: string): string {
+  return `${createFolderName(cxId, patientId)}/${createFileName(cxId, patientId, fileId)}`;
+}
+
+export type ParsedFileName = { cxId: string; patientId: string; fileId: string };
+
+export function parseFileName(fileName: string): ParsedFileName | undefined {
+  const parts = fileName.split("_");
+  const cxId = parts[0];
+  const patientId = parts[1];
+  const fileId = parts[2];
+  if (cxId && patientId && fileId) {
+    return { cxId, patientId, fileId };
+  }
+  return undefined;
+}
+
+export function parseFilePath(filePath: string): ParsedFileName | undefined {
+  if (filePath.includes("/")) {
+    const pathParts = filePath.split("/");
+    const fileName = pathParts[pathParts.length - 1];
+    if (fileName) return parseFileName(fileName);
+  }
+  return undefined;
+}

--- a/packages/core/src/domain/medical-record-summary.ts
+++ b/packages/core/src/domain/medical-record-summary.ts
@@ -1,4 +1,4 @@
-import { createS3FileName } from "../external/aws/s3";
+import { createFilePath } from "./filename";
 
 export const MEDICAL_RECORD_KEY = "MR";
 
@@ -8,7 +8,7 @@ export const createMRSummaryFileName = (
   extension: "pdf" | "html" | "json"
 ): string => {
   if (extension === "pdf") {
-    return createS3FileName(cxId, patientId, `${MEDICAL_RECORD_KEY}.html.pdf`);
+    return createFilePath(cxId, patientId, `${MEDICAL_RECORD_KEY}.html.pdf`);
   }
-  return createS3FileName(cxId, patientId, `${MEDICAL_RECORD_KEY}.${extension}`);
+  return createFilePath(cxId, patientId, `${MEDICAL_RECORD_KEY}.${extension}`);
 };

--- a/packages/core/src/external/aws/s3.ts
+++ b/packages/core/src/external/aws/s3.ts
@@ -1,8 +1,8 @@
 import {
-  PutObjectCommand,
-  S3Client,
   CopyObjectCommand,
   DeleteObjectCommand,
+  PutObjectCommand,
+  S3Client,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl as getPresignedUrl } from "@aws-sdk/s3-request-presigner";
 import * as AWS from "aws-sdk";
@@ -12,35 +12,15 @@ import * as stream from "stream";
 import { capture } from "../../util/notifications";
 
 dayjs.extend(duration);
-const UPLOADS_FOLDER = "uploads";
+
 const DEFAULT_SIGNED_URL_DURATION = dayjs.duration({ minutes: 3 }).asSeconds();
 
+/**
+ * @deprecated Use S3Utils instead, adding functions as needed
+ */
 export function makeS3Client(region: string): AWS.S3 {
   return new AWS.S3({ signatureVersion: "v4", region });
 }
-
-export const createS3FileName = (cxId: string, patientId: string, fileName: string): string => {
-  return `${cxId}/${patientId}/${cxId}_${patientId}_${fileName}`;
-};
-
-export const parseS3FileName = (
-  fileKey: string
-): { cxId: string; patientId: string; docId: string } | undefined => {
-  if (fileKey.includes("/")) {
-    const keyParts = fileKey.split("/");
-    const docName = keyParts[keyParts.length - 1];
-    if (docName) {
-      const docNameParts = docName.split("_");
-      const cxId = docNameParts[0];
-      const patientId = docNameParts[1];
-      const docId = docNameParts[2];
-      if (cxId && patientId && docId) {
-        return { cxId, patientId, docId };
-      }
-    }
-  }
-  return;
-};
 
 /**
  * @deprecated Use `S3Utils.getSignedUrl()` instead
@@ -70,7 +50,7 @@ export class S3Utils {
   }
 
   /**
-   * @deprecated This is v2 of the S3 client. Use `s3` instead.
+   * @deprecated This is v2 of the S3 client. Use `s3Client` instead.
    */
   get s3(): AWS.S3 {
     return this._s3;
@@ -285,12 +265,4 @@ export class S3Utils {
       return undefined;
     }
   }
-}
-
-export function buildDestinationKeyMetadata(
-  cxId: string,
-  patientId: string,
-  docId: string
-): string {
-  return `${cxId}/${patientId}/${UPLOADS_FOLDER}/${cxId}_${patientId}_${docId}_metadata.xml`;
 }

--- a/packages/core/src/external/fhir/shared/namespaces.ts
+++ b/packages/core/src/external/fhir/shared/namespaces.ts
@@ -1,0 +1,1 @@
+export const IETF_URL = "urn:ietf:rfc:3986";

--- a/packages/core/src/external/fhir/shared/namespaces.ts
+++ b/packages/core/src/external/fhir/shared/namespaces.ts
@@ -1,1 +1,1 @@
-export const IETF_URL = "urn:ietf:rfc:3986";
+export const IETF_URI = "urn:ietf:rfc:3986";

--- a/packages/core/src/util/mime.ts
+++ b/packages/core/src/util/mime.ts
@@ -1,3 +1,5 @@
+import { contentType, extension } from "mime-types";
+
 /**
  * Returns boolean indicating whether a given MIME type is XML.
  * This takes into consideration of our usage of XMLs, which based on "pure"
@@ -37,3 +39,12 @@ export const OCTET_MIME_TYPE = "application/octet-stream";
 export const OCTET_FILE_EXTENSION = ".bin";
 export const HTML_MIME_TYPE = "text/html";
 export const HTML_FILE_EXTENSION = ".html";
+
+/**
+ * Returns a file extension based on a given MIME type.
+ */
+export function getFileExtension(value: string | undefined): string {
+  if (!value || !contentType(value)) return "";
+  const fileExtension = extension(value);
+  return fileExtension ? `.${fileExtension}` : "";
+}

--- a/packages/lambdas/src/cw-doc-contribution.ts
+++ b/packages/lambdas/src/cw-doc-contribution.ts
@@ -15,6 +15,19 @@ const s3Utils = new S3Utils(region);
 const bucketName = getEnvOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
 const SIGNED_URL_DURATION_SECONDS = 60;
 
+/**
+ * This lambda is called by CommonWell as part of document retrieval - DR.
+ *
+ * It's called after document query - DQ - with the Document Refeference's
+ * attachment URL - which points to here.
+ *
+ * This lambda should be behind API GW's OAuth authorizer at all times.
+ *
+ * It will:
+ * - receive the attachment URL;
+ * - generate a signed URL for the file (60s expiration);
+ * - returns a redirect to the signed URL.
+ */
 export const handler = Sentry.AWSLambda.wrapHandler(
   async (event: lambda.APIGatewayRequestAuthorizerEvent) => {
     const fileName = event.queryStringParameters?.[docContributionFileParam] ?? "";

--- a/packages/utils/src/fhir-converter/shared.ts
+++ b/packages/utils/src/fhir-converter/shared.ts
@@ -1,5 +1,5 @@
 import { Bundle, Resource, ResourceType } from "@medplum/fhirtypes";
-import { parseS3FileName } from "@metriport/core/external/aws/s3";
+import { parseFilePath } from "@metriport/core/domain/filename";
 import { getFileContentsAsync, getFileNames } from "../shared/fs";
 import { uuidv7 } from "../shared/uuid-v7";
 
@@ -60,7 +60,7 @@ export async function getResourceCountByFile(fileName: string) {
 }
 
 export function getPatientIdFromFileName(fileName: string) {
-  const parts = parseS3FileName(fileName);
+  const parts = parseFilePath(fileName);
   if (!parts) return uuidv7();
   return parts.patientId;
 }


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1467

### Dependencies

- downstream: https://github.com/metriport/metriport/pull/1560

### Description

- avoid error when querying empty DQ status - fixes https://github.com/metriport/metriport-internal/issues/1468
- fix duplicate documents on inbound DQs
- refactor code to name/parse file and document names
   - now uploaded files also have the a file extension

### Testing

- Local
  - [x] CW always return the same doc IDs
  - [x] SDK doesn't fail when empty DQ progress
- Staging
  - [ ] download existing documents
  - [ ] upload new documents
  - [ ] download new documents
  - [ ] multiple DQ don't result in new documents
- Sandbox
  - none
- Production
  - none

### Release Plan

- nothing special