### PR TITLE
HAPI-1096: Missing Provider Details

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Sections/Medication.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Medication.hbs
@@ -18,12 +18,19 @@
                                 {{/with}}
                                 {{>References/MedicationRequest/medicationReference.hbs ID=(generateUUID (toJsonString this.supply)) REF=(concat 'Medication/' (generateUUID (toJsonString medEntry.substanceAdministration.consumable)))}},
                             {{/if}}
+                            {!-- I am keeping what was originally here but I have yet to see an author placed here --}}
                             {{#if medReq.supply.author.assignedAuthor}}
                                 {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=medReq.supply.author.assignedAuthor) as |practitionerId|}}
                                     {{>Resources/Practitioner.hbs practitioner=medReq.supply.author.assignedAuthor ID=practitionerId.Id}},
                                     {{>References/MedicationRequest/requester.hbs ID=(generateUUID (toJsonString ../supply)) REF=(concat 'Practitioner/' practitionerId.Id)}}
                                 {{/with}}
+                            {{else if ../this.substanceAdministration.author.assignedAuthor}}
+                                {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=../this.substanceAdministration.author.assignedAuthor) as |practitionerId|}}
+                                    {{>Resources/Practitioner.hbs practitioner=../this.substanceAdministration.author.assignedAuthor ID=practitionerId.Id}},
+                                    {{>References/MedicationRequest/requester.hbs ID=(generateUUID (toJsonString ../supply)) REF=(concat 'Practitioner/' practitionerId.Id)}}
+                                {{/with}}
                             {{/if}}
+
                         {{/each}}
                     {{/if}}
                     {{#if medEntry.substanceAdministration.informant.assignedEntity.representedOrganization.name._}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Medication.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Medication.hbs
@@ -18,7 +18,7 @@
                                 {{/with}}
                                 {{>References/MedicationRequest/medicationReference.hbs ID=(generateUUID (toJsonString this.supply)) REF=(concat 'Medication/' (generateUUID (toJsonString medEntry.substanceAdministration.consumable)))}},
                             {{/if}}
-                            {!-- I am keeping what was originally here but I have yet to see an author placed here --}}
+                            {{!-- I am keeping what was originally here but I have yet to see an author placed here --}}
                             {{#if medReq.supply.author.assignedAuthor}}
                                 {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=medReq.supply.author.assignedAuthor) as |practitionerId|}}
                                     {{>Resources/Practitioner.hbs practitioner=medReq.supply.author.assignedAuthor ID=practitionerId.Id}},

--- a/packages/fhir-converter/src/templates/cda/Sections/Procedures.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Procedures.hbs
@@ -11,6 +11,13 @@
                         {{>Resources/Organization.hbs org=procEntry.procedure.performer.assignedEntity.representedOrganization ID=(generateUUID (toJsonString procEntry.procedure.performer.assignedEntity.representedOrganization))}},
                         {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString procEntry.procedure)) REF=(concat 'Organization/' (generateUUID (toJsonString procEntry.procedure.performer.assignedEntity.representedOrganization)))}},
                     {{/if}}
+                    
+                    {{#if procEntry.procedure.performer.assignedEntity}}
+                        {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=procEntry.procedure.performer.assignedEntity) as |practitionerId|}}
+                            {{>Resources/Practitioner.hbs practitioner=procEntry.procedure.performer.assignedEntity ID=practitionerId.Id}},
+                            {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString procEntry.procedure)) REF=(concat 'Practitioner/' practitionerId.Id)}},
+                        {{/with}}
+                    {{/if}}
                 {{/if}}
                 
                 {{#if procEntry.observation}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
@@ -28,7 +28,9 @@
                         {{#if obsEntry.observation.author.assignedAuthor}}
                             {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=obsEntry.observation.author.assignedAuthor) as |practitionerId|}}
                                 {{!--assert aaa toJsonString this.Id--}}
-                                {{>References/Observation/performer.hbs ID=(generateUUID (toJsonString obsEntry.observation)) REF=(concat 'Practitioner/' practitionerId.Id )}},        
+                                {{#if practitionerId.Id}}
+                                    {{>References/Observation/performer.hbs ID=(generateUUID (toJsonString obsEntry.observation)) REF=(concat 'Practitioner/' practitionerId.Id )}},
+                                {{/if}}                            
                             {{/with}}
                         {{/if}}
                     {{/if}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
@@ -27,10 +27,8 @@
                         {{/with}}
                         {{#if obsEntry.observation.author.assignedAuthor}}
                             {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=obsEntry.observation.author.assignedAuthor) as |practitionerId|}}
-                                {{!--assert aaa toJsonString this.Id--}}
-                                {{#if practitionerId.Id}}
-                                    {{>References/Observation/performer.hbs ID=(generateUUID (toJsonString obsEntry.observation)) REF=(concat 'Practitioner/' practitionerId.Id )}},
-                                {{/if}}                            
+                                {{>Resources/Practitioner.hbs practitioner=obsEntry.observation.author.assignedAuthor ID=practitionerId.Id}},
+                                {{>References/Observation/performer.hbs ID=(generateUUID (toJsonString obsEntry.observation)) REF=(concat 'Practitioner/' practitionerId.Id )}},                           
                             {{/with}}
                         {{/if}}
                     {{/if}}

--- a/packages/fhir-converter/src/templates/cda/Utils/GeneratePractitionerId.hbs
+++ b/packages/fhir-converter/src/templates/cda/Utils/GeneratePractitionerId.hbs
@@ -6,9 +6,6 @@
             {{else if FirstId.root}}
                 {{!--If only root is provided, it is supposed to be unique--}}
                 "{{generateUUID (toString FirstId.root)}}"
-            {{else}}
-                {{!--Generate using obj if no root or id is available--}}
-                "{{generateUUID (toJsonString ..)}}"
             {{/if}}
         {{/with}}
 }

--- a/packages/fhir-converter/src/templates/cda/Utils/GeneratePractitionerId.hbs
+++ b/packages/fhir-converter/src/templates/cda/Utils/GeneratePractitionerId.hbs
@@ -6,6 +6,8 @@
             {{else if FirstId.root}}
                 {{!--If only root is provided, it is supposed to be unique--}}
                 "{{generateUUID (toString FirstId.root)}}"
+            {{else}}
+                "{{generateUUID (toString ..)}}"
             {{/if}}
         {{/with}}
 }


### PR DESCRIPTION
Refs: #[1469](https://github.com/metriport/metriport-internal/issues/1469)

### Downstream

- https://github.com/metriport/metriport/pull/1566

### Description

- patching hapi 1096 bug
- `"diagnostics":"HAPI-1096: Resource Practitioner/4130df42-2908-3c82-a50b-60abc20f68b9 is deleted, specified in path: Observation.performer"`. Root cause of the bug is we generate a practitioner id for a practitioner that does not exist

### Testing

- Local
  - [ ] run e2e 
  - [ ] A little tough since error doesnt repro on my local hapi fhir
  
### Release Plan

- [ ] Merge this
