### PR TITLE
PATCH RELEASE remove invalid query param from CW request

### DIFF
--- a/packages/api/src/external/commonwell/proxy/shared.ts
+++ b/packages/api/src/external/commonwell/proxy/shared.ts
@@ -1,7 +1,6 @@
-import { out } from "@metriport/core/util/log";
 import { Config } from "../../../shared/config";
 
-export const { log } = out(`CW FHIR proxy`);
+export const proxyPrefix = `CW FHIR proxy`;
 
 export const fhirServerUrl = Config.getFHIRServerUrl();
 export const pathSeparator = "/";


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Description

Remove invalid query param from CW request

### Testing

- Local
  - [x] Removes invalid query param and forward request
- Production
  - [ ] monitor inbound requests for a while

### Release Plan

- :warning: Points to `master`
- nothing special, asap