### PR TITLE
PATCH RELEASE avoid pagination on CW FHIR proxy

### DIFF
--- a/packages/api/src/external/commonwell/proxy/__tests__/cw-fhir-proxy.test.ts
+++ b/packages/api/src/external/commonwell/proxy/__tests__/cw-fhir-proxy.test.ts
@@ -39,7 +39,8 @@ describe("cw-fhir-proxy", () => {
       `&_include=DocumentReference:custodian` +
       `&_include=DocumentReference:encounter` +
       `&${patientParamName}=${patientParamValue}` +
-      `&status=current`;
+      `&status=current` +
+      `&_count=500`;
 
     it("throws when gets no query params", async () => {
       const path = `/DocumentReference`;
@@ -64,7 +65,9 @@ describe("cw-fhir-proxy", () => {
       const inputPatientParam = "patient.identifier";
       const expectedPatientParam = "patient";
       const inputQuery = makeQuery(inputPatientParam, `urn:oid:${orgId}%7C${patientId}`);
-      const expectedQuery = makeQuery(expectedPatientParam, patientId);
+      const expectedQuery = new URLSearchParams(
+        makeQuery(expectedPatientParam, patientId)
+      ).toString();
       mock_getOrgOrFail.mockImplementation(async () => ({ cxId: tenant }));
       const res = await processDocReference(path, inputQuery);
       expect(res).toBeTruthy();

--- a/packages/api/src/external/commonwell/proxy/shared.ts
+++ b/packages/api/src/external/commonwell/proxy/shared.ts
@@ -6,3 +6,14 @@ export const fhirServerUrl = Config.getFHIRServerUrl();
 export const pathSeparator = "/";
 export const binaryResourceName = "Binary";
 export const docReferenceResourceName = "DocumentReference";
+
+export const defaultError = {
+  resourceType: "OperationOutcome",
+  issue: [
+    {
+      severity: "error",
+      code: "processing",
+      diagnostics: "Error processing request",
+    },
+  ],
+};


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Description

Avoid pagination on CW FHIR proxy - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1706753574921439?thread_ts=1706731392.225699&cid=C0616FCPAKZ)

### Testing

- Local
  - [x] Returns FHIR resources as requested
  - [x] Forces count param to avoid pagination

### Release Plan

- :warning: Points to `master`
- nothing special, asap