### PR TITLE
fix(api): add production url to carequality sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28480,7 +28480,7 @@
       }
     },
     "packages/api": {
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -28561,11 +28561,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.11.0",
+      "version": "7.11.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.0",
-        "@metriport/shared": "^0.4.0",
+        "@metriport/commonwell-sdk": "^4.12.1",
+        "@metriport/shared": "^0.4.1",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28621,11 +28621,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/core": "^1.9.0",
-        "@metriport/ihe-gateway-sdk": "^0.4.1"
+        "@metriport/core": "^1.9.1",
+        "@metriport/ihe-gateway-sdk": "^0.4.2"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -28639,7 +28639,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -28648,10 +28648,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.0",
+        "@metriport/commonwell-sdk": "^4.12.1",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -28690,10 +28690,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.0",
+        "@metriport/commonwell-sdk": "^4.12.1",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -28725,7 +28725,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.12.0",
+      "version": "4.12.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",
@@ -28818,7 +28818,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -28885,10 +28885,10 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.4.0",
+        "@metriport/shared": "^0.4.1",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
@@ -28901,7 +28901,7 @@
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "dependencies": {
         "aws-cdk-lib": "^2.87.0",
         "constructs": "^10.2.69",
@@ -28948,7 +28948,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -29975,14 +29975,14 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT"
     },
     "packages/tester-node": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "ISC",
       "dependencies": {
-        "@metriport/api-sdk": "^7.11.0",
+        "@metriport/api-sdk": "^7.11.1",
         "@metriport/core": "file:packages/core",
         "dotenv": "^16.0.3"
       },
@@ -30012,7 +30012,7 @@
     },
     "packages/tester-node/packages/core": {},
     "packages/utils": {
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28480,7 +28480,7 @@
       }
     },
     "packages/api": {
-      "version": "1.13.1",
+      "version": "1.13.2-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -28561,11 +28561,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.11.1",
+      "version": "7.11.2-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.1",
-        "@metriport/shared": "^0.4.1",
+        "@metriport/commonwell-sdk": "^4.12.2-alpha.0",
+        "@metriport/shared": "^0.4.2-alpha.0",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28621,11 +28621,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.3.2",
+      "version": "1.3.3-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/core": "^1.9.1",
-        "@metriport/ihe-gateway-sdk": "^0.4.2"
+        "@metriport/core": "^1.9.2-alpha.0",
+        "@metriport/ihe-gateway-sdk": "^0.4.3-alpha.0"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -28639,7 +28639,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.4.2-alpha.0",
+      "version": "0.4.3-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -28648,10 +28648,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.13.1",
+      "version": "1.13.2-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.1",
+        "@metriport/commonwell-sdk": "^4.12.2-alpha.0",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -28690,10 +28690,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.10.1",
+      "version": "1.10.2-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.1",
+        "@metriport/commonwell-sdk": "^4.12.2-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -28725,7 +28725,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.12.1",
+      "version": "4.12.2-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",
@@ -28818,7 +28818,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.9.1",
+      "version": "1.9.2-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -28885,10 +28885,10 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.4.2",
+      "version": "0.4.3-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.4.1",
+        "@metriport/shared": "^0.4.2-alpha.0",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
@@ -28901,7 +28901,7 @@
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.8.1",
+      "version": "1.8.2-alpha.0",
       "dependencies": {
         "aws-cdk-lib": "^2.87.0",
         "constructs": "^10.2.69",
@@ -28948,7 +28948,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.8.1",
+      "version": "1.8.2-alpha.0",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -29975,14 +29975,14 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.4.1",
+      "version": "0.4.2-alpha.0",
       "license": "MIT"
     },
     "packages/tester-node": {
-      "version": "1.4.1",
+      "version": "1.4.2-alpha.0",
       "license": "ISC",
       "dependencies": {
-        "@metriport/api-sdk": "^7.11.1",
+        "@metriport/api-sdk": "^7.11.2-alpha.0",
         "@metriport/core": "file:packages/core",
         "dotenv": "^16.0.3"
       },
@@ -30012,7 +30012,7 @@
     },
     "packages/tester-node/packages/core": {},
     "packages/utils": {
-      "version": "1.10.1",
+      "version": "1.10.2-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28639,7 +28639,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.4.1",
+      "version": "0.4.2-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28480,7 +28480,7 @@
       }
     },
     "packages/api": {
-      "version": "1.13.2-alpha.1",
+      "version": "1.13.2-alpha.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -28561,11 +28561,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.11.2-alpha.1",
+      "version": "7.11.2-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.2-alpha.1",
-        "@metriport/shared": "^0.4.2-alpha.1",
+        "@metriport/commonwell-sdk": "^4.12.2-alpha.2",
+        "@metriport/shared": "^0.4.2-alpha.2",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28621,11 +28621,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.3.3-alpha.1",
+      "version": "1.3.3-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/core": "^1.9.2-alpha.1",
-        "@metriport/ihe-gateway-sdk": "^0.4.3-alpha.1"
+        "@metriport/core": "^1.9.2-alpha.2",
+        "@metriport/ihe-gateway-sdk": "^0.4.3-alpha.2"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -28639,7 +28639,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.4.3-alpha.1",
+      "version": "0.4.3-alpha.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -28648,10 +28648,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.13.2-alpha.1",
+      "version": "1.13.2-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.2-alpha.1",
+        "@metriport/commonwell-sdk": "^4.12.2-alpha.2",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -28690,10 +28690,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.10.2-alpha.1",
+      "version": "1.10.2-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.2-alpha.1",
+        "@metriport/commonwell-sdk": "^4.12.2-alpha.2",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -28725,7 +28725,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.12.2-alpha.1",
+      "version": "4.12.2-alpha.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",
@@ -28818,7 +28818,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.9.2-alpha.1",
+      "version": "1.9.2-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -28885,10 +28885,10 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.4.3-alpha.1",
+      "version": "0.4.3-alpha.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.4.2-alpha.1",
+        "@metriport/shared": "^0.4.2-alpha.2",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
@@ -28901,7 +28901,7 @@
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.8.2-alpha.1",
+      "version": "1.8.2-alpha.2",
       "dependencies": {
         "aws-cdk-lib": "^2.87.0",
         "constructs": "^10.2.69",
@@ -28948,7 +28948,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.8.2-alpha.1",
+      "version": "1.8.2-alpha.2",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -29975,14 +29975,14 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.4.2-alpha.1",
+      "version": "0.4.2-alpha.2",
       "license": "MIT"
     },
     "packages/tester-node": {
-      "version": "1.4.2-alpha.1",
+      "version": "1.4.3-alpha.2",
       "license": "ISC",
       "dependencies": {
-        "@metriport/api-sdk": "^7.11.2-alpha.1",
+        "@metriport/api-sdk": "^7.11.2-alpha.2",
         "@metriport/core": "file:packages/core",
         "dotenv": "^16.0.3"
       },
@@ -30012,7 +30012,7 @@
     },
     "packages/tester-node/packages/core": {},
     "packages/utils": {
-      "version": "1.10.2-alpha.1",
+      "version": "1.10.2-alpha.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28480,7 +28480,7 @@
       }
     },
     "packages/api": {
-      "version": "1.13.2-alpha.0",
+      "version": "1.13.2-alpha.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -28561,11 +28561,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.11.2-alpha.0",
+      "version": "7.11.2-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.2-alpha.0",
-        "@metriport/shared": "^0.4.2-alpha.0",
+        "@metriport/commonwell-sdk": "^4.12.2-alpha.1",
+        "@metriport/shared": "^0.4.2-alpha.1",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28621,11 +28621,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.3.3-alpha.0",
+      "version": "1.3.3-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/core": "^1.9.2-alpha.0",
-        "@metriport/ihe-gateway-sdk": "^0.4.3-alpha.0"
+        "@metriport/core": "^1.9.2-alpha.1",
+        "@metriport/ihe-gateway-sdk": "^0.4.3-alpha.1"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -28639,7 +28639,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.4.3-alpha.0",
+      "version": "0.4.3-alpha.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -28648,10 +28648,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.13.2-alpha.0",
+      "version": "1.13.2-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.2-alpha.0",
+        "@metriport/commonwell-sdk": "^4.12.2-alpha.1",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -28690,10 +28690,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.10.2-alpha.0",
+      "version": "1.10.2-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.2-alpha.0",
+        "@metriport/commonwell-sdk": "^4.12.2-alpha.1",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -28725,7 +28725,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.12.2-alpha.0",
+      "version": "4.12.2-alpha.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",
@@ -28818,7 +28818,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.9.2-alpha.0",
+      "version": "1.9.2-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -28885,10 +28885,10 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.4.3-alpha.0",
+      "version": "0.4.3-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.4.2-alpha.0",
+        "@metriport/shared": "^0.4.2-alpha.1",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
@@ -28901,7 +28901,7 @@
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.8.2-alpha.0",
+      "version": "1.8.2-alpha.1",
       "dependencies": {
         "aws-cdk-lib": "^2.87.0",
         "constructs": "^10.2.69",
@@ -28948,7 +28948,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.8.2-alpha.0",
+      "version": "1.8.2-alpha.1",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -29975,14 +29975,14 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.4.2-alpha.0",
+      "version": "0.4.2-alpha.1",
       "license": "MIT"
     },
     "packages/tester-node": {
-      "version": "1.4.2-alpha.0",
+      "version": "1.4.2-alpha.1",
       "license": "ISC",
       "dependencies": {
-        "@metriport/api-sdk": "^7.11.2-alpha.0",
+        "@metriport/api-sdk": "^7.11.2-alpha.1",
         "@metriport/core": "file:packages/core",
         "dotenv": "^16.0.3"
       },
@@ -30012,7 +30012,7 @@
     },
     "packages/tester-node/packages/core": {},
     "packages/utils": {
-      "version": "1.10.2-alpha.0",
+      "version": "1.10.2-alpha.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.11.0",
+  "version": "7.11.1",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -56,8 +56,8 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.0",
-    "@metriport/shared": "^0.4.0",
+    "@metriport/commonwell-sdk": "^4.12.1",
+    "@metriport/shared": "^0.4.1",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.11.2-alpha.0",
+  "version": "7.11.2-alpha.1",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -56,8 +56,8 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.2-alpha.0",
-    "@metriport/shared": "^0.4.2-alpha.0",
+    "@metriport/commonwell-sdk": "^4.12.2-alpha.1",
+    "@metriport/shared": "^0.4.2-alpha.1",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.11.2-alpha.1",
+  "version": "7.11.2-alpha.2",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -56,8 +56,8 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.2-alpha.1",
-    "@metriport/shared": "^0.4.2-alpha.1",
+    "@metriport/commonwell-sdk": "^4.12.2-alpha.2",
+    "@metriport/shared": "^0.4.2-alpha.2",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.11.1",
+  "version": "7.11.2-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -56,8 +56,8 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.1",
-    "@metriport/shared": "^0.4.1",
+    "@metriport/commonwell-sdk": "^4.12.2-alpha.0",
+    "@metriport/shared": "^0.4.2-alpha.0",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.13.2-alpha.1",
+  "version": "1.13.2-alpha.2",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.13.1",
+  "version": "1.13.2-alpha.0",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.13.2-alpha.0",
+  "version": "1.13.2-alpha.1",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/src/external/carequality/api.ts
+++ b/packages/api/src/external/carequality/api.ts
@@ -1,6 +1,12 @@
-import { Carequality } from "@metriport/carequality-sdk";
-import { IHEGateway, APIMode } from "@metriport/ihe-gateway-sdk";
+import { Carequality, APIMode as CQAPIMode } from "@metriport/carequality-sdk";
+import { IHEGateway, APIMode as IHEGatewayAPIMode } from "@metriport/ihe-gateway-sdk";
 import { Config } from "../../shared/config";
+
+const cqApiMode = Config.isProdEnv()
+  ? CQAPIMode.production
+  : Config.isStaging()
+  ? CQAPIMode.staging
+  : CQAPIMode.dev;
 
 /**
  * Creates a new instance of the Carequality API client.
@@ -10,7 +16,7 @@ import { Config } from "../../shared/config";
 export function makeCarequalityAPI(apiKey?: string): Carequality | undefined {
   if (Config.isSandbox()) return;
   const cqApiKey = apiKey ?? Config.getCQApiKey();
-  return new Carequality(cqApiKey);
+  return new Carequality(cqApiKey, cqApiMode);
 }
 
 /**
@@ -23,5 +29,5 @@ export function makeIheGatewayAPI(): IHEGateway | undefined {
     return;
   }
 
-  return new IHEGateway(APIMode.dev);
+  return new IHEGateway(IHEGatewayAPIMode.dev);
 }

--- a/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory.ts
@@ -1,7 +1,7 @@
-import { Carequality } from "@metriport/carequality-sdk/client/carequality";
 import { sleep } from "@metriport/core/util/sleep";
 import { QueryTypes, Sequelize } from "sequelize";
 import { Config } from "../../../../shared/config";
+import { makeCarequalityAPI } from "../../api";
 import { capture } from "../../../../shared/notifications";
 import { bulkInsertCQDirectoryEntries } from "./create-cq-directory-entry";
 import { parseCQDirectoryEntries } from "./parse-cq-directory-entry";
@@ -32,8 +32,8 @@ export async function rebuildCQDirectory(failGracefully = false): Promise<void> 
     await createTempCQDirectoryTable();
     while (!isDone) {
       try {
-        const apiKey = Config.getCQApiKey();
-        const cq = new Carequality(apiKey); // TODO: use the prod API mode - https://github.com/metriport/metriport-internal/issues/1350
+        const cq = makeCarequalityAPI();
+        if (!cq) throw new Error("Carequality API not initialized");
         const orgs = await cq.listOrganizations({ start: currentPosition, count: BATCH_SIZE });
         if (orgs.length < BATCH_SIZE) isDone = true; // if CQ directory returns less than BATCH_SIZE number of orgs, that means we've hit the end
         currentPosition += BATCH_SIZE;

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -1,4 +1,3 @@
-import { Carequality } from "@metriport/carequality-sdk/client/carequality";
 import NotFoundError from "@metriport/core/util/error/not-found";
 import {
   patientDiscoveryRespFromExternalGWSchema,
@@ -10,6 +9,7 @@ import duration from "dayjs/plugin/duration";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import httpStatus from "http-status";
+import { makeCarequalityAPI } from "../../external/carequality/api";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
 import { parseCQDirectoryEntries } from "../../external/carequality/command/cq-directory/parse-cq-directory-entry";
 import { rebuildCQDirectory } from "../../external/carequality/command/cq-directory/rebuild-cq-directory";
@@ -55,8 +55,8 @@ router.get(
   "/directory/organization/:oid",
   asyncHandler(async (req: Request, res: Response) => {
     if (Config.isSandbox()) return res.sendStatus(httpStatus.NOT_IMPLEMENTED);
-    const apiKey = Config.getCQApiKey();
-    const cq = new Carequality(apiKey);
+    const cq = makeCarequalityAPI();
+    if (!cq) throw new Error("Carequality API not initialized");
     const oid = getFrom("params").orFail("oid", req);
     const resp = await cq.listOrganizations({ count: 1, oid });
     const org = parseCQDirectoryEntries(resp);

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.3.2",
+  "version": "1.3.3-alpha.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/core": "^1.9.1",
-    "@metriport/ihe-gateway-sdk": "^0.4.2"
+    "@metriport/core": "^1.9.2-alpha.0",
+    "@metriport/ihe-gateway-sdk": "^0.4.3-alpha.0"
   }
 }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.3.3-alpha.1",
+  "version": "1.3.3-alpha.2",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/core": "^1.9.2-alpha.1",
-    "@metriport/ihe-gateway-sdk": "^0.4.3-alpha.1"
+    "@metriport/core": "^1.9.2-alpha.2",
+    "@metriport/ihe-gateway-sdk": "^0.4.3-alpha.2"
   }
 }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.3.3-alpha.0",
+  "version": "1.3.3-alpha.1",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/core": "^1.9.2-alpha.0",
-    "@metriport/ihe-gateway-sdk": "^0.4.3-alpha.0"
+    "@metriport/core": "^1.9.2-alpha.1",
+    "@metriport/ihe-gateway-sdk": "^0.4.3-alpha.1"
   }
 }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/core": "^1.9.0",
-    "@metriport/ihe-gateway-sdk": "^0.4.1"
+    "@metriport/core": "^1.9.1",
+    "@metriport/ihe-gateway-sdk": "^0.4.2"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.4.3-alpha.1",
+  "version": "0.4.3-alpha.2",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2-alpha.0",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.4.2-alpha.0",
+  "version": "0.4.3-alpha.0",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.4.3-alpha.0",
+  "version": "0.4.3-alpha.1",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/carequality-sdk/src/client/carequality.ts
+++ b/packages/carequality-sdk/src/client/carequality.ts
@@ -15,6 +15,7 @@ const XML_FORMAT = "xml";
 export enum APIMode {
   dev = "dev",
   staging = "stage",
+  production = "production",
 }
 
 /**
@@ -23,6 +24,8 @@ export enum APIMode {
 export class Carequality implements CarequalityAPI {
   private static readonly devUrl = "https://dev-dir-ceq.sequoiadns.org/fhir-stu3/1.0.1";
   private static readonly stagingUrl = "https://stage-dir-ceq.sequoiaproject.org/fhir-stu3/1.0.1";
+  private static readonly productionUrl =
+    "https://prod-dir-ceq-01.sequoiaproject.org/fhir-stu3/1.0.1/";
 
   // NOTE: These URLs can be used if we migrate to FHIR R4 format.
   // private static readonly devUrl = "https://directory.dev.carequality.org/fhir";
@@ -43,7 +46,7 @@ export class Carequality implements CarequalityAPI {
    */
   constructor(
     apiKey: string,
-    apiMode: APIMode = APIMode.staging,
+    apiMode: APIMode = APIMode.production,
     options: { timeout?: number } = {}
   ) {
     let baseUrl;
@@ -54,6 +57,9 @@ export class Carequality implements CarequalityAPI {
         break;
       case APIMode.staging:
         baseUrl = Carequality.stagingUrl;
+        break;
+      case APIMode.production:
+        baseUrl = Carequality.productionUrl;
         break;
       default:
         throw new Error("API mode not supported.");

--- a/packages/carequality-sdk/src/models/address.ts
+++ b/packages/carequality-sdk/src/models/address.ts
@@ -20,8 +20,7 @@ export const addressSchema = z.object({
   managingOrg: z
     .object({
       reference: objectValue,
-    })
-    .optional(),
+    }).optional(),
   contained: z
     .array(
       z.object({

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.0",
+    "@metriport/commonwell-sdk": "^4.12.1",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.13.2-alpha.0",
+  "version": "1.13.2-alpha.1",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.2-alpha.0",
+    "@metriport/commonwell-sdk": "^4.12.2-alpha.1",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.13.2-alpha.1",
+  "version": "1.13.2-alpha.2",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.2-alpha.1",
+    "@metriport/commonwell-sdk": "^4.12.2-alpha.2",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.13.1",
+  "version": "1.13.2-alpha.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.1",
+    "@metriport/commonwell-sdk": "^4.12.2-alpha.0",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.0",
+    "@metriport/commonwell-sdk": "^4.12.1",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.10.2-alpha.0",
+  "version": "1.10.2-alpha.1",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.2-alpha.0",
+    "@metriport/commonwell-sdk": "^4.12.2-alpha.1",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.10.1",
+  "version": "1.10.2-alpha.0",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.1",
+    "@metriport/commonwell-sdk": "^4.12.2-alpha.0",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.10.2-alpha.1",
+  "version": "1.10.2-alpha.2",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.2-alpha.1",
+    "@metriport/commonwell-sdk": "^4.12.2-alpha.2",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.12.1",
+  "version": "4.12.2-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.12.2-alpha.0",
+  "version": "4.12.2-alpha.1",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.12.2-alpha.1",
+  "version": "4.12.2-alpha.2",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.9.2-alpha.1",
+  "version": "1.9.2-alpha.2",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.9.2-alpha.0",
+  "version": "1.9.2-alpha.1",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.9.1",
+  "version": "1.9.2-alpha.0",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.4.3-alpha.1",
+  "version": "0.4.3-alpha.2",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -55,7 +55,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.4.2-alpha.1",
+    "@metriport/shared": "^0.4.2-alpha.2",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.4.3-alpha.0",
+  "version": "0.4.3-alpha.1",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -55,7 +55,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.4.2-alpha.0",
+    "@metriport/shared": "^0.4.2-alpha.1",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -55,7 +55,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.4.0",
+    "@metriport/shared": "^0.4.1",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.4.2",
+  "version": "0.4.3-alpha.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -55,7 +55,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.4.1",
+    "@metriport/shared": "^0.4.2-alpha.0",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.8.2-alpha.1",
+  "version": "1.8.2-alpha.2",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.8.1",
+  "version": "1.8.2-alpha.0",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.8.2-alpha.0",
+  "version": "1.8.2-alpha.1",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.8.2-alpha.1",
+  "version": "1.8.2-alpha.2",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.8.1",
+  "version": "1.8.2-alpha.0",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.8.2-alpha.0",
+  "version": "1.8.2-alpha.1",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.4.2-alpha.0",
+  "version": "0.4.2-alpha.1",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.4.2-alpha.1",
+  "version": "0.4.2-alpha.2",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.4.1",
+  "version": "0.4.2-alpha.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/tester-node/package.json
+++ b/packages/tester-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tester-node",
-  "version": "1.4.1",
+  "version": "1.4.2-alpha.0",
   "description": "",
   "private": true,
   "scripts": {
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@metriport/api-sdk": "^7.11.1",
+    "@metriport/api-sdk": "^7.11.2-alpha.0",
     "@metriport/core": "file:packages/core",
     "dotenv": "^16.0.3"
   },

--- a/packages/tester-node/package.json
+++ b/packages/tester-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tester-node",
-  "version": "1.4.2-alpha.0",
+  "version": "1.4.2-alpha.1",
   "description": "",
   "private": true,
   "scripts": {
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@metriport/api-sdk": "^7.11.2-alpha.0",
+    "@metriport/api-sdk": "^7.11.2-alpha.1",
     "@metriport/core": "file:packages/core",
     "dotenv": "^16.0.3"
   },

--- a/packages/tester-node/package.json
+++ b/packages/tester-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tester-node",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "",
   "private": true,
   "scripts": {
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@metriport/api-sdk": "^7.11.0",
+    "@metriport/api-sdk": "^7.11.1",
     "@metriport/core": "file:packages/core",
     "dotenv": "^16.0.3"
   },

--- a/packages/tester-node/package.json
+++ b/packages/tester-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tester-node",
-  "version": "1.4.2-alpha.1",
+  "version": "1.4.3-alpha.2",
   "description": "",
   "private": true,
   "scripts": {
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@metriport/api-sdk": "^7.11.2-alpha.1",
+    "@metriport/api-sdk": "^7.11.2-alpha.2",
     "@metriport/core": "file:packages/core",
     "dotenv": "^16.0.3"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.10.2-alpha.1",
+  "version": "1.10.2-alpha.2",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.10.2-alpha.0",
+  "version": "1.10.2-alpha.1",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.10.1",
+  "version": "1.10.2-alpha.0",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: #1350

### Dependencies

- Upstream: none
- Downstream: none

### Description

add production url to carequality sdk

### Testing

No testing and is only being used by internal routes triggered by us

### Release Plan

Nothing special

- [ ] Upstream dependencies are met/released
- [ ] Release NPM packages
- [ ] Merge this
