### PR TITLE
Patch: Triple Braces with unescaped quotes

### DIFF
--- a/packages/fhir-converter/src/templates/cda/DataType/Address.hbs
+++ b/packages/fhir-converter/src/templates/cda/DataType/Address.hbs
@@ -2,7 +2,7 @@
     "use": {{>ValueSet/AddressUse.hbs code=addr.use}},
     "line": [
        	{{#each (toArray addr.streetAddressLine)}}
-           	"{{{this._}}}",
+           	"{{this._}}",
        	{{/each}}
     ],
     "city": "{{addr.city._}}",

--- a/packages/fhir-converter/src/templates/cda/DataType/CodeableConcept.hbs
+++ b/packages/fhir-converter/src/templates/cda/DataType/CodeableConcept.hbs
@@ -1,6 +1,6 @@
 {
 	{{#if code.originalText}}
-		"text":"{{{code.originalText._}}}",
+		"text":"{{code.originalText._}}",
 	{{/if}}
 	"coding": 
     [

--- a/packages/fhir-converter/src/templates/cda/DataType/CodeableConcept.hbs
+++ b/packages/fhir-converter/src/templates/cda/DataType/CodeableConcept.hbs
@@ -1,6 +1,8 @@
 {
 	{{#if code.originalText}}
-		"text":"{{code.originalText._}}",
+		"text":"{{{parseReferenceData code.originalText._ }}}",
+	{{else if text}}
+		"text": "{{{parseReferenceData text}}}",
 	{{/if}}
 	"coding": 
     [

--- a/packages/fhir-converter/src/templates/cda/DataType/Quantity.hbs
+++ b/packages/fhir-converter/src/templates/cda/DataType/Quantity.hbs
@@ -11,6 +11,7 @@
         {{#if comparator.isValid}}
           {
             "value": "{{comparator.number}}",
+            {{!-- safe to use triple braces here since we control the input and can ensure no single quotes --}}
             "comparator": "{{{comparator.comparator}}}",
             "unit": "{{../../../quantity.unit}}",
             "system": "http://unitsofmeasure.org"

--- a/packages/fhir-converter/src/templates/cda/Resources/DiagnosticReport.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/DiagnosticReport.hbs
@@ -22,6 +22,7 @@
             "presentedForm": [
                 {
                     "contentType": "text/plain",
+                    {{!-- safe to use triple braces here since we control the input and can ensure no single quotes --}}
                     "data": "{{{diagReport.text._b64}}}",
                 }
             ],

--- a/packages/fhir-converter/src/templates/cda/Resources/DocumentReference.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/DocumentReference.hbs
@@ -17,6 +17,7 @@
                 {
                     "contentType":"text/plain",
                     {{! Missing contentType mapping }}
+                    {{!-- safe to use triple braces here since we control the input and can ensure no single quotes --}}
                     "data":"{{{gzip docref._originalData 'utf8' 'base64'}}}",
                     "hash":"{{{base64Encode (sha1Hash (gzip docref._originalData 'utf8' 'base64')) 'hex'}}}",
                 },

--- a/packages/fhir-converter/src/templates/cda/Resources/MedicationStatement.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/MedicationStatement.hbs
@@ -19,7 +19,7 @@
         "dosage":
         [
             {
-                "text":"{{medicationStatement.text._}}",
+                "text":"{{{ parseReferenceData medicationStatement.text._ }}}",
                 "route":{{>DataType/CodeableConcept.hbs code=medicationStatement.routeCode}},
                 "doseAndRate": [
                     {

--- a/packages/fhir-converter/src/templates/cda/Resources/Observation.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/Observation.hbs
@@ -34,26 +34,7 @@
             {{/if}}
         
         "status":{{>ValueSet/ObservationStatus.hbs code=observationEntry.statusCode.code}},
-        "code": {
-            {{#if observationEntry.code.originalText}}
-                "text":"{{observationEntry.code.originalText._}}",
-            {{else if observationEntry.text._}}
-                "text":"{{observationEntry.text._}}",
-            {{/if}}
-            {{#if observationEntry.code}}
-                "coding": 
-                [
-                    {{>DataType/Coding.hbs code=observationEntry.code}},
-                    {{#if observationEntry.code.translation.code}}
-                        {{>DataType/Coding.hbs code=observationEntry.code.translation}},
-                    {{else}}
-                        {{#each observationEntry.code.translation}}
-                            {{>DataType/Coding.hbs code=this}},
-                        {{/each}}
-                    {{/if}}
-                ],
-            {{/if}}
-        },
+        "code": {{>DataType/CodeableConcept.hbs code=observationEntry.code text=observationEntry.text._}},
         
         {{#if observationEntry.effectiveTime.low.value}}
             "effectivePeriod":

--- a/packages/fhir-converter/src/templates/cda/Resources/Observation.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/Observation.hbs
@@ -36,9 +36,9 @@
         "status":{{>ValueSet/ObservationStatus.hbs code=observationEntry.statusCode.code}},
         "code": {
             {{#if observationEntry.code.originalText}}
-                "text":"{{{observationEntry.code.originalText._}}}",
+                "text":"{{observationEntry.code.originalText._}}",
             {{else if observationEntry.text._}}
-                "text":"{{{observationEntry.text._}}}",
+                "text":"{{observationEntry.text._}}",
             {{/if}}
             {{#if observationEntry.code}}
                 "coding": 
@@ -78,6 +78,7 @@
                 {{/if}}
             {{/with}}
         {{else}}
+            {{!-- okay since we control the input and escape all single quotes in parseReferenceData --}}
             "valueString":"{{{parseReferenceData observationEntry.value._}}}",
         {{/if}}
         

--- a/packages/fhir-converter/src/templates/cda/Resources/Procedure.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/Procedure.hbs
@@ -30,7 +30,7 @@
         {{/if}}
         {{#if procedureEntry.text._}}
             "note": {
-                "text": "{{procedureEntry.text._}}",
+                "text": "{{{parseReferenceData procedureEntry.text._}}}",
             },
         {{/if}}
         "bodySite":

--- a/packages/fhir-converter/src/templates/cda/Resources/RelatedPerson.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/RelatedPerson.hbs
@@ -14,7 +14,7 @@
             [
                 {
                     {{#if ../relatedPerson.code.originalText}}
-                        "text":"{{../relatedPerson.code.originalText._}}",
+                        "text":"{{{ parseReferenceData ../relatedPerson.code.originalText._ }}}",
                     {{/if}}
                     "coding": 
                     [

--- a/packages/fhir-converter/src/templates/cda/Resources/RelatedPerson.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/RelatedPerson.hbs
@@ -14,7 +14,7 @@
             [
                 {
                     {{#if ../relatedPerson.code.originalText}}
-                        "text":"{{{../relatedPerson.code.originalText._}}}",
+                        "text":"{{../relatedPerson.code.originalText._}}",
                     {{/if}}
                     "coding": 
                     [
@@ -29,7 +29,7 @@
                 },
                 {
                     {{#with (evaluate 'Utils/ContactRoleCode.hbs' code=(trimAndUpper ../relatedPerson.classCode)) as |respObjRole|}}
-                        "text":"{{{respObjRole.code.displayName}}}",
+                        "text":"{{respObjRole.code.displayName}}",
                         "coding":
                         [
                                 {{>DataType/Coding.hbs code=respObjRole.code}},


### PR DESCRIPTION
Refs: #[1442](https://github.com/metriport/metriport-internal/issues/1442)

### Description

- triple braces instead of double braces caused malformed json bug with unescaped html i.e `"Pen Needles 5/16"; 31G X 8 MM Miscellaneous"`in CodeableConcept.hbs field text 
- patching remaining triple braces bugs 

### Explanation 

- In Handlebars templates, the difference between double braces {{ }} and triple braces {{{ }}} is how they handle HTML encoding.
- Double braces` {{ }}`: This is the standard syntax for Handlebars expressions. It automatically escapes HTML to prevent injection attacks. This means characters like <, >, ", ', and & are converted into their corresponding HTML entities (`&lt;, &gt;, &quot;, &#x27;, and &amp;`, respectively).
- Triple braces `{{{ }}}`: This syntax tells Handlebars to not escape the content. It will be inserted into the template as is. This is useful when you want to render HTML or when you have special characters that you don't want to be escaped.
- In our example with `originalText: { _: 'Pen Needles 5/16" 31G X 8 MM Miscellaneous' }`, if we use triple braces around `{{code.originalText._}}`, it will insert the text as is, including the double quote ". This breaks the JSON structure because you have floating text not in a string field: 31G X 8 MM Miscellaneous'
- When we use double braces, the text becomes `'Pen Needles 5/16&quot 31G X 8 MM Miscellaneous' `and all the string is appropriately captured in the "text" field 
- ⚠️  It is very dangerous to use triple braces because of the danger of unescaped quotes. Unless we strictly control the input into the text field, we should not be using triple braces. This PR patches other instances where this bug exists too. We have 10 other instances in the templates using triple braces. 
  - [ ] `Quantity.hbs`: This is ok because we control the input. It comes from the output of extractComparator.comparator which we know will be only a comparator (<, >, <=) and not a quote
  - [ ] `DiagnosticReport.hbs`, `DocumentReference.hbs`: This is ok because we control the input and its always b64 (we don't use DocRef afaik anyway)
  - [ ] `Observation.hbs`, `RelatedPerson.hbs`, `Address.hbs`: bad because uses `._` which could have an unescaped quote in it

### Testing

- [ ] run full e2e testing

Check each PR.

### Release Plan

- [ ] Merge this
