### PR TITLE
PATCH RELEASE 2024-02-04: remove location services from sandbox CI/CD

### DIFF
--- a/.github/workflows/_deploy_cdk.yml
+++ b/.github/workflows/_deploy_cdk.yml
@@ -172,6 +172,7 @@ jobs:
       # Location Stack CDK DIFF
       - name: Diff Location Services CDK stack
         uses: metriport/deploy-with-cdk@master
+        if: inputs.location_services_cdk_stack != null
         with:
           cdk_action: "diff"
           cdk_version: "2.87.0"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -124,7 +124,6 @@ jobs:
     if: ${{ !failure() && needs.infra-api-lambdas.result == 'success' }}
     with:
       deploy_env: "sandbox"
-      location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_SANDBOX }}
       cdk_stack: ${{ vars.API_STACK_NAME_SANDBOX }}
       AWS_REGION: ${{ vars.API_REGION_SANDBOX  }}
       INFRA_CONFIG: ${{ vars.INFRA_CONFIG_SANDBOX  }}


### PR DESCRIPTION
refs. metriport/metriport-internal#1447


### Dependencies

n/a

### Description

remove location services from sandbox CI/CD

### Testing

the release will test it as it's CICD changes

### Release Plan


- :warning: Points to `master`
- [ ] Merge this
