### PR TITLE
fix(api): create a mr record summary for ADHD

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
@@ -588,7 +588,7 @@ function createDiagnosticReportsSection(
   return `
     <div id="reports" class="section">
       <div class="section-title">
-        <h3 id="reports" title="reports">&#x276F; Reports</h3>
+        <h3 id="reports" title="reports">&#x276F; Visit Notes</h3>
         <a href="#mr-header">&#x25B2; Back to Top</a>
       </div>
       <div class="section-content">
@@ -1774,7 +1774,6 @@ function createOtherObservationsByDate(observations: Observation[]): string {
   const filteredObservations = observations.reduce((acc, observation) => {
     const observationDate = formatDateForDisplay(observation.effectiveDateTime);
     const existingObservation = acc.find(observation => observation.date === observationDate);
-
     if (!observationDate.length) return acc;
 
     if (existingObservation) {

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -137,6 +137,7 @@ export class APIStack extends Stack {
       appConfigConfigId,
       cxsWithEnhancedCoverageFeatureFlag,
       cxsWithCQDirectFeatureFlag,
+      cxsWithADHDMRFeatureFlag,
     } = createAppConfigStack(this, { config: props.config });
 
     //-------------------------------------------
@@ -351,6 +352,11 @@ export class APIStack extends Stack {
         envType: props.config.environmentType,
         sentryDsn: props.config.lambdasSentryDSN,
         alarmAction: slackNotification?.alarmAction,
+        appConfigEnvVars: {
+          appId: appConfigAppId,
+          configId: appConfigConfigId,
+          cxsWithADHDMRFeatureFlag,
+        }
       });
     }
 
@@ -1204,8 +1210,13 @@ export class APIStack extends Stack {
     envType: EnvType;
     sentryDsn: string | undefined;
     alarmAction: SnsAction | undefined;
+    appConfigEnvVars: {
+      appId: string;
+      configId: string;
+      cxsWithADHDMRFeatureFlag: string;
+    };
   }): Lambda {
-    const { lambdaLayers, vpc, sentryDsn, envType, alarmAction, medicalDocumentsBucket } = ownProps;
+    const { lambdaLayers, vpc, sentryDsn, envType, alarmAction, medicalDocumentsBucket, appConfigEnvVars } = ownProps;
 
     const lambdaTimeout = MAXIMUM_LAMBDA_TIMEOUT.minus(Duration.seconds(5));
     const axiosTimeout = lambdaTimeout.minus(Duration.seconds(5));
@@ -1220,6 +1231,9 @@ export class APIStack extends Stack {
         AXIOS_TIMEOUT_SECONDS: axiosTimeout.toSeconds().toString(),
         MEDICAL_DOCUMENTS_BUCKET_NAME: medicalDocumentsBucket.bucketName,
         PDF_CONVERT_TIMEOUT_MS: CDA_TO_VIS_TIMEOUT.toMilliseconds().toString(),
+        APPCONFIG_APPLICATION_ID: appConfigEnvVars.appId,
+        APPCONFIG_CONFIGURATION_ID: appConfigEnvVars.configId,
+        ADHD_MR_FEATURE_FLAG: appConfigEnvVars.cxsWithADHDMRFeatureFlag,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
       layers: [lambdaLayers.shared, lambdaLayers.chromium],

--- a/packages/infra/lib/app-config-stack.ts
+++ b/packages/infra/lib/app-config-stack.ts
@@ -16,6 +16,7 @@ export function createAppConfigStack(
   appConfigConfigId: string;
   cxsWithEnhancedCoverageFeatureFlag: string;
   cxsWithCQDirectFeatureFlag: string;
+  cxsWithADHDMRFeatureFlag: string;
 } {
   const appConfigOSSApp = new appConfig.CfnApplication(stack, "OSSAPIConfig", {
     name: "OSSAPIConfig",
@@ -30,6 +31,7 @@ export function createAppConfigStack(
 
   const cxsWithEnhancedCoverageFeatureFlag = "cxsWithEnhancedCoverage";
   const cxsWithCQDirectFeatureFlag = "cxsWithCQDirect";
+  const cxsWithADHDMRFeatureFlag = "cxsWithADHDMR";
   const appConfigOSSVersion = new appConfig.CfnHostedConfigurationVersion(
     stack,
     "OSSAPIConfigVersion",
@@ -55,6 +57,14 @@ export function createAppConfigStack(
               },
             },
           },
+          [cxsWithADHDMRFeatureFlag]: {
+            name: cxsWithADHDMRFeatureFlag,
+            attributes: {
+              cxIds: {
+                type: "string[]",
+              },
+            },
+          },
         },
         values: {
           [cxsWithEnhancedCoverageFeatureFlag]: {
@@ -62,6 +72,10 @@ export function createAppConfigStack(
             cxIds: [],
           },
           [cxsWithCQDirectFeatureFlag]: {
+            enabled: true,
+            cxIds: [],
+          },
+          [cxsWithADHDMRFeatureFlag]: {
             enabled: true,
             cxIds: [],
           },
@@ -100,5 +114,6 @@ export function createAppConfigStack(
     appConfigConfigId: appConfigOSSProfile.ref,
     cxsWithEnhancedCoverageFeatureFlag,
     cxsWithCQDirectFeatureFlag,
+    cxsWithADHDMRFeatureFlag,
   };
 }

--- a/packages/lambdas/src/fhir-to-medical-record.ts
+++ b/packages/lambdas/src/fhir-to-medical-record.ts
@@ -1,7 +1,10 @@
 import puppeteer from "puppeteer-core";
 import fs from "fs";
+import { getFeatureFlagValue } from "@metriport/core/external/aws/appConfig";
 import { Input, Output } from "@metriport/core/domain/conversion/fhir-to-medical-record";
 import { bundleToHtml } from "@metriport/core/external/aws/lambda-logic/bundle-to-html";
+import { getEnvType } from "@metriport/core/util/env-var";
+import { bundleToHtmlADHD } from "@metriport/core/external/aws/lambda-logic/bundle-to-html-adhd";
 import chromium from "@sparticuz/chromium";
 import * as uuid from "uuid";
 import { getSignedUrl as coreGetSignedUrl, makeS3Client } from "@metriport/core/external/aws/s3";
@@ -21,6 +24,9 @@ const region = getEnvOrFail("AWS_REGION");
 const bucketName = getEnvOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
 // converter config
 const PDFConvertTimeout = getEnvOrFail("PDF_CONVERT_TIMEOUT_MS");
+const cxsWithADHDMRFeatureFlag = getEnvOrFail("ADHD_MR_FEATURE_FLAG");
+const appConfigAppID = getEnvOrFail("APPCONFIG_APPLICATION_ID");
+const appConfigConfigID = getEnvOrFail("APPCONFIG_CONFIGURATION_ID");
 const GRACEFUL_SHUTDOWN_ALLOWANCE_MS = 3_000;
 const s3Client = makeS3Client(region);
 
@@ -40,9 +46,11 @@ export const handler = Sentry.AWSLambda.wrapHandler(
     );
 
     try {
+      const cxsWithADHDFeatureFlagValue = await getCxsWithADHDFeatureFlagValue();
+      const isADHDFeatureFlagEnabled = cxsWithADHDFeatureFlagValue.includes(cxId);
       const bundle = await getBundleFromS3(fhirFileName);
 
-      const html = bundleToHtml(bundle);
+      const html = isADHDFeatureFlagEnabled ? bundleToHtmlADHD(bundle) : bundleToHtml(bundle);
       const htmlFileName = getHTMLFileName(fhirFileName);
 
       await s3Client
@@ -191,3 +199,13 @@ const convertStoreAndReturnPdfUrl = async ({
 
   return urlPdf;
 };
+
+async function getCxsWithADHDFeatureFlagValue(): Promise<string[]> {
+  const featureFlag = await getFeatureFlagValue<{
+    enabled: boolean | undefined;
+    cxIds: string[] | undefined;
+  }>(region, appConfigAppID, appConfigConfigID, getEnvType(), cxsWithADHDMRFeatureFlag);
+
+  if (featureFlag?.enabled && featureFlag?.cxIds) return featureFlag.cxIds;
+  else return [];
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ticket: 799

### Dependencies

- Upstream: none
- Downstream: none

### Description

CX has specific changes needed to MR summary that we dont want to apply to the rest of the cx's.  As a quick solution added a feature flag to the specific bundle logic that will create a adhd MR.

### Testing

_[Regular PRs:]_

- Local
  - [x] Generated the MR locally
- Staging
  - [ ] Generate ADHD MR Summary by adding cx to feature flag
- Sandbox
  - [ ] none
- Production
  - [ ] Generate ADHD MR Summary by adding cx to feature flag

### Release Plan

- [ ] Merge this
