### PR TITLE
feat(api): preserve correct formatting on doctors notes, clean up arifacts on MR rendering

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -656,7 +656,7 @@ function buildEncounterSections(
 
         if (diagnosticReportsType === "documentation") {
           const documentationDecodedNote = report.presentedForm?.[0]?.data ?? "";
-          const decodeNote = Buffer.from(documentationDecodedNote, "base64").toString("binary");
+          const decodeNote = Buffer.from(documentationDecodedNote, "base64").toString("utf-8");
           const blackListNote = "Not on file";
           const noteIsBlacklisted = decodeNote.toLowerCase().includes(blackListNote.toLowerCase());
 
@@ -771,7 +771,7 @@ function createWhatWasDocumentedFromDiagnosticReports(
   const documentations = documentation
     .map(documentation => {
       const note = documentation.presentedForm?.[0]?.data ?? "";
-      const decodeNote = Buffer.from(note, "base64").toString("binary");
+      const decodeNote = Buffer.from(note, "base64").toString("utf-8");
       const cleanNote = decodeNote.replace(new RegExp(REMOVE_FROM_NOTE.join("|"), "g"), "");
 
       const practitionerField = createPractionerField(documentation, mappedPractitioners);

--- a/packages/fhir-converter/src/lib/cda/cda.js
+++ b/packages/fhir-converter/src/lib/cda/cda.js
@@ -104,7 +104,7 @@ module.exports = class cda extends dataHandler {
     for (const stringToReplace of ["<br />", "<br/>", "<br>"]) {
       // doing this is apparently more efficient than just using replace
       const regex = new RegExp(stringToReplace, "g");
-      res = res.replace(regex, " ");
+      res = res.replace(regex, "\n");
     }
     res = res.replace(elementTime00010101Regex, elementTime00010101Replacement);
     res = res.replace(valueTime00010101Regex, valueTime00010101Replacement);

--- a/packages/utils/src/fhir-converter/convert-and-generate-mr.ts
+++ b/packages/utils/src/fhir-converter/convert-and-generate-mr.ts
@@ -79,7 +79,7 @@ export async function main() {
   }
 
   // Consolidate all bundles' resources into a single bundle
-  const resources = await getResourcesPerDirectory(folder, fhirExtension);
+  const resources = await getResourcesPerDirectory(outputFolderName, fhirExtension);
   const bundleFileName = `${outputFolderName}/bundle.json`;
   const bundle: Bundle<Resource> = {
     resourceType: "Bundle",
@@ -96,7 +96,7 @@ export async function main() {
 
   // count by looking at the files
   console.log(`Counting from folder...`);
-  const stats = await countResourcesPerDirectory(folder, fhirExtension);
+  const stats = await countResourcesPerDirectory(outputFolderName, fhirExtension);
   console.log(`Resources: ${JSON.stringify(stats.countPerType, null, 2)}`);
   console.log(`Total: ${stats.total}`);
   storeStats(stats);

--- a/packages/utils/src/fhir-converter/convert.ts
+++ b/packages/utils/src/fhir-converter/convert.ts
@@ -2,6 +2,7 @@ import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { AxiosInstance } from "axios";
 import { getFileContents, makeDirIfNeeded, writeFileContents } from "../shared/fs";
 import { getPatientIdFromFileName } from "./shared";
+import path = require("node:path");
 
 export async function convertCDAsToFHIR(
   baseFolderName: string,
@@ -69,7 +70,7 @@ async function convert(
   const conversionResult = res.data.fhirResource;
   addMissingRequests(conversionResult);
 
-  const destFileName = `${outputFolderName}${fileName.replace(".xml", fhirExtension)}`;
+  const destFileName = path.join(outputFolderName, fileName.replace(".xml", fhirExtension));
   makeDirIfNeeded(destFileName);
   writeFileContents(destFileName, JSON.stringify(conversionResult));
 }


### PR DESCRIPTION
refs. metriport/metriport-internal#1496

### Dependencies

n/a

### Description

- preserve formatting on doctor's notes by replacing `<br>` elements with `\n` instead of a space
- fix artifacts by decoding b64 in the MR summary in the same way we encode it, ie `utf-8`, not `binary`
- couple small util pathing fixes

### Testing

- Local
  - [x] e2e converter test
  - [x] ran `src/fhir-converter/convert-and-generate-mr.ts` and verified output is as expected
- Production
  - [ ] generate MR for a patient created after the release to ensure notes are now formatted properly

```
Inserted 9446 files in 3628908 ms.
Resources:  {
  AllergyIntolerance: 737,
  Communication: 790,
  Composition: 9411,
  Condition: 12911,
  Consent: 44,
  Coverage: 558,
  Device: 3830,
  DiagnosticReport: 21796,
  Encounter: 18460,
  FamilyMemberHistory: 725,
  Goal: 45,
  Immunization: 2117,
  MedicationAdministration: 3403,
  MedicationRequest: 3261,
  MedicationStatement: 4553,
  Observation: 78392,
  Procedure: 8898,
  RelatedPerson: 269,
  ServiceRequest: 1
}
Total resources: 170201
Total time: 3636362 ms / 60.606033333333336 min
```

### Release Plan

- [x] Merge this
