### PR TITLE
fix(api): 799 only replace if it has id

### DIFF
--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -215,7 +215,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent) => {
 
         // post-process conversion result
         const postProcessStart = Date.now();
-        conversionResult.entry = conversionResult.entry.filter(e => e.resource);
+        conversionResult.entry = conversionResult.entry.filter(e => e.resource.id);
         const updatedConversionResult = replaceIDs(conversionResult, patientId);
         addExtensionToConversion(updatedConversionResult, documentExtension);
         removePatientFromConversion(updatedConversionResult);

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -200,16 +200,14 @@ export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent) => {
 
         const preProcessedFilename = `${s3FileName}.from_converter`;
 
-        await sendConversionResult(
-          cxId,
-          patientId,
-          preProcessedFilename,
-          conversionResult,
-          jobStartedAt,
-          jobId,
-          source,
-          log
-        );
+        await s3Utils.s3
+          .upload({
+            Bucket: conversionResultBucketName,
+            Key: preProcessedFilename,
+            Body: JSON.stringify(conversionResult),
+            ContentType: "application/fhir+json",
+          })
+          .promise();
 
         await cloudWatchUtils.reportMemoryUsage();
 

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -46,7 +46,8 @@ const ossApi = apiClient(apiURL);
 function replaceIDs(fhirBundle: FHIRBundle, patientId: string): FHIRBundle {
   const stringsToReplace: { old: string; new: string }[] = [];
   for (const bundleEntry of fhirBundle.entry) {
-    if (!bundleEntry.resource.id || bundleEntry.resource.id === patientId) continue;
+    if (!bundleEntry.resource.id) throw new Error(`Missing resource id`);
+    if (bundleEntry.resource.id === patientId) continue;
     const idToUse = bundleEntry.resource.id;
     const newId = uuid.v4();
     bundleEntry.resource.id = newId;
@@ -220,7 +221,6 @@ export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent) => {
 
         // post-process conversion result
         const postProcessStart = Date.now();
-        conversionResult.entry = conversionResult.entry.filter(e => e.resource.id);
         const updatedConversionResult = replaceIDs(conversionResult, patientId);
         addExtensionToConversion(updatedConversionResult, documentExtension);
         removePatientFromConversion(updatedConversionResult);


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ticket: #799

### Dependencies

- Upstream: none
- Downstream: none

### Description

Resources without id breaking post processing - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1707410757885269) 

### Testing

_[Regular PRs:]_

- Local
  - [x] Test locally to replace ids with changes

- Production
  - [ ] Monitor to make sure error doesnt reoccur

Check each PR.

### Release Plan

- [ ] Merge this
