### PR TITLE
fix(api): give mr lambda access to app config

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -8,6 +8,7 @@ import {
   StackProps,
 } from "aws-cdk-lib";
 import * as apig from "aws-cdk-lib/aws-apigateway";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { BackupResource } from "aws-cdk-lib/aws-backup";
 import * as cert from "aws-cdk-lib/aws-certificatemanager";
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
@@ -1242,6 +1243,27 @@ export class APIStack extends Stack {
       vpc,
       alarmSnsAction: alarmAction,
     });
+
+    fhirToMedicalRecordLambda.role?.attachInlinePolicy(
+      new iam.Policy(this, "FhirLambdaPermissionsForAppConfig", {
+        statements: [
+          new iam.PolicyStatement({
+            actions: [
+              "appconfig:StartConfigurationSession",
+              "appconfig:GetLatestConfiguration",
+              "appconfig:GetConfiguration",
+              "apigateway:GET",
+            ],
+            resources: ["*"],
+          }),
+          new iam.PolicyStatement({
+            actions: ["geo:SearchPlaceIndexForText"],
+            resources: [`arn:aws:geo:*`],
+            effect: iam.Effect.ALLOW,
+          }),
+        ],
+      })
+    );
 
     medicalDocumentsBucket.grantReadWrite(fhirToMedicalRecordLambda);
 

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1252,7 +1252,6 @@ export class APIStack extends Stack {
               "appconfig:StartConfigurationSession",
               "appconfig:GetLatestConfiguration",
               "appconfig:GetConfiguration",
-              "apigateway:GET",
             ],
             resources: ["*"],
           })

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1255,12 +1255,7 @@ export class APIStack extends Stack {
               "apigateway:GET",
             ],
             resources: ["*"],
-          }),
-          new iam.PolicyStatement({
-            actions: ["geo:SearchPlaceIndexForText"],
-            resources: [`arn:aws:geo:*`],
-            effect: iam.Effect.ALLOW,
-          }),
+          })
         ],
       })
     );


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

Ticket: #1040

### Dependencies

- Upstream: 
- Downstream: none

### Description

MR lambda does not have access to appconfig

### Testing

- Staging
  - [ ]  has access to appconfig
- Production
  - [ ] Will test when testing ideal flow

### Release Plan

- [ ] Merge this
