### PR TITLE
1377 prod CICD for IHE GW

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -189,7 +189,7 @@ jobs:
   release:
     uses: ./.github/workflows/_release.yml
     # TODO 1377 revert this
-    # needs: [api, infra-api-lambdas-sandbox, ihe-gw-config]
+    # needs: [api-sandbox, infra-api-lambdas-sandbox, ihe-gw-config]
     needs: [api-sandbox, infra-api-lambdas-sandbox, ihe-gw-server]
     # run even if one of the dependencies didn't
     # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -25,6 +25,8 @@ jobs:
     # Map a step output to a job output
     outputs:
       api: ${{ steps.changes.outputs.api }}
+      ihe-gw-config: ${{ steps.changes.outputs.ihe-gw-config }}
+      ihe-gw-server: ${{ steps.changes.outputs.ihe-gw-server }}
       fhir-converter: ${{ steps.changes.outputs.fhir-converter }}
       infra-lambdas: ${{ steps.changes.outputs.infra-lambdas }}
     steps:
@@ -49,6 +51,13 @@ jobs:
               - "packages/ihe-gateway-sdk/**"
               - "packages/core/**"
               - "package*.json"
+            ihe-gw-config:
+              - "packages/ihe-gateway/config/**"
+              - "packages/ihe-gateway/scripts/**"
+              - "packages/ihe-gateway/server/**"
+            ihe-gw-server:
+              - "packages/ihe-gateway/Dockerfile"
+              - "packages/ihe-gateway/entrypoint.sh"
             # Doing them individually because there are other stuff there that we don't want to trigger a deploy b/c of that
             fhir-converter:
               - "packages/fhir-converter/Dockerfile"
@@ -108,8 +117,7 @@ jobs:
       deploy_env: "production"
       location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_PRODUCTION }}
       cdk_stack: ${{ vars.API_STACK_NAME_PRODUCTION }}
-      # TODO 1377 uncomment this line when the IHE stack is ready for production
-      # ihe_cdk_stack: ${{ vars.IHE_STACK_NAME }}
+      ihe_cdk_stack: ${{ vars.IHE_STACK_NAME }}
       AWS_REGION: ${{ vars.API_REGION_PRODUCTION }}
       IHE_GW_CONFIG_BUCKET_NAME: ${{ vars.IHE_GW_CONFIG_BUCKET_NAME }}
     secrets:
@@ -142,13 +150,49 @@ jobs:
       IHE_GW_KEYSTORE_STOREPASS: ${{ secrets.IHE_GW_KEYSTORE_STOREPASS }}
       IHE_GW_KEYSTORE_KEYPASS: ${{ secrets.IHE_GW_KEYSTORE_KEYPASS }}
 
+  ihe-gw-server:
+    if: needs.files-changed.outputs.ihe-gw-server == 'true'
+    needs: files-changed
+    uses: ./.github/workflows/_deploy-ihe-gw.yml
+    with:
+      deploy_env: "production"
+      ECR_REPO_URI: ${{ vars.ECR_REPO_URI_PRODUCTION }}
+      ECS_CLUSTER: ${{ vars.ECS_CLUSTER_PRODUCTION }}
+      ECS_SERVICE: ${{ vars.ECS_SERVICE_PRODUCTION }}
+      AWS_REGION: ${{ vars.API_REGION_PRODUCTION }}
+      IHE_GW_ARTIFACT_URL: ${{ vars.IHE_GW_ARTIFACT_URL }}
+      IHE_GW_KEYSTORENAME: ${{ vars.IHE_GW_KEYSTORENAME }}
+      IHE_GW_ZULUKEY: ${{ vars.IHE_GW_ZULUKEY }}
+      IHE_GW_CONFIG_BUCKET_NAME: ${{ vars.IHE_GW_CONFIG_BUCKET_NAME }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      IHE_GW_STOREPASS: ${{ secrets.IHE_GW_STOREPASS }}
+      IHE_GW_KEYSTOREPASS: ${{ secrets.IHE_GW_KEYSTOREPASS }}
+      IHE_GW_LICENSE_KEY: ${{ secrets.IHE_GW_LICENSE_KEY }}
+
+  ihe-gw-config:
+    needs: [files-changed, ihe-gw-server]
+    if: ${{ !failure() && needs.files-changed.outputs.ihe-gw-config == 'true' }}
+    uses: ./.github/workflows/_ihe-gw-push-config.yml
+    with:
+      deploy_env: "production"
+      IHE_GW_CONFIG_BUCKET_NAME: ${{ vars.IHE_GW_CONFIG_BUCKET_NAME }}
+      IHE_GW_FULL_BACKUP_LOCATION: ${{ vars.IHE_GW_FULL_BACKUP_LOCATION }}
+    secrets:
+      IHE_GW_URL: ${{ secrets.IHE_GW_URL_PRODUCTION }}
+      IHE_GW_USER: ${{ secrets.IHE_GW_USER }}
+      IHE_GW_PASSWORD: ${{ secrets.IHE_GW_PASSWORD }}
+
   release:
     uses: ./.github/workflows/_release.yml
-    needs: [api-sandbox, infra-api-lambdas-sandbox]
+    needs: [api-sandbox, infra-api-lambdas-sandbox, ihe-gw-config]
     # run even if one of the dependencies didn't
     # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."
     # can't use ${{ ! failure() && contains(needs.*.result, 'success') }} because if anything that came before succeeded, even if not a direct dependency, it will run
-    if: ${{ !failure() && (needs.api-sandbox.result == 'success' || needs.infra-api-lambdas-sandbox.result == 'success') }}
+    if: ${{ !failure() && (needs.api-sandbox.result == 'success' || needs.infra-api-lambdas-sandbox.result == 'success' || needs.ihe-gw-config.result == 'success') }}
     secrets: inherit
 
   e2e-tests:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -158,10 +158,11 @@ jobs:
       deploy_env: "production"
       ECR_REPO_URI: ${{ vars.ECR_REPO_URI_PRODUCTION }}
       ECS_CLUSTER: ${{ vars.ECS_CLUSTER_PRODUCTION }}
-      ECS_SERVICE: ${{ vars.ECS_SERVICE_PRODUCTION }}
+      IHE_INBOUND_ECS_SERVICE: ${{ vars.IHE_INBOUND_ECS_SERVICE_PRODUCTION }}
+      IHE_OUTBOUND_ECS_SERVICE: ${{ vars.IHE_OUTBOUND_ECS_SERVICE_PRODUCTION }}
       AWS_REGION: ${{ vars.API_REGION_PRODUCTION }}
       IHE_GW_ARTIFACT_URL: ${{ vars.IHE_GW_ARTIFACT_URL }}
-      IHE_GW_KEYSTORENAME: ${{ vars.IHE_GW_KEYSTORENAME }}
+      IHE_GW_KEYSTORE_NAME: ${{ vars.IHE_GW_KEYSTORE_NAME }}
       IHE_GW_ZULUKEY: ${{ vars.IHE_GW_ZULUKEY }}
       IHE_GW_CONFIG_BUCKET_NAME: ${{ vars.IHE_GW_CONFIG_BUCKET_NAME }}
     secrets:
@@ -169,30 +170,33 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      IHE_GW_STOREPASS: ${{ secrets.IHE_GW_STOREPASS }}
-      IHE_GW_KEYSTOREPASS: ${{ secrets.IHE_GW_KEYSTOREPASS }}
-      IHE_GW_LICENSE_KEY: ${{ secrets.IHE_GW_LICENSE_KEY }}
+      IHE_GW_KEYSTORE_STOREPASS: ${{ secrets.IHE_GW_KEYSTORE_STOREPASS }}
+      IHE_GW_KEYSTORE_KEYPASS: ${{ secrets.IHE_GW_KEYSTORE_KEYPASS }}
 
-  ihe-gw-config:
-    needs: [files-changed, ihe-gw-server]
-    if: ${{ !failure() && needs.files-changed.outputs.ihe-gw-config == 'true' }}
-    uses: ./.github/workflows/_ihe-gw-push-config.yml
-    with:
-      deploy_env: "production"
-      IHE_GW_CONFIG_BUCKET_NAME: ${{ vars.IHE_GW_CONFIG_BUCKET_NAME }}
-      IHE_GW_FULL_BACKUP_LOCATION: ${{ vars.IHE_GW_FULL_BACKUP_LOCATION }}
-    secrets:
-      IHE_GW_URL: ${{ secrets.IHE_GW_URL_PRODUCTION }}
-      IHE_GW_USER: ${{ secrets.IHE_GW_USER }}
-      IHE_GW_PASSWORD: ${{ secrets.IHE_GW_PASSWORD }}
+  # ihe-gw-config:
+  #   needs: [files-changed, ihe-gw-server]
+  #   if: ${{ !failure() && needs.files-changed.outputs.ihe-gw-config == 'true' }}
+  #   uses: ./.github/workflows/_ihe-gw-push-config.yml
+  #   with:
+  #     deploy_env: "production"
+  #     IHE_GW_CONFIG_BUCKET_NAME: ${{ vars.IHE_GW_CONFIG_BUCKET_NAME }}
+  #     IHE_GW_FULL_BACKUP_LOCATION: ${{ vars.IHE_GW_FULL_BACKUP_LOCATION }}
+  #   secrets:
+  #     IHE_GW_URL: ${{ secrets.IHE_GW_URL_PRODUCTION }}
+  #     IHE_GW_USER: ${{ secrets.IHE_GW_USER }}
+  #     IHE_GW_PASSWORD: ${{ secrets.IHE_GW_PASSWORD }}
 
   release:
     uses: ./.github/workflows/_release.yml
-    needs: [api-sandbox, infra-api-lambdas-sandbox, ihe-gw-config]
+    # TODO 1377 revert this
+    # needs: [api, infra-api-lambdas-sandbox, ihe-gw-config]
+    needs: [api-sandbox, infra-api-lambdas-sandbox, ihe-gw-server]
     # run even if one of the dependencies didn't
     # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."
     # can't use ${{ ! failure() && contains(needs.*.result, 'success') }} because if anything that came before succeeded, even if not a direct dependency, it will run
-    if: ${{ !failure() && (needs.api-sandbox.result == 'success' || needs.infra-api-lambdas-sandbox.result == 'success' || needs.ihe-gw-config.result == 'success') }}
+    # TODO 1377 revert this
+    # if: ${{ !failure() && (needs.api-sandbox.result == 'success' || needs.infra-api-lambdas-sandbox.result == 'success' || needs.ihe-gw-config.result == 'success') }}
+    if: ${{ !failure() && (needs.api-sandbox.result == 'success' || needs.infra-api-lambdas-sandbox.result == 'success' || needs.ihe-gw-server.result == 'success') }}
     secrets: inherit
 
   e2e-tests:


### PR DESCRIPTION
Ref. metriport/metriport-internal#1377

### Dependencies

- Upstream: 
   - https://github.com/metriport/metriport/pull/1590
   - https://github.com/metriport/metriport-internal/pull/1546
- Downstream: none

### Description

Add `prod` CICD for IHE GW.

### Testing

- Sandbox
  - [ ] nothing for IHE GW
- Production
  - [ ] changes on config result in pushing those to the server
  - [ ] changes on dockerfile re-redeploy the server

### Release Plan

- [ ] Manually deploy the IHE Stack to `prod`
- set GH vars
   - [ ] `ECR_REPO_URI_PRODUCTION`
   - [ ] `ECS_CLUSTER_PRODUCTION`
   - [ ] `IHE_INBOUND_ECS_SERVICE_PRODUCTION`
   - [ ] `IHE_OUTBOUND_ECS_SERVICE_PRODUCTION`
- [ ] merge this
- [ ] Update IHE GW config on `staging`