### PR TITLE
1040 Sandbox patient limit FF doesn't error on invalid number

### DIFF
--- a/packages/api/src/domain/medical/get-patient-limit.ts
+++ b/packages/api/src/domain/medical/get-patient-limit.ts
@@ -1,27 +1,41 @@
+import { MetriportError } from "@metriport/core/util/error/metriport-error";
+import { capture } from "@metriport/core/util/notifications";
+import { errorToString } from "@metriport/shared/common/error";
 import { getCxsWithIncreasedSandboxLimitFeatureFlagValue } from "../../external/aws/appConfig";
 import { Config } from "../../shared/config";
-import { capture } from "../../shared/notifications";
 
 export async function getSandboxPatientLimitForCx(cxId: string): Promise<number> {
-  const cxIdsWithIncreasedSandboxPatientVolumeEnabled =
-    await getCxsWithIncreasedSandboxLimitFeatureFlagValue();
-  if (!cxIdsWithIncreasedSandboxPatientVolumeEnabled) return Config.SANDBOX_PATIENT_LIMIT;
-
-  const cxIdAndLimit = cxIdsWithIncreasedSandboxPatientVolumeEnabled.find(i => i.includes(cxId));
-  const limit = cxIdAndLimit ? parsePatientLimit(cxIdAndLimit) : undefined;
-  return limit ?? Config.SANDBOX_PATIENT_LIMIT;
-}
-
-function parsePatientLimit(increasedPatientLimitFeatureFlagValue: string): number | undefined {
-  const patientLimit = increasedPatientLimitFeatureFlagValue.split(":")[1];
-
-  if (!patientLimit) {
-    const msg = "Failed to parse patient limit from increasedPatientLimitFeatureFlagValue";
-    console.error(`${msg} - ${increasedPatientLimitFeatureFlagValue}`);
+  try {
+    const cxIdsWithSandboxPatientVolume = await getCxsWithIncreasedSandboxLimitFeatureFlagValue();
+    if (!cxIdsWithSandboxPatientVolume || cxIdsWithSandboxPatientVolume.length <= 0) {
+      return Config.SANDBOX_PATIENT_LIMIT;
+    }
+    const cxIdAndLimit = cxIdsWithSandboxPatientVolume.find(i => i.includes(cxId));
+    if (cxIdAndLimit) {
+      return parsePatientLimit(cxIdAndLimit);
+    }
+  } catch (error) {
+    const msg = "Failed to get sandbox patient limit";
+    console.error(`${msg} - ${errorToString(error)}`);
     capture.error(msg, {
-      extra: { increasedPatientLimitFeatureFlagValue, context: "parseCxIdAndLimit" },
+      extra: {
+        context: "getSandboxPatientLimitForCx",
+        cxId,
+        error,
+      },
     });
   }
+  return Config.SANDBOX_PATIENT_LIMIT;
+}
 
-  return parseInt(patientLimit);
+function parsePatientLimit(patientAndLimit: string): number {
+  const limitAsString = patientAndLimit.split(":")[1];
+  if (!limitAsString) {
+    throw new MetriportError("Missing patient limit", undefined, { patientAndLimit });
+  }
+  const parsedLimit = parseInt(limitAsString);
+  if (isNaN(parsedLimit)) {
+    throw new MetriportError("Invalid patient limit", undefined, { limit: limitAsString });
+  }
+  return parsedLimit;
 }

--- a/packages/api/src/external/aws/appConfig.ts
+++ b/packages/api/src/external/aws/appConfig.ts
@@ -1,4 +1,4 @@
-import { getFeatureFlagValue, FeatureFlagDatastore } from "@metriport/core/external/aws/appConfig";
+import { FeatureFlagDatastore, getFeatureFlagValue } from "@metriport/core/external/aws/appConfig";
 import { capture } from "@metriport/core/util/notifications";
 import { errorToString } from "@metriport/shared/common/error";
 import { Config } from "../../shared/config";
@@ -7,11 +7,11 @@ import { Util } from "../../shared/util";
 const log = Util.log(`App Config`);
 
 /**
- * Returns the list of Customer IDs that are enabled for the given feature flag.
+ * Returns the list of customers that are enabled for the given feature flag.
  *
- * @returns Array of cxIds
+ * @returns Array of cxIds or cxIdsAndLimits
  */
-async function getCxsWithFeatureFlagValue(
+async function getCxsWithFeatureFlagEnabled(
   featureFlagName: keyof FeatureFlagDatastore
 ): Promise<string[]> {
   try {
@@ -36,15 +36,15 @@ async function getCxsWithFeatureFlagValue(
 }
 
 export async function getCxsWithEnhancedCoverageFeatureFlagValue(): Promise<string[]> {
-  return getCxsWithFeatureFlagValue("cxsWithEnhancedCoverageFeatureFlag");
+  return getCxsWithFeatureFlagEnabled("cxsWithEnhancedCoverageFeatureFlag");
 }
 
 export async function getCxsWithCQDirectFeatureFlagValue(): Promise<string[]> {
-  return getCxsWithFeatureFlagValue("cxsWithCQDirectFeatureFlag");
+  return getCxsWithFeatureFlagEnabled("cxsWithCQDirectFeatureFlag");
 }
 
 export async function getCxsWithIncreasedSandboxLimitFeatureFlagValue(): Promise<string[]> {
-  return getCxsWithFeatureFlagValue("cxsWithIncreasedSandboxLimitFeatureFlag");
+  return getCxsWithFeatureFlagEnabled("cxsWithIncreasedSandboxLimitFeatureFlag");
 }
 
 export async function isEnhancedCoverageEnabledForCx(cxId: string): Promise<boolean> {

--- a/packages/api/src/routes/helpers/default-error-handler.ts
+++ b/packages/api/src/routes/helpers/default-error-handler.ts
@@ -8,6 +8,9 @@ import { isClientError } from "../../shared/http";
 import { capture } from "../../shared/notifications";
 import { httpResponseBody } from "../util";
 import { isReportClientErrors } from "./report-client-errors";
+import { out } from "@metriport/core/util/log";
+
+const { log } = out(`error-handler`);
 
 // Errors in Metriport are based off of https://www.rfc-editor.org/rfc/rfc7807
 // This is specifically how the fields are used:
@@ -68,7 +71,7 @@ export const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
     } else {
       const detail = getDetailFromOutcomeError(err);
       if (status > 499) {
-        console.log(`Error on FHIR: ${detail}`);
+        log(`Error on FHIR: ${detail}`);
       }
       return res
         .contentType("json")
@@ -96,7 +99,7 @@ export const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
         name: httpStatus[err.statusCode],
       });
   }
-  console.log(`Error: ${err}`);
+  log(`Error: ${err}`);
   const internalErrStatus = httpStatus.INTERNAL_SERVER_ERROR;
   return res
     .contentType("json")

--- a/packages/api/src/routes/util.ts
+++ b/packages/api/src/routes/util.ts
@@ -4,6 +4,9 @@ import { Config } from "../shared/config";
 import { errorToString } from "../shared/log";
 import { capture } from "../shared/notifications";
 import { stringToBoolean } from "@metriport/shared";
+import { out } from "@metriport/core/util/log";
+
+const { log } = out("asyncHandler");
 
 export const asyncHandler =
   (
@@ -18,8 +21,8 @@ export const asyncHandler =
     try {
       await f(req, res, next);
     } catch (err) {
-      if (Config.isCloudEnv()) console.error(errorToString(err));
-      else console.error(err);
+      if (Config.isCloudEnv()) log(errorToString(err));
+      else log("", err);
       next(err);
     }
   };


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport/pull/1598

### Description

- FF patient limit not error on invalid number
- stable error messages on getFeatureFlagValue 
- default error logs include request ID 

### Testing

- Local
  - [x] get FF value correctly
  - [x] return default sandbox limit if no value for cx
  - [x] return default sandbox limit if fails to parse limit
  - [x] return sandbox limit when cx has a valid limit
  - [x] unhandled error is logged on console as local/dev
  - [x] unhandled error is logged on console as cloud
- Staging
  - none
- Sandbox
  - [ ] creates patient correctly
- Production
  - none

### Release Plan

- nothing special