### PR TITLE
build: fail to start API if FFs fail

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "command": "ts-node ./packages/api/src/app.ts",
+            "command": "npm run dev -w packages/api",
             "name": "Run Api App",
             "request": "launch",
             "type": "node-terminal"

--- a/packages/api/src/external/aws/appConfig.ts
+++ b/packages/api/src/external/aws/appConfig.ts
@@ -1,10 +1,60 @@
 import { FeatureFlagDatastore, getFeatureFlagValue } from "@metriport/core/external/aws/appConfig";
+import { MetriportError } from "@metriport/core/util/error/metriport-error";
 import { capture } from "@metriport/core/util/notifications";
 import { errorToString } from "@metriport/shared/common/error";
 import { Config } from "../../shared/config";
 import { Util } from "../../shared/util";
 
-const log = Util.log(`App Config`);
+const log = Util.log(`App Config - FF`);
+
+const listOfFeatureFlags: Array<keyof FeatureFlagDatastore> = [
+  "cxsWithEnhancedCoverageFeatureFlag",
+  "cxsWithCQDirectFeatureFlag",
+  "cxsWithADHDMRFeatureFlag",
+  "cxsWithIncreasedSandboxLimitFeatureFlag",
+];
+
+/**
+ * Go through all Feature Flags to make sure they are accessible.
+ */
+export async function initFeatureFlags() {
+  if (Config.isDev()) {
+    log(`Skipping initializing Feature Flags - Develop/Local env`);
+    return;
+  }
+  const res = await Promise.allSettled(
+    listOfFeatureFlags.map(ff =>
+      getFeatureFlagValueLocal(ff).catch(initFeatureFlagsErrorHandling(ff))
+    )
+  );
+  const failed = res.flatMap(r => (r.status === "rejected" ? r.reason : []));
+  if (failed.length > 0) {
+    throw new MetriportError(`Failed to initialize Feature Flags`, undefined, {
+      failed: failed.map(f => f.reason).join("; "),
+    });
+  }
+  log(`Feature Flags initialized.`);
+}
+
+function initFeatureFlagsErrorHandling(featureFlagName: keyof FeatureFlagDatastore) {
+  return (error: unknown) => {
+    const msg = `Failed to get Feature Flag Value`;
+    const extra = { featureFlagName };
+    log(`${msg} - ${JSON.stringify(extra)} - ${errorToString(error)}`);
+    capture.error(msg, { extra: { ...extra, error } });
+    throw error;
+  };
+}
+
+function getFeatureFlagValueLocal(featureFlagName: keyof FeatureFlagDatastore) {
+  return getFeatureFlagValue(
+    Config.getAWSRegion(),
+    Config.getAppConfigAppId(),
+    Config.getAppConfigConfigId(),
+    Config.getEnvType(),
+    featureFlagName
+  );
+}
 
 /**
  * Returns the list of customers that are enabled for the given feature flag.
@@ -15,13 +65,7 @@ async function getCxsWithFeatureFlagEnabled(
   featureFlagName: keyof FeatureFlagDatastore
 ): Promise<string[]> {
   try {
-    const featureFlag = await getFeatureFlagValue(
-      Config.getAWSRegion(),
-      Config.getAppConfigAppId(),
-      Config.getAppConfigConfigId(),
-      Config.getEnvType(),
-      featureFlagName
-    );
+    const featureFlag = await getFeatureFlagValueLocal(featureFlagName);
     if (featureFlag.enabled) {
       if (featureFlag.cxIds) return featureFlag.cxIds;
       if (featureFlag.cxIdsAndLimits) return featureFlag.cxIdsAndLimits;

--- a/packages/core/src/external/aws/appConfig.ts
+++ b/packages/core/src/external/aws/appConfig.ts
@@ -2,7 +2,7 @@ import { AppConfig } from "aws-sdk";
 import { MetriportError } from "../../util/error/metriport-error";
 import { out } from "../../util/log";
 
-const { log } = out(`appConfig`);
+const { log } = out(`Core appConfig - FF`);
 
 function makeAppConfigClient(region: string): AWS.AppConfig {
   return new AppConfig({ region });


### PR DESCRIPTION
Ref. https://github.com/metriport/metriport-internal/issues/1437

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1597
- Downstream: none

### Description

API fail to start if it fails to load Feature Flags.

### Testing

- Local
  - [x] Fails to start when FF init fails
  - [x] Starts when FF init works
- Staging
  - [ ] Fails to start when FF init fails
  - [ ] Starts when FF init works
- Sandbox
  - [ ] API loads
- Production
  - [ ] API loads

### Release Plan

- nothing special