### PR TITLE
1377 Fix IHE GW push config GH workflow

### DIFF
--- a/.github/workflows/_ihe-gw-push-config.yml
+++ b/.github/workflows/_ihe-gw-push-config.yml
@@ -19,6 +19,10 @@ on:
         required: true
         type: string
     secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
       IHE_GW_URL:
         required: true
       IHE_GW_USER:
@@ -89,7 +93,7 @@ jobs:
 
       - name: Push configs to IHE Gateway
         env:
-          ENV_TYPE: ${{ secrets.ENV_TYPE }}
+          ENV_TYPE: ${{ inputs.deploy_env }}
           IHE_GW_CONFIG_BUCKET_NAME: ${{ inputs.IHE_GW_CONFIG_BUCKET_NAME }}
           IHE_GW_FULL_BACKUP_LOCATION: ${{ inputs.IHE_GW_FULL_BACKUP_LOCATION }}
           IHE_GW_URL: ${{ secrets.IHE_GW_URL }}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1377

### Dependencies

none

### Description

Fix IHE GW push config GH workflow, env vars - [context](https://metriport.slack.com/archives/C04FZ9859FZ/p1707605230923729?thread_ts=1707603824.403399&cid=C04FZ9859FZ).

### Testing

- Local
  - none
- Staging
  - [ ] workflow `ihe-gw-config` works
- Sandbox
  - none
- Production
  - none

### Release Plan

- nothing special