### PR TITLE
CQ-API 2-way-TLS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28199,7 +28199,7 @@
       }
     },
     "packages/api": {
-      "version": "1.13.5-alpha.0",
+      "version": "1.13.5-alpha.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -28340,10 +28340,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.3.6-alpha.0",
+      "version": "1.3.6-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/core": "^1.9.5-alpha.0",
+        "@metriport/core": "^1.9.5-alpha.1",
         "@metriport/ihe-gateway-sdk": "^0.4.6-alpha.0"
       },
       "bin": {
@@ -28352,7 +28352,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.5.0-alpha.0",
+      "version": "0.5.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -28488,7 +28488,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.9.5-alpha.0",
+      "version": "1.9.5-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -28564,7 +28564,7 @@
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.8.5-alpha.0",
+      "version": "1.8.5-alpha.1",
       "dependencies": {
         "aws-cdk-lib": "^2.87.0",
         "constructs": "^10.2.69",
@@ -29670,7 +29670,7 @@
       "extraneous": true
     },
     "packages/utils": {
-      "version": "1.10.5-alpha.0",
+      "version": "1.10.5-alpha.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28519,7 +28519,7 @@
       }
     },
     "packages/api": {
-      "version": "1.13.4",
+      "version": "1.13.5-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -28600,11 +28600,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.12.1",
+      "version": "7.12.2-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.4",
-        "@metriport/shared": "^0.4.4",
+        "@metriport/commonwell-sdk": "^4.12.5-alpha.0",
+        "@metriport/shared": "^0.4.5-alpha.0",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28660,11 +28660,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.3.5",
+      "version": "1.3.6-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/core": "^1.9.4",
-        "@metriport/ihe-gateway-sdk": "^0.4.5"
+        "@metriport/core": "^1.9.5-alpha.0",
+        "@metriport/ihe-gateway-sdk": "^0.4.6-alpha.0"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -28678,7 +28678,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.4.5",
+      "version": "0.5.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -28687,10 +28687,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.13.4",
+      "version": "1.13.5-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.4",
+        "@metriport/commonwell-sdk": "^4.12.5-alpha.0",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -28729,10 +28729,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.10.4",
+      "version": "1.10.5-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.4",
+        "@metriport/commonwell-sdk": "^4.12.5-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -28764,7 +28764,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.12.4",
+      "version": "4.12.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",
@@ -28857,7 +28857,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.9.4",
+      "version": "1.9.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -28924,10 +28924,10 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.4.5",
+      "version": "0.4.6-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.4.4",
+        "@metriport/shared": "^0.4.5-alpha.0",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
@@ -28940,7 +28940,7 @@
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.8.4",
+      "version": "1.8.5-alpha.0",
       "dependencies": {
         "aws-cdk-lib": "^2.87.0",
         "constructs": "^10.2.69",
@@ -28988,7 +28988,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.8.4",
+      "version": "1.8.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -30015,11 +30015,12 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.4.4",
+      "version": "0.4.5-alpha.0",
       "license": "MIT"
     },
     "packages/tester-node": {
       "version": "1.4.5",
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
         "@metriport/api-sdk": "^7.12.1",
@@ -30045,7 +30046,7 @@
       "extraneous": true
     },
     "packages/utils": {
-      "version": "1.10.4",
+      "version": "1.10.5-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.12.1",
+  "version": "7.12.2-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -56,8 +56,8 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.4",
-    "@metriport/shared": "^0.4.4",
+    "@metriport/commonwell-sdk": "^4.12.5-alpha.0",
+    "@metriport/shared": "^0.4.5-alpha.0",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.13.5-alpha.0",
+  "version": "1.13.5-alpha.1",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.13.4",
+  "version": "1.13.5-alpha.0",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/src/external/carequality/api.ts
+++ b/packages/api/src/external/carequality/api.ts
@@ -20,15 +20,15 @@ export function makeCarequalityManagementAPI(): CarequalityManagementAPI | undef
   if (Config.isSandbox()) return;
   const cqApiKey = Config.getCQApiKey();
   const cqOrgCert = Config.getCQOrgCertificate();
-  const cqPrivateKey = Config.getCQOrgPrivateKey();
-  const cqPassphrase = Config.getCQKeyPassphrase();
+  const cqOrgPrivateKey = Config.getCQOrgPrivateKey();
+  const cqPrivateKeyPassword = Config.getCQOrgPrivateKeyPassword();
 
   return new CarequalityManagementAPIImpl({
     apiKey: cqApiKey,
     apiMode: cqApiMode,
     orgCert: cqOrgCert,
-    rsaPrivateKey: cqPrivateKey,
-    passphrase: cqPassphrase,
+    rsaPrivateKey: cqOrgPrivateKey,
+    rsaPrivateKeyPassword: cqPrivateKeyPassword,
   });
 }
 

--- a/packages/api/src/external/carequality/api.ts
+++ b/packages/api/src/external/carequality/api.ts
@@ -10,13 +10,22 @@ const cqApiMode = Config.isProdEnv()
 
 /**
  * Creates a new instance of the Carequality API client.
- * @param apiKey Optional, API key to use for authentication. If not used, the API key will be retrieved from the environment variables.
  * @returns Carequality API.
  */
-export function makeCarequalityAPI(apiKey?: string): Carequality | undefined {
+export function makeCarequalityAPI(): Carequality | undefined {
   if (Config.isSandbox()) return;
-  const cqApiKey = apiKey ?? Config.getCQApiKey();
-  return new Carequality(cqApiKey, cqApiMode);
+  const cqApiKey = Config.getCQApiKey();
+  const cqOrgCert = Config.getCQOrgCertificate();
+  const cqPrivateKey = Config.getCQOrgPrivateKey();
+  const cqPassphrase = Config.getCQKeyPassphrase();
+
+  return new Carequality({
+    apiKey: cqApiKey,
+    apiMode: cqApiMode,
+    orgCert: cqOrgCert,
+    rsaPrivateKey: cqPrivateKey,
+    passphrase: cqPassphrase,
+  });
 }
 
 /**

--- a/packages/api/src/external/carequality/api.ts
+++ b/packages/api/src/external/carequality/api.ts
@@ -1,4 +1,8 @@
-import { Carequality, APIMode as CQAPIMode } from "@metriport/carequality-sdk";
+import {
+  CarequalityManagementAPI,
+  CarequalityManagementAPIImpl,
+  APIMode as CQAPIMode,
+} from "@metriport/carequality-sdk";
 import { IHEGateway, APIMode as IHEGatewayAPIMode } from "@metriport/ihe-gateway-sdk";
 import { Config } from "../../shared/config";
 
@@ -9,17 +13,17 @@ const cqApiMode = Config.isProdEnv()
   : CQAPIMode.dev;
 
 /**
- * Creates a new instance of the Carequality API client.
+ * Creates a new instance of the Carequality Management API client.
  * @returns Carequality API.
  */
-export function makeCarequalityAPI(): Carequality | undefined {
+export function makeCarequalityManagementAPI(): CarequalityManagementAPI | undefined {
   if (Config.isSandbox()) return;
   const cqApiKey = Config.getCQApiKey();
   const cqOrgCert = Config.getCQOrgCertificate();
   const cqPrivateKey = Config.getCQOrgPrivateKey();
   const cqPassphrase = Config.getCQKeyPassphrase();
 
-  return new Carequality({
+  return new CarequalityManagementAPIImpl({
     apiKey: cqApiKey,
     apiMode: cqApiMode,
     orgCert: cqOrgCert,

--- a/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory.ts
@@ -1,15 +1,15 @@
 import { sleep } from "@metriport/core/util/sleep";
-import { QueryTypes, Sequelize } from "sequelize";
-import { Config } from "../../../../shared/config";
-import { makeCarequalityAPI } from "../../api";
-import { capture } from "../../../../shared/notifications";
-import { bulkInsertCQDirectoryEntries } from "./create-cq-directory-entry";
-import { parseCQDirectoryEntries } from "./parse-cq-directory-entry";
-import { cqDirectoryEntryTemp, cqDirectoryEntry, cqDirectoryEntryBackup } from "./shared";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
+import { QueryTypes, Sequelize } from "sequelize";
 import { executeOnDBTx } from "../../../../models/transaction-wrapper";
+import { Config } from "../../../../shared/config";
+import { capture } from "../../../../shared/notifications";
+import { makeCarequalityManagementAPI } from "../../api";
 import { CQDirectoryEntryModel } from "../../models/cq-directory";
+import { bulkInsertCQDirectoryEntries } from "./create-cq-directory-entry";
+import { parseCQDirectoryEntries } from "./parse-cq-directory-entry";
+import { cqDirectoryEntry, cqDirectoryEntryBackup, cqDirectoryEntryTemp } from "./shared";
 
 dayjs.extend(duration);
 const BATCH_SIZE = 1000;
@@ -32,7 +32,7 @@ export async function rebuildCQDirectory(failGracefully = false): Promise<void> 
     await createTempCQDirectoryTable();
     while (!isDone) {
       try {
-        const cq = makeCarequalityAPI();
+        const cq = makeCarequalityManagementAPI();
         if (!cq) throw new Error("Carequality API not initialized");
         const orgs = await cq.listOrganizations({ start: currentPosition, count: BATCH_SIZE });
         if (orgs.length < BATCH_SIZE) isDone = true; // if CQ directory returns less than BATCH_SIZE number of orgs, that means we've hit the end

--- a/packages/api/src/external/carequality/organization.ts
+++ b/packages/api/src/external/carequality/organization.ts
@@ -1,8 +1,8 @@
 import { Config } from "../../shared/config";
-import { makeCarequalityAPI } from "./api";
+import { makeCarequalityManagementAPI } from "./api";
 import { buildOrganizationFromTemplate } from "./organization-template";
 
-const cq = makeCarequalityAPI();
+const cq = makeCarequalityManagementAPI();
 
 export type CQOrgDetails = {
   name: string;

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -1,16 +1,16 @@
 import NotFoundError from "@metriport/core/util/error/not-found";
 import {
-  patientDiscoveryRespFromExternalGWSchema,
   documentQueryRespFromExternalGWSchema,
   documentRetrievalRespFromExternalGWSchema,
+  patientDiscoveryRespFromExternalGWSchema,
 } from "@metriport/ihe-gateway-sdk";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import httpStatus from "http-status";
-import { makeCarequalityAPI } from "../../external/carequality/api";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
+import { makeCarequalityManagementAPI } from "../../external/carequality/api";
 import { parseCQDirectoryEntries } from "../../external/carequality/command/cq-directory/parse-cq-directory-entry";
 import { rebuildCQDirectory } from "../../external/carequality/command/cq-directory/rebuild-cq-directory";
 import {
@@ -21,11 +21,11 @@ import {
   IHEResultType,
   handleIHEResponse,
 } from "../../external/carequality/command/ihe-result/create-ihe-result";
+import { processDocumentQueryResults } from "../../external/carequality/document/process-document-query-results";
 import { createOrUpdateCQOrganization } from "../../external/carequality/organization";
 import { Config } from "../../shared/config";
 import { capture } from "../../shared/notifications";
 import { asyncHandler, getFrom } from "../util";
-import { processDocumentQueryResults } from "../../external/carequality/document/process-document-query-results";
 
 dayjs.extend(duration);
 const router = Router();
@@ -55,7 +55,7 @@ router.get(
   "/directory/organization/:oid",
   asyncHandler(async (req: Request, res: Response) => {
     if (Config.isSandbox()) return res.sendStatus(httpStatus.NOT_IMPLEMENTED);
-    const cq = makeCarequalityAPI();
+    const cq = makeCarequalityManagementAPI();
     if (!cq) throw new Error("Carequality API not initialized");
     const oid = getFrom("params").orFail("oid", req);
     const resp = await cq.listOrganizations({ count: 1, oid });

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -90,6 +90,18 @@ export class Config {
     return getEnvVarOrFail("CQ_API_KEY");
   }
 
+  static getCQOrgPrivateKey(): string {
+    return getEnvVarOrFail("CQ_ORG_PRIVATE_KEY");
+  }
+
+  static getCQKeyPassphrase(): string {
+    return getEnvVarOrFail("CQ_KEY_PASSPHRASE");
+  }
+
+  static getCQOrgCertificate(): string {
+    return getEnvVarOrFail("CQ_ORG_CERTIFICATE");
+  }
+
   static getPlaceIndexName(): string {
     return getEnvVarOrFail("PLACE_INDEX_NAME");
   }

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -94,8 +94,8 @@ export class Config {
     return getEnvVarOrFail("CQ_ORG_PRIVATE_KEY");
   }
 
-  static getCQKeyPassphrase(): string {
-    return getEnvVarOrFail("CQ_KEY_PASSPHRASE");
+  static getCQOrgPrivateKeyPassword(): string {
+    return getEnvVarOrFail("CQ_ORG_PRIVATE_KEY_PASSWORD");
   }
 
   static getCQOrgCertificate(): string {

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.3.6-alpha.0",
+  "version": "1.3.6-alpha.1",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/core": "^1.9.5-alpha.0",
+    "@metriport/core": "^1.9.5-alpha.1",
     "@metriport/ihe-gateway-sdk": "^0.4.6-alpha.0"
   }
 }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.3.5",
+  "version": "1.3.6-alpha.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/core": "^1.9.4",
-    "@metriport/ihe-gateway-sdk": "^0.4.5"
+    "@metriport/core": "^1.9.5-alpha.0",
+    "@metriport/ihe-gateway-sdk": "^0.4.6-alpha.0"
   }
 }

--- a/packages/carequality-sdk/README.md
+++ b/packages/carequality-sdk/README.md
@@ -10,10 +10,13 @@ import {
   Carequality
 } from "@metriport/carequality-sdk";
 
-const Carequality = new Carequality(
-    "API_KEY",
-    APIMode.dev
-  );
+const Carequality = new Carequality({
+    apiKey: "API_KEY",
+    apiMode: APIMode.dev,
+    orgCert: "ORG_CERTIFICATE",
+    rsaPrivateKey: "ORG_PRIVATE_KEY",
+    passphrase: "KEY_PASSPHRASE"
+});
 ```
 
 ```

--- a/packages/carequality-sdk/README.md
+++ b/packages/carequality-sdk/README.md
@@ -15,7 +15,7 @@ const Carequality = new Carequality({
     apiMode: APIMode.dev,
     orgCert: "ORG_CERTIFICATE",
     rsaPrivateKey: "ORG_PRIVATE_KEY",
-    passphrase: "KEY_PASSPHRASE"
+    rsaPrivateKeyPassword: "ORG_PRIVATE_KEY_PASSWORD"
 });
 ```
 

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.5.0-alpha.0",
+  "version": "0.5.0-alpha.1",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.4.5",
+  "version": "0.5.0-alpha.0",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/carequality-sdk/src/client/carequality-api.ts
+++ b/packages/carequality-sdk/src/client/carequality-api.ts
@@ -1,6 +1,6 @@
 import { Organization } from "../models/organization";
 
-export interface CarequalityAPI {
+export interface CarequalityManagementAPI {
   listOrganizations({
     count,
     start,

--- a/packages/carequality-sdk/src/client/carequality.ts
+++ b/packages/carequality-sdk/src/client/carequality.ts
@@ -37,13 +37,13 @@ export class CarequalityManagementAPIImpl implements CarequalityManagementAPI {
    * Creates a new instance of the Carequality API client pertaining to an
    * organization to make requests on behalf of.
    *
-   * @param orgCert         The certificate (public key) for the organization.
-   * @param rsaPrivateKey   An RSA key corresponding to the specified orgCert.
-   * @param passphrase      The passphrase to decrypt the private key.
-   * @param apiKey          The API key to use for authentication.
-   * @param apiMode         Optional, the mode the client will be running. Defaults to staging.
-   * @param options         Optional parameters
-   * @param options.timeout Connection timeout in milliseconds, default 120 seconds.
+   * @param orgCert                 The certificate (public key) for the organization.
+   * @param rsaPrivateKey           An RSA key corresponding to the specified orgCert.
+   * @param rsaPrivateKeyPassword   The passphrase to decrypt the private key.
+   * @param apiKey                  The API key to use for authentication.
+   * @param apiMode                 Optional, the mode the client will be running. Defaults to staging.
+   * @param options                 Optional parameters
+   * @param options.timeout         Connection timeout in milliseconds, default 120 seconds.
    */
   constructor({
     orgCert,

--- a/packages/carequality-sdk/src/client/carequality.ts
+++ b/packages/carequality-sdk/src/client/carequality.ts
@@ -39,7 +39,7 @@ export class CarequalityManagementAPIImpl implements CarequalityManagementAPI {
    *
    * @param orgCert                 The certificate (public key) for the organization.
    * @param rsaPrivateKey           An RSA key corresponding to the specified orgCert.
-   * @param rsaPrivateKeyPassword   The passphrase to decrypt the private key.
+   * @param rsaPrivateKeyPassword   The password to decrypt the private key.
    * @param apiKey                  The API key to use for authentication.
    * @param apiMode                 Optional, the mode the client will be running. Defaults to staging.
    * @param options                 Optional parameters

--- a/packages/carequality-sdk/src/client/carequality.ts
+++ b/packages/carequality-sdk/src/client/carequality.ts
@@ -23,14 +23,10 @@ export enum APIMode {
  * This SDK operates on FHIR STU3 format.
  */
 export class CarequalityManagementAPIImpl implements CarequalityManagementAPI {
-  private static readonly devUrl = "https://dev-dir-ceq.sequoiadns.org/fhir-stu3/1.0.1";
+  private static readonly devUrl = "https://directory.dev.carequality.org/fhir-pre-stu3/";
   private static readonly stagingUrl = "https://stage-dir-ceq.sequoiaproject.org/fhir-stu3/1.0.1";
   private static readonly productionUrl =
     "https://prod-dir-ceq-01.sequoiaproject.org/fhir-stu3/1.0.1/";
-
-  // NOTE: These URLs can be used if we migrate to FHIR R4 format.
-  // private static readonly devUrl = "https://directory.dev.carequality.org/fhir";
-  // private static readonly  stagingUrl = "https://directory.stage.carequality.org/fhir";
 
   static ORG_ENDPOINT = "/Organization";
   readonly api: AxiosInstance;
@@ -52,14 +48,14 @@ export class CarequalityManagementAPIImpl implements CarequalityManagementAPI {
   constructor({
     orgCert,
     rsaPrivateKey,
-    passphrase,
+    rsaPrivateKeyPassword,
     apiKey,
     apiMode = APIMode.production,
     options = {},
   }: {
     orgCert: string;
     rsaPrivateKey: string;
-    passphrase: string;
+    rsaPrivateKeyPassword: string;
     apiKey: string;
     apiMode: APIMode;
     options?: { timeout?: number };
@@ -67,7 +63,7 @@ export class CarequalityManagementAPIImpl implements CarequalityManagementAPI {
     this.httpsAgent = new Agent({
       cert: orgCert,
       key: rsaPrivateKey,
-      passphrase,
+      passphrase: rsaPrivateKeyPassword,
     });
     let baseUrl;
 

--- a/packages/carequality-sdk/src/index.ts
+++ b/packages/carequality-sdk/src/index.ts
@@ -1,5 +1,6 @@
 export { PurposeOfUse } from "@metriport/shared";
-export { APIMode, Carequality } from "./client/carequality";
+export { APIMode, CarequalityManagementAPIImpl } from "./client/carequality";
+export { CarequalityManagementAPI } from "./client/carequality-api";
 export { Contained } from "./models/contained";
 export { Contact } from "./models/contact";
 export { Address } from "./models/address";

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.13.4",
+  "version": "1.13.5-alpha.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.4",
+    "@metriport/commonwell-sdk": "^4.12.5-alpha.0",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.10.4",
+  "version": "1.10.5-alpha.0",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.4",
+    "@metriport/commonwell-sdk": "^4.12.5-alpha.0",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.12.4",
+  "version": "4.12.5-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.9.4",
+  "version": "1.9.5-alpha.0",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.9.5-alpha.0",
+  "version": "1.9.5-alpha.1",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.4.5",
+  "version": "0.4.6-alpha.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -55,7 +55,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.4.4",
+    "@metriport/shared": "^0.4.5-alpha.0",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -45,7 +45,10 @@ export type EnvConfig = {
   };
   carequality?: {
     secretNames?: {
-      CQ_API_KEY?: string;
+      CQ_API_KEY: string;
+      CQ_ORG_PRIVATE_KEY: string;
+      CQ_ORG_CERTIFICATE: string;
+      CQ_KEY_PASSPHRASE: string;
     };
     envVars?: {
       CQ_ORG_DETAILS?: string;

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -48,7 +48,7 @@ export type EnvConfig = {
       CQ_API_KEY: string;
       CQ_ORG_PRIVATE_KEY: string;
       CQ_ORG_CERTIFICATE: string;
-      CQ_KEY_PASSPHRASE: string;
+      CQ_ORG_PRIVATE_KEY_PASSWORD: string;
     };
     envVars?: {
       CQ_ORG_DETAILS?: string;

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -66,7 +66,7 @@ export const config: EnvConfig = {
       CQ_API_KEY: "CQ_API_KEY",
       CQ_ORG_PRIVATE_KEY: "CQ_ORG_PRIVATE_KEY",
       CQ_ORG_CERTIFICATE: "CQ_ORG_CERTIFICATE",
-      CQ_KEY_PASSPHRASE: "CQ_KEY_PASSPHRASE",
+      CQ_ORG_PRIVATE_KEY_PASSWORD: "CQ_KEY_PASSPHRASE",
     },
     envVars: {
       CQ_ORG_DETAILS: `{"name": "Test org","oid": "1.2.3.1.4.1.11.12.29.2022.1234","addressLine1": "123 Main St","city": "Phoenix","state": "AZ","zip": "12345","lat": "33.12345","lon": "-112.12345","urlXCPD": "https://api.myhealthapp.com/xcpd","urlDQ": "https://api.myhealthapp.com/xca-dq","urlDR": "https://api.myhealthapp.com/xca-dr","contactName": "Engineering","phone": "(123)-123-1234","email": "support@healthapp.com"}`,

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -66,7 +66,7 @@ export const config: EnvConfig = {
       CQ_API_KEY: "CQ_API_KEY",
       CQ_ORG_PRIVATE_KEY: "CQ_ORG_PRIVATE_KEY",
       CQ_ORG_CERTIFICATE: "CQ_ORG_CERTIFICATE",
-      CQ_ORG_PRIVATE_KEY_PASSWORD: "CQ_KEY_PASSPHRASE",
+      CQ_ORG_PRIVATE_KEY_PASSWORD: "CQ_ORG_PRIVATE_KEY_PASSWORD",
     },
     envVars: {
       CQ_ORG_DETAILS: `{"name": "Test org","oid": "1.2.3.1.4.1.11.12.29.2022.1234","addressLine1": "123 Main St","city": "Phoenix","state": "AZ","zip": "12345","lat": "33.12345","lon": "-112.12345","urlXCPD": "https://api.myhealthapp.com/xcpd","urlDQ": "https://api.myhealthapp.com/xca-dq","urlDR": "https://api.myhealthapp.com/xca-dr","contactName": "Engineering","phone": "(123)-123-1234","email": "support@healthapp.com"}`,

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -64,6 +64,9 @@ export const config: EnvConfig = {
   carequality: {
     secretNames: {
       CQ_API_KEY: "CQ_API_KEY",
+      CQ_ORG_PRIVATE_KEY: "CQ_ORG_PRIVATE_KEY",
+      CQ_ORG_CERTIFICATE: "CQ_ORG_CERTIFICATE",
+      CQ_KEY_PASSPHRASE: "CQ_KEY_PASSPHRASE",
     },
     envVars: {
       CQ_ORG_DETAILS: `{"name": "Test org","oid": "1.2.3.1.4.1.11.12.29.2022.1234","addressLine1": "123 Main St","city": "Phoenix","state": "AZ","zip": "12345","lat": "33.12345","lon": "-112.12345","urlXCPD": "https://api.myhealthapp.com/xcpd","urlDQ": "https://api.myhealthapp.com/xca-dq","urlDR": "https://api.myhealthapp.com/xca-dr","contactName": "Engineering","phone": "(123)-123-1234","email": "support@healthapp.com"}`,

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.8.5-alpha.0",
+  "version": "1.8.5-alpha.1",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.8.4",
+  "version": "1.8.5-alpha.0",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.8.4",
+  "version": "1.8.5-alpha.0",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.4.4",
+  "version": "0.4.5-alpha.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.10.4",
+  "version": "1.10.5-alpha.0",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,
@@ -64,9 +64,9 @@
     "@typescript-eslint/parser": "^5.50.0",
     "eslint": "^8.33.0",
     "eslint-config-prettier": "^8.6.0",
+    "jsondiffpatch": "^0.6.0",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^4.9.5",
-    "jsondiffpatch": "^0.6.0"
+    "typescript": "^4.9.5"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.10.5-alpha.0",
+  "version": "1.10.5-alpha.1",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
refs. metriport/metriport-internal#1350

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1514

### Description

- Added 2-way-TLS to CQ API as per the [IG requirements](https://carequality.org/healthcare-directory/security.html#tls).

### Testing

- Local
  - [x] Tested locally using the CQ staging directory and certs/keys
- Staging
  - [ ] Make sure this works in staging by rebuilding the staging directory or getting Metriport org
- Production
  - [ ] Make sure this works in staging by rebuilding the prod directory or getting any existing org

### Release Plan
- [ ] Upstream dependencies are met/released
- [ ] Release NPM packages
- [ ] Merge this
