### PR TITLE
Mapping: Care Plan (Archive)

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Resources/CarePlan.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/CarePlan.hbs
@@ -1,0 +1,11 @@
+{
+    "fullUrl":"urn:uuid:{{ID}}",
+    "resource":{
+        "resourceType": "CarePlan",
+        "id":"{{ID}}",
+    },
+    "request":{
+        "method":"PUT",
+        "url":"CarePlan/{{ID}}",
+    },
+},

--- a/packages/fhir-converter/src/templates/cda/Resources/Composition.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/Composition.hbs
@@ -76,6 +76,11 @@
                                         },
                                     {{/each}}
                                 {{/each}}
+                            {{else if (eq resObj.resourceType 'CarePlan')}}
+                                {
+                                    "reference":"{{concat resObj.resourceType '/' (generateUUID (toJsonString ../this.section))}}",
+                                    {{>Utils/DisplayFromSectionEntry.hbs section=../../this.section entry=this}}
+                                },
                             {{else if resObj.resourceType}}
                                 {{#each (toArray ../this.section.entry)}}                           	
                                     {

--- a/packages/fhir-converter/src/templates/cda/Sections/Care_Plan.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Care_Plan.hbs
@@ -1,0 +1,86 @@
+{{#if (contains (toString (toJsonString msg)) '2.16.840.1.113883.10.20.22.2.10')}}
+    {{#with (getFirstCdaSectionsByTemplateId msg '2.16.840.1.113883.10.20.22.2.10') as |carePlan|}}
+        {{#each (toArray 2_16_840_1_113883_10_20_22_2_10.entry) as |carePlanEntry|}}
+            {{#if carePlanEntry.observation}}
+                    {{>Resources/CarePlan.hbs carePlan=carePlan ID=(generateUUID (toJsonString carePlan))}}
+                    {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                        {{>References/CarePlan/subject.hbs ID=(generateUUID (toJsonString carePlan)) REF=(concat 'Patient/' patientId.Id)}},
+                    {{/with}}
+
+                    {{>References/CarePlan/supportingInfo.hbs ID=(generateUUID (toJsonString carePlan)) REF=(concat 'Observation/' (generateUUID (toJsonString carePlanEntry.observation)))}}
+                    {{>Resources/Observation.hbs observationEntry=carePlanEntry.observation ID=(generateUUID (toJsonString carePlanEntry.observation))}}
+                    {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                        {{>References/Observation/subject.hbs ID=(generateUUID (toJsonString carePlanEntry.observation)) REF=(concat 'Patient/' patientId.Id)}},
+                    {{/with}}
+
+                    {{#if carePlanEntry.observation.author.assignedAuthor}}
+                        {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=carePlanEntry.observation.author.assignedAuthor) as |practitionerId|}}
+                            {{>Resources/Practitioner.hbs practitioner=carePlanEntry.observation.author.assignedAuthor ID=practitionerId.Id}},
+                            {{>References/Observation/performer.hbs ID=(generateUUID (toJsonString carePlanEntry.observation)) REF=(concat 'Practitioner/' practitionerId.Id)}},
+                        {{/with}}
+                        {{#if observation.author.assignedAuthor.representedOrganization}}
+                            {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=carePlanEntry.observation.author.assignedAuthor.representedOrganization) as |orgId|}}
+                                {{>Resources/Organization.hbs org=carePlanEntry.observation.author.assignedAuthor.representedOrganization ID=orgId.Id}},
+                                {{>References/Observation/performer.hbs ID=(generateUUID (toJsonString carePlanEntry.observation)) REF=(concat 'Organization/' orgId.Id)}},
+                            {{/with}}
+                        {{/if}}
+                    {{/if}}
+            {{/if}}
+            {{#if carePlanEntry.encounter}}
+
+                {{>Resources/CarePlan.hbs carePlan=carePlan ID=(generateUUID (toJsonString carePlan))}}
+                {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                    {{>References/CarePlan/subject.hbs ID=(generateUUID (toJsonString carePlan)) REF=(concat 'Patient/' patientId.Id)}},
+                {{/with}}
+                {{>Resources/Encounter.hbs encounter=carePlanEntry.encounter ID=(generateUUID (toJsonString carePlanEntry.encounter))}},
+                {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                    {{>References/CarePlan/supportingInfo.hbs ID=(generateUUID (toJsonString carePlan)) REF=(concat 'Encounter/' (generateUUID (toJsonString carePlanEntry.encounter)))}},
+                {{/with}}
+
+                {{#if carePlanEntry.encounter.author.assignedAuthor}}
+                    {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=carePlanEntry.encounter.author.assignedAuthor) as |practitionerId|}}
+                        {{>Resources/Practitioner.hbs practitioner=carePlanEntry.encounter.author.assignedAuthor ID=practitionerId.Id}},
+                        {{>References/Encounter/participant.individual.hbs ID=(generateUUID (toJsonString carePlanEntry.encounter)) REF=(concat 'Practitioner/' practitionerId.Id)}},
+                    {{/with}}
+                        {{#if carePlanEntry.encounter.author.assignedAuthor.representedOrganization}}
+                            {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=carePlanEntry.encounter.author.assignedAuthor.representedOrganization) as |orgId|}}
+                                {{>Resources/Organization.hbs org=carePlanEntry.encounter.author.assignedAuthor.representedOrganization ID=orgId.Id}},
+                                {{>References/Encounter/serviceProvider.hbs ID=(generateUUID (toJsonString carePlanEntry.encounter)) REF=(concat 'Organization/' orgId.Id)}},
+                            {{/with}}
+                        {{/if}}
+                {{/if}}
+            {{/if}}
+            {{#if carePlanEntry.procedure}}
+
+                {{>Resources/CarePlan.hbs carePlan=carePlan ID=(generateUUID (toJsonString carePlan))}}
+                {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                    {{>References/CarePlan/subject.hbs ID=(generateUUID (toJsonString carePlan)) REF=(concat 'Patient/' patientId.Id)}},
+                {{/with}}
+                {{>Resources/Procedure.hbs procedureEntry=carePlanEntry.procedure ID=(generateUUID (toJsonString carePlanEntry.procedure))}},
+                {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                    {{>References/CarePlan/supportingInfo.hbs ID=(generateUUID (toJsonString carePlan)) REF=(concat 'Procedure/' (generateUUID (toJsonString carePlanEntry.procedure)))}},
+                {{/with}}
+
+                {{#if carePlanEntry.procedure.author.assignedAuthor}}
+                    {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=carePlanEntry.procedure.author.assignedAuthor) as |practitionerId|}}
+                        {{>Resources/Practitioner.hbs practitioner=carePlanEntry.procedure.author.assignedAuthor ID=practitionerId.Id}},
+                        {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString carePlanEntry.procedure)) REF=(concat 'Practitioner/' practitionerId.Id)}},
+                    {{/with}}
+                    {{#if carePlanEntry.procedure.author.assignedAuthor.representedOrganization}}
+                        {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=carePlanEntry.procedure.author.assignedAuthor.representedOrganization) as |orgId|}}
+                            {{>Resources/Organization.hbs org=carePlanEntry.procedure.author.assignedAuthor.representedOrganization ID=orgId.Id}},
+                            {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString carePlanEntry.procedure)) REF=(concat 'Organization/' orgId.Id)}},
+                        {{/with}}
+                    {{/if}}
+                {{/if}}
+            {{/if}}            
+        {{/each}}
+        {{#with (getFirstCdaSectionsByTemplateId ../msg '2.16.840.1.113883.10.20.22.2.22.1' '2.16.840.1.113883.10.20.22.2.22') as |encounters|}}
+            {{#with (elementAt (multipleToArray encounters.[2_16_840_1_113883_10_20_22_2_22_1].entry encounters.[2_16_840_1_113883_10_20_22_2_22].entry) 0) as |encounterEntry|}}
+                {{#if encounterEntry.encounter}}
+                    {{>References/CarePlan/encounter.hbs ID=(generateUUID (toJsonString carePlan)) REF=(concat 'Encounter/' (generateUUID (toJsonString encounterEntry.encounter)))}},
+                {{/if}}
+            {{/with}}
+        {{/with}}
+    {{/with}}
+{{/if}}

--- a/packages/fhir-converter/src/templates/cda/ccd.hbs
+++ b/packages/fhir-converter/src/templates/cda/ccd.hbs
@@ -68,6 +68,10 @@
       {{>Sections/Social_History.hbs}},
 
       {{>Sections/Vital_Signs.hbs}},
+
+      {{>Sections/Advance_Directives.hbs}},
+
+      {{>Sections/Care_Plan.hbs}},
         {{! Document Resource Creation }}
         {{!-- Document Reference commented out --}}
       ]


### PR DESCRIPTION
Refs: #[1442](https://github.com/metriport/metriport-internal/issues/1442)

### Description

- added Care Plan. Increases encounters count by a lot.
- Not yet a cx demand for this, but data here is valuable if you want to know if their are care gaps. Old Sidechain used tasks for this as opposed to CarePlan w/ links to Obs, Proc, Encounter. 

### Testing

- Local
  - [x] run insert

### Release Plan

- [ ] Merge this
