### PR TITLE
PATCH RELEASE set final as docStatus if not set by cx

### DIFF
--- a/packages/api/src/command/medical/admin/upload-doc.ts
+++ b/packages/api/src/command/medical/admin/upload-doc.ts
@@ -154,7 +154,7 @@ export async function updateDocumentReference({
 
     updatedDocumentReference.extension = [metriportDataSourceExtension];
     updatedDocumentReference.content = [metriportContent];
-    updatedDocumentReference.docStatus = updatedDocumentReference.docStatus ?? "final";
+    updatedDocumentReference.docStatus = "final";
     console.log("Updated the DocRef:", JSON.stringify(updatedDocumentReference));
 
     const docRefFinal = await fhirApi.updateResource(updatedDocumentReference);


### PR DESCRIPTION
refs. metriport/metriport#1623


### Dependencies

n/a

### Description

set final as docStatus if not set by cx
see thread for context: https://metriport.slack.com/archives/C04DMKE9DME/p1707947387359609

### Testing

triple checked the logic - low risk change

### Release Plan


- :warning: Points to `master`
- [ ] Merge this
