### PR TITLE
PATCH RELEASE - don't send nonXMLBody ccdas to converter

### DIFF
--- a/packages/fhir-converter/src/lib/cda/cda.js
+++ b/packages/fhir-converter/src/lib/cda/cda.js
@@ -113,6 +113,9 @@ module.exports = class cda extends dataHandler {
 
   parseSrcData(data) {
     return new Promise((fulfill, reject) => {
+      if (typeof data === "string" && data.includes("nonXMLBody")) {
+        return reject(new Error("Can not convert unstructured CDA with nonXMLBody"));
+      }
       let minifiedData = minifyXML.minify(data, {
         removeComments: true,
         removeWhitespaceBetweenTags: true,


### PR DESCRIPTION
refs. metriport/metriport#1629

### Dependencies

n/a

### Description

don't send nonXMLBody C-CDAs to converter

### Testing

- Local
  - [x] ensure C-CDAs containing nonXMLBody are skipped for conversion


### Release Plan


- :warning: Points to `master`
- [ ] Merge this
