### PR TITLE
fix(api): added set-cq-link-status to enhance-coverage script

### DIFF
--- a/packages/api/src/external/commonwell/cq-bridge/cq-link-status.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/cq-link-status.ts
@@ -1,14 +1,35 @@
+import { Patient } from "@metriport/core/domain/patient";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import { cloneDeep } from "lodash";
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
-import { Patient } from "@metriport/core/domain/patient";
 import { PatientModel } from "../../../models/medical/patient";
 import { executeOnDBTx } from "../../../models/transaction-wrapper";
 import { getLinkStatusCQ } from "../patient";
 import { CQLinkStatus } from "../patient-shared";
 
 dayjs.extend(duration);
+const PARALLEL_UPDATES = 10;
+
+export async function setCQLinkStatuses({
+  cxId,
+  patientIds,
+  cqLinkStatus,
+}: {
+  cxId: string;
+  patientIds: string[];
+  cqLinkStatus: CQLinkStatus;
+}): Promise<void> {
+  const setCQLinkStatusBulk = async (patientId: string): Promise<void> => {
+    const { updated } = await setCQLinkStatus({ cxId, patientId, cqLinkStatus });
+    if (!updated) return;
+  };
+
+  await executeAsynchronously(patientIds, setCQLinkStatusBulk, {
+    numberOfParallelExecutions: PARALLEL_UPDATES,
+  });
+}
 
 /**
  * Set the CQ link status on the patient.

--- a/packages/api/src/external/commonwell/patient-updater-commonwell.ts
+++ b/packages/api/src/external/commonwell/patient-updater-commonwell.ts
@@ -7,7 +7,7 @@ import { errorToString } from "../../shared/log";
 import { capture } from "../../shared/notifications";
 import { getPatients } from "../../command/medical/patient/get-patient";
 
-const maxNumberOfParallelRequestsToCW = 20;
+const maxNumberOfParallelRequestsToCW = 10;
 
 /**
  * Implementation of the PatientUpdater that executes the logic on CommonWell.


### PR DESCRIPTION
refs. [metriport/metriport-internal#799](https://github.com/metriport/metriport-internal/issues/1432)

### Description

- Updated the `enhance-coverage` script with a call to an internal route that sets cq link status for patients

### Testing

- Local
  - [x] Tested with a list of local patients

### Release Plan
- [ ] Merge this
