### PR TITLE
PATCH RELEASE 1475 Fix CW proxy searchParam processing

### DIFF
--- a/packages/api/src/external/commonwell/proxy/cw-process-request.ts
+++ b/packages/api/src/external/commonwell/proxy/cw-process-request.ts
@@ -116,11 +116,12 @@ function fromHttpRequestToFHIR(req: Request): {
 }
 
 function getAllowedSearchParams(searchParams: URLSearchParams): URLSearchParams {
-  for (const [param] of searchParams.entries()) {
-    if (!allowedQueryParams.includes(param)) searchParams.delete(param);
+  const paramsToUse = new URLSearchParams();
+  for (const [param, value] of searchParams.entries()) {
+    if (allowedQueryParams.includes(param)) paramsToUse.append(param, value);
   }
-  if (searchParams.size <= 0) throw new BadRequestError(`Missing query parameters`);
-  return searchParams;
+  if (paramsToUse.size <= 0) throw new BadRequestError(`Missing query parameters`);
+  return paramsToUse;
 }
 
 async function queryFHIRServer({


### PR DESCRIPTION
Ref: metriport/metriport-internal#1475

### Description

Build new `searchParams` on CW proxy instead of updating existing ones.

### Testing

- Local
  - [x] Keeps accepted params
  - [x] Remove non-accepted params
- Staging
  - none
- Sandbox
  - none
- Production
  - [x] Keeps accepted params
  - [x] Remove non-accepted params

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
- [ ] Merge master into develop