### PR TITLE
:herb: Remove `resources` from Python SDK imports

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -3,15 +3,17 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 0.7.5
+        version: 0.11.2
         output:
           location: pypi
           package-name: metriport
           token: ${PYPI_TOKEN}
         config:
           client_class_name: Metriport
+          improved_imports: true
         github: 
           repository: metriport/metriport-python
+          mode: pull-request # Generates a pull request (instead of commit) 
   java-sdk:
     generators:
       - name: fernapi/fern-java-sdk


### PR DESCRIPTION
This PR flattens the import hierarchy for the Python SDK.
