### PR TITLE
PATCH RELEASE 2024-02-23

### DIFF
--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -213,9 +213,11 @@ export const sendTestPayload = async (url: string, key: string, cxId: string): P
   };
 
   const res = await sendPayload(payload, url, key, DEFAULT_TIMEOUT_SEND_TEST_MS);
+
   const isNoWebhookPongEnabled = await isNoWebhookPongEnabledForCx(cxId);
+  if (!res) return false;
   // check for a matching pong response, unless FF is enabled to skip that check
-  return res && (isNoWebhookPongEnabled || (res.pong && res.pong === ping));
+  return isNoWebhookPongEnabled ?? (res.pong && res.pong === ping);
 };
 
 export const isWebhookDisabled = (meta?: unknown): boolean => {

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -227,7 +227,7 @@ export const sendTestPayload = async (url: string, key: string, cxId: string): P
   if (!res) return false;
   if (isWebhookPongDisabled) return true;
   // check for a matching pong response, unless FF is enabled to skip that check
-  return res.pong && res.pong === ping ? true : false;
+  return typeof res !== "string" && res.pong && res.pong === ping ? true : false;
 };
 
 export const isWebhookDisabled = (meta?: unknown): boolean => {

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -177,7 +177,7 @@ export const processRequest = async (
 };
 
 const webhookResponseSchema = z.object({
-  pong: z.string(),
+  pong: z.string().optional(),
 });
 
 type WebhookResponseSchema = z.infer<typeof webhookResponseSchema>;
@@ -219,14 +219,13 @@ export const sendTestPayload = async (url: string, key: string, cxId: string): P
     },
   };
 
-  const isWebhookPongDisabled = await isWebhookPongDisabledForCx(cxId);
-  if (isWebhookPongDisabled) return true;
-
   const res = await sendPayload(payload, url, key, DEFAULT_TIMEOUT_SEND_TEST_MS);
+  const isWebhookPongDisabled = await isWebhookPongDisabledForCx(cxId);
 
+  if (isWebhookPongDisabled) return true;
   if (!res) return false;
   // check for a matching pong response, unless FF is enabled to skip that check
-  return res.pong === ping ? true : false;
+  return res.pong && res.pong === ping ? true : false;
 };
 
 export const isWebhookDisabled = (meta?: unknown): boolean => {

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -222,8 +222,8 @@ export const sendTestPayload = async (url: string, key: string, cxId: string): P
   const res = await sendPayload(payload, url, key, DEFAULT_TIMEOUT_SEND_TEST_MS);
   const isWebhookPongDisabled = await isWebhookPongDisabledForCx(cxId);
 
-  if (isWebhookPongDisabled) return true;
   if (!res) return false;
+  if (isWebhookPongDisabled) return true;
   // check for a matching pong response, unless FF is enabled to skip that check
   return res.pong && res.pong === ping ? true : false;
 };

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -222,9 +222,9 @@ export const sendTestPayload = async (url: string, key: string, cxId: string): P
   };
 
   const res = await sendPayload(payload, url, key, DEFAULT_TIMEOUT_SEND_TEST_MS);
-  const isWebhookPongDisabled = await isWebhookPongDisabledForCx(cxId);
-
   if (!res) return false;
+
+  const isWebhookPongDisabled = await isWebhookPongDisabledForCx(cxId);
   if (isWebhookPongDisabled) return true;
   // check for a matching pong response, unless FF is enabled to skip that check
   return typeof res !== "string" && res.pong && res.pong === ping ? true : false;

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -176,9 +176,11 @@ export const processRequest = async (
   return false;
 };
 
-const webhookResponseSchema = z.object({
-  pong: z.string().optional(),
-});
+const webhookResponseSchema = z
+  .object({
+    pong: z.string().optional(),
+  })
+  .or(z.string());
 
 type WebhookResponseSchema = z.infer<typeof webhookResponseSchema>;
 

--- a/packages/api/src/external/aws/appConfig.ts
+++ b/packages/api/src/external/aws/appConfig.ts
@@ -106,7 +106,7 @@ export async function isCQDirectEnabledForCx(cxId: string): Promise<boolean> {
   return cxIdsWithCQDirectEnabled.some(i => i === cxId);
 }
 
-export async function isNoWebhookPongEnabledForCx(cxId: string): Promise<boolean> {
+export async function isWebhookPongDisabledForCx(cxId: string): Promise<boolean> {
   const cxIdsWithECEnabled = await getCxsWithNoWebhookPongFeatureFlagValue();
   return cxIdsWithECEnabled.some(i => i === cxId);
 }


### PR DESCRIPTION
refs. metriport/metriport#1653

### Description

- Fixed a bug in sendTestPayload, ensuring that it always returns a boolean

### Testing
- Local
  - [x] Tested locally with updating webhook settings

### Release Plan
- :warning: Points to `master`
- [ ] Merge this
