### PR TITLE
1377 Fix API env vars names for IHE GW

### DIFF
--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -265,16 +265,16 @@ export class Config {
   }
 
   static getIheGatewayUrl(): string | undefined {
-    return getEnvVar("IHE_GATEWAY_URL");
+    return getEnvVar("IHE_GW_URL");
   }
   static getIheGatewayPortPD(): string | undefined {
-    return getEnvVar("IHE_GATEWAY_PORT_PD");
+    return getEnvVar("IHE_GW_PORT_PD");
   }
   static getIheGatewayPortDQ(): string | undefined {
-    return getEnvVar("IHE_GATEWAY_PORT_DQ");
+    return getEnvVar("IHE_GW_PORT_DQ");
   }
   static getIheGatewayPortDR(): string | undefined {
-    return getEnvVar("IHE_GATEWAY_PORT_DR");
+    return getEnvVar("IHE_GW_PORT_DR");
   }
 
   static getOutboundDocumentQueryLambdaName(): string | undefined {


### PR DESCRIPTION
Ref. metriport/metriport-internal#1377

### Dependencies

none

### Description

Fix API env vars names for IHE GW

### Testing

none

### Release Plan

- nothing special