### PR TITLE
1350 Add CQ PD to patient update

### DIFF
--- a/packages/api/src/command/medical/patient/create-patient.ts
+++ b/packages/api/src/command/medical/patient/create-patient.ts
@@ -1,13 +1,13 @@
-import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { Patient, PatientCreate, PatientData } from "@metriport/core/domain/patient";
+import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { processAsyncError } from "../../../errors";
-import cwCommands from "../../../external/commonwell";
 import cqCommands from "../../../external/carequality";
+import cwCommands from "../../../external/commonwell";
 import { PatientModel } from "../../../models/medical/patient";
 import { getFacilityOrFail } from "../facility/get-facility";
+import { addCoordinatesToAddresses } from "./add-coordinates";
 import { getPatientByDemo } from "./get-patient";
 import { sanitize, validate } from "./shared";
-import { addCoordinatesToAddresses } from "./add-coordinates";
 
 type Identifier = Pick<Patient, "cxId" | "externalId"> & { facilityId: string };
 type PatientNoExternalData = Omit<PatientData, "externalData">;
@@ -46,14 +46,13 @@ export const createPatient = async (patient: PatientCreateCmd): Promise<Patient>
 
   const newPatient = await PatientModel.create(patientCreate);
 
-  // TODO: #393 declarative, event-based integration
-  // Intentionally asynchronous - it takes too long to perform
+  // Intentionally asynchronous
   cwCommands.patient.create(newPatient, facilityId).catch(processAsyncError(`cw.patient.create`));
 
-  // Intentionally asynchronous - it takes too long to perform
+  // Intentionally asynchronous
   cqCommands.patient
     .discover(newPatient, facility.data.npi)
-    .catch(processAsyncError(`cq.patient.discover`));
+    .catch(processAsyncError(`cq.patient.create`));
 
   return newPatient;
 };

--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -36,7 +36,7 @@ export async function processOutboundDocumentQueryResps({
   cxId: string;
   outboundDocumentQueryResps: OutboundDocumentQueryResp[];
 }): Promise<void> {
-  const { log } = out(`CQ DR - requestId ${requestId}, M patient ${patientId}`);
+  const { log } = out(`CQ DR - requestId ${requestId}, patient ${patientId}`);
 
   const interrupt = buildInterrupt({ requestId, patientId, cxId, log });
   if (!iheGateway) return interrupt(`IHE GW not available`);

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -26,7 +26,7 @@ export async function getDocumentsFromCQ({
   requestId: string;
   patient: Patient;
 }) {
-  const { log } = out(`CQ DQ - requestId ${requestId}, M patient ${patient.id}`);
+  const { log } = out(`CQ DQ - requestId ${requestId}, patient ${patient.id}`);
   const { cxId, id: patientId } = patient;
 
   const interrupt = buildInterrupt({ patientId, cxId, log });

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -44,7 +44,7 @@ export const PATIENT_DISCOVERY_TIMEOUT = dayjs.duration({ seconds: 15 });
 const CHECK_DB_INTERVAL = dayjs.duration({ seconds: 5 });
 
 export async function discover(patient: Patient, facilityNPI: string): Promise<void> {
-  const baseLogMessage = `CQ PD - M patientId ${patient.id}`;
+  const baseLogMessage = `CQ PD - patientId ${patient.id}`;
   const { log: outerLog } = out(baseLogMessage);
   const { cxId } = patient;
 
@@ -100,7 +100,7 @@ export async function discover(patient: Patient, facilityNPI: string): Promise<v
 
     log(`Completed.`);
   } catch (error) {
-    const msg = `Failed to carry out patient discovery`;
+    const msg = `Error on Patient Discovery`;
     outerLog(`${msg} - ${errorToString(error)}`);
     capture.error(msg, {
       extra: {

--- a/packages/api/src/external/commonwell/cq-bridge/patient-event-listener.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/patient-event-listener.ts
@@ -1,6 +1,7 @@
 import { PatientEvents, patientEvents } from "../../../event/medical/patient-event";
 import { setCQLinkStatus } from "./cq-link-status";
 
+// TODO 1543 remove this when we remove EC - as well as the respective fields from the DB
 export default function () {
   patientEvents().on(PatientEvents.UPDATED, async patient => {
     const cqLinkStatus = "unlinked";

--- a/packages/api/src/routes/medical/internal-patient.ts
+++ b/packages/api/src/routes/medical/internal-patient.ts
@@ -3,6 +3,7 @@ import { consolidationConversionType } from "@metriport/core/domain/conversion/f
 import { MedicalDataSource } from "@metriport/core/external/index";
 import { out } from "@metriport/core/util/log";
 import { sleep, stringToBoolean } from "@metriport/shared";
+import { errorToString } from "@metriport/shared/common/error";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import { Request, Response } from "express";
@@ -17,10 +18,13 @@ import { deletePatient } from "../../command/medical/patient/delete-patient";
 import {
   getPatientIds,
   getPatientOrFail,
-  getPatientStates,
   getPatients,
+  getPatientStates,
 } from "../../command/medical/patient/get-patient";
-import { PatientUpdateCmd, updatePatient } from "../../command/medical/patient/update-patient";
+import {
+  PatientUpdateCmd,
+  updatePatientWithoutHIEs,
+} from "../../command/medical/patient/update-patient";
 import { getFacilityIdOrFail } from "../../domain/medical/patient-facility";
 import BadRequestError from "../../errors/bad-request";
 import {
@@ -53,7 +57,7 @@ import {
   getFromQueryAsArray,
   getFromQueryAsArrayOrFail,
 } from "../util";
-import { PatientLinksDTO, dtoFromCW } from "./dtos/linkDTO";
+import { dtoFromCW, PatientLinksDTO } from "./dtos/linkDTO";
 import { dtoFromModel } from "./dtos/patientDTO";
 import { getResourcesQueryParam } from "./schemas/fhir";
 import { linkCreateSchema } from "./schemas/link";
@@ -108,19 +112,18 @@ const updateAllSchema = z.object({
 });
 
 /** ---------------------------------------------------------------------------
- * POST /internal/patient/update-all
+ * POST /internal/patient/update-all/commonwell
  *
  * Triggers an update for all of a cx's patients without changing any
  * demographics. The point of this is to trigger an outbound XCPD from
  * CommonWell to Carequality so new patient links are formed.
- *
  *
  * @param req.query.cxId The customer ID.
  * @param req.body.patientIds The patient IDs to update (optional, defaults to all patients).
  * @return count of update failues, 0 if all successful
  */
 router.post(
-  "/update-all",
+  "/update-all/commonwell",
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const { patientIds = [] } = updateAllSchema.parse(req.body);
@@ -578,25 +581,34 @@ router.post(
     log(`Will update ${patients.length} patients in ${chunks.length} chunks`);
 
     let totalUpdated = 0;
+    let totalFailed = 0;
     for (const chunk of chunks) {
       const results = await Promise.allSettled(
         chunk.map(async patient => {
-          const updateInfo: PatientUpdateCmd = {
-            id: patient.id,
-            cxId: patient.cxId,
-            ...patient.data,
-          };
-          await updatePatient(updateInfo, false);
+          try {
+            const updateInfo: PatientUpdateCmd = {
+              id: patient.id,
+              cxId: patient.cxId,
+              facilityId: getFacilityIdOrFail(patient),
+              ...patient.data,
+            };
+            await updatePatientWithoutHIEs(updateInfo, false);
+          } catch (error) {
+            console.log(`Error updating patient ${patient.id}: ${errorToString(error)}`);
+            throw error;
+          }
         })
       );
       const successful = results.filter(r => r.status === "fulfilled").length;
       totalUpdated += successful;
+      const failed = results.filter(r => r.status === "rejected").length;
+      totalFailed += failed;
 
-      log(`Updated ${successful} patients in this chunk`);
+      log(`Updated ${successful} patients in this chunk (${failed} failed)`);
       await sleep(SLEEP_TIME.asMilliseconds());
     }
 
-    log(`Finished updating ${totalUpdated} patients`);
+    log(`Finished updating patients, ${totalUpdated} succeeded, ${totalFailed} failed`);
     return res.sendStatus(status.OK);
   })
 );

--- a/packages/ihe-gateway-sdk/src/models/patient-discovery/patient-discovery-responses.ts
+++ b/packages/ihe-gateway-sdk/src/models/patient-discovery/patient-discovery-responses.ts
@@ -40,7 +40,7 @@ export type InboundPatientDiscoveryResp = z.infer<typeof inboundPatientDiscovery
 // FROM EXTERNAL GATEWAY
 const outboundPatientDiscoveryRespDefaultSchema = baseResponseSchema.extend({
   gateway: XCPDGatewaySchema,
-  patientResourceId: z.string(),
+  patientId: z.string(),
 });
 
 const outboundPatientDiscoveryRespSuccessfulSchema =


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

### Dependencies

none

### Description

- Add CQ PD to patient update
- Fix PD response schema

### Testing

- Local
  - [x] Patient create triggers PD to IHE GW
  - [x] Patient update triggers PD to IHE GW
  - [x] Patient update adds address location to Patient
  - [x] PD response gets processed and stored on the DB
  - [ ] Patient gets links updated

### Release Plan

- nothing special