### PR TITLE
fix(api): allow getCQOrgUrls return undefined

### DIFF
--- a/packages/api/src/external/carequality/organization.ts
+++ b/packages/api/src/external/carequality/organization.ts
@@ -2,11 +2,13 @@ import { Config } from "../../shared/config";
 import { buildXmlStringFromTemplate } from "./organization-template";
 import { CQOrgDetails, CQOrgUrls, cqOrgUrlsSchema } from "./shared";
 
+const cqOrgUrlsString = Config.getCQOrgUrls();
+
 /**
  * Represents an organization to be registered / updated in the Carequality directory.
  */
 export class CQOrganization {
-  static urls = cqOrgUrlsSchema.parse(JSON.parse(Config.getCQOrgUrls()));
+  static urls = cqOrgUrlsString ? cqOrgUrlsSchema.parse(JSON.parse(cqOrgUrlsString)) : {};
   xmlString: string | undefined;
 
   constructor(

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -288,8 +288,8 @@ export class Config {
     return getEnvVarOrFail("SEARCH_INDEX");
   }
 
-  static getCQOrgUrls(): string {
-    return getEnvVarOrFail("CQ_ORG_URLS");
+  static getCQOrgUrls(): string | undefined {
+    return getEnvVar("CQ_ORG_URLS");
   }
 
   static getCWManagementUrl(): string | undefined {


### PR DESCRIPTION
refs. metriport/metriport-internal#1350

### Description

- making `getCQOrgUrls` function return `string | undefined` since it's not used on Sandbox. 

### Testing
- Local
  - [x] Tested org creation locally to make sure the urls get fetched properly

### Release Plan
- [ ] Merge this
