### PR TITLE
fix(ihe): add metriport id to filename

### DIFF
--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-38 Inbound Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-38 Inbound Processor.xml
@@ -9,7 +9,7 @@ Note:
  - IHE ITI-38 queries other than FindDocuments are not currently supported (see ITI Vol2a 3.18.4.1.2.4)
 
 Last updated: Dec 26 2023</description>
-  <revision>42</revision>
+  <revision>46</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-39 Inbound Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-39 Inbound Processor.xml
@@ -6,7 +6,7 @@
  - Generates AWS Lambda request based on the ITI-39 "Cross Gateway Retrieve" SOAP message
 
 Last updated: Dec 27 2023</description>
-  <revision>42</revision>
+  <revision>46</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA Inbound Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA Inbound Interface.xml
@@ -14,7 +14,7 @@ Note:
 Last updated: Jan 02 2024
 
 </description>
-  <revision>42</revision>
+  <revision>46</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCPD Inbound Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCPD Inbound Interface.xml
@@ -11,7 +11,7 @@ Note:
  - If 'Validate WS-Security' is set to 'Yes,' Mirth Interop rejects failing messages with the SOAP Fault message but does not increase the channel's Received and Sent count.
 
 Last updated: Jan 10 2024</description>
-  <revision>42</revision>
+  <revision>46</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCPD Inbound Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCPD Inbound Processor.xml
@@ -6,7 +6,7 @@
  - Generates ITI-55 "Cross Gateway Patient Discovery Response" SOAP message based on the AWS Lambda response
 
 Last updated: Dec 18 2023</description>
-  <revision>42</revision>
+  <revision>46</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA - DQ App Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA - DQ App Interface.xml
@@ -6,7 +6,7 @@
     - forwards a single request back to the calling app or DB
     
   </description>
-  <revision>30</revision>
+  <revision>34</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA - DR App Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA - DR App Interface.xml
@@ -4,7 +4,7 @@
   <name>XCA - DR App Interface</name>
   <description>XCA App Interface channel
     - forwards a single request back to the calling app or DB</description>
-  <revision>18</revision>
+  <revision>22</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA DQ ITI-38 Bulk Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA DQ ITI-38 Bulk Interface.xml
@@ -10,7 +10,7 @@ Comments:
  - see example of the request here: https://drive.google.com/drive/folders/1yKVHYyQPhkCHDo9Ow8lpT4vFHq7LY_9O
 
 Last updated: Dec 20 2023</description>
-  <revision>42</revision>
+  <revision>46</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA DR ITI-39 Bulk Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA DR ITI-39 Bulk Interface.xml
@@ -10,12 +10,15 @@ Comments:
  - see example of the request here: https://drive.google.com/drive/folders/1yKVHYyQPhkCHDo9Ow8lpT4vFHq7LY_9O
 
 Last updated: Dec 05 2023</description>
-  <revision>42</revision>
+  <revision>46</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
     <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="4.4.2">
       <pluginProperties>
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.4.2">
+          <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
         <com.mirth.connect.plugins.ssl.model.SSLConnectorPluginProperties version="4.4.2">
           <enabled>false</enabled>
           <clientAuthentication>DISABLED</clientAuthentication>
@@ -39,9 +42,6 @@ Last updated: Dec 05 2023</description>
           <implicitFTPS>true</implicitFTPS>
           <useSTARTTLS>false</useSTARTTLS>
         </com.mirth.connect.plugins.ssl.model.SSLConnectorPluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.4.2">
-          <authType>NONE</authType>
-        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
       <listenerConnectorProperties version="4.4.2">
         <host>0.0.0.0</host>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Interface.xml
@@ -6,7 +6,7 @@
  - expects to receive a single requests to be transmitted to the XCA ITI-38 [Cross Gateway Query] Processor channel
 
 Last updated: Nov 29 2023</description>
-  <revision>51</revision>
+  <revision>55</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor.xml
@@ -10,7 +10,7 @@
 TODO: Update SAML Attributes
 
 Last updated: Dec 07 2023</description>
-  <revision>73</revision>
+  <revision>77</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Interface.xml
@@ -6,12 +6,15 @@
  - expects to receive a single requests to be transmitted to the XCA ITI-39 [Cross Gateway Retrieve] Processor channel
 
 Last updated: Nov 14 2023</description>
-  <revision>42</revision>
+  <revision>46</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
     <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="4.4.2">
       <pluginProperties>
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.4.2">
+          <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
         <com.mirth.connect.plugins.ssl.model.SSLConnectorPluginProperties version="4.4.2">
           <enabled>false</enabled>
           <clientAuthentication>DISABLED</clientAuthentication>
@@ -35,9 +38,6 @@ Last updated: Nov 14 2023</description>
           <implicitFTPS>true</implicitFTPS>
           <useSTARTTLS>false</useSTARTTLS>
         </com.mirth.connect.plugins.ssl.model.SSLConnectorPluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.4.2">
-          <authType>NONE</authType>
-        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
       <listenerConnectorProperties version="4.4.2">
         <host>0.0.0.0</host>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor.xml
@@ -8,7 +8,7 @@
  - Processes responses
 
 Last updated: Jan 12 2024</description>
-  <revision>72</revision>
+  <revision>77</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -409,7 +409,7 @@ Last updated: Jan 12 2024</description>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1708898888531</time>
+        <time>1708956880097</time>
         <timezone>America/New_York</timezone>
       </lastModified>
       <pruningSettings>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
@@ -50,7 +50,7 @@ if ('Success' == queryResponseCode.toString() || 'PartialSuccess' == queryRespon
 				var detectedFileType = type[0];
 				var detectedExtension = type[1];
 
-				var fileName = [request.cxId, request.patientId, attachment.docUniqueId + detectedExtension].join('_');
+				var fileName = [request.cxId, request.patientId, attachment.metriportId + detectedExtension].join('_');
 				var filePath = [request.cxId, request.patientId, fileName].join('/');
 				var docExists = xcaReadFromFile(filePath.toString());
 
@@ -85,6 +85,7 @@ if ('Success' == queryResponseCode.toString() || 'PartialSuccess' == queryRespon
 		}
 
 	} catch(ex) {
+logger.error('XCA ITI-39 Processor: Response (Case1) - ' + ex);
 		if (globalMap.containsKey('TEST_MODE')) logger.error('XCA ITI-39 Processor: Response (Case1) - ' + ex);
 	}
 

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD App Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD App Interface.xml
@@ -6,7 +6,7 @@
  - forwards a single request back to the calling app or DB
 
 Last updated: Nov 23 2023</description>
-  <revision>22</revision>
+  <revision>26</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD Bulk Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD Bulk Interface.xml
@@ -7,7 +7,7 @@
  - takes individual requests and sends to the XCPD Interface channel
 
 Last updated: Dec 08 2023</description>
-  <revision>42</revision>
+  <revision>46</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor.xml
@@ -8,7 +8,7 @@
  - Processes responses
 
 Last updated: Dec 20 2023</description>
-  <revision>44</revision>
+  <revision>48</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD Interface.xml
@@ -6,12 +6,15 @@
  - expects to receive a single requests to be transmitted to the XCPD ITI-55 Processor channel
 
 Last updated: Dec 20 2023</description>
-  <revision>42</revision>
+  <revision>46</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
     <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="4.4.2">
       <pluginProperties>
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.4.2">
+          <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
         <com.mirth.connect.plugins.ssl.model.SSLConnectorPluginProperties version="4.4.2">
           <enabled>false</enabled>
           <clientAuthentication>DISABLED</clientAuthentication>
@@ -35,9 +38,6 @@ Last updated: Dec 20 2023</description>
           <implicitFTPS>true</implicitFTPS>
           <useSTARTTLS>false</useSTARTTLS>
         </com.mirth.connect.plugins.ssl.model.SSLConnectorPluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.4.2">
-          <authType>NONE</authType>
-        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
       <listenerConnectorProperties version="4.4.2">
         <host>0.0.0.0</host>

--- a/packages/ihe-gateway/server/CodeTemplates/Common Library/File type.xml
+++ b/packages/ihe-gateway/server/CodeTemplates/Common Library/File type.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?><codeTemplate version="4.4.2">
   <id>476ce6dd-1ae0-43c8-b6fa-a3d887c9edd5</id>
   <name>File type</name>
-  <revision>20</revision>
+  <revision>23</revision>
   <lastModified>
-    <time>1708895663774</time>
+    <time>1708956838383</time>
     <timezone>GMT</timezone>
   </lastModified>
   <contextSet>

--- a/packages/ihe-gateway/server/CodeTemplates/Common Library/Write document to AWS S3 bucket.xml
+++ b/packages/ihe-gateway/server/CodeTemplates/Common Library/Write document to AWS S3 bucket.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?><codeTemplate version="4.4.2">
   <id>00903944-3070-4bc2-8324-a13c4124295d</id>
   <name>Write document to AWS S3 bucket</name>
-  <revision>26</revision>
+  <revision>29</revision>
   <lastModified>
-    <time>1708898683551</time>
+    <time>1708956838407</time>
     <timezone>GMT</timezone>
   </lastModified>
   <contextSet>


### PR DESCRIPTION
Ref. metriport/metriport-internal#1317

### Dependencies

n/a

### Description


Update the filename to s3 to include metriport id not the docuniqueid

### Testing

- Local
  - [x]  Send a request and see the message being sent


### Release Plan


- [ ] Merge this
