### PR TITLE
fix(api): fixed passing incorrect managing org for cq dir registration

### DIFF
--- a/packages/api/src/external/carequality/organization-template.ts
+++ b/packages/api/src/external/carequality/organization-template.ts
@@ -8,6 +8,7 @@ import { Config } from "../../shared/config";
 import { CQOrgDetailsWithUrls } from "./shared";
 
 const metriportOid = Config.getSystemRootOID();
+const metriportName = Config.getSystemRootOrgName();
 
 export function buildXmlStringFromTemplate(orgDetails: CQOrgDetailsWithUrls) {
   const {
@@ -102,7 +103,7 @@ export function buildXmlStringFromTemplate(orgDetails: CQOrgDetailsWithUrls) {
     ${getPartOf(hostOrgOID)}
     ${endpoints}
     <managingOrg>
-        <reference value="org.sequoiaproject.fhir.stu3/Organization/${name}">
+        <reference value="org.sequoiaproject.fhir.stu3/Organization/${metriportName}">
     </managingOrg>
 </Organization>`;
 }

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -194,6 +194,10 @@ export class Config {
     return getEnvVarOrFail("SYSTEM_ROOT_OID");
   }
 
+  static getSystemRootOrgName(): string {
+    return getEnvVarOrFail("SYSTEM_ROOT_ORG_NAME");
+  }
+
   static getGatewayEndpoint(): string {
     return getEnvVarOrFail("CW_GATEWAY_ENDPOINT");
   }

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -137,6 +137,7 @@ export function createAPIService({
             : {}),
           CONNECT_WIDGET_URL: connectWidgetUrlEnvVar,
           SYSTEM_ROOT_OID: props.config.systemRootOID,
+          SYSTEM_ROOT_ORG_NAME: props.config.systemRootOrgName,
           ...props.config.commonwell.envVars,
           ...(props.config.slack ? props.config.slack : undefined),
           ...(props.config.sentryDSN ? { SENTRY_DSN: props.config.sentryDSN } : undefined),


### PR DESCRIPTION
refs. metriport/metriport-internal#1350

### Description

- Managing organization fix, now correctly referencing Metriport for all our clients

### Testing

- Local
  - [x] Created XML payload locally

### Release Plan
- [ ] Merge this
