### PR TITLE
fix(ihe-gateway-sdk): made the documentReference field nullish for th…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28222,7 +28222,7 @@
       }
     },
     "packages/api": {
-      "version": "1.13.6-alpha.0",
+      "version": "1.13.7-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -28303,11 +28303,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.12.3-alpha.0",
+      "version": "7.12.4-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.6-alpha.0",
-        "@metriport/shared": "^0.4.6-alpha.0",
+        "@metriport/commonwell-sdk": "^4.12.7-alpha.0",
+        "@metriport/shared": "^0.4.7-alpha.0",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28363,11 +28363,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.4.0-alpha.0",
+      "version": "1.4.1-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/core": "^1.9.6-alpha.0",
-        "@metriport/ihe-gateway-sdk": "^0.5.0-alpha.0"
+        "@metriport/core": "^1.9.7-alpha.0",
+        "@metriport/ihe-gateway-sdk": "^0.5.1-alpha.0"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -28375,7 +28375,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.6.0-alpha.1",
+      "version": "0.6.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -28385,10 +28385,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.13.6-alpha.0",
+      "version": "1.13.7-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.6-alpha.0",
+        "@metriport/commonwell-sdk": "^4.12.7-alpha.0",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -28427,10 +28427,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.10.6-alpha.0",
+      "version": "1.10.7-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.6-alpha.0",
+        "@metriport/commonwell-sdk": "^4.12.7-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -28462,7 +28462,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.12.6-alpha.0",
+      "version": "4.12.7-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",
@@ -28512,7 +28512,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.9.6-alpha.0",
+      "version": "1.9.7-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -28578,17 +28578,17 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.5.0-alpha.0",
+      "version": "0.5.1-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.4.6-alpha.0",
+        "@metriport/shared": "^0.4.7-alpha.0",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.8.6-alpha.0",
+      "version": "1.8.7-alpha.0",
       "dependencies": {
         "aws-cdk-lib": "^2.122.0",
         "constructs": "^10.2.69",
@@ -28636,7 +28636,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.8.6-alpha.0",
+      "version": "1.8.7-alpha.0",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -29663,11 +29663,11 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.4.6-alpha.0",
+      "version": "0.4.7-alpha.0",
       "license": "MIT"
     },
     "packages/utils": {
-      "version": "1.10.6-alpha.0",
+      "version": "1.10.7-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.12.3-alpha.0",
+  "version": "7.12.4-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -56,8 +56,8 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.6-alpha.0",
-    "@metriport/shared": "^0.4.6-alpha.0",
+    "@metriport/commonwell-sdk": "^4.12.7-alpha.0",
+    "@metriport/shared": "^0.4.7-alpha.0",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.13.6-alpha.0",
+  "version": "1.13.7-alpha.0",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
@@ -40,8 +40,8 @@ export async function processOutboundDocumentRetrievalResps({
 
         if (docRetrievalResp.documentReference) {
           successDocsCount += docRetrievalResp.documentReference.length;
+          await handleDocReferences(docRetrievalResp.documentReference, requestId, patientId, cxId);
         }
-        await handleDocReferences(docRetrievalResp.documentReference, requestId, patientId, cxId);
       })
     );
 

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.4.0-alpha.0",
+  "version": "1.4.1-alpha.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/core": "^1.9.6-alpha.0",
-    "@metriport/ihe-gateway-sdk": "^0.5.0-alpha.0"
+    "@metriport/core": "^1.9.7-alpha.0",
+    "@metriport/ihe-gateway-sdk": "^0.5.1-alpha.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.1-alpha.0",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.13.6-alpha.0",
+  "version": "1.13.7-alpha.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.6-alpha.0",
+    "@metriport/commonwell-sdk": "^4.12.7-alpha.0",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.10.6-alpha.0",
+  "version": "1.10.7-alpha.0",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.6-alpha.0",
+    "@metriport/commonwell-sdk": "^4.12.7-alpha.0",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.12.6-alpha.0",
+  "version": "4.12.7-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.9.6-alpha.0",
+  "version": "1.9.7-alpha.0",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.5.0-alpha.0",
+  "version": "0.5.1-alpha.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -55,7 +55,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.4.6-alpha.0",
+    "@metriport/shared": "^0.4.7-alpha.0",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/ihe-gateway-sdk/src/models/document-query/document-query-responses.ts
+++ b/packages/ihe-gateway-sdk/src/models/document-query/document-query-responses.ts
@@ -35,7 +35,7 @@ const documentQueryRespFromExternalSuccessfulSchema = baseResponseSchema.extend(
 });
 
 const documentQueryRespFromExternalFaultSchema = baseErrorResponseSchema.extend({
-  documentReference: z.never(),
+  documentReference: z.never().or(z.literal(undefined)),
   gateway: xcaGatewaySchema,
 });
 

--- a/packages/ihe-gateway-sdk/src/models/document-retrieval/document-retrieval-responses.ts
+++ b/packages/ihe-gateway-sdk/src/models/document-retrieval/document-retrieval-responses.ts
@@ -38,7 +38,7 @@ const outboundDocumentRetrievalRespSuccessfulSchema = baseResponseSchema.extend(
 
 const outboundDocumentRetrievalRespFaultSchema = baseErrorResponseSchema.extend({
   gateway: xcaGatewaySchema,
-  documentReference: z.array(documentReferenceSchema).nullish(),
+  documentReference: z.never().or(z.literal(undefined)),
 });
 
 export const outboundDocumentRetrievalRespSchema = z.union([

--- a/packages/ihe-gateway-sdk/src/models/document-retrieval/document-retrieval-responses.ts
+++ b/packages/ihe-gateway-sdk/src/models/document-retrieval/document-retrieval-responses.ts
@@ -38,7 +38,7 @@ const outboundDocumentRetrievalRespSuccessfulSchema = baseResponseSchema.extend(
 
 const outboundDocumentRetrievalRespFaultSchema = baseErrorResponseSchema.extend({
   gateway: xcaGatewaySchema,
-  documentReference: z.never(),
+  documentReference: z.array(documentReferenceSchema).nullish(),
 });
 
 export const outboundDocumentRetrievalRespSchema = z.union([

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.8.6-alpha.0",
+  "version": "1.8.7-alpha.0",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.8.6-alpha.0",
+  "version": "1.8.7-alpha.0",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.4.6-alpha.0",
+  "version": "0.4.7-alpha.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.10.6-alpha.0",
+  "version": "1.10.7-alpha.0",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
…e fault resp schema

refs. metriport/metriport-internal#1413

### Description

- Updated the DR fault response schema 

### Testing
- Local
  - [x] Tested with the Postman route: `/internal/carequality/document-retrieval/response`

### Release Plan
- [ ] Release NPM packages
- [ ] Merge this
