### PR TITLE
fix(api): reordered and deduplicated orgs for xcpd

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
@@ -101,9 +101,15 @@ export function toBasicOrgAttributes(org: CQDirectoryEntryModel): CQOrgBasicDeta
 }
 
 export function filterCQOrgsToSearch(orgs: CQOrgBasicDetails[]): CQOrgBasicDetails[] {
-  return orgs.filter(org => {
-    if (org.active && hasValidXcpdLink(org)) return org;
-  });
+  const uniqueOrgsById = new Map<string, CQOrgBasicDetails>();
+  for (const org of orgs) {
+    if (org.active && hasValidXcpdLink(org)) {
+      if (!uniqueOrgsById.has(org.id)) {
+        uniqueOrgsById.set(org.id, org);
+      }
+    }
+  }
+  return Array.from(uniqueOrgsById.values());
 }
 
 function constructGatewayExcludeList(): string[] {

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -138,7 +138,7 @@ async function prepareForPatientDiscovery(
   ]);
 
   const cqGatewaysBasicDetails = cqGateways.map(toBasicOrgAttributes);
-  const orgsToSearch = filterCQOrgsToSearch([...nearbyCQOrgs, ...cqGatewaysBasicDetails]);
+  const orgsToSearch = filterCQOrgsToSearch([...cqGatewaysBasicDetails, ...nearbyCQOrgs]);
   const xcpdGatewaysWithoutIds = cqOrgsToXCPDGateways(orgsToSearch);
   const xcpdGateways = generateIdsForGateways(xcpdGatewaysWithoutIds);
 


### PR DESCRIPTION
refs. metriport/metriport-internal#1350

### Description

- Put gateways in the front of the line, and nearby orgs after
- Deduplicated the orgs in the list of xcpd request

### Testing
- Local
  - [x] Tested locally with patient updates to see how the number and order of orgs changes after the fix

### Release Plan
- [ ] Merge this
