### PR TITLE
fix(ihe): update all to rediscover cq patients links

### DIFF
--- a/packages/api/src/external/aws/appConfig.ts
+++ b/packages/api/src/external/aws/appConfig.ts
@@ -103,7 +103,6 @@ export async function isEnhancedCoverageEnabledForCx(cxId: string): Promise<bool
 
 export async function isCQDirectEnabledForCx(cxId: string): Promise<boolean> {
   const cxIdsWithCQDirectEnabled = await getCxsWithCQDirectFeatureFlagValue();
-  return true;
   return cxIdsWithCQDirectEnabled.some(i => i === cxId);
 }
 

--- a/packages/api/src/external/aws/appConfig.ts
+++ b/packages/api/src/external/aws/appConfig.ts
@@ -103,6 +103,7 @@ export async function isEnhancedCoverageEnabledForCx(cxId: string): Promise<bool
 
 export async function isCQDirectEnabledForCx(cxId: string): Promise<boolean> {
   const cxIdsWithCQDirectEnabled = await getCxsWithCQDirectFeatureFlagValue();
+  return true;
   return cxIdsWithCQDirectEnabled.some(i => i === cxId);
 }
 

--- a/packages/api/src/external/carequality/command/update-patient-discovery-status.ts
+++ b/packages/api/src/external/carequality/command/update-patient-discovery-status.ts
@@ -1,0 +1,50 @@
+import { Patient } from "@metriport/core/domain/patient";
+import { PatientModel } from "../../../models/medical/patient";
+import { executeOnDBTx } from "../../../models/transaction-wrapper";
+import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
+
+/**
+ * Updates the patient discovery status for patient
+ *
+ * @returns
+ */
+export async function updatePatientDiscoveryStatus({
+  patient,
+  status,
+}: {
+  patient: Pick<Patient, "id" | "cxId">;
+  status: "processing" | "completed" | "failed";
+}): Promise<void> {
+  const patientFilter = {
+    id: patient.id,
+    cxId: patient.cxId,
+  };
+
+  await executeOnDBTx(PatientModel.prototype, async transaction => {
+    const existingPatient = await getPatientOrFail({
+      ...patientFilter,
+      lock: true,
+      transaction,
+    });
+
+    const externalData = existingPatient.data.externalData ?? {};
+
+    const updatePatientDiscoveryStatus = {
+      ...externalData,
+      CAREQUALITY: { ...externalData.CAREQUALITY, discoveryStatus: status },
+    };
+
+    const updatedPatient = {
+      ...existingPatient,
+      data: {
+        ...existingPatient.data,
+        externalData: updatePatientDiscoveryStatus,
+      },
+    };
+
+    await PatientModel.update(updatedPatient, {
+      where: patientFilter,
+      transaction,
+    });
+  });
+}

--- a/packages/api/src/external/carequality/patient-shared.ts
+++ b/packages/api/src/external/carequality/patient-shared.ts
@@ -1,7 +1,7 @@
 import { PatientExternalDataEntry } from "@metriport/core/domain/patient";
 
 export class PatientDataCarequality extends PatientExternalDataEntry {
-  constructor() {
+  constructor(public discoveryStatus?: "processing" | "completed" | "failed") {
     super();
   }
 }

--- a/packages/api/src/external/carequality/patient-updater-carequality.ts
+++ b/packages/api/src/external/carequality/patient-updater-carequality.ts
@@ -1,14 +1,26 @@
 import { PatientUpdater } from "@metriport/core/command/patient-updater";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { Patient } from "@metriport/core/domain/patient";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import {
+  checkIfRaceIsComplete,
+  RaceControl,
+  controlDuration,
+} from "@metriport/core/util/race-control";
 import { getFacilityOrFail } from "../../command/medical/facility/get-facility";
 import { getFacilityIdOrFail } from "../../domain/medical/patient-facility";
 import cqCommands from ".";
 import { errorToString } from "../../shared/log";
 import { capture } from "../../shared/notifications";
 import { getPatients } from "../../command/medical/patient/get-patient";
+import { PatientDataCarequality } from "./patient-shared";
+
+dayjs.extend(duration);
 
 const maxNumberOfParallelRequestsToCQ = 10;
+const CONTROL_TIMEOUT = dayjs.duration({ minutes: 15 });
+const CHECK_DB_INTERVAL = dayjs.duration({ seconds: 60 });
 
 /**
  * Implementation of the PatientUpdater that executes the logic on Carequality.
@@ -16,7 +28,7 @@ const maxNumberOfParallelRequestsToCQ = 10;
 export class PatientUpdaterCarequality extends PatientUpdater {
   public async updateAll(
     cxId: string,
-    patientIds: string[]
+    patientIds?: string[]
   ): Promise<{ failedUpdateCount: number }> {
     let failedUpdateCount = 0;
 
@@ -24,6 +36,7 @@ export class PatientUpdaterCarequality extends PatientUpdater {
       cxId,
       patientIds,
     });
+
     // Promise that will be executed for each patient
     const updatePatient = async (patient: Patient) => {
       try {
@@ -31,6 +44,7 @@ export class PatientUpdaterCarequality extends PatientUpdater {
         const facility = await getFacilityOrFail({ cxId, id: facilityId });
 
         await cqCommands.patient.discover(patient, facility.data.npi);
+        await this.isPatientDiscoveryComplete(patient);
       } catch (error) {
         failedUpdateCount++;
         const msg = `Failed to update CQ patient`;
@@ -44,5 +58,43 @@ export class PatientUpdaterCarequality extends PatientUpdater {
     });
 
     return { failedUpdateCount };
+  }
+
+  private async isPatientDiscoveryComplete(patient: Patient): Promise<boolean> {
+    const raceControl: RaceControl = { isRaceInProgress: true };
+
+    try {
+      const successMessage = "CQ discovery polling status complete";
+      const timeoutMessage = "CQ discovery polling status reached timeout";
+
+      const raceResult = await Promise.race([
+        controlDuration(CONTROL_TIMEOUT.asMilliseconds(), timeoutMessage),
+        checkIfRaceIsComplete(
+          () => this.getPatientDiscoveryStatus(patient),
+          raceControl,
+          successMessage,
+          CHECK_DB_INTERVAL.asMilliseconds()
+        ),
+      ]);
+
+      if (raceResult === successMessage) {
+        console.log(`CQ discovery polling status complete for patient ${patient.id}.`);
+        return true;
+      }
+
+      throw new Error(timeoutMessage);
+    } catch (error) {
+      throw new Error(`CQ discovery polling failed`);
+    }
+  }
+
+  private getPatientDiscoveryStatus(patient: Patient): boolean {
+    const cqExternalData = patient.data.externalData?.CAREQUALITY as PatientDataCarequality;
+
+    if (!cqExternalData) {
+      return false;
+    }
+
+    return cqExternalData.discoveryStatus === "completed";
   }
 }

--- a/packages/api/src/external/carequality/patient-updater-carequality.ts
+++ b/packages/api/src/external/carequality/patient-updater-carequality.ts
@@ -1,0 +1,48 @@
+import { PatientUpdater } from "@metriport/core/command/patient-updater";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
+import { Patient } from "@metriport/core/domain/patient";
+import { getFacilityOrFail } from "../../command/medical/facility/get-facility";
+import { getFacilityIdOrFail } from "../../domain/medical/patient-facility";
+import cqCommands from ".";
+import { errorToString } from "../../shared/log";
+import { capture } from "../../shared/notifications";
+import { getPatients } from "../../command/medical/patient/get-patient";
+
+const maxNumberOfParallelRequestsToCQ = 10;
+
+/**
+ * Implementation of the PatientUpdater that executes the logic on Carequality.
+ */
+export class PatientUpdaterCarequality extends PatientUpdater {
+  public async updateAll(
+    cxId: string,
+    patientIds: string[]
+  ): Promise<{ failedUpdateCount: number }> {
+    let failedUpdateCount = 0;
+
+    const patients = await getPatients({
+      cxId,
+      patientIds,
+    });
+    // Promise that will be executed for each patient
+    const updatePatient = async (patient: Patient) => {
+      try {
+        const facilityId = getFacilityIdOrFail(patient);
+        const facility = await getFacilityOrFail({ cxId, id: facilityId });
+
+        await cqCommands.patient.discover(patient, facility.data.npi);
+      } catch (error) {
+        failedUpdateCount++;
+        const msg = `Failed to update CQ patient`;
+        console.log(`${msg}. Patient ID: ${patient.id}. Cause: ${errorToString(error)}`);
+        capture.message(msg, { extra: { cxId, patientId: patient.id }, level: "error" });
+      }
+    };
+    // Execute the promises in parallel
+    await executeAsynchronously(patients, async patient => updatePatient(patient), {
+      numberOfParallelExecutions: maxNumberOfParallelRequestsToCQ,
+    });
+
+    return { failedUpdateCount };
+  }
+}

--- a/packages/api/src/external/commonwell/patient-updater-commonwell.ts
+++ b/packages/api/src/external/commonwell/patient-updater-commonwell.ts
@@ -15,7 +15,7 @@ const maxNumberOfParallelRequestsToCW = 10;
 export class PatientUpdaterCommonWell extends PatientUpdater {
   public async updateAll(
     cxId: string,
-    patientIds: string[]
+    patientIds?: string[]
   ): Promise<{ failedUpdateCount: number }> {
     let failedUpdateCount = 0;
 

--- a/packages/api/src/routes/medical/internal-patient.ts
+++ b/packages/api/src/routes/medical/internal-patient.ts
@@ -127,7 +127,7 @@ router.post(
   "/update-all/commonwell",
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
-    const { patientIds = [] } = updateAllSchema.parse(req.body);
+    const { patientIds } = updateAllSchema.parse(req.body);
 
     const { failedUpdateCount } = await new PatientUpdaterCommonWell().updateAll(cxId, patientIds);
 
@@ -150,7 +150,7 @@ router.post(
   "/update-all/carequality",
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
-    const { patientIds = [] } = updateAllSchema.parse(req.body);
+    const { patientIds } = updateAllSchema.parse(req.body);
 
     const { failedUpdateCount } = await new PatientUpdaterCarequality().updateAll(cxId, patientIds);
 

--- a/packages/api/src/routes/medical/internal-patient.ts
+++ b/packages/api/src/routes/medical/internal-patient.ts
@@ -42,6 +42,7 @@ import { ECUpdaterLocal } from "../../external/commonwell/cq-bridge/ec-updater-l
 import { PatientLoaderLocal } from "../../external/commonwell/patient-loader-local";
 import { cqLinkStatus } from "../../external/commonwell/patient-shared";
 import { PatientUpdaterCommonWell } from "../../external/commonwell/patient-updater-commonwell";
+import { PatientUpdaterCarequality } from "../../external/carequality/patient-updater-carequality";
 import { parseISODate } from "../../shared/date";
 import { getETag } from "../../shared/http";
 import {
@@ -129,6 +130,29 @@ router.post(
     const { patientIds = [] } = updateAllSchema.parse(req.body);
 
     const { failedUpdateCount } = await new PatientUpdaterCommonWell().updateAll(cxId, patientIds);
+
+    return res.status(status.OK).json({ failedUpdateCount });
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * POST /internal/patient/update-all/carequality
+ *
+ * Triggers an update for all of a cx's patients without changing any
+ * demographics. The point of this is to trigger an outbound XCPD for
+ * Carequality so new patient links are formed.
+ *
+ * @param req.query.cxId The customer ID.
+ * @param req.body.patientIds The patient IDs to update (optional, defaults to all patients).
+ * @return count of update failues, 0 if all successful
+ */
+router.post(
+  "/update-all/carequality",
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").orFail();
+    const { patientIds = [] } = updateAllSchema.parse(req.body);
+
+    const { failedUpdateCount } = await new PatientUpdaterCarequality().updateAll(cxId, patientIds);
 
     return res.status(status.OK).json({ failedUpdateCount });
   })

--- a/packages/core/src/util/race-control.ts
+++ b/packages/core/src/util/race-control.ts
@@ -3,7 +3,7 @@ import { sleep } from "@metriport/shared";
 export type RaceControl = { isRaceInProgress: boolean };
 
 export async function checkIfRaceIsComplete(
-  isRaceComplete: () => Promise<boolean>,
+  isRaceComplete: () => Promise<boolean> | boolean,
   raceControl: RaceControl,
   completeMsg: string,
   sleepIntervalMS: number


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

### Dependencies

- Upstream: none
- Downstream: none

### Description

Add an update-all for cq to be able to link all cx's patients to external GW's

### Testing

- Local
  - [x] Ran endpoint locally
- Staging
  - [ ] Ping the endpoint to verify patient gets links
- Production
  - [ ] Ping the endpoint to verify patients gets links


### Release Plan

- [ ] Merge this
