### PR TITLE
fix(ihe): remove ihe url response  logs

### DIFF
--- a/packages/api/src/routes/helpers/request-logger.ts
+++ b/packages/api/src/routes/helpers/request-logger.ts
@@ -6,7 +6,7 @@ import { analyzeRoute } from "./request-analytics";
 const asyncLocalStorage = getLocalStorage("reqId");
 const blackListedRoutes = [
   "/internal/carequality/document-query/response",
-  "/internal/carequality/patient-discovery/response",
+  "/internal/carequality/document-retrieval/response",
   "/internal/carequality/patient-discovery/response",
 ];
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

### Dependencies

- Upstream: none
- Downstream: none

### Description

Remove ihe response logs by blacklisting them.

### Testing

- Local
  - [x] Check logs no longer visible
- Staging
  - [ ]Check logs no longer visible
- Production
  - [ ] Check logs no longer visible


### Release Plan

- [ ] Merge this
