### PR TITLE
feat(api): add cw/cq flags on pt create, update, and dq

### DIFF
--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -42,14 +42,22 @@ export async function queryDocumentsAcrossHIEs({
   facilityId,
   override,
   cxDocumentRequestMetadata,
+  // START TODO #1572 - remove
   forceQuery = false,
-}: {
+  commonwell = false,
+  carequality = false,
+}: // END TODO #1572 - remove
+{
   cxId: string;
   patientId: string;
   facilityId?: string;
   override?: boolean;
   cxDocumentRequestMetadata?: unknown;
   forceQuery?: boolean;
+  // START TODO #1572 - remove
+  commonwell?: boolean;
+  carequality?: boolean;
+  // END TODO #1572 - remove
 }): Promise<DocumentQueryProgress> {
   const { log } = Util.out(`queryDocumentsAcrossHIEs - M patient ${patientId}`);
 
@@ -79,18 +87,22 @@ export async function queryDocumentsAcrossHIEs({
     cxDocumentRequestMetadata,
   });
 
-  getDocumentsFromCW({
-    patient,
-    facilityId,
-    forceDownload: override,
-    forceQuery,
-    requestId,
-  }).catch(emptyFunction);
+  if (commonwell) {
+    getDocumentsFromCW({
+      patient,
+      facilityId,
+      forceDownload: override,
+      forceQuery,
+      requestId,
+    }).catch(emptyFunction);
+  }
 
-  getDocumentsFromCQ({
-    patient,
-    requestId,
-  }).catch(emptyFunction);
+  if (carequality) {
+    getDocumentsFromCQ({
+      patient,
+      requestId,
+    }).catch(emptyFunction);
+  }
 
   return createQueryResponse("processing", updatedPatient);
 }

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -42,8 +42,8 @@ export async function queryDocumentsAcrossHIEs({
   facilityId,
   override,
   cxDocumentRequestMetadata,
-  // START TODO #1572 - remove
   forceQuery = false,
+  // START TODO #1572 - remove
   commonwell = false,
   carequality = false,
 }: // END TODO #1572 - remove

--- a/packages/api/src/command/medical/patient/update-patient.ts
+++ b/packages/api/src/command/medical/patient/update-patient.ts
@@ -23,7 +23,11 @@ export type PatientUpdateCmd = BaseUpdateCmdWithCustomer &
 // See: https://metriport.slack.com/archives/C04DMKE9DME/p1686779391180389
 export async function updatePatient(
   patientUpdate: PatientUpdateCmd,
-  emit = true
+  emit = true,
+  // START TODO #1572 - remove
+  commonwell?: boolean,
+  carequality?: boolean
+  // END TODO #1572 - remove
 ): Promise<Patient> {
   const { cxId, facilityId } = patientUpdate;
 
@@ -36,12 +40,16 @@ export async function updatePatient(
   await upsertPatientToFHIRServer(patientUpdate.cxId, fhirPatient);
 
   // Intentionally asynchronous
-  cwCommands.patient.update(result, facilityId).catch(processAsyncError(`cw.patient.update`));
+  if (commonwell) {
+    cwCommands.patient.update(result, facilityId).catch(processAsyncError(`cw.patient.update`));
+  }
 
   // Intentionally asynchronous
-  cqCommands.patient
-    .discover(result, facility.data.npi)
-    .catch(processAsyncError(`cq.patient.update`));
+  if (carequality) {
+    cqCommands.patient
+      .discover(result, facility.data.npi)
+      .catch(processAsyncError(`cq.patient.update`));
+  }
 
   return result;
 }

--- a/packages/api/src/routes/medical/document.ts
+++ b/packages/api/src/routes/medical/document.ts
@@ -125,7 +125,6 @@ router.post(
       facilityId,
       override,
       cxDocumentRequestMetadata: cxDocumentRequestMetadata?.metadata,
-      forceQuery: false,
       commonwell,
       carequality,
     });

--- a/packages/api/src/routes/medical/document.ts
+++ b/packages/api/src/routes/medical/document.ts
@@ -114,6 +114,10 @@ router.post(
     const facilityId = getFrom("query").optional("facilityId", req);
     const override = stringToBoolean(getFrom("query").optional("override", req));
     const cxDocumentRequestMetadata = cxRequestMetadataSchema.parse(req.body);
+    // START TODO #1572 - remove
+    const commonwell = stringToBoolean(getFrom("query").optional("commonwell", req));
+    const carequality = stringToBoolean(getFrom("query").optional("carequality", req));
+    // END TODO #1572 - remove
 
     const docQueryProgress = await queryDocumentsAcrossHIEs({
       cxId,
@@ -121,6 +125,9 @@ router.post(
       facilityId,
       override,
       cxDocumentRequestMetadata: cxDocumentRequestMetadata?.metadata,
+      forceQuery: false,
+      commonwell,
+      carequality,
     });
 
     return res.status(OK).json(docQueryProgress);

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -46,6 +46,7 @@ import {
   schemaUpdateToPatient,
 } from "./schemas/patient";
 import { cxRequestMetadataSchema } from "./schemas/request-metadata";
+import { stringToBoolean } from "@metriport/shared";
 
 const router = Router();
 const MAX_RESOURCE_POST_COUNT = 50;
@@ -66,6 +67,10 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const facilityId = getFromQueryOrFail("facilityId", req);
+    // START TODO #1572 - remove
+    const commonwell = stringToBoolean(getFrom("query").optional("commonwell", req));
+    const carequality = stringToBoolean(getFrom("query").optional("carequality", req));
+    // END TODO #1572 - remove
     const payload = patientCreateSchema.parse(req.body);
 
     if (Config.isSandbox()) {
@@ -84,7 +89,7 @@ router.post(
       facilityId,
     };
 
-    const patient = await createPatient(patientCreate);
+    const patient = await createPatient(patientCreate, commonwell, carequality);
 
     // temp solution until we migrate to FHIR
     const fhirPatient = toFHIR(patient);
@@ -108,6 +113,10 @@ router.put(
     const cxId = getCxIdOrFail(req);
     const id = getFromParamsOrFail("id", req);
     const facilityIdParam = getFrom("query").optional("facilityId", req);
+    // START TODO #1572 - remove
+    const commonwell = stringToBoolean(getFrom("query").optional("commonwell", req));
+    const carequality = stringToBoolean(getFrom("query").optional("carequality", req));
+    // END TODO #1572 - remove
     const payload = patientUpdateSchema.parse(req.body);
 
     const patient = await getPatientOrFail({ id, cxId });
@@ -123,7 +132,7 @@ router.put(
       facilityId,
     };
 
-    const updatedPatient = await updatePatient(patientUpdate);
+    const updatedPatient = await updatePatient(patientUpdate, true, commonwell, carequality);
 
     return res.status(status.OK).json(dtoFromModel(updatedPatient));
   })


### PR DESCRIPTION
refs. metriport/metriport-internal#1572

### Dependencies

n/a

### Description

 add cw/cq flags on pt create, update, and dq so HIE functions need to be explicitly specified to be triggered

### Testing

🏈 

### Release Plan


- :warning: Points to `master`
- [ ] Merge this
