### PR TITLE
fix(ihe): dont uploaded undefined string

### DIFF
--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor.xml
@@ -8,7 +8,7 @@
  - Processes responses
 
 Last updated: Jan 12 2024</description>
-  <revision>79</revision>
+  <revision>84</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
@@ -66,7 +66,7 @@ if ('Success' == queryResponseCode.toString() || 'PartialSuccess' == queryRespon
 
         if (!decodedAsString) {
           var errorMessage = 'Error with decoded document';
-          logger.error(errorMessage + fileName);
+          logger.error(errorMessage + ' ' + fileName);
           throw new Error(errorMessage);
         }
 

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
@@ -65,14 +65,14 @@ if ('Success' == queryResponseCode.toString() || 'PartialSuccess' == queryRespon
 				var decodedAsString = Packages.java.lang.String(decoded);
 
         if (!decodedAsString) {
-          var errorMessage = 'Error with decoded document';
+          const errorMessage = 'Error with decoded document';
           logger.error(errorMessage + ' ' + fileName);
           throw new Error(errorMessage);
         }
 
 				// Parse the document header for some metadata
 				try {
-          var hasTitle = decodedAsString.indexOf("<title>") > -1;
+          const hasTitle = decodedAsString.indexOf("<title>") > -1;
           if (hasTitle) {
 					  var title = decodedAsString.split("<title>")[1].split("</title>")[0];
 					  if (title) attachment.title = title;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
@@ -63,19 +63,25 @@ if ('Success' == queryResponseCode.toString() || 'PartialSuccess' == queryRespon
 				var documentEncodedString = entry.*::Document.toString();
 				var decoded = FileUtil.decode(documentEncodedString);
 				var decodedAsString = Packages.java.lang.String(decoded);
-				
+
+        if (!decodedAsString) {
+          var errorMessage = 'Error with decoded document';
+          logger.error(errorMessage + fileName);
+          throw new Error(errorMessage);
+        }
+
 				// Parse the document header for some metadata
 				try {
 					var title = decodedAsString.split("<title>")[1].split("</title>")[0];
 					if (title) attachment.title = title;
-	
+
 					var fileSize = decodedAsString.getBytes("UTF-8").length;
 					if (fileSize) attachment.size = parseInt(fileSize);
 
 				} catch (ex) {
 					logger.error("Error decoding document: " + ex);
 				}
-				
+
 				var result = xcaWriteToFile(filePath.toString(), decodedAsString, attachment);
 			} catch(ex) {
 				var issue = {

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
@@ -72,8 +72,11 @@ if ('Success' == queryResponseCode.toString() || 'PartialSuccess' == queryRespon
 
 				// Parse the document header for some metadata
 				try {
-					var title = decodedAsString.split("<title>")[1].split("</title>")[0];
-					if (title) attachment.title = title;
+          var hasTitle = decodedAsString.indexOf("<title>") > -1;
+          if (hasTitle) {
+					  var title = decodedAsString.split("<title>")[1].split("</title>")[0];
+					  if (title) attachment.title = title;
+          }
 
 					var fileSize = decodedAsString.getBytes("UTF-8").length;
 					if (fileSize) attachment.size = parseInt(fileSize);


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

### Dependencies

- Upstream:  none
- Downstream: none

### Description

Dont upload docs to s3 if they werent decoded to string properly 

### Testing

- Production
  - [ ] Verify logs appear and no broken docs are added


### Release Plan

- :warning: Points to `master`
- [ ] Merge this
