### PR TITLE
fix(ihe): dont fail if cant find directory org

### DIFF
--- a/packages/api/src/external/carequality/document/create-outbound-document-query-req.ts
+++ b/packages/api/src/external/carequality/document/create-outbound-document-query-req.ts
@@ -42,7 +42,7 @@ export function createOutboundDocumentQueryRequests({
         purposeOfUse: createPurposeOfUse(),
       },
       gateway: {
-        homeCommunityId: externalGateway.systemId,
+        homeCommunityId: externalGateway.oid,
         url: externalGateway.url,
       },
       externalGatewayPatient: {

--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -80,7 +80,7 @@ export async function processOutboundDocumentQueryResps({
       const gateway = await getCQDirectoryEntry(outboundDocumentQueryResp.gateway.homeCommunityId);
 
       if (!gateway) {
-        const msg = `Gateway not found`;
+        const msg = `Doc Retrieval - Gateway not found`;
         console.log(`${msg}: ${outboundDocumentQueryResp.gateway.homeCommunityId} skipping...`);
         capture.message(msg, {
           extra: {

--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -80,7 +80,7 @@ export async function processOutboundDocumentQueryResps({
       const gateway = await getCQDirectoryEntry(outboundDocumentQueryResp.gateway.homeCommunityId);
 
       if (!gateway) {
-        const msg = `Doc Retrieval - Gateway not found`;
+        const msg = `Gateway not found - Doc Retrieval`;
         console.log(`${msg}: ${outboundDocumentQueryResp.gateway.homeCommunityId} skipping...`);
         capture.message(msg, {
           extra: {

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -48,7 +48,7 @@ export async function getDocumentsFromCQ({
       const gateway = await getCQDirectoryEntry(patientLink.oid);
 
       if (!gateway) {
-        const msg = `Doc Query - Gateway not found`;
+        const msg = `Gateway not found - Doc Query`;
         console.log(`${msg}: ${patientLink.oid} skipping...`);
         capture.message(msg, {
           extra: {

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -48,7 +48,7 @@ export async function getDocumentsFromCQ({
       const gateway = await getCQDirectoryEntry(patientLink.oid);
 
       if (!gateway) {
-        const msg = `Gateway not found`;
+        const msg = `Doc Query - Gateway not found`;
         console.log(`${msg}: ${patientLink.oid} skipping...`);
         capture.message(msg, {
           extra: {


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

### Dependencies

- Upstream: none
- Downstream: none

### Description

We are failing the whole thing if we cant find a cq directory orgs, so we want to log and make sure we continue the processes.

### Testing

- Production
  - [ ] Test process still runs

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
