### PR TITLE
fix(ihe): retrieve patient while checking if race complete

### DIFF
--- a/packages/api/src/external/carequality/patient-updater-carequality.ts
+++ b/packages/api/src/external/carequality/patient-updater-carequality.ts
@@ -13,7 +13,7 @@ import { getFacilityIdOrFail } from "../../domain/medical/patient-facility";
 import cqCommands from ".";
 import { errorToString } from "../../shared/log";
 import { capture } from "../../shared/notifications";
-import { getPatients } from "../../command/medical/patient/get-patient";
+import { getPatients, getPatient } from "../../command/medical/patient/get-patient";
 import { PatientDataCarequality } from "./patient-shared";
 
 dayjs.extend(duration);
@@ -88,8 +88,14 @@ export class PatientUpdaterCarequality extends PatientUpdater {
     }
   }
 
-  private getPatientDiscoveryStatus(patient: Patient): boolean {
-    const cqExternalData = patient.data.externalData?.CAREQUALITY as PatientDataCarequality;
+  private async getPatientDiscoveryStatus(patient: Patient): Promise<boolean> {
+    const updatedPatient = await getPatient({ id: patient.id, cxId: patient.cxId });
+
+    if (!updatedPatient) {
+      return false;
+    }
+
+    const cqExternalData = updatedPatient.data.externalData?.CAREQUALITY as PatientDataCarequality;
 
     if (!cqExternalData) {
       return false;

--- a/packages/api/src/external/carequality/patient-updater-carequality.ts
+++ b/packages/api/src/external/carequality/patient-updater-carequality.ts
@@ -14,7 +14,7 @@ import cqCommands from ".";
 import { errorToString } from "../../shared/log";
 import { capture } from "../../shared/notifications";
 import { getPatients, getPatient } from "../../command/medical/patient/get-patient";
-import { PatientDataCarequality } from "./patient-shared";
+import { getCQData } from "./patient";
 
 dayjs.extend(duration);
 
@@ -95,7 +95,7 @@ export class PatientUpdaterCarequality extends PatientUpdater {
       return false;
     }
 
-    const cqExternalData = updatedPatient.data.externalData?.CAREQUALITY as PatientDataCarequality;
+    const cqExternalData = getCQData(updatedPatient.data.externalData);
 
     if (!cqExternalData) {
       return false;


### PR DESCRIPTION
Ticket: #1350

### Dependencies

- Upstream: none
- Downstream: none

### Description

Update all not working because we reference initial patient data

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
