### PR TITLE
fix(api): cut out extra cycles on the api for xcpd

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
@@ -69,16 +69,20 @@ export async function searchCQDirectoriesByRadius({
   const orgs: CQDirectoryEntryModel[] = [];
 
   for (const coord of coordinates) {
-    // Building the WHERE clause conditionally
-    let whereClause = `earth_box(ll_to_earth (${coord.lat}, ${coord.lon}), ${radiusInMeters}) @> point
-      AND earth_distance(ll_to_earth (${coord.lat}, ${coord.lon}), point) < ${radiusInMeters}`;
+    const replacements = {
+      lat: coord.lat,
+      lon: coord.lon,
+      radius: radiusInMeters,
+    };
+
+    let whereClause = `earth_box(ll_to_earth(:lat, :lon), :radius) @> point AND earth_distance(ll_to_earth(:lat, :lon), point) < :radius`;
 
     if (mustHaveXcpdLink) {
-      // Append the condition for urlXCPD only if mustHaveXcpdLink is true
       whereClause += ` AND url_xcpd IS NOT NULL`;
     }
 
     const orgsForAddress = await CQDirectoryEntryModel.findAll({
+      replacements,
       attributes: {
         include: [
           [

--- a/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
@@ -1,7 +1,7 @@
 import { Patient } from "@metriport/core/domain/patient";
 import { Coordinates } from "@metriport/core/external/aws/location";
 import convert from "convert-units";
-import { Sequelize } from "sequelize";
+import { Op, Sequelize } from "sequelize";
 import { Config } from "../../../../shared/config";
 import { CQDirectoryEntryModel } from "../../models/cq-directory";
 
@@ -75,9 +75,13 @@ export async function searchCQDirectoriesByRadius({
           ],
         ],
       },
-      where:
-        Sequelize.literal(`earth_box(ll_to_earth (${coord.lat}, ${coord.lon}), ${radiusInMeters}) @> point
-        AND earth_distance(ll_to_earth (${coord.lat}, ${coord.lon}), point) < ${radiusInMeters}`),
+      where: {
+        [Op.and]: [
+          Sequelize.literal(`earth_box(ll_to_earth (${coord.lat}, ${coord.lon}), ${radiusInMeters}) @> point
+      AND earth_distance(ll_to_earth (${coord.lat}, ${coord.lon}), point) < ${radiusInMeters}`),
+          { urlXCPD: { [Op.ne]: "" } },
+        ],
+      },
       order: Sequelize.literal("distance"),
     });
 

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -88,15 +88,15 @@ async function prepareForPatientDiscovery(
 ): Promise<OutboundPatientDiscoveryReq> {
   const { cxId } = patient;
   const fhirPatient = toFHIR(patient);
-  const nearbyOrgsWithUrls = await searchCQDirectoriesAroundPatientAddresses({ patient });
+  const nearbyOrgsWithUrls = await searchCQDirectoriesAroundPatientAddresses({
+    patient,
+    mustHaveXcpdLink: true,
+  });
   const orgOrderMap = new Map<string, number>();
+
   nearbyOrgsWithUrls.forEach((org, index) => {
     orgOrderMap.set(org.id, index);
   });
-
-  for (const org of nearbyOrgsWithUrls) {
-    console.log(org.id, org.name, org.managingOrganization);
-  }
 
   const [organization, allOrgs] = await Promise.all([
     getOrganizationOrFail({ cxId }),

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -88,14 +88,13 @@ async function prepareForPatientDiscovery(
 ): Promise<OutboundPatientDiscoveryReq> {
   const { cxId } = patient;
   const fhirPatient = toFHIR(patient);
-  const nearbyOrgs = await searchCQDirectoriesAroundPatientAddresses({ patient });
-  const nearbyWithUrls = nearbyOrgs.filter(org => org.urlXCPD);
+  const nearbyOrgsWithUrls = await searchCQDirectoriesAroundPatientAddresses({ patient });
   const orgOrderMap = new Map<string, number>();
-  nearbyWithUrls.forEach((org, index) => {
+  nearbyOrgsWithUrls.forEach((org, index) => {
     orgOrderMap.set(org.id, index);
   });
 
-  for (const org of nearbyWithUrls) {
+  for (const org of nearbyOrgsWithUrls) {
     console.log(org.id, org.name, org.managingOrganization);
   }
 

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -107,7 +107,7 @@ router.post(
 /**
  * GET /internal/carequality/directory/nearby-organizations
  *
- * Retrieves the organizations within a specified radius from the patient's address.
+ * Retrieves the organizations with XCPD URLs within a specified radius from the patient's address.
  * @param req.query.cxId The ID of the customer organization.
  * @param req.query.patientId The ID of the patient.
  * @param req.query.radius Optional, the radius in miles within which to search for organizations. Defaults to 50 miles.

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -120,12 +120,14 @@ router.get(
     const cxId = getFrom("query").orFail("cxId", req);
     const patientId = getFrom("query").orFail("patientId", req);
     const radiusQuery = getFrom("query").optional("radius", req);
+    const mustHaveXcpdLink = getFrom("query").optional("mustHaveXcpdLink", req);
     const radius = radiusQuery ? parseInt(radiusQuery) : DEFAULT_RADIUS_IN_MILES;
 
     const patient = await getPatientOrFail({ cxId, id: patientId });
     const orgs = await searchCQDirectoriesAroundPatientAddresses({
       patient,
       radiusInMiles: radius,
+      mustHaveXcpdLink: mustHaveXcpdLink === "true" ?? false,
     });
 
     const orgsWithBasicDetails = orgs.map(toBasicOrgAttributes);

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -37,7 +37,7 @@ import {
 import { processOutboundPatientDiscoveryResps } from "../../external/carequality/process-outbound-patient-discovery-resps";
 import { cqOrgDetailsSchema } from "../../external/carequality/shared";
 import { Config } from "../../shared/config";
-import { asyncHandler, getFrom } from "../util";
+import { asyncHandler, getFrom, getFromQueryAsBoolean } from "../util";
 
 dayjs.extend(duration);
 const router = Router();
@@ -120,14 +120,14 @@ router.get(
     const cxId = getFrom("query").orFail("cxId", req);
     const patientId = getFrom("query").orFail("patientId", req);
     const radiusQuery = getFrom("query").optional("radius", req);
-    const mustHaveXcpdLink = getFrom("query").optional("mustHaveXcpdLink", req);
+    const mustHaveXcpdLink = getFromQueryAsBoolean("mustHaveXcpdLink", req);
     const radius = radiusQuery ? parseInt(radiusQuery) : DEFAULT_RADIUS_IN_MILES;
 
     const patient = await getPatientOrFail({ cxId, id: patientId });
     const orgs = await searchCQDirectoriesAroundPatientAddresses({
       patient,
       radiusInMiles: radius,
-      mustHaveXcpdLink: mustHaveXcpdLink === "true" ?? false,
+      mustHaveXcpdLink,
     });
 
     const orgsWithBasicDetails = orgs.map(toBasicOrgAttributes);


### PR DESCRIPTION
refs. metriport/metriport-internal#1350

### Description

- Searching for nearby orgs for XCPD now only returns orgs with `url_xcpd`
- Removing post-filtering for this ^

### Testing

- Local
  - [x] Checked that this works locally

### Release Plan
- [ ] Merge this
