### PR TITLE
1040 Add lambda insights to MR generation lambda

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1215,6 +1215,7 @@ export class APIStack extends Stack {
       layers: [lambdaLayers.shared, lambdaLayers.chromium],
       memory: 4096,
       timeout: lambdaTimeout,
+      isEnableInsights: true,
       vpc,
       alarmSnsAction: alarmAction,
     });

--- a/packages/infra/lib/shared/lambda.ts
+++ b/packages/infra/lib/shared/lambda.ts
@@ -10,6 +10,7 @@ import {
   Code,
   Function as Lambda,
   ILayerVersion,
+  LambdaInsightsVersion,
   Runtime,
   RuntimeManagementMode,
   SingletonFunction,
@@ -74,6 +75,7 @@ export function createLambda(props: LambdaProps): Lambda {
     ...(props.layers && props.layers.length > 0 ? { layers: props.layers } : {}),
     vpc: props.vpc,
     vpcSubnets: props.subnets ? { subnets: props.subnets } : undefined,
+    insightsVersion: LambdaInsightsVersion.VERSION_1_0_229_0,
     /**
      * Watch out if this is more than 60s while using SQS we likely need to update the
      * queue's VisibilityTimeout so the message is not processed more than once.

--- a/packages/infra/lib/shared/lambda.ts
+++ b/packages/infra/lib/shared/lambda.ts
@@ -60,6 +60,17 @@ export interface LambdaProps extends StackProps {
   readonly architecture?: Architecture;
   readonly layers: ILayerVersion[];
   readonly version?: string | undefined;
+  /**
+   * Whether to enable Lambda insights.
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights.html
+   */
+  readonly isEnableInsights?: boolean | undefined;
+  /**
+   * Which lambda insights version to use.
+   * Defaults to the latest version available in the CDK version.
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-extension-versions.html
+   */
+  readonly insightsVersion?: LambdaInsightsVersion | undefined;
 }
 
 export function createLambda(props: LambdaProps): Lambda {
@@ -75,7 +86,9 @@ export function createLambda(props: LambdaProps): Lambda {
     ...(props.layers && props.layers.length > 0 ? { layers: props.layers } : {}),
     vpc: props.vpc,
     vpcSubnets: props.subnets ? { subnets: props.subnets } : undefined,
-    insightsVersion: LambdaInsightsVersion.VERSION_1_0_229_0,
+    insightsVersion: props.isEnableInsights
+      ? props.insightsVersion ?? LambdaInsightsVersion.VERSION_1_0_229_0 // latest version on CDK 2.122.0
+      : undefined,
     /**
      * Watch out if this is more than 60s while using SQS we likely need to update the
      * queue's VisibilityTimeout so the message is not processed more than once.


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

none

### Description

Add lambda insights to the MR generation lambda. This is to help identifying issues w/ the lambda that generates MRs timing out/OOM'ing.

Also:
- add execution time for the PDF generation
- isolate functions that load the file from the filesystem
- reuse the stylesheet files across lambda executions

### Testing

- Staging
  - [ ] Lambdas working
  - [ ] MR generation works
- Sandbox
  - none
- Production
  - none

### Release Plan

- nothing special