### PR TITLE
RELEASE 1350 Wait for PD before DQ

### DIFF
--- a/packages/api/src/external/carequality/command/update-patient-discovery-status.ts
+++ b/packages/api/src/external/carequality/command/update-patient-discovery-status.ts
@@ -53,7 +53,7 @@ export async function updatePatientDiscoveryStatus({
     };
 
     const updatedPatient = {
-      ...existingPatient,
+      ...existingPatient.dataValues,
       data: {
         ...existingPatient.data,
         externalData: updatePatientDiscoveryStatus,
@@ -65,7 +65,7 @@ export async function updatePatientDiscoveryStatus({
       transaction,
     });
 
-    return updatedPatient.dataValues;
+    return updatedPatient;
   });
 
   if (docQueryRequestIdToTrigger) {

--- a/packages/api/src/external/carequality/document/get-non-existent-doc-refs.ts
+++ b/packages/api/src/external/carequality/document/get-non-existent-doc-refs.ts
@@ -2,6 +2,7 @@ import { createFileName } from "@metriport/core/domain/filename";
 import { S3Utils } from "@metriport/core/external/aws/s3";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { errorToString } from "@metriport/core/util/error/shared";
+import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import { DocumentReferenceWithMetriportId } from "../../../external/carequality/document/shared";
 import { Config } from "../../../shared/config";
@@ -41,6 +42,7 @@ async function checkDocRefsExistInS3(
   patientId: string,
   cxId: string
 ): Promise<ObservedDocRefs> {
+  const { log } = out(`CQ checkDocRefsExistInS3 - patient ${patientId}`);
   const successfulDocs: { docId: string; exists: boolean }[] = [];
 
   await executeAsynchronously(
@@ -57,7 +59,7 @@ async function checkDocRefsExistInS3(
         });
       } catch (error) {
         const msg = `Failed to check if document exists in S3`;
-        console.log(`${msg}: ${errorToString(error)}`);
+        log(`${msg}: ${errorToString(error)}`);
         capture.message(msg, {
           extra: {
             context: `cq.checkDocRefsExistInS3`,

--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -70,7 +70,7 @@ export async function processOutboundDocumentQueryResps({
     // Since we have most of the document contents when doing the document query,
     // we will store this in FHIR and then upsert the reference to the s3 object in FHIR
     // when doing the doc retrieval
-    await storeInitDocRefInFHIR(docRefsWithMetriportId, cxId, patientId);
+    await storeInitDocRefInFHIR(docRefsWithMetriportId, cxId, patientId, log);
 
     const respWithDRUrl: OutboundDocumentQueryResp[] = [];
 
@@ -81,7 +81,7 @@ export async function processOutboundDocumentQueryResps({
 
       if (!gateway) {
         const msg = `Gateway not found - Doc Retrieval`;
-        console.log(`${msg}: ${outboundDocumentQueryResp.gateway.homeCommunityId} skipping...`);
+        log(`${msg}: ${outboundDocumentQueryResp.gateway.homeCommunityId} skipping...`);
         capture.message(msg, {
           extra: {
             context: `cq.dq.getCQDirectoryEntry`,
@@ -93,7 +93,7 @@ export async function processOutboundDocumentQueryResps({
         });
         return;
       } else if (!gateway.urlDR) {
-        console.log(`Gateway ${gateway.id} has no DR URL, skipping...`);
+        log(`Gateway ${gateway.id} has no DR URL, skipping...`);
         return;
       }
 
@@ -186,7 +186,8 @@ function buildInterrupt({
 async function storeInitDocRefInFHIR(
   docRefs: DocumentReferenceWithMetriportId[],
   cxId: string,
-  patientId: string
+  patientId: string,
+  log: typeof console.log
 ) {
   await executeAsynchronously(
     docRefs,
@@ -199,7 +200,7 @@ async function storeInitDocRefInFHIR(
         await upsertDocumentToFHIRServer(cxId, fhirDocRef);
       } catch (error) {
         const msg = `Failed to store initial doc ref in FHIR`;
-        console.log(`${msg}: ${errorToString(error)}`);
+        log(`${msg}: ${errorToString(error)}`);
         capture.message(msg, {
           extra: {
             context: `cq.storeInitDocRefInFHIR`,

--- a/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
@@ -21,6 +21,9 @@ export async function processOutboundDocumentRetrievalResps({
   cxId,
   results,
 }: OutboundDocRetrievalRespParam): Promise<void> {
+  const { log } = out(
+    `CQ processOutboundDocumentRetrievalResps - requestId ${requestId}, patient ${patientId}`
+  );
   try {
     let newDocRefCount = 0;
     let issuesWithGateway = 0;
@@ -63,7 +66,7 @@ export async function processOutboundDocumentRetrievalResps({
 
     if (failed.length > 0) {
       const msg = `Failed to handle doc references in Carequality`;
-      console.log(`${msg}`);
+      log(`${msg}`);
 
       capture.message(msg, {
         extra: {
@@ -88,7 +91,7 @@ export async function processOutboundDocumentRetrievalResps({
     });
   } catch (error) {
     const msg = `Failed to process documents in Carequality.`;
-    console.log(`${msg}. Error: ${errorToString(error)}`);
+    log(`${msg}. Error: ${errorToString(error)}`);
 
     await setDocQueryProgress({
       patient: { id: patientId, cxId: cxId },

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -41,12 +41,13 @@ export async function getDocumentsFromCQ({
       getCQPatientData({ id: patient.id, cxId }),
     ]);
 
+    // If DQ is triggered while the PD is in progress, schedule it to be done when PD is completed
+    if (getCQData(patient.data.externalData)?.discoveryStatus === "processing") {
+      await scheduleDocQuery({ requestId, patient });
+      return;
+    }
     if (!cqPatientData || cqPatientData.data.links.length <= 0) {
-      // If DQ is triggered while the PD is in progress, schedule it to be done when PD is completed
-      if (getCQData(patient.data.externalData)?.discoveryStatus === "processing") {
-        await scheduleDocQuery({ requestId, patient });
-      }
-      return interrupt(`Patient has no CQ links, DQ has been scheduled`);
+      return interrupt(`Patient has no CQ links, skipping DQ`);
     }
 
     const linksWithDqUrl: CQLink[] = [];

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -13,7 +13,9 @@ import { makeOutboundResultPoller } from "../../ihe-gateway/outbound-result-poll
 import { getCQDirectoryEntry } from "../command/cq-directory/get-cq-directory-entry";
 import { getCQPatientData } from "../command/cq-patient-data/get-cq-data";
 import { CQLink } from "../cq-patient-data";
+import { getCQData } from "../patient";
 import { createOutboundDocumentQueryRequests } from "./create-outbound-document-query-req";
+import { scheduleDocQuery } from "./schedule-document-query";
 
 const iheGateway = makeIheGatewayAPIForDocQuery();
 const resultPoller = makeOutboundResultPoller();
@@ -40,7 +42,11 @@ export async function getDocumentsFromCQ({
     ]);
 
     if (!cqPatientData || cqPatientData.data.links.length <= 0) {
-      return interrupt(`Patient has no CQ links, skipping DQ`);
+      // If DQ is triggered while the PD is in progress, schedule it to be done when PD is completed
+      if (getCQData(patient.data.externalData)?.discoveryStatus === "processing") {
+        await scheduleDocQuery({ requestId, patient });
+      }
+      return interrupt(`Patient has no CQ links, DQ has been scheduled`);
     }
 
     const linksWithDqUrl: CQLink[] = [];
@@ -49,7 +55,7 @@ export async function getDocumentsFromCQ({
 
       if (!gateway) {
         const msg = `Gateway not found - Doc Query`;
-        console.log(`${msg}: ${patientLink.oid} skipping...`);
+        log(`${msg}: ${patientLink.oid} skipping...`);
         capture.message(msg, {
           extra: {
             context: `cq.pd.getCQDirectoryEntry`,

--- a/packages/api/src/external/carequality/document/schedule-document-query.ts
+++ b/packages/api/src/external/carequality/document/schedule-document-query.ts
@@ -1,0 +1,57 @@
+import { Patient } from "@metriport/core/domain/patient";
+import { out } from "@metriport/core/util/log";
+import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
+import { PatientModel } from "../../../models/medical/patient";
+import { executeOnDBTx } from "../../../models/transaction-wrapper";
+
+/**
+ * Stores the requestId as the scheduled document query to be executed when the patient discovery
+ * is completed.
+ */
+export async function scheduleDocQuery({
+  requestId,
+  patient,
+}: {
+  requestId: string;
+  patient: Pick<Patient, "id" | "cxId">;
+}) {
+  const { log } = out(`CQ DQ - requestId ${requestId}, patient ${patient.id}`);
+
+  log(`Scheduling document query to be executed when PD is completed`);
+
+  const patientFilter = {
+    id: patient.id,
+    cxId: patient.cxId,
+  };
+
+  await executeOnDBTx(PatientModel.prototype, async transaction => {
+    const existingPatient = await getPatientOrFail({
+      ...patientFilter,
+      lock: true,
+      transaction,
+    });
+
+    const externalData = existingPatient.data.externalData ?? {};
+
+    const updatedExternalData = {
+      ...externalData,
+      CAREQUALITY: {
+        ...externalData.CAREQUALITY,
+        scheduledDocQueryRequestId: requestId,
+      },
+    };
+
+    const updatedPatient = {
+      ...existingPatient,
+      data: {
+        ...existingPatient.data,
+        externalData: updatedExternalData,
+      },
+    };
+
+    await PatientModel.update(updatedPatient, {
+      where: patientFilter,
+      transaction,
+    });
+  });
+}

--- a/packages/api/src/external/carequality/patient-shared.ts
+++ b/packages/api/src/external/carequality/patient-shared.ts
@@ -1,7 +1,16 @@
 import { PatientExternalDataEntry } from "@metriport/core/domain/patient";
 
 export class PatientDataCarequality extends PatientExternalDataEntry {
-  constructor(public discoveryStatus?: "processing" | "completed" | "failed") {
+  constructor(
+    /**
+     * The status of the patient discovery.
+     */
+    public discoveryStatus?: "processing" | "completed" | "failed",
+    /**
+     * The request ID for the document query triggered while the patient discovery was processing.
+     */
+    public scheduledDocQueryRequestId?: string | undefined
+  ) {
     super();
   }
 }

--- a/packages/api/src/external/commonwell/cq-bridge/cq-link-status.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/cq-link-status.ts
@@ -1,5 +1,6 @@
 import { Patient } from "@metriport/core/domain/patient";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
+import { out } from "@metriport/core/util/log";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import { cloneDeep } from "lodash";
@@ -44,6 +45,7 @@ export const setCQLinkStatus = async ({
   patientId: string;
   cqLinkStatus?: CQLinkStatus | undefined;
 }): Promise<{ patient: Patient; updated: boolean }> => {
+  const { log } = out(`setCQLinkStatus - patient ${patientId}`);
   return executeOnDBTx(PatientModel.prototype, async transaction => {
     const originalPatient = await getPatientOrFail({
       id: patientId,
@@ -55,9 +57,7 @@ export const setCQLinkStatus = async ({
     // Important so we don't trigger WH notif if the CQ link was already done
     const currentCQLinkStatus = getLinkStatusCQ(originalPatient.data.externalData);
     if (currentCQLinkStatus === cqLinkStatus) {
-      console.log(
-        `Patient ${patientId} already has CQ link status ${cqLinkStatus}, skipping update...`
-      );
+      log(`Patient already has CQ link status ${cqLinkStatus}, skipping update...`);
       return { patient: originalPatient, updated: false };
     }
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

### Dependencies

none

### Description

- Wait for PD before DQ - [context](https://metriport.slack.com/archives/C065BLRBUDQ/p1709600814239239?thread_ts=1709570864.511359&cid=C065BLRBUDQ)
- Updated some logging code that I came across so we can follow what happens for a given request

### Testing

- Local
  - [x] DQ scheduled when PD not completed
  - [x] DQ triggered when PD completed

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
