### PR TITLE
1040 Decompose .dataValues when prepping the update object to Sequelize

### DIFF
--- a/packages/api/src/command/medical/document/check-doc-queries.ts
+++ b/packages/api/src/command/medical/document/check-doc-queries.ts
@@ -152,7 +152,7 @@ async function updatePatientsInSequence([patientId, { cxId, ...whatToUpdate }]: 
         : undefined;
     }
     const updatedPatient = {
-      ...patient,
+      ...patient.dataValues,
       data: {
         ...patient.data,
         documentQueryProgress: docProgress,

--- a/packages/api/src/command/medical/patient/__tests__/append-doc-query-progress.test.ts
+++ b/packages/api/src/command/medical/patient/__tests__/append-doc-query-progress.test.ts
@@ -294,12 +294,15 @@ describe("appendDocQueryProgress", () => {
     const patient = makePatient({
       data: makePatientData({ documentQueryProgress: { download: { status: "completed" } } }),
     });
-    jest.spyOn(PatientModel, "findOne").mockResolvedValue(patient as PatientModel);
+    jest
+      .spyOn(PatientModel, "findOne")
+      .mockResolvedValue({ ...patient, dataValues: { ...patient } } as PatientModel);
     const res = await appendDocQueryProgress({
       patient: { id: "theId", cxId: "theCxId" },
       downloadProgress: expectedDownloadProgress,
       requestId,
     });
+    expect(res).toBeTruthy();
     expect(res).toEqual(
       expect.objectContaining({
         ...patient,

--- a/packages/api/src/command/medical/patient/append-consolidated-query-progress.ts
+++ b/packages/api/src/command/medical/patient/append-consolidated-query-progress.ts
@@ -40,7 +40,7 @@ export async function updateConsolidatedQueryProgress({
         };
 
     const updatedPatient = {
-      ...patient,
+      ...patient.dataValues,
       data: {
         ...patient.data,
         consolidatedQuery,

--- a/packages/api/src/command/medical/patient/append-doc-query-progress.ts
+++ b/packages/api/src/command/medical/patient/append-doc-query-progress.ts
@@ -73,7 +73,7 @@ export async function appendDocQueryProgress({
     updatedDocumentQueryProgress.requestId = requestId;
 
     const updatedPatient = {
-      ...existingPatient,
+      ...existingPatient.dataValues,
       data: {
         ...existingPatient.data,
         documentQueryProgress: updatedDocumentQueryProgress,
@@ -106,7 +106,7 @@ export async function updateProgressWebhookSent(
     });
 
     const updatedPatient = {
-      ...existingPatient,
+      ...existingPatient.dataValues,
       data: {
         ...existingPatient.data,
         documentQueryProgress: {

--- a/packages/api/src/command/medical/patient/bulk-get-doc-url-progress.ts
+++ b/packages/api/src/command/medical/patient/bulk-get-doc-url-progress.ts
@@ -46,7 +46,7 @@ export async function appendBulkGetDocUrlProgress({
     }
 
     const updatedPatient = {
-      ...existingPatient,
+      ...existingPatient.dataValues,
       data: {
         ...existingPatient.data,
         bulkGetDocumentsUrlProgress,

--- a/packages/api/src/external/hie/reset-doc-query-progress.ts
+++ b/packages/api/src/external/hie/reset-doc-query-progress.ts
@@ -34,7 +34,7 @@ export async function resetDocQueryProgress({
     const resetExternalData = { ...externalData };
 
     const updatedPatient = {
-      ...existingPatient,
+      ...existingPatient.dataValues,
       data: {
         ...existingPatient.data,
         externalData: resetExternalData,

--- a/packages/api/src/external/hie/reset-scheduled-doc-query-request-id.ts
+++ b/packages/api/src/external/hie/reset-scheduled-doc-query-request-id.ts
@@ -34,7 +34,7 @@ export async function resetPatientScheduledDocQueryRequestId({
     };
 
     const updatedPatient = {
-      ...existingPatient,
+      ...existingPatient.dataValues,
       data: {
         ...existingPatient.data,
         externalData: updatedExternalData,

--- a/packages/api/src/external/hie/schedule-document-query.ts
+++ b/packages/api/src/external/hie/schedule-document-query.ts
@@ -17,7 +17,7 @@ export async function scheduleDocQuery({
   requestId: string;
   patient: Pick<Patient, "id" | "cxId">;
   source: MedicalDataSource;
-}) {
+}): Promise<void> {
   const { log } = out(`${source} DQ - requestId ${requestId}, patient ${patient.id}`);
 
   log(`Scheduling document query to be executed`);
@@ -45,7 +45,7 @@ export async function scheduleDocQuery({
     };
 
     const updatedPatient = {
-      ...existingPatient,
+      ...existingPatient.dataValues,
       data: {
         ...existingPatient.data,
         externalData: updatedExternalData,

--- a/packages/api/src/external/hie/set-doc-query-progress.ts
+++ b/packages/api/src/external/hie/set-doc-query-progress.ts
@@ -70,7 +70,7 @@ export async function setDocQueryProgress({
     );
 
     const updatedPatient = {
-      ...existingPatient,
+      ...existingPatient.dataValues,
       data: {
         ...existingPatient.data,
         externalData,
@@ -87,7 +87,7 @@ export async function setDocQueryProgress({
   });
 
   await processDocQueryProgressWebhook({
-    patient: result.dataValues,
+    patient: result,
     documentQueryProgress: result.data.documentQueryProgress,
     requestId,
   });

--- a/packages/api/src/external/hie/tally-doc-query-progress.ts
+++ b/packages/api/src/external/hie/tally-doc-query-progress.ts
@@ -57,7 +57,7 @@ export async function tallyDocQueryProgress({
     );
 
     const updatedPatient = {
-      ...existingPatient,
+      ...existingPatient.dataValues,
       data: {
         ...existingPatient.data,
         requestId,
@@ -75,7 +75,7 @@ export async function tallyDocQueryProgress({
   });
 
   await processDocQueryProgressWebhook({
-    patient: result.dataValues,
+    patient: result,
     documentQueryProgress: result.data.documentQueryProgress,
     requestId,
     progressType: type,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Decompose Model with `.dataValues` when preparing the update object to Sequelize.

### Testing

- Local
  - [x] tested with another part of the code - [this PR](https://github.com/metriport/metriport/pull/1719)
- Staging
  - [ ] main flows work
- Sandbox
  - none
- Production
  - none

### Release Plan

- nothing special
