### PR TITLE
1350 Add AWS CLI to _deploy-cdk-ihe-gw.yml

### DIFF
--- a/.github/workflows/_deploy-cdk-ihe-gw.yml
+++ b/.github/workflows/_deploy-cdk-ihe-gw.yml
@@ -75,6 +75,13 @@ jobs:
         with:
           node-version: "18.14"
 
+      - name: Setup AWS CLI
+        run: |
+          aws configure set aws_access_key_id "${{ secrets.AWS_ACCESS_KEY_ID }}"
+          aws configure set aws_secret_access_key "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+          aws configure set default.region "${{ inputs.AWS_REGION }}"
+        working-directory: "./"
+  
       # checkout the actual repo
       - name: Checkout
         uses: actions/checkout@v3
@@ -146,7 +153,6 @@ jobs:
         run: npm run test
         working-directory: "metriport/packages/infra"
 
-      # IHE Stack
       - name: Init the repository
         run: |
           ./scripts/init.sh
@@ -155,6 +161,7 @@ jobs:
         env:
           IHE_GW_CONFIG_BUCKET_NAME: ${{ inputs.IHE_GW_CONFIG_BUCKET_NAME }}
           ENV_TYPE: ${{ inputs.deploy_env }}
+
       - name: CDK Diff
         uses: metriport/deploy-with-cdk@master
         with:
@@ -170,6 +177,7 @@ jobs:
           ENV_TYPE: ${{ inputs.deploy_env }}
           IHE_GW_KEYSTORE_STOREPASS: ${{ secrets.IHE_GW_KEYSTORE_STOREPASS }}
           IHE_GW_KEYSTORE_KEYPASS: ${{ secrets.IHE_GW_KEYSTORE_KEYPASS }}
+
       - name: CDK Deploy
         uses: metriport/deploy-with-cdk@master
         with:
@@ -185,4 +193,3 @@ jobs:
           METRIPORT_VERSION: ${{ github.sha }}
           IHE_GW_KEYSTORE_STOREPASS: ${{ secrets.IHE_GW_KEYSTORE_STOREPASS }}
           IHE_GW_KEYSTORE_KEYPASS: ${{ secrets.IHE_GW_KEYSTORE_KEYPASS }}
-


### PR DESCRIPTION
Ref: metriport/metriport-internal#1350

### Dependencies

- Upstream:  https://github.com/metriport/metriport/pull/1707

### Description

Add AWS CLI to `_deploy-cdk-ihe-gw.yml`

### Testing

- Staging
  - [ ] Deploys IHE GW
- Production
  - [ ] Deploys IHE GW

### Release Plan

- nothing special