### PR TITLE
feat(api): add network standby mode FF

### DIFF
--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -10,10 +10,7 @@ import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { emptyFunction } from "@metriport/shared";
 import { calculateConversionProgress } from "../../../domain/medical/conversion-progress";
 import { validateOptionalFacilityId } from "../../../domain/medical/patient-facility";
-import {
-  isCarequalityStandbyModeEnabled,
-  isCommonwellStandbyModeEnabled,
-} from "../../../external/aws/appConfig";
+import { isCarequalityEnabled, isCommonwellEnabled } from "../../../external/aws/appConfig";
 import { getDocumentsFromCQ } from "../../../external/carequality/document/query-documents";
 import { queryAndProcessDocuments as getDocumentsFromCW } from "../../../external/commonwell/document/document-query";
 import { resetDocQueryProgress } from "../../../external/hie/reset-doc-query-progress";
@@ -88,8 +85,8 @@ export async function queryDocumentsAcrossHIEs({
     cxDocumentRequestMetadata,
   });
 
-  const commonwellStandbyModeEnabled = await isCommonwellStandbyModeEnabled();
-  if (!commonwellStandbyModeEnabled || forceCommonwell || Config.isSandbox()) {
+  const commonwellEnabled = await isCommonwellEnabled();
+  if (commonwellEnabled || forceCommonwell || Config.isSandbox()) {
     getDocumentsFromCW({
       patient,
       facilityId,
@@ -99,8 +96,8 @@ export async function queryDocumentsAcrossHIEs({
     }).catch(emptyFunction);
   }
 
-  const carequalityStandbyModeEnabled = await isCarequalityStandbyModeEnabled();
-  if (!carequalityStandbyModeEnabled || forceCarequality) {
+  const carequalityEnabled = await isCarequalityEnabled();
+  if (carequalityEnabled || forceCarequality) {
     getDocumentsFromCQ({
       patient,
       requestId,

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -10,6 +10,10 @@ import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { emptyFunction } from "@metriport/shared";
 import { calculateConversionProgress } from "../../../domain/medical/conversion-progress";
 import { validateOptionalFacilityId } from "../../../domain/medical/patient-facility";
+import {
+  isCarequalityStandbyModeEnabled,
+  isCommonwellStandbyModeEnabled,
+} from "../../../external/aws/appConfig";
 import { getDocumentsFromCQ } from "../../../external/carequality/document/query-documents";
 import { queryAndProcessDocuments as getDocumentsFromCW } from "../../../external/commonwell/document/document-query";
 import { resetDocQueryProgress } from "../../../external/hie/reset-doc-query-progress";
@@ -44,21 +48,17 @@ export async function queryDocumentsAcrossHIEs({
   override,
   cxDocumentRequestMetadata,
   forceQuery = false,
-  // START TODO #1572 - remove
-  commonwell = false,
-  carequality = true,
-}: // END TODO #1572 - remove
-{
+  forceCommonwell = false,
+  forceCarequality = false,
+}: {
   cxId: string;
   patientId: string;
   facilityId?: string;
   override?: boolean;
   cxDocumentRequestMetadata?: unknown;
   forceQuery?: boolean;
-  // START TODO #1572 - remove
-  commonwell?: boolean;
-  carequality?: boolean;
-  // END TODO #1572 - remove
+  forceCommonwell?: boolean;
+  forceCarequality?: boolean;
 }): Promise<DocumentQueryProgress> {
   const { log } = Util.out(`queryDocumentsAcrossHIEs - M patient ${patientId}`);
 
@@ -88,7 +88,8 @@ export async function queryDocumentsAcrossHIEs({
     cxDocumentRequestMetadata,
   });
 
-  if (commonwell || Config.isSandbox()) {
+  const commonwellStandbyModeEnabled = await isCommonwellStandbyModeEnabled();
+  if (!commonwellStandbyModeEnabled || forceCommonwell || Config.isSandbox()) {
     getDocumentsFromCW({
       patient,
       facilityId,
@@ -98,7 +99,8 @@ export async function queryDocumentsAcrossHIEs({
     }).catch(emptyFunction);
   }
 
-  if (carequality) {
+  const carequalityStandbyModeEnabled = await isCarequalityStandbyModeEnabled();
+  if (!carequalityStandbyModeEnabled || forceCarequality) {
     getDocumentsFromCQ({
       patient,
       requestId,

--- a/packages/api/src/command/medical/patient/create-patient.ts
+++ b/packages/api/src/command/medical/patient/create-patient.ts
@@ -1,10 +1,7 @@
 import { Patient, PatientCreate, PatientData } from "@metriport/core/domain/patient";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { processAsyncError } from "../../../errors";
-import {
-  isCarequalityStandbyModeEnabled,
-  isCommonwellStandbyModeEnabled,
-} from "../../../external/aws/appConfig";
+import { isCarequalityEnabled, isCommonwellEnabled } from "../../../external/aws/appConfig";
 import cqCommands from "../../../external/carequality";
 import cwCommands from "../../../external/commonwell";
 import { PatientModel } from "../../../models/medical/patient";
@@ -55,14 +52,14 @@ export const createPatient = async (
 
   const newPatient = await PatientModel.create(patientCreate);
 
-  const commonwellStandbyModeEnabled = await isCommonwellStandbyModeEnabled();
-  if (!commonwellStandbyModeEnabled || forceCommonwell || Config.isSandbox()) {
+  const commonwellEnabled = await isCommonwellEnabled();
+  if (commonwellEnabled || forceCommonwell || Config.isSandbox()) {
     cwCommands.patient.create(newPatient, facilityId).catch(processAsyncError(`cw.patient.create`));
   }
 
   // Intentionally asynchronous
-  const carequalityStandbyModeEnabled = await isCarequalityStandbyModeEnabled();
-  if (!carequalityStandbyModeEnabled || forceCarequality) {
+  const carequalityEnabled = await isCarequalityEnabled();
+  if (carequalityEnabled || forceCarequality) {
     cqCommands.patient
       .discover(newPatient, facility.data.npi)
       .catch(processAsyncError(`cq.patient.create`));

--- a/packages/api/src/command/medical/patient/update-patient.ts
+++ b/packages/api/src/command/medical/patient/update-patient.ts
@@ -2,6 +2,10 @@ import { Patient, PatientData } from "@metriport/core/domain/patient";
 import { toFHIR } from "@metriport/core/external/fhir/patient/index";
 import { processAsyncError } from "../../../errors";
 import { patientEvents } from "../../../event/medical/patient-event";
+import {
+  isCarequalityStandbyModeEnabled,
+  isCommonwellStandbyModeEnabled,
+} from "../../../external/aws/appConfig";
 import cqCommands from "../../../external/carequality";
 import cwCommands from "../../../external/commonwell";
 import { upsertPatientToFHIRServer } from "../../../external/fhir/patient/upsert-patient";
@@ -26,8 +30,8 @@ export async function updatePatient(
   patientUpdate: PatientUpdateCmd,
   emit = true,
   // START TODO #1572 - remove
-  commonwell?: boolean,
-  carequality?: boolean
+  forceCommonwell?: boolean,
+  forceCarequality?: boolean
   // END TODO #1572 - remove
 ): Promise<Patient> {
   const { cxId, facilityId } = patientUpdate;
@@ -41,12 +45,14 @@ export async function updatePatient(
   await upsertPatientToFHIRServer(patientUpdate.cxId, fhirPatient);
 
   // Intentionally asynchronous
-  if (commonwell || Config.isSandbox()) {
+  const commonwellStandbyModeEnabled = await isCommonwellStandbyModeEnabled();
+  if (!commonwellStandbyModeEnabled || forceCommonwell || Config.isSandbox()) {
     cwCommands.patient.update(result, facilityId).catch(processAsyncError(`cw.patient.update`));
   }
 
   // Intentionally asynchronous
-  if (carequality) {
+  const carequalityStandbyModeEnabled = await isCarequalityStandbyModeEnabled();
+  if (!carequalityStandbyModeEnabled || forceCarequality) {
     cqCommands.patient
       .discover(result, facility.data.npi)
       .catch(processAsyncError(`cq.patient.update`));

--- a/packages/api/src/command/medical/patient/update-patient.ts
+++ b/packages/api/src/command/medical/patient/update-patient.ts
@@ -2,10 +2,7 @@ import { Patient, PatientData } from "@metriport/core/domain/patient";
 import { toFHIR } from "@metriport/core/external/fhir/patient/index";
 import { processAsyncError } from "../../../errors";
 import { patientEvents } from "../../../event/medical/patient-event";
-import {
-  isCarequalityStandbyModeEnabled,
-  isCommonwellStandbyModeEnabled,
-} from "../../../external/aws/appConfig";
+import { isCarequalityEnabled, isCommonwellEnabled } from "../../../external/aws/appConfig";
 import cqCommands from "../../../external/carequality";
 import cwCommands from "../../../external/commonwell";
 import { upsertPatientToFHIRServer } from "../../../external/fhir/patient/upsert-patient";
@@ -45,14 +42,14 @@ export async function updatePatient(
   await upsertPatientToFHIRServer(patientUpdate.cxId, fhirPatient);
 
   // Intentionally asynchronous
-  const commonwellStandbyModeEnabled = await isCommonwellStandbyModeEnabled();
-  if (!commonwellStandbyModeEnabled || forceCommonwell || Config.isSandbox()) {
+  const commonwellEnabled = await isCommonwellEnabled();
+  if (commonwellEnabled || forceCommonwell || Config.isSandbox()) {
     cwCommands.patient.update(result, facilityId).catch(processAsyncError(`cw.patient.update`));
   }
 
   // Intentionally asynchronous
-  const carequalityStandbyModeEnabled = await isCarequalityStandbyModeEnabled();
-  if (!carequalityStandbyModeEnabled || forceCarequality) {
+  const carequalityEnabled = await isCarequalityEnabled();
+  if (carequalityEnabled || forceCarequality) {
     cqCommands.patient
       .discover(result, facility.data.npi)
       .catch(processAsyncError(`cq.patient.update`));

--- a/packages/api/src/external/aws/appConfig.ts
+++ b/packages/api/src/external/aws/appConfig.ts
@@ -13,8 +13,8 @@ const listOfFeatureFlags: Array<keyof FeatureFlagDatastore> = [
   "cxsWithADHDMRFeatureFlag",
   "cxsWithIncreasedSandboxLimitFeatureFlag",
   "cxsWithNoWebhookPongFeatureFlag",
-  "commonwellStandbyModeFeatureFlag",
-  "carequalityStandbyModeFeatureFlag",
+  "commonwellFeatureFlag",
+  "carequalityFeatureFlag",
 ];
 
 /**
@@ -132,10 +132,10 @@ export async function isWebhookPongDisabledForCx(cxId: string): Promise<boolean>
   return cxIdsWithECEnabled.some(i => i === cxId);
 }
 
-export async function isCommonwellStandbyModeEnabled(): Promise<boolean> {
-  return isFeatureFlagEnabled("commonwellStandbyModeFeatureFlag");
+export async function isCommonwellEnabled(): Promise<boolean> {
+  return isFeatureFlagEnabled("commonwellFeatureFlag");
 }
 
-export async function isCarequalityStandbyModeEnabled(): Promise<boolean> {
-  return isFeatureFlagEnabled("carequalityStandbyModeFeatureFlag");
+export async function isCarequalityEnabled(): Promise<boolean> {
+  return isFeatureFlagEnabled("carequalityFeatureFlag");
 }

--- a/packages/api/src/external/aws/appConfig.ts
+++ b/packages/api/src/external/aws/appConfig.ts
@@ -13,6 +13,8 @@ const listOfFeatureFlags: Array<keyof FeatureFlagDatastore> = [
   "cxsWithADHDMRFeatureFlag",
   "cxsWithIncreasedSandboxLimitFeatureFlag",
   "cxsWithNoWebhookPongFeatureFlag",
+  "commonwellStandbyModeFeatureFlag",
+  "carequalityStandbyModeFeatureFlag",
 ];
 
 /**
@@ -80,6 +82,25 @@ async function getCxsWithFeatureFlagEnabled(
   return [];
 }
 
+/**
+ * Checks whether the specified feature flag is enabled.
+ *
+ * @returns true if enabled; false otherwise
+ */
+async function isFeatureFlagEnabled(featureFlagName: keyof FeatureFlagDatastore): Promise<boolean> {
+  let isEnabled = false;
+  try {
+    const featureFlag = await getFeatureFlagValueLocal(featureFlagName);
+    isEnabled = featureFlag.enabled;
+  } catch (error) {
+    const msg = `Failed to get Feature Flag Value`;
+    const extra = { featureFlagName };
+    log(`${msg} - ${JSON.stringify(extra)} - ${errorToString(error)}`);
+    capture.error(msg, { extra: { ...extra, error } });
+  }
+  return isEnabled;
+}
+
 export async function getCxsWithEnhancedCoverageFeatureFlagValue(): Promise<string[]> {
   return getCxsWithFeatureFlagEnabled("cxsWithEnhancedCoverageFeatureFlag");
 }
@@ -109,4 +130,12 @@ export async function isCQDirectEnabledForCx(cxId: string): Promise<boolean> {
 export async function isWebhookPongDisabledForCx(cxId: string): Promise<boolean> {
   const cxIdsWithECEnabled = await getCxsWithNoWebhookPongFeatureFlagValue();
   return cxIdsWithECEnabled.some(i => i === cxId);
+}
+
+export async function isCommonwellStandbyModeEnabled(): Promise<boolean> {
+  return isFeatureFlagEnabled("commonwellStandbyModeFeatureFlag");
+}
+
+export async function isCarequalityStandbyModeEnabled(): Promise<boolean> {
+  return isFeatureFlagEnabled("carequalityStandbyModeFeatureFlag");
 }

--- a/packages/api/src/routes/medical/document.ts
+++ b/packages/api/src/routes/medical/document.ts
@@ -114,10 +114,8 @@ router.post(
     const facilityId = getFrom("query").optional("facilityId", req);
     const override = stringToBoolean(getFrom("query").optional("override", req));
     const cxDocumentRequestMetadata = cxRequestMetadataSchema.parse(req.body);
-    // START TODO #1572 - remove
-    const commonwell = stringToBoolean(getFrom("query").optional("commonwell", req));
-    // const carequality = stringToBoolean(getFrom("query").optional("carequality", req));
-    // END TODO #1572 - remove
+    const forceCommonwell = stringToBoolean(getFrom("query").optional("commonwell", req));
+    const forceCarequality = stringToBoolean(getFrom("query").optional("carequality", req));
 
     const docQueryProgress = await queryDocumentsAcrossHIEs({
       cxId,
@@ -125,8 +123,8 @@ router.post(
       facilityId,
       override,
       cxDocumentRequestMetadata: cxDocumentRequestMetadata?.metadata,
-      commonwell,
-      carequality: true,
+      forceCommonwell,
+      forceCarequality,
     });
 
     return res.status(OK).json(docQueryProgress);

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -67,10 +67,8 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const facilityId = getFromQueryOrFail("facilityId", req);
-    // START TODO #1572 - remove
-    const commonwell = stringToBoolean(getFrom("query").optional("commonwell", req));
-    // const carequality = stringToBoolean(getFrom("query").optional("carequality", req));
-    // END TODO #1572 - remove
+    const forceCommonwell = stringToBoolean(getFrom("query").optional("commonwell", req));
+    const forceCarequality = stringToBoolean(getFrom("query").optional("carequality", req));
     const payload = patientCreateSchema.parse(req.body);
 
     if (Config.isSandbox()) {
@@ -89,7 +87,7 @@ router.post(
       facilityId,
     };
 
-    const patient = await createPatient(patientCreate, commonwell, true);
+    const patient = await createPatient(patientCreate, forceCommonwell, forceCarequality);
 
     // temp solution until we migrate to FHIR
     const fhirPatient = toFHIR(patient);
@@ -113,10 +111,8 @@ router.put(
     const cxId = getCxIdOrFail(req);
     const id = getFromParamsOrFail("id", req);
     const facilityIdParam = getFrom("query").optional("facilityId", req);
-    // START TODO #1572 - remove
-    const commonwell = stringToBoolean(getFrom("query").optional("commonwell", req));
-    // const carequality = stringToBoolean(getFrom("query").optional("carequality", req));
-    // END TODO #1572 - remove
+    const forceCommonwell = stringToBoolean(getFrom("query").optional("commonwell", req));
+    const forceCarequality = stringToBoolean(getFrom("query").optional("carequality", req));
     const payload = patientUpdateSchema.parse(req.body);
 
     const patient = await getPatientOrFail({ id, cxId });
@@ -132,7 +128,12 @@ router.put(
       facilityId,
     };
 
-    const updatedPatient = await updatePatient(patientUpdate, true, commonwell, true);
+    const updatedPatient = await updatePatient(
+      patientUpdate,
+      true,
+      forceCommonwell,
+      forceCarequality
+    );
 
     return res.status(status.OK).json(dtoFromModel(updatedPatient));
   })

--- a/packages/core/src/external/aws/appConfig.ts
+++ b/packages/core/src/external/aws/appConfig.ts
@@ -20,7 +20,7 @@ export type SandboxLimitFF = {
   cxIds: never;
 };
 
-export type EnabledFF = {
+export type BooleanFF = {
   enabled: boolean;
   cxIds: never;
   cxIdsAndLimits: never;
@@ -32,8 +32,8 @@ export type FeatureFlagDatastore = {
   cxsWithADHDMRFeatureFlag: CustomerIdsFF;
   cxsWithNoWebhookPongFeatureFlag: CustomerIdsFF;
   cxsWithIncreasedSandboxLimitFeatureFlag: SandboxLimitFF;
-  commonwellFeatureFlag: EnabledFF;
-  carequalityFeatureFlag: EnabledFF;
+  commonwellFeatureFlag: BooleanFF;
+  carequalityFeatureFlag: BooleanFF;
 };
 
 export async function getFeatureFlagValue<T extends keyof FeatureFlagDatastore>(

--- a/packages/core/src/external/aws/appConfig.ts
+++ b/packages/core/src/external/aws/appConfig.ts
@@ -20,12 +20,20 @@ export type SandboxLimitFF = {
   cxIds: never;
 };
 
+export type EnabledFF = {
+  enabled: boolean;
+  cxIds: never;
+  cxIdsAndLimits: never;
+};
+
 export type FeatureFlagDatastore = {
   cxsWithEnhancedCoverageFeatureFlag: CustomerIdsFF;
   cxsWithCQDirectFeatureFlag: CustomerIdsFF;
   cxsWithADHDMRFeatureFlag: CustomerIdsFF;
   cxsWithNoWebhookPongFeatureFlag: CustomerIdsFF;
   cxsWithIncreasedSandboxLimitFeatureFlag: SandboxLimitFF;
+  commonwellStandbyModeFeatureFlag: EnabledFF;
+  carequalityStandbyModeFeatureFlag: EnabledFF;
 };
 
 export async function getFeatureFlagValue<T extends keyof FeatureFlagDatastore>(

--- a/packages/core/src/external/aws/appConfig.ts
+++ b/packages/core/src/external/aws/appConfig.ts
@@ -32,8 +32,8 @@ export type FeatureFlagDatastore = {
   cxsWithADHDMRFeatureFlag: CustomerIdsFF;
   cxsWithNoWebhookPongFeatureFlag: CustomerIdsFF;
   cxsWithIncreasedSandboxLimitFeatureFlag: SandboxLimitFF;
-  commonwellStandbyModeFeatureFlag: EnabledFF;
-  carequalityStandbyModeFeatureFlag: EnabledFF;
+  commonwellFeatureFlag: EnabledFF;
+  carequalityFeatureFlag: EnabledFF;
 };
 
 export async function getFeatureFlagValue<T extends keyof FeatureFlagDatastore>(


### PR DESCRIPTION
refs. metriport/metriport-internal#1377


### Dependencies

n/a

### Description

add network standby mode FF

### Testing

🏈 

### Release Plan

add the following app config to prod:
```
    "commonwellFeatureFlag": {
      "name": "commonwellFeatureFlag"
      }
    },
    "carequalityFeatureFlag": {
      "name": "carequalityFeatureFlag"
      }
    }
    ...
    "commonwellFeatureFlag": {
      "enabled": false
    },
    "carequalityFeatureFlag": {
      "enabled": false
    },
```

add the following app config to sandbox:
```
    "commonwellFeatureFlag": {
      "name": "commonwellFeatureFlag"
      }
    },
    "carequalityFeatureFlag": {
      "name": "carequalityFeatureFlag"
      }
    }
    ...
    "commonwellFeatureFlag": {
      "enabled": true
    },
    "carequalityFeatureFlag": {
      "enabled": true
    },
```

add the following app config to staging:
```
    "commonwellFeatureFlag": {
      "name": "commonwellFeatureFlag"
      }
    },
    "carequalityFeatureFlag": {
      "name": "carequalityFeatureFlag"
      }
    }
    ...
    "commonwellFeatureFlag": {
      "enabled": true
    },
    "carequalityFeatureFlag": {
      "enabled": true
    },
```

- :warning: Points to `master`
- [ ] Merge this
