### PR TITLE
fix(ihe): splat doc query progress

### DIFF
--- a/packages/api/src/external/hie/set-doc-query-progress.ts
+++ b/packages/api/src/external/hie/set-doc-query-progress.ts
@@ -107,14 +107,18 @@ export function aggregateAndSetHIEProgresses(
     ...documentQueryProgress,
     ...(aggregatedDocProgress.convert
       ? {
-          ...documentQueryProgress.convert,
-          ...aggregatedDocProgress.convert,
+          convert: {
+            ...documentQueryProgress.convert,
+            ...aggregatedDocProgress.convert,
+          },
         }
       : {}),
     ...(aggregatedDocProgress.download
       ? {
-          ...documentQueryProgress.download,
-          ...aggregatedDocProgress.download,
+          download: {
+            ...documentQueryProgress.download,
+            ...aggregatedDocProgress.download,
+          },
         }
       : {}),
   };


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: #1350

### Dependencies

- Upstream: none
- Downstream: none

### Description

Whats happening is every time we update the doc query progress we are loosing the webhookSent boolean because we dont splat the doc query progress types and so it gets overriden.

[Context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1709695936592569?thread_ts=1709670094.144059&cid=C04GEQ1GH9D)

### Testing

🏈

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
