### PR TITLE
1350 Fix IHE container and CICD

### DIFF
--- a/.github/workflows/_restart-ecs.yml
+++ b/.github/workflows/_restart-ecs.yml
@@ -45,9 +45,9 @@ jobs:
       - name: Log Environment
         run: |
           env
-          echo "ECS_CLUSTER: ${{ vars.ECS_CLUSTER_STAGING }}"
-          echo "ECS_SERVICE: ${{ vars.ECS_SERVICE_STAGING }}"
-          echo "AWS_REGION: ${{ vars.API_REGION_STAGING }}"
+          echo "ECS_CLUSTER: ${{ inputs.ECS_CLUSTER }}"
+          echo "ECS_SERVICE: ${{ inputs.ECS_SERVICE }}"
+          echo "AWS_REGION: ${{ inputs.AWS_REGION }}"
         shell: bash
 
       - name: Setup AWS CLI

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -52,15 +52,14 @@ jobs:
               - "packages/core/**"
               - "package*.json"
             ihe-gw-config:
-              - "packages/ihe-gateway/config/**"
-              - "packages/ihe-gateway/scripts/**"
               - "packages/ihe-gateway/server/**"
             ihe-gw-server:
               - "packages/ihe-gateway/Dockerfile"
               - "packages/ihe-gateway/entrypoint.sh"
-              - "packages/ihe-gateway/config/**"
+              - "packages/ihe-gateway/config/custom-extensions/**"
+              - "packages/ihe-gateway/config/custom-libs/**"
+              - "packages/ihe-gateway/config/schemas/**"
               - "packages/ihe-gateway/scripts/**"
-              - "packages/ihe-gateway/server/**"
             # Doing them individually because there are other stuff there that we don't want to trigger a deploy b/c of that
             fhir-converter:
               - "packages/fhir-converter/Dockerfile"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -51,15 +51,14 @@ jobs:
               - "packages/core/**"
               - "package*.json"
             ihe-gw-config:
-              - "packages/ihe-gateway/config/**"
-              - "packages/ihe-gateway/scripts/**"
               - "packages/ihe-gateway/server/**"
             ihe-gw-server:
               - "packages/ihe-gateway/Dockerfile"
               - "packages/ihe-gateway/entrypoint.sh"
-              - "packages/ihe-gateway/config/**"
+              - "packages/ihe-gateway/config/custom-extensions/**"
+              - "packages/ihe-gateway/config/custom-libs/**"
+              - "packages/ihe-gateway/config/schemas/**"
               - "packages/ihe-gateway/scripts/**"
-              - "packages/ihe-gateway/server/**"
             # Doing them individually because there are other stuff there that we don't want to trigger a deploy b/c of that
             fhir-converter:
               - "packages/fhir-converter/Dockerfile"

--- a/.github/workflows/restart-ihe-gw_staging.yml
+++ b/.github/workflows/restart-ihe-gw_staging.yml
@@ -1,0 +1,40 @@
+name: Restart IHE GW - Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      server:
+        type: choice
+        description: Outbound or Inbound servers?
+        options:
+        - inbound
+        - outbound
+
+jobs:
+  restart-outbound:
+    if: ${{ inputs.server == 'outbound' }}
+    uses: ./.github/workflows/_restart-ecs.yml
+    with:
+      ECR_REPO_URI: ${{ vars.IHE_ECR_REPO_URI_STAGING }}
+      ECS_CLUSTER: ${{ vars.IHE_ECS_CLUSTER_STAGING }}
+      ECS_SERVICE: ${{ vars.IHE_OUTBOUND_ECS_SERVICE_STAGING }}
+      AWS_REGION: ${{ vars.IHE_REGION_STAGING }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  restart-inbound:
+    if: ${{ inputs.server == 'inbound' }}
+    uses: ./.github/workflows/_restart-ecs.yml
+    with:
+      ECR_REPO_URI: ${{ vars.IHE_ECR_REPO_URI_STAGING }}
+      ECS_CLUSTER: ${{ vars.IHE_ECS_CLUSTER_STAGING }}
+      ECS_SERVICE: ${{ vars.IHE_INBOUND_ECS_SERVICE_STAGING }}
+      AWS_REGION: ${{ vars.IHE_REGION_STAGING }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/restart_api_prod.yml
+++ b/.github/workflows/restart_api_prod.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   restart:
-    uses: ./.github/workflows/_restart_api.yml
+    uses: ./.github/workflows/_restart-ecs.yml
     with:
       ECR_REPO_URI: ${{ vars.ECR_REPO_URI_PRODUCTION }}
       ECS_CLUSTER: ${{ vars.ECS_CLUSTER_PRODUCTION }}

--- a/.github/workflows/restart_api_sandbox.yml
+++ b/.github/workflows/restart_api_sandbox.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   restart:
-    uses: ./.github/workflows/_restart_api.yml
+    uses: ./.github/workflows/_restart-ecs.yml
     with:
       ECR_REPO_URI: ${{ vars.ECR_REPO_URI_SANDBOX }}
       ECS_CLUSTER: ${{ vars.ECS_CLUSTER_SANDBOX }}

--- a/.github/workflows/restart_api_staging.yml
+++ b/.github/workflows/restart_api_staging.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   restart:
-    uses: ./.github/workflows/_restart_api.yml
+    uses: ./.github/workflows/_restart-ecs.yml
     with:
       ECR_REPO_URI: ${{ vars.ECR_REPO_URI_STAGING }}
       ECS_CLUSTER: ${{ vars.ECS_CLUSTER_STAGING }}

--- a/packages/api/src/models/db.ts
+++ b/packages/api/src/models/db.ts
@@ -71,7 +71,7 @@ const initDB = async (): Promise<void> => {
     dialect: dbCreds.engine,
     pool: {
       max: 300,
-      min: 20,
+      min: 50,
       acquire: 30000,
       idle: 10000,
     },

--- a/packages/ihe-gateway/docker-compose.yml
+++ b/packages/ihe-gateway/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - "8086:8086"
       - "9091:9091"
       - "9092:9092"
+      - "8099:8099" # Tester channel
   ihe-postgres:
     image: postgres:14.4-alpine
     container_name: ihe-postgres

--- a/packages/ihe-gateway/entrypoint.sh
+++ b/packages/ihe-gateway/entrypoint.sh
@@ -260,6 +260,7 @@ if ! [ -z "${DELAY+x}" ]; then
 fi
 
 # Send configs to server when its available
-IHE_GW_URL=http://127.0.0.1:8080/api ./scripts/push-to-server.sh configurationMap strict &
+# IHE_GW_URL=http://127.0.0.1:8080/api ./scripts/push-to-server.sh configurationMap strict &
+IHE_GW_URL=http://127.0.0.1:8080/api ./scripts/push-to-server.sh configurationMap  &
 
 exec "$@"

--- a/packages/ihe-gateway/entrypoint.sh
+++ b/packages/ihe-gateway/entrypoint.sh
@@ -259,8 +259,10 @@ if ! [ -z "${DELAY+x}" ]; then
 	sleep $DELAY
 fi
 
-# Send configs to server when its available
-# IHE_GW_URL=http://127.0.0.1:8080/api ./scripts/push-to-server.sh configurationMap strict &
-IHE_GW_URL=http://127.0.0.1:8080/api ./scripts/push-to-server.sh configurationMap  &
+# Send configs to server when it is available
+# 1. With 'strict' mode, if it fails to send configs it will kill all Java processes
+IHE_GW_URL=http://127.0.0.1:8080/api ./scripts/push-to-server.sh configurationMap strict &
+# 2. Without 'strict' mode, if it fails to send configs it will just leave the script and leave Mirth running
+# IHE_GW_URL=http://127.0.0.1:8080/api ./scripts/push-to-server.sh configurationMap &
 
 exec "$@"

--- a/packages/ihe-gateway/entrypoint.sh
+++ b/packages/ihe-gateway/entrypoint.sh
@@ -260,6 +260,6 @@ if ! [ -z "${DELAY+x}" ]; then
 fi
 
 # Send configs to server when its available
-IHE_GW_URL=http://127.0.0.1:8080/api ./scripts/push-to-server.sh &
+IHE_GW_URL=http://127.0.0.1:8080/api ./scripts/push-to-server.sh configurationMap strict &
 
 exec "$@"

--- a/packages/ihe-gateway/scripts/init.sh
+++ b/packages/ihe-gateway/scripts/init.sh
@@ -5,12 +5,14 @@ set -e
 
 source ./scripts/load-env.sh
 
+if [[ -z "${ENV_TYPE}" ]]; then
+  echo "Warning: ENV_TYPE is missing, default to 'staging'"
+  set -o allexport
+  ENV_TYPE="staging"
+  set +o allexport
+fi
 if [ -z "${IHE_GW_CONFIG_BUCKET_NAME}" ]; then
   echo "Error: IHE_GW_CONFIG_BUCKET_NAME is not set, skipping downloading certs and custom extensions."
-  exit 1
-fi
-if [ -z "${ENV_TYPE}" ]; then
-  echo "Error: ENV_TYPE is not set, skipping downloading certs and custom extensions."
   exit 1
 fi
 

--- a/packages/ihe-gateway/scripts/load-default-server-url.sh
+++ b/packages/ihe-gateway/scripts/load-default-server-url.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [[ -z "${IHE_GW_URL}" ]]; then
+    if [[ -z "${IHE_GW_URL_OUTBOUND}" ]]; then
+        echo "IHE_GW_URL_OUTBOUND is not set, trying IHE_GW_URL_INBOUND"
+        if [[ -z "${IHE_GW_URL_INBOUND}" ]]; then
+            echo "IHE_GW_URL_INBOUND is not set, exiting"
+            exit 1
+        else
+            IHE_GW_URL=$IHE_GW_URL_INBOUND
+        fi
+    else
+        IHE_GW_URL=$IHE_GW_URL_OUTBOUND
+    fi
+fi

--- a/packages/ihe-gateway/scripts/load-env.sh
+++ b/packages/ihe-gateway/scripts/load-env.sh
@@ -26,10 +26,3 @@ else
     fi
     echo "Warning: No $DOT_ENV_FILE file found, expecting env vars to be set"
 fi
-
-if [[ -z "${ENV_TYPE}" ]]; then
-    echo "Warning: ENV_TYPE is missing, default to 'staging'"
-    set -o allexport
-    ENV_TYPE="staging"
-    set +o allexport
-fi

--- a/packages/ihe-gateway/scripts/pull-from-server.sh
+++ b/packages/ihe-gateway/scripts/pull-from-server.sh
@@ -57,8 +57,8 @@ rm -rf ./server/Channels
 rm -rf ./server/CodeTemplates
 rm -rf ./server/GlobalScripts
 
-# "-m" flag = default behavior: Expands everything to the most granular level (Javascript, Sql, etc).
-./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t ./server --include-configuration-map -f pull
+# "-m" flag = "code" (default behavior): Expands everything to the most granular level (Javascript, Sql, etc).
+./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t ./server --include-configuration-map -m code -f pull
 
 # "-m" flag = "backup": only the FullBackup.xml file, equivalent to Mirth Administrator backup and restore
 ./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t $IHE_GW_FULL_BACKUP_LOCATION --include-configuration-map -m backup -f pull

--- a/packages/ihe-gateway/scripts/pull-from-server.sh
+++ b/packages/ihe-gateway/scripts/pull-from-server.sh
@@ -5,6 +5,14 @@ set -e
 
 source ./scripts/load-env.sh
 
+source ./scripts/load-default-server-url.sh
+
+if [[ -z "${ENV_TYPE}" ]]; then
+  echo "Warning: ENV_TYPE is missing, default to 'staging'"
+  set -o allexport
+  ENV_TYPE="staging"
+  set +o allexport
+fi
 if [ -z "${IHE_GW_FULL_BACKUP_LOCATION}" ]; then
   echo "Error: IHE_GW_FULL_BACKUP_LOCATION is not set, exiting"
   exit 1
@@ -15,10 +23,10 @@ rm -rf ./server/Channels
 rm -rf ./server/CodeTemplates
 rm -rf ./server/GlobalScripts
 
-# "-m" flag: default behavior. Expands everything to the most granular level (Javascript, Sql, etc).
+# "-m" flag = default behavior: Expands everything to the most granular level (Javascript, Sql, etc).
 ./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t ./server --include-configuration-map -f pull
 
-# "-m" flag: only the FullBackup.xml file, "Equivalent to Mirth Administrator backup and restore"
-./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t $IHE_GW_FULL_BACKUP_LOCATION -m backup -f pull
+# "-m" flag = "backup": only the FullBackup.xml file, equivalent to Mirth Administrator backup and restore
+./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t $IHE_GW_FULL_BACKUP_LOCATION --include-configuration-map -m backup -f pull
 
 mv $IHE_GW_FULL_BACKUP_LOCATION/FullBackup.xml $IHE_GW_FULL_BACKUP_LOCATION/FullBackup-$ENV_TYPE.xml

--- a/packages/ihe-gateway/scripts/pull-from-server.sh
+++ b/packages/ihe-gateway/scripts/pull-from-server.sh
@@ -18,6 +18,40 @@ if [ -z "${IHE_GW_FULL_BACKUP_LOCATION}" ]; then
   exit 1
 fi
 
+isApiAvailable() {
+  local checkApiResult=$(curl -s --header "X-Requested-With: push-to-server" -u $IHE_GW_USER:$IHE_GW_PASSWORD -w '%{response_code}' -o /dev/null "$IHE_GW_URL/server/jvm")
+  if [[ $checkApiResult -lt 100 ]]; then
+    return 1 # not ready
+  elif [[ $checkApiResult -ge 300 ]]; then
+    echo "[config] Failed login to server, trying up to $MAX_LOGIN_ATTEMPTS times - Result: $checkApiResult" >/dev/stderr
+    if [ $INCORRECT_LOGIN_ATTEMPTS -ge $MAX_LOGIN_ATTEMPTS ]; then
+      echo "[config] Too many incorrect login attempts, stopping..."
+      cleanup
+      exit 1
+    fi
+    INCORRECT_LOGIN_ATTEMPTS=$((INCORRECT_LOGIN_ATTEMPTS + 1))
+  fi
+  return 0
+}
+
+waitServerOnline() {
+  echo "[config] Waiting for the server to start... (${IHE_GW_URL})"
+  until curl -s -f -o /dev/null $IHE_GW_URL; do
+    sleep 1
+  done
+  until isApiAvailable; do
+    sleep 1
+  done
+  sleep 2
+}
+
+###################################################################################################
+#
+# MAIN LOGIC
+#
+###################################################################################################
+waitServerOnline
+
 # clear out the server directory because mirthsync doesn't remove files that are no longer on the server
 rm -rf ./server/Channels
 rm -rf ./server/CodeTemplates
@@ -30,3 +64,5 @@ rm -rf ./server/GlobalScripts
 ./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t $IHE_GW_FULL_BACKUP_LOCATION --include-configuration-map -m backup -f pull
 
 mv $IHE_GW_FULL_BACKUP_LOCATION/FullBackup.xml $IHE_GW_FULL_BACKUP_LOCATION/FullBackup-$ENV_TYPE.xml
+
+echo "[config] Done."

--- a/packages/ihe-gateway/scripts/push-to-cloud.sh
+++ b/packages/ihe-gateway/scripts/push-to-cloud.sh
@@ -44,26 +44,6 @@ Execute() {
    IHE_GW_URL=$IHE_GW_URL_INBOUND
    source ./scripts/push-to-server.sh
 
-   # Can't restart servers after the push because the configs are stored on the filesystem and not in the DB.
-   # To be fixed on https://github.com/metriport/metriport-internal/issues/1564
-   #   echo "Restarting the outbound service"
-   #   set -o allexport
-   #   ECS_SERVICE=$ECS_SERVICE_OUTBOUND
-   #   set +o allexport
-   #   ../scripts/restart-ecs.sh &
-
-   #   echo "Restarting the inbound service"
-   #   set -o allexport
-   #   ECS_SERVICE=$ECS_SERVICE_INBOUND
-   #   set +o allexport
-   #   ../scripts/restart-ecs.sh &
-
-   #   set -o allexport
-   #   ECS_SERVICE=""
-   #   set +o allexport
-
-   #   echo "Waiting for them to finish..."
-   #   wait
    echo "Done."
 }
 

--- a/packages/ihe-gateway/scripts/push-to-server.sh
+++ b/packages/ihe-gateway/scripts/push-to-server.sh
@@ -1,20 +1,99 @@
 #!/bin/bash
 
+###################################################################################################
+#
+# Script to push configurations to the IHE Gateway.
+#
+# Usage:
+#   ./scripts/push-to-server.sh [configurationMap] [strict]
+#
+# Arguments:
+#   - configurationMap: Only push the configuration map to the server. If not present, push all
+#                       configurations.
+#   - strict: If the server fails to accept the configuration map, stop all Java processes.
+#
+###################################################################################################
+
 # Fail on error
+set -o pipefail
+set -o errtrace
 set -e
 
+cleanup() {
+  if containsElement "strict"; then
+    echo "[config] Strict mode: stopping all Java processes..."
+    pkill java
+  else
+    echo "[config] Non-strict mode, just leaving..."
+  fi
+}
+trap cleanup ERR
+
+CONFIG_MAP_FILE=./server/ConfigurationMap.xml
 source ./scripts/load-env.sh
+source ./scripts/load-default-server-url.sh
+ARGUMENTS=("$@")
 
-echo "[config] Waiting for the server to start... (${IHE_GW_URL})"
-until curl -s -f -o /dev/null $IHE_GW_URL; do
-  sleep 1
-done
+containsElement() {
+  for i in "${ARGUMENTS[@]}"; do
+    if [ "$i" == "$1" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+setConfigurationMap() {
+  echo "[config] -- Config map only --"
+  if [ -f $CONFIG_MAP_FILE ]; then
+    CONFIG_MAP=$(cat $CONFIG_MAP_FILE)
+  else
+    echo "[config] Error: Configuration map file not found."
+    exit 1
+  fi
+
+  RESULT=$(curl -s -w '%{response_code}' --request PUT "$IHE_GW_URL/server/configurationMap" \
+    --header "X-Requested-With: push-to-server" \
+    --header 'Accept: application/xml' \
+    --header 'Content-Type: application/xml' \
+    -u $IHE_GW_USER:$IHE_GW_PASSWORD \
+    --data "$CONFIG_MAP")
+
+  if [[ $RESULT -ge 300 ]] || [[ $RESULT -lt 200 ]]; then
+    echo "[config] Failed to push configuration map to the server - Result: $RESULT"
+    cleanup
+    exit 1
+  else
+    echo "[config] Configuration map pushed to the server."
+  fi
+}
+
+setAllConfigs() {
+  echo "[config] -- Full config --"
+  # "-m" flag = "backup": only the FullBackup.xml file, equivalent to Mirth Administrator backup and restore
+  ./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t ./server -m backup -f push
+  # "-m" flag = default behavior: Expands everything to the most granular level (Javascript, Sql, etc).
+  ./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t ./server --include-configuration-map -f -d push
+}
+
+waitServerOnline() {
+  echo "[config] Waiting for the server to start... (${IHE_GW_URL})"
+  until curl -s --header "X-Requested-With: push-to-server" -u $IHE_GW_USER:$IHE_GW_PASSWORD -o /dev/null "$IHE_GW_URL/server/jvm"; do
+    sleep 1
+  done
+  sleep 2
+}
+
+###################################################################################################
+#
+# MAIN LOGIC
+#
+###################################################################################################
+waitServerOnline
 echo "[config] Pushing configs to the server..."
-
-# "-m" flag: only the FullBackup.xml file, "Equivalent to Mirth Administrator backup and restore"
-./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t ./server -m backup -f push
-
-# "-m" flag: default behavior. Expands everything to the most granular level (Javascript, Sql, etc).
-./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t ./server --include-configuration-map -f -d push
-
+if containsElement "configurationMap"; then
+  setConfigurationMap
+else
+  setAllConfigs
+fi
 echo "[config] Done."

--- a/packages/ihe-gateway/scripts/push-to-server.sh
+++ b/packages/ihe-gateway/scripts/push-to-server.sh
@@ -106,11 +106,9 @@ setConfigurationMap() {
 setAllConfigs() {
   echo "[config] -- Full config --"
   # "-m" flag = "backup": only the FullBackup.xml file, equivalent to Mirth Administrator backup and restore
-  ./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t ./server -m backup -f push
-
+  # ./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t ./server -m backup -f push
   # Wait for the server to process the backup to avoid failing to recognize the SSL certs and other recently loaded configs
-  sleep 5
-
+  # sleep 5
   # "-m" flag = default behavior: Expands everything to the most granular level (Javascript, Sql, etc).
   ./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t ./server --include-configuration-map -f -d push
 }
@@ -174,12 +172,6 @@ waitServerOnline() {
 ###################################################################################################
 waitServerOnline
 
-if containsParameter "no-ssl-check"; then
-  echo "[config] Skipping SSL cert check..."
-else
-  verifySSLCerts
-fi
-
 echo "[config] Pushing configs to the server..."
 
 if containsParameter "configurationMap"; then
@@ -187,4 +179,11 @@ if containsParameter "configurationMap"; then
 else
   setAllConfigs
 fi
+
+if containsParameter "no-ssl-check"; then
+  echo "[config] Skipping SSL cert check..."
+else
+  verifySSLCerts
+fi
+
 echo "[config] Done."

--- a/packages/ihe-gateway/scripts/push-to-server.sh
+++ b/packages/ihe-gateway/scripts/push-to-server.sh
@@ -55,6 +55,7 @@ isNumber() {
 }
 
 uploadConfigurationMapRes=999
+
 uploadConfigurationMap() {
   echo "[config] -- Config map only --"
   if [ -f $CONFIG_MAP_FILE ]; then
@@ -76,6 +77,8 @@ uploadConfigurationMap() {
     uploadConfigurationMapRes="not-number"
   elif [[ $res -ge 300 ]] || [[ $res -lt 200 ]]; then
     uploadConfigurationMapRes="not-success"
+  else
+    uploadConfigurationMapRes="success"
   fi
 }
 
@@ -102,6 +105,10 @@ setAllConfigs() {
   echo "[config] -- Full config --"
   # "-m" flag = "backup": only the FullBackup.xml file, equivalent to Mirth Administrator backup and restore
   ./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t ./server -m backup -f push
+
+  # Wait for the server to process the backup to avoid failing to recognize the SSL certs and other recently loaded configs
+  sleep 5
+
   # "-m" flag = default behavior: Expands everything to the most granular level (Javascript, Sql, etc).
   ./scripts/mirthsync.sh -s $IHE_GW_URL -u $IHE_GW_USER -p $IHE_GW_PASSWORD -i -t ./server --include-configuration-map -f -d push
 }

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-38 Inbound Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-38 Inbound Processor.xml
@@ -9,7 +9,7 @@ Note:
  - IHE ITI-38 queries other than FindDocuments are not currently supported (see ITI Vol2a 3.18.4.1.2.4)
 
 Last updated: Dec 26 2023</description>
-  <revision>48</revision>
+  <revision>123</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -321,7 +321,9 @@ Last updated: Dec 26 2023</description>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <dependentIds/>
+    <dependentIds>
+      <string>3d78b44c-d132-485a-8423-f5a6c681f249</string>
+    </dependentIds>
     <dependencyIds/>
     <channelTags/>
   </exportData>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-39 Inbound Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-39 Inbound Processor.xml
@@ -6,7 +6,7 @@
  - Generates AWS Lambda request based on the ITI-39 "Cross Gateway Retrieve" SOAP message
 
 Last updated: Dec 27 2023</description>
-  <revision>48</revision>
+  <revision>123</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -318,7 +318,9 @@ Last updated: Dec 27 2023</description>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <dependentIds/>
+    <dependentIds>
+      <string>3d78b44c-d132-485a-8423-f5a6c681f249</string>
+    </dependentIds>
     <dependencyIds/>
     <channelTags/>
   </exportData>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA Inbound Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA Inbound Interface.xml
@@ -14,7 +14,7 @@ Note:
 Last updated: Jan 02 2024
 
 </description>
-  <revision>48</revision>
+  <revision>121</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -5825,7 +5825,10 @@ Last updated: Jan 02 2024
       <userId>1</userId>
     </metadata>
     <dependentIds/>
-    <dependencyIds/>
+    <dependencyIds>
+      <string>279057c4-65eb-4cbd-ae23-6d9d66de14a0</string>
+      <string>8af32eb7-1153-4c8f-be64-db8cb45ceb1b</string>
+    </dependencyIds>
     <channelTags/>
   </exportData>
 </channel>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCPD Inbound Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCPD Inbound Interface.xml
@@ -11,7 +11,7 @@ Note:
  - If 'Validate WS-Security' is set to 'Yes,' Mirth Interop rejects failing messages with the SOAP Fault message but does not increase the channel's Received and Sent count.
 
 Last updated: Jan 10 2024</description>
-  <revision>49</revision>
+  <revision>120</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -40513,7 +40513,9 @@ RoseTree XML to Schema: $Id: VocabXMLtoXSD.xsl,v 1.8 2007/03/20 02:48:50 wbeeler
       <userId>1</userId>
     </metadata>
     <dependentIds/>
-    <dependencyIds/>
+    <dependencyIds>
+      <string>830d9530-a006-4b9c-9b9b-302065bc2eea</string>
+    </dependencyIds>
     <channelTags/>
   </exportData>
 </channel>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCPD Inbound Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCPD Inbound Processor.xml
@@ -6,7 +6,7 @@
  - Generates ITI-55 "Cross Gateway Patient Discovery Response" SOAP message based on the AWS Lambda response
 
 Last updated: Dec 18 2023</description>
-  <revision>49</revision>
+  <revision>118</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -325,7 +325,9 @@ Last updated: Dec 18 2023</description>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <dependentIds/>
+    <dependentIds>
+      <string>1f09811d-57b1-4219-9427-09f0d63a77a6</string>
+    </dependentIds>
     <dependencyIds/>
     <channelTags/>
   </exportData>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/index.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/index.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?><channelGroup version="4.4.2">
   <id>17a4bbcb-23fc-4a63-8069-fb1d38f8c255</id>
   <name>CareQuality Document Exchange - Inbound</name>
-  <revision>2</revision>
+  <revision>1</revision>
   <lastModified>
-    <time>1708660218391</time>
+    <time>1709505265693</time>
     <timezone>GMT</timezone>
   </lastModified>
   <description>Inbound CareQuality Query Based Document Exchange</description>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA - DQ App Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA - DQ App Interface.xml
@@ -6,7 +6,7 @@
     - forwards a single request back to the calling app or DB
     
   </description>
-  <revision>33</revision>
+  <revision>124</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -227,8 +227,8 @@
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1708811127360</time>
-        <timezone>America/New_York</timezone>
+        <time>1709753610426</time>
+        <timezone>America/Winnipeg</timezone>
       </lastModified>
       <pruningSettings>
         <pruneMetaDataDays>5</pruneMetaDataDays>
@@ -238,7 +238,9 @@
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <dependentIds/>
+    <dependentIds>
+      <string>3f38affa-7132-4c4d-8597-2679b2651a13</string>
+    </dependentIds>
     <dependencyIds/>
     <channelTags/>
   </exportData>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA - DQ App Interface/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA - DQ App Interface/DeployScript.js
@@ -14,4 +14,6 @@ if (!baseAddress) {
 const destinationURL = baseAddress + "/internal/carequality/document-query/response";
 globalChannelMap.put("URL", destinationURL);
 
+logger.info("Deploying " + channelName);
+
 return;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA - DR App Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA - DR App Interface.xml
@@ -4,7 +4,7 @@
   <name>XCA - DR App Interface</name>
   <description>XCA App Interface channel
     - forwards a single request back to the calling app or DB</description>
-  <revision>25</revision>
+  <revision>124</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -225,8 +225,8 @@
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1708811106854</time>
-        <timezone>America/New_York</timezone>
+        <time>1709753616727</time>
+        <timezone>America/Winnipeg</timezone>
       </lastModified>
       <pruningSettings>
         <pruneMetaDataDays>5</pruneMetaDataDays>
@@ -236,7 +236,9 @@
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <dependentIds/>
+    <dependentIds>
+      <string>c7b1fb54-6dce-410c-a16a-e3ba6b6c6722</string>
+    </dependentIds>
     <dependencyIds/>
     <channelTags/>
   </exportData>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA - DR App Interface/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA - DR App Interface/DeployScript.js
@@ -14,4 +14,6 @@ if (!baseAddress) {
 const destinationURL = baseAddress + "/internal/carequality/document-retrieval/response";
 globalChannelMap.put("URL", destinationURL);
 
+logger.info("Deploying " + channelName);
+
 return;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA DQ ITI-38 Bulk Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA DQ ITI-38 Bulk Interface.xml
@@ -10,7 +10,7 @@ Comments:
  - see example of the request here: https://drive.google.com/drive/folders/1yKVHYyQPhkCHDo9Ow8lpT4vFHq7LY_9O
 
 Last updated: Dec 20 2023</description>
-  <revision>49</revision>
+  <revision>126</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -260,7 +260,7 @@ Last updated: Dec 20 2023</description>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1709002430047</time>
+        <time>1709753520589</time>
         <timezone>America/Winnipeg</timezone>
       </lastModified>
       <pruningSettings>
@@ -272,7 +272,9 @@ Last updated: Dec 20 2023</description>
       <userId>1</userId>
     </metadata>
     <dependentIds/>
-    <dependencyIds/>
+    <dependencyIds>
+      <string>ce8aa1cf-5df6-4825-82c9-b51d5b2dfcfa</string>
+    </dependencyIds>
     <channelTags/>
   </exportData>
 </channel>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA DQ ITI-38 Bulk Interface/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA DQ ITI-38 Bulk Interface/DeployScript.js
@@ -1,3 +1,6 @@
 // This script executes once when the channel is deployed
 // You only have access to the globalMap and globalChannelMap here to persist data
+
+logger.info("Deploying " + channelName);
+
 return;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA DR ITI-39 Bulk Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA DR ITI-39 Bulk Interface.xml
@@ -10,7 +10,7 @@ Comments:
  - see example of the request here: https://drive.google.com/drive/folders/1yKVHYyQPhkCHDo9Ow8lpT4vFHq7LY_9O
 
 Last updated: Dec 05 2023</description>
-  <revision>49</revision>
+  <revision>126</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -255,7 +255,7 @@ Last updated: Dec 05 2023</description>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1709002449506</time>
+        <time>1709753525951</time>
         <timezone>America/Winnipeg</timezone>
       </lastModified>
       <pruningSettings>
@@ -267,7 +267,9 @@ Last updated: Dec 05 2023</description>
       <userId>1</userId>
     </metadata>
     <dependentIds/>
-    <dependencyIds/>
+    <dependencyIds>
+      <string>cbd49d4a-24fa-40b6-aa12-d59d64168dd1</string>
+    </dependencyIds>
     <channelTags/>
   </exportData>
 </channel>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA DR ITI-39 Bulk Interface/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA DR ITI-39 Bulk Interface/DeployScript.js
@@ -1,3 +1,6 @@
 // This script executes once when the channel is deployed
 // You only have access to the globalMap and globalChannelMap here to persist data
+
+logger.info("Deploying " + channelName);
+
 return;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Interface.xml
@@ -6,12 +6,15 @@
  - expects to receive a single requests to be transmitted to the XCA ITI-38 [Cross Gateway Query] Processor channel
 
 Last updated: Nov 29 2023</description>
-  <revision>56</revision>
+  <revision>124</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
     <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="4.4.2">
       <pluginProperties>
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.4.2">
+          <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
         <com.mirth.connect.plugins.ssl.model.SSLConnectorPluginProperties version="4.4.2">
           <enabled>false</enabled>
           <clientAuthentication>DISABLED</clientAuthentication>
@@ -35,9 +38,6 @@ Last updated: Nov 29 2023</description>
           <implicitFTPS>true</implicitFTPS>
           <useSTARTTLS>false</useSTARTTLS>
         </com.mirth.connect.plugins.ssl.model.SSLConnectorPluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.4.2">
-          <authType>NONE</authType>
-        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
       <listenerConnectorProperties version="4.4.2">
         <host>0.0.0.0</host>
@@ -245,7 +245,7 @@ Last updated: Nov 29 2023</description>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1709002480992</time>
+        <time>1709753540015</time>
         <timezone>America/Winnipeg</timezone>
       </lastModified>
       <pruningSettings>
@@ -256,8 +256,12 @@ Last updated: Nov 29 2023</description>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <dependentIds/>
-    <dependencyIds/>
+    <dependentIds>
+      <string>574e7271-1b21-4b79-82c3-fead249fc450</string>
+    </dependentIds>
+    <dependencyIds>
+      <string>3f38affa-7132-4c4d-8597-2679b2651a13</string>
+    </dependencyIds>
     <channelTags/>
   </exportData>
 </channel>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Interface/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Interface/DeployScript.js
@@ -4,4 +4,6 @@
 // Store for the XCA Bulk Interface
 globalMap.put('XCAITI38INTERFACE', channelId);
 
+logger.info("Deploying " + channelName);
+
 return;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor.xml
@@ -10,7 +10,7 @@
 TODO: Update SAML Attributes
 
 Last updated: Dec 07 2023</description>
-  <revision>49</revision>
+  <revision>126</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -412,7 +412,7 @@ Last updated: Dec 07 2023</description>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1709074732734</time>
+        <time>1709754298109</time>
         <timezone>America/Winnipeg</timezone>
       </lastModified>
       <pruningSettings>
@@ -423,8 +423,12 @@ Last updated: Dec 07 2023</description>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <dependentIds/>
-    <dependencyIds/>
+    <dependentIds>
+      <string>ce8aa1cf-5df6-4825-82c9-b51d5b2dfcfa</string>
+    </dependentIds>
+    <dependencyIds>
+      <string>c1b69481-12ef-4e81-9a4d-e7b362cf6c5d</string>
+    </dependencyIds>
     <channelTags/>
   </exportData>
 </channel>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor/DeployScript.js
@@ -3,4 +3,6 @@
 
 globalMap.put('ITI38PROCESSOR', channelId);
 
+logger.info("Deploying " + channelName);
+
 return;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Interface.xml
@@ -6,7 +6,7 @@
  - expects to receive a single requests to be transmitted to the XCA ITI-39 [Cross Gateway Retrieve] Processor channel
 
 Last updated: Nov 14 2023</description>
-  <revision>52</revision>
+  <revision>124</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -245,8 +245,8 @@ Last updated: Nov 14 2023</description>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1709512711695</time>
-        <timezone>America/Los_Angeles</timezone>
+        <time>1709753549013</time>
+        <timezone>America/Winnipeg</timezone>
       </lastModified>
       <pruningSettings>
         <pruneMetaDataDays>5</pruneMetaDataDays>
@@ -256,8 +256,12 @@ Last updated: Nov 14 2023</description>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <dependentIds/>
-    <dependencyIds/>
+    <dependentIds>
+      <string>ed739638-6120-4aee-bcb2-acc661f2b12b</string>
+    </dependentIds>
+    <dependencyIds>
+      <string>c7b1fb54-6dce-410c-a16a-e3ba6b6c6722</string>
+    </dependencyIds>
     <channelTags/>
   </exportData>
 </channel>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Interface/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Interface/DeployScript.js
@@ -14,4 +14,6 @@ if (!globalMap.containsKey("SECRET_KEY")) {
   ChannelUtil.stopChannel(channelId);
 }
 
+logger.info("Deploying " + channelName);
+
 return;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor.xml
@@ -8,7 +8,7 @@
  - Processes responses
 
 Last updated: Jan 12 2024</description>
-  <revision>86</revision>
+  <revision>130</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -415,8 +415,8 @@ Last updated: Jan 12 2024</description>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1709512736502</time>
-        <timezone>America/Los_Angeles</timezone>
+        <time>1709753576860</time>
+        <timezone>America/Winnipeg</timezone>
       </lastModified>
       <pruningSettings>
         <pruneMetaDataDays>5</pruneMetaDataDays>
@@ -426,8 +426,12 @@ Last updated: Jan 12 2024</description>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <dependentIds/>
-    <dependencyIds/>
+    <dependentIds>
+      <string>cbd49d4a-24fa-40b6-aa12-d59d64168dd1</string>
+    </dependentIds>
+    <dependencyIds>
+      <string>8240f77a-19d4-4225-90fc-ed1c232286c3</string>
+    </dependencyIds>
     <channelTags/>
   </exportData>
 </channel>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/DeployScript.js
@@ -2,5 +2,7 @@
 // You only have access to the globalMap and globalChannelMap here to persist data
 
 globalMap.put('ITI39PROCESSOR', channelId);
-	
+
+logger.info("Deploying " + channelName);
+
 return;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD App Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD App Interface.xml
@@ -6,7 +6,7 @@
  - forwards a single request back to the calling app or DB
 
 Last updated: Nov 23 2023</description>
-  <revision>34</revision>
+  <revision>124</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -229,7 +229,7 @@ Last updated: Nov 23 2023</description>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1709074667131</time>
+        <time>1709753584607</time>
         <timezone>America/Winnipeg</timezone>
       </lastModified>
       <pruningSettings>
@@ -240,7 +240,9 @@ Last updated: Nov 23 2023</description>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <dependentIds/>
+    <dependentIds>
+      <string>79208c1b-3cbb-4d6e-aeb3-a8387cee4f93</string>
+    </dependentIds>
     <dependencyIds/>
     <channelTags/>
   </exportData>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD App Interface/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD App Interface/DeployScript.js
@@ -14,4 +14,6 @@ if (!baseAddress) {
 const destinationURL = baseAddress + "/internal/carequality/patient-discovery/response";
 globalChannelMap.put("URL", destinationURL);
 
+logger.info("Deploying " + channelName);
+
 return;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD Bulk Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD Bulk Interface.xml
@@ -7,7 +7,7 @@
  - takes individual requests and sends to the XCPD Interface channel
 
 Last updated: Dec 08 2023</description>
-  <revision>49</revision>
+  <revision>128</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -252,7 +252,7 @@ Last updated: Dec 08 2023</description>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1708710346392</time>
+        <time>1709753514839</time>
         <timezone>America/Winnipeg</timezone>
       </lastModified>
       <pruningSettings>
@@ -264,7 +264,9 @@ Last updated: Dec 08 2023</description>
       <userId>1</userId>
     </metadata>
     <dependentIds/>
-    <dependencyIds/>
+    <dependencyIds>
+      <string>c240418b-26ef-4836-a857-01c74fb07963</string>
+    </dependencyIds>
     <channelTags/>
   </exportData>
 </channel>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD Bulk Interface/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD Bulk Interface/DeployScript.js
@@ -1,3 +1,6 @@
 // This script executes once when the channel is deployed
 // You only have access to the globalMap and globalChannelMap here to persist data
+
+logger.info("Deploying " + channelName);
+
 return;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor.xml
@@ -8,7 +8,7 @@
  - Processes responses
 
 Last updated: Dec 20 2023</description>
-  <revision>57</revision>
+  <revision>123</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
@@ -438,8 +438,8 @@ Last updated: Dec 20 2023</description>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1709512688050</time>
-        <timezone>America/Los_Angeles</timezone>
+        <time>1709753603752</time>
+        <timezone>America/Winnipeg</timezone>
       </lastModified>
       <pruningSettings>
         <pruneMetaDataDays>5</pruneMetaDataDays>
@@ -449,8 +449,12 @@ Last updated: Dec 20 2023</description>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <dependentIds/>
-    <dependencyIds/>
+    <dependentIds>
+      <string>c240418b-26ef-4836-a857-01c74fb07963</string>
+    </dependentIds>
+    <dependencyIds>
+      <string>6cdb6776-3488-47c6-8c90-2015ea051f93</string>
+    </dependencyIds>
     <channelTags/>
   </exportData>
 </channel>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor/DeployScript.js
@@ -3,4 +3,6 @@
 
 globalMap.put('ITI55PROCESSOR', channelId);
 
+logger.info("Deploying " + channelName);
+
 return;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD Interface.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD Interface.xml
@@ -6,12 +6,15 @@
  - expects to receive a single requests to be transmitted to the XCPD ITI-55 Processor channel
 
 Last updated: Dec 20 2023</description>
-  <revision>60</revision>
+  <revision>123</revision>
   <sourceConnector version="4.4.2">
     <metaDataId>0</metaDataId>
     <name>sourceConnector</name>
     <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="4.4.2">
       <pluginProperties>
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.4.2">
+          <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
         <com.mirth.connect.plugins.ssl.model.SSLConnectorPluginProperties version="4.4.2">
           <enabled>false</enabled>
           <clientAuthentication>DISABLED</clientAuthentication>
@@ -35,9 +38,6 @@ Last updated: Dec 20 2023</description>
           <implicitFTPS>true</implicitFTPS>
           <useSTARTTLS>false</useSTARTTLS>
         </com.mirth.connect.plugins.ssl.model.SSLConnectorPluginProperties>
-        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.4.2">
-          <authType>NONE</authType>
-        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
       </pluginProperties>
       <listenerConnectorProperties version="4.4.2">
         <host>0.0.0.0</host>
@@ -251,7 +251,7 @@ Last updated: Dec 20 2023</description>
     <metadata>
       <enabled>true</enabled>
       <lastModified>
-        <time>1708993973587</time>
+        <time>1709753563218</time>
         <timezone>America/Winnipeg</timezone>
       </lastModified>
       <pruningSettings>
@@ -262,8 +262,12 @@ Last updated: Dec 20 2023</description>
       </pruningSettings>
       <userId>1</userId>
     </metadata>
-    <dependentIds/>
-    <dependencyIds/>
+    <dependentIds>
+      <string>f6899f98-6671-44f9-a764-d5f7c1858f02</string>
+    </dependentIds>
+    <dependencyIds>
+      <string>79208c1b-3cbb-4d6e-aeb3-a8387cee4f93</string>
+    </dependencyIds>
     <channelTags/>
   </exportData>
 </channel>

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD Interface/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD Interface/DeployScript.js
@@ -3,4 +3,6 @@
 
 globalMap.put('XCPDINTERFACE', channelId);
 
+logger.info("Deploying " + channelName);
+
 return;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/index.xml
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/index.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?><channelGroup version="4.4.2">
   <id>7a4e6d78-a130-4aa7-9d85-6aa8921c6e65</id>
   <name>CareQuality Document Exchange - Outbound</name>
-  <revision>8</revision>
+  <revision>1</revision>
   <lastModified>
-    <time>1708924582123</time>
+    <time>1709505265696</time>
     <timezone>GMT</timezone>
   </lastModified>
   <description>Outbound CareQuality Query Based Document Exchange

--- a/packages/ihe-gateway/server/Channels/Default Group/Tester.xml
+++ b/packages/ihe-gateway/server/Channels/Default Group/Tester.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8"?><channel version="4.4.2">
+  <id>cbdd09d8-af65-4cc6-869a-8c1617a29881</id>
+  <nextMetaDataId>2</nextMetaDataId>
+  <name>Tester</name>
+  <description/>
+  <revision>2</revision>
+  <sourceConnector version="4.4.2">
+    <metaDataId>0</metaDataId>
+    <name>sourceConnector</name>
+    <properties class="com.mirth.connect.connectors.http.HttpReceiverProperties" version="4.4.2">
+      <pluginProperties>
+        <com.mirth.connect.plugins.ssl.model.SSLConnectorPluginProperties version="4.4.2">
+          <enabled>false</enabled>
+          <clientAuthentication>DISABLED</clientAuthentication>
+          <hostnameVerificationEnabled>true</hostnameVerificationEnabled>
+          <trustAllCertificates>false</trustAllCertificates>
+          <trustedCertificates>
+            <trustedCertificateAliases/>
+            <trustCACerts>true</trustCACerts>
+          </trustedCertificates>
+          <localCertificateAlias/>
+          <ocspEnabled>false</ocspEnabled>
+          <ocspURI/>
+          <ocspHardFail>false</ocspHardFail>
+          <crlEnabled>false</crlEnabled>
+          <crlURI/>
+          <crlHardFail>false</crlHardFail>
+          <subjectDNValidationEnabled>false</subjectDNValidationEnabled>
+          <trustedSubjectDNs class="linked-hash-map"/>
+          <hideIssuerDNs>false</hideIssuerDNs>
+          <allowExpiredCertificates>false</allowExpiredCertificates>
+          <implicitFTPS>true</implicitFTPS>
+          <useSTARTTLS>false</useSTARTTLS>
+        </com.mirth.connect.plugins.ssl.model.SSLConnectorPluginProperties>
+        <com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties version="4.4.2">
+          <authType>NONE</authType>
+        </com.mirth.connect.plugins.httpauth.NoneHttpAuthProperties>
+      </pluginProperties>
+      <listenerConnectorProperties version="4.4.2">
+        <host>0.0.0.0</host>
+        <port>8099</port>
+      </listenerConnectorProperties>
+      <sourceConnectorProperties version="4.4.2">
+        <responseVariable>d1</responseVariable>
+        <respondAfterProcessing>true</respondAfterProcessing>
+        <processBatch>false</processBatch>
+        <firstResponse>false</firstResponse>
+        <processingThreads>1</processingThreads>
+        <resourceIds class="linked-hash-map">
+          <entry>
+            <string>Default Resource</string>
+            <string>[Default Resource]</string>
+          </entry>
+        </resourceIds>
+        <queueBufferSize>1000</queueBufferSize>
+      </sourceConnectorProperties>
+      <xmlBody>false</xmlBody>
+      <parseMultipart>true</parseMultipart>
+      <includeMetadata>false</includeMetadata>
+      <binaryMimeTypes>application/.*(?&lt;!json|xml)$|image/.*|video/.*|audio/.*</binaryMimeTypes>
+      <binaryMimeTypesRegex>true</binaryMimeTypesRegex>
+      <responseContentType>application/json</responseContentType>
+      <responseDataTypeBinary>false</responseDataTypeBinary>
+      <responseStatusCode>200</responseStatusCode>
+      <responseHeaders class="linked-hash-map"/>
+      <responseHeadersVariable/>
+      <useResponseHeadersVariable>false</useResponseHeadersVariable>
+      <charset>UTF-8</charset>
+      <contextPath/>
+      <timeout>30000</timeout>
+      <staticResources/>
+    </properties>
+    <transformer version="4.4.2">
+      <elements>
+        <com.mirth.connect.plugins.javascriptstep.JavaScriptStep version="4.4.2">
+          <name>parse-request</name>
+          <sequenceNumber>0</sequenceNumber>
+          <enabled>true</enabled>
+          <script msync-fileref="sourceConnector-transformer-step-0-parse-request.js"/>
+        </com.mirth.connect.plugins.javascriptstep.JavaScriptStep>
+      </elements>
+      <inboundTemplate encoding="base64"/>
+      <outboundTemplate encoding="base64"/>
+      <inboundDataType>JSON</inboundDataType>
+      <outboundDataType>JSON</outboundDataType>
+      <inboundProperties class="com.mirth.connect.plugins.datatypes.json.JSONDataTypeProperties" version="4.4.2">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.json.JSONBatchProperties" version="4.4.2">
+          <splitType>JavaScript</splitType>
+          <batchScript/>
+        </batchProperties>
+      </inboundProperties>
+      <outboundProperties class="com.mirth.connect.plugins.datatypes.json.JSONDataTypeProperties" version="4.4.2">
+        <batchProperties class="com.mirth.connect.plugins.datatypes.json.JSONBatchProperties" version="4.4.2">
+          <splitType>JavaScript</splitType>
+          <batchScript/>
+        </batchProperties>
+      </outboundProperties>
+    </transformer>
+    <filter version="4.4.2">
+      <elements/>
+    </filter>
+    <transportName>HTTP Listener</transportName>
+    <mode>SOURCE</mode>
+    <enabled>true</enabled>
+    <waitForPrevious>true</waitForPrevious>
+  </sourceConnector>
+  <destinationConnectors>
+    <connector version="4.4.2">
+      <metaDataId>1</metaDataId>
+      <name>Destination 1</name>
+      <properties class="com.mirth.connect.connectors.js.JavaScriptDispatcherProperties" version="4.4.2">
+        <pluginProperties/>
+        <destinationConnectorProperties version="4.4.2">
+          <queueEnabled>false</queueEnabled>
+          <sendFirst>false</sendFirst>
+          <retryIntervalMillis>10000</retryIntervalMillis>
+          <regenerateTemplate>false</regenerateTemplate>
+          <retryCount>0</retryCount>
+          <rotate>false</rotate>
+          <includeFilterTransformer>false</includeFilterTransformer>
+          <threadCount>1</threadCount>
+          <threadAssignmentVariable/>
+          <validateResponse>false</validateResponse>
+          <resourceIds class="linked-hash-map">
+            <entry>
+              <string>Default Resource</string>
+              <string>[Default Resource]</string>
+            </entry>
+          </resourceIds>
+          <queueBufferSize>1000</queueBufferSize>
+          <reattachAttachments>false</reattachAttachments>
+        </destinationConnectorProperties>
+        <script msync-fileref="destinationConnector-Destination 1.js"/>
+      </properties>
+      <transformer version="4.4.2">
+        <elements/>
+        <inboundDataType>JSON</inboundDataType>
+        <outboundDataType>JSON</outboundDataType>
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.json.JSONDataTypeProperties" version="4.4.2">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.json.JSONBatchProperties" version="4.4.2">
+            <splitType>JavaScript</splitType>
+            <batchScript/>
+          </batchProperties>
+        </inboundProperties>
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.json.JSONDataTypeProperties" version="4.4.2">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.json.JSONBatchProperties" version="4.4.2">
+            <splitType>JavaScript</splitType>
+            <batchScript/>
+          </batchProperties>
+        </outboundProperties>
+      </transformer>
+      <responseTransformer version="4.4.2">
+        <elements/>
+        <inboundDataType>JSON</inboundDataType>
+        <outboundDataType>JSON</outboundDataType>
+        <inboundProperties class="com.mirth.connect.plugins.datatypes.json.JSONDataTypeProperties" version="4.4.2">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.json.JSONBatchProperties" version="4.4.2">
+            <splitType>JavaScript</splitType>
+            <batchScript/>
+          </batchProperties>
+        </inboundProperties>
+        <outboundProperties class="com.mirth.connect.plugins.datatypes.json.JSONDataTypeProperties" version="4.4.2">
+          <batchProperties class="com.mirth.connect.plugins.datatypes.json.JSONBatchProperties" version="4.4.2">
+            <splitType>JavaScript</splitType>
+            <batchScript/>
+          </batchProperties>
+        </outboundProperties>
+      </responseTransformer>
+      <filter version="4.4.2">
+        <elements/>
+      </filter>
+      <transportName>JavaScript Writer</transportName>
+      <mode>DESTINATION</mode>
+      <enabled>true</enabled>
+      <waitForPrevious>true</waitForPrevious>
+    </connector>
+  </destinationConnectors>
+  <preprocessingScript msync-fileref="PreprocessingScript.js"/>
+  <postprocessingScript msync-fileref="PostprocessingScript.js"/>
+  <deployScript msync-fileref="DeployScript.js"/>
+  <undeployScript msync-fileref="UndeployScript.js"/>
+  <properties version="4.4.2">
+    <clearGlobalChannelMap>true</clearGlobalChannelMap>
+    <messageStorageMode>DEVELOPMENT</messageStorageMode>
+    <encryptData>false</encryptData>
+    <encryptAttachments>false</encryptAttachments>
+    <encryptCustomMetaData>false</encryptCustomMetaData>
+    <removeContentOnCompletion>false</removeContentOnCompletion>
+    <removeOnlyFilteredOnCompletion>false</removeOnlyFilteredOnCompletion>
+    <removeAttachmentsOnCompletion>false</removeAttachmentsOnCompletion>
+    <initialState>STARTED</initialState>
+    <storeAttachments>true</storeAttachments>
+    <metaDataColumns>
+      <metaDataColumn>
+        <name>SOURCE</name>
+        <type>STRING</type>
+        <mappingName>mirth_source</mappingName>
+      </metaDataColumn>
+      <metaDataColumn>
+        <name>TYPE</name>
+        <type>STRING</type>
+        <mappingName>mirth_type</mappingName>
+      </metaDataColumn>
+    </metaDataColumns>
+    <attachmentProperties version="4.4.2">
+      <type>None</type>
+      <properties/>
+    </attachmentProperties>
+    <resourceIds class="linked-hash-map">
+      <entry>
+        <string>Default Resource</string>
+        <string>[Default Resource]</string>
+      </entry>
+    </resourceIds>
+  </properties>
+  <exportData>
+    <metadata>
+      <enabled>false</enabled>
+      <lastModified>
+        <time>1709701230316</time>
+        <timezone>America/Winnipeg</timezone>
+      </lastModified>
+      <pruningSettings>
+        <archiveEnabled>true</archiveEnabled>
+        <pruneErroredMessages>false</pruneErroredMessages>
+      </pruningSettings>
+      <userId>1</userId>
+    </metadata>
+    <dependentIds/>
+    <dependencyIds/>
+    <channelTags/>
+  </exportData>
+</channel>

--- a/packages/ihe-gateway/server/Channels/Default Group/Tester/DeployScript.js
+++ b/packages/ihe-gateway/server/Channels/Default Group/Tester/DeployScript.js
@@ -1,0 +1,3 @@
+// This script executes once when the channel is deployed
+// You only have access to the globalMap and globalChannelMap here to persist data
+return;

--- a/packages/ihe-gateway/server/Channels/Default Group/Tester/PostprocessingScript.js
+++ b/packages/ihe-gateway/server/Channels/Default Group/Tester/PostprocessingScript.js
@@ -1,0 +1,3 @@
+// This script executes once after a message has been processed
+// Responses returned from here will be stored as "Postprocessor" in the response map
+return;

--- a/packages/ihe-gateway/server/Channels/Default Group/Tester/PreprocessingScript.js
+++ b/packages/ihe-gateway/server/Channels/Default Group/Tester/PreprocessingScript.js
@@ -1,0 +1,2 @@
+// Modify the message variable below to pre process data
+return message;

--- a/packages/ihe-gateway/server/Channels/Default Group/Tester/UndeployScript.js
+++ b/packages/ihe-gateway/server/Channels/Default Group/Tester/UndeployScript.js
@@ -1,0 +1,3 @@
+// This script executes once when the channel is undeployed
+// You only have access to the globalMap and globalChannelMap here to persist data
+return;

--- a/packages/ihe-gateway/server/Channels/Default Group/Tester/destinationConnector-Destination 1.js
+++ b/packages/ihe-gateway/server/Channels/Default Group/Tester/destinationConnector-Destination 1.js
@@ -1,0 +1,13 @@
+const payload = channelMap.get("REQ_BODY");
+const result = JSON.stringify(payload);
+
+const logIt = () => {
+	logger.info("[Tester] Got this2: " + result);
+}
+
+logger.info("[Tester] Running...");
+
+logIt();
+
+logger.info("[Tester] Returning...");
+return result;

--- a/packages/ihe-gateway/server/Channels/Default Group/Tester/sourceConnector-transformer-step-0-parse-request.js
+++ b/packages/ihe-gateway/server/Channels/Default Group/Tester/sourceConnector-transformer-step-0-parse-request.js
@@ -1,0 +1,1 @@
+channelMap.put("REQ_BODY", msg);

--- a/packages/infra/config/ihe-gateway-config.ts
+++ b/packages/infra/config/ihe-gateway-config.ts
@@ -71,8 +71,20 @@ export type IHEGatewayProps = {
   };
   rds: {
     dbName: string;
+    dbNameInbound: string;
     userName: string;
+    /**
+     * The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster.
+     * You can specify ACU values in half-step increments, such as 8, 8.5, 9, and so on. The smallest value that you can use is 0.5.
+     * @see — http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbcluster-serverlessv2scalingconfiguration.html#cfn-rds-dbcluster-serverlessv2scalingconfiguration-mincapacity
+     */
     minDBCap: number;
+    /**
+     * The maximum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster.
+     * You can specify ACU values in half-step increments, such as 40, 40.5, 41, and so on. The largest value that you can use is 128.
+     * The maximum capacity must be higher than 0.5 ACUs.
+     * @see — http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbcluster-serverlessv2scalingconfiguration.html#cfn-rds-dbcluster-serverlessv2scalingconfiguration-maxcapacity
+     */
     maxDBCap: number;
     minSlowLogDurationInMs: number;
     alarmThresholds?: RDSAlarmThresholds;

--- a/packages/infra/lib/ihe-stack/ihe-gw-construct.ts
+++ b/packages/infra/lib/ihe-stack/ihe-gw-construct.ts
@@ -81,7 +81,11 @@ export default class IHEGatewayConstruct extends Construct {
     const id = name;
     const dbAddress = db.server.clusterEndpoint.socketAddress;
     const dbReadonlyAddress = db.server.clusterReadEndpoint.socketAddress;
-    const dbIdentifier = config.rds.dbName;
+    // Temporary workaround to connect to the right DB based on the name
+    // TODO As we mature the IHE GW installation, let's review this
+    const dbIdentifier = name.toLocaleLowerCase().includes("inbound")
+      ? config.rds.dbNameInbound
+      : config.rds.dbName;
     const httpPorts = [pdPort, dqPort, drPort];
     if (httpPorts.length > maxPortsOnProps) {
       throw new Error(`This construct can have at most ${maxPortsOnProps} HTTP ports`);

--- a/packages/infra/lib/ihe-stack/ihe-gw-construct.ts
+++ b/packages/infra/lib/ihe-stack/ihe-gw-construct.ts
@@ -173,8 +173,9 @@ export default class IHEGatewayConstruct extends Construct {
     const portToListener: { [key: number]: ApplicationListener } = {};
 
     const healthCheck: HealthCheck = {
-      healthyThresholdCount: 2,
-      unhealthyThresholdCount: 2,
+      healthyThresholdCount: 4,
+      unhealthyThresholdCount: 4,
+      interval: Duration.seconds(30),
       path: "/",
       port: "8080",
       protocol: Protocol.HTTP,

--- a/packages/scripts/deploy-ihe-gw.sh
+++ b/packages/scripts/deploy-ihe-gw.sh
@@ -39,7 +39,7 @@ FOLDER=packages/ihe-gateway
 pushd ${FOLDER}
 
 echo "Initializing the IHE GW repo"
-./scripts/init.sh
+source ./scripts/init.sh
 
 echo "Building Docker dependencies"
 source ./scripts/build-docker-dependencies.sh


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1350

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1582
- Downstream: none

### Description

- ihe gw container init only loads config map 
- push-to-server more robust
   - don't restore full backup
   - verifies SSL certs
   - kills Java if fails to send configs or SSL certs are not available
- update CICD and `push-to-cloud`
- separated db for inbound instance 
- add disabled test channel 

More on https://metriport.slack.com/archives/C065BLRBUDQ/p1709754122860249

### Testing

- Local
  - [x] Docker container loads config map
  - [x] Docker container exits if fails to load config map
  - [x] Docker container exits if no SSL cert
  - [x] `push-to-cloud` loads config on staging
  - [x] Tester channel works (http req to port 8099 w/ payload and it responds the payload back)
- Staging
  - [x] Docker container loads config map
  - [ ] `push-to-cloud` loads config on staging without errors

### Release Plan

- `staging`
   - [ ] Update prod full backup
   - [x] Create DB/Schema
      - `CREATE DATABASE metriport_ihe_inbound;`
   - [ ] Merge upstream
   - [ ] Merge this
   - [x] Login to admin and create user w/ pwd from 1Pwd
   - [ ] Update IHE GW Config - `./scripts/push-to-cloud.sh -e staging`
- `production`
   - [ ] Create DB/Schema
      - `CREATE DATABASE metriport_ihe_inbound;`
   - [ ] Merge upstream
   - [ ] Merge this
   - [ ] Login to admin and create user w/ pwd from 1Pwd
   - [ ] Update IHE GW Config - `./scripts/push-to-cloud.sh -e staging`
