### PR TITLE
HAPI-1821 Patch

### DIFF
--- a/packages/fhir-converter/src/templates/cda/References/DiagnosticReport/assessment.hbs
+++ b/packages/fhir-converter/src/templates/cda/References/DiagnosticReport/assessment.hbs
@@ -6,7 +6,7 @@
         "presentedForm": [
                 {
                     "contentType": "text/plain",
-                    "data": "{{base64Encode text}}",
+                    "data": "{{{base64Encode text}}}",
                 }
             ],
     },


### PR DESCRIPTION
Refs: #[1442](https://github.com/metriport/metriport-internal/issues/1442)

### Description

- b64 encoded text was being wrapped in {{. This means if there are any special chars, they get escaped as html. So if there were equal signs they were becoming html junk. And HAPI doesnt like HTML in fields that are supposed to be strings
- Fixed by wrapping in {{{ braces, which means we dont do any html escaping. This is ok in this instance since we are removing all single quotes from the text by b64ing it. 

### Testing

_[Regular PRs:]_

- Local
  - [x] ran insert. This edge case isn't represented in the forward data sample afaik, so we know the patch works on the erroring docs from sentry and doesnt break out old conversions. 

### Release Plan

- :warning: Points to `master`
- [ ] Merge this