### PR TITLE
fix(ihe): prevent conversion sending download webhooks

### DIFF
--- a/packages/api/src/external/hie/tally-doc-query-progress.ts
+++ b/packages/api/src/external/hie/tally-doc-query-progress.ts
@@ -73,6 +73,7 @@ export async function tallyDocQueryProgress({
     patient: result.dataValues,
     documentQueryProgress: result.data.documentQueryProgress,
     requestId,
+    progressType: type,
   });
 
   return result;


### PR DESCRIPTION
Ticket: #1350

### Dependencies

- Upstream: none
- Downstream: none

### Description

Prevent conversion tallys from sending download webhooks. 

My hypothesis is that we are converting faster than we are sending the download webhook leading to webhookSent still being false and conversion tallys are then sending download webhooks

### Testing

- Production
  - [ ] Test with circle patient (lots of docs) only sends on download webhook

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
