### PR TITLE
Patch pdfs tiffs borked

### DIFF
--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
@@ -120,7 +120,6 @@ if ('Success' == queryResponseCode.toString() || 'PartialSuccess' == queryRespon
 		}
 
 		// TODO: Process and generate OperationOutcome
-		logger.info("contentList " + contentList.length);
 
 		if (contentList.length > 0) {
 			channelMap.put('RESULT', contentList.length + ' doc(s)');

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
@@ -59,11 +59,11 @@ if ('Success' == queryResponseCode.toString() || 'PartialSuccess' == queryRespon
 
 					// We use decoded bytes to decode the actual raw document. 
 					var decoder = java.util.Base64.getDecoder();
-    				var decodedBytes = decoder.decode(documentEncodedString);
+    				decodedBytes = decoder.decode(documentEncodedString);
 				} catch (ex) {
 					logError(ex);
 				}
-				if (!decodedAsString) continue;
+				if (!decodedAsString || !decodedBytes) continue;
 
 				var type = detectFileType(decodedAsString);
 				var detectedFileType = type[0];
@@ -90,7 +90,7 @@ if ('Success' == queryResponseCode.toString() || 'PartialSuccess' == queryRespon
 							if (title) attachment.title = title;
 						}
 					}
-					const fileSize = decodedAsString.getBytes().length;
+					const fileSize = decodedBytes.length;
 					if (fileSize) attachment.size = parseInt(fileSize);
 				} catch (ex) {
 					logError(ex);

--- a/packages/ihe-gateway/server/CodeTemplates/Common Library/Write document to AWS S3 bucket/Write document to AWS S3 bucket.js
+++ b/packages/ihe-gateway/server/CodeTemplates/Common Library/Write document to AWS S3 bucket/Write document to AWS S3 bucket.js
@@ -25,7 +25,7 @@ function xcaWriteToFile(path, documentContents, metadata) {
       .metadata(meta)
       .build();
     var requestBody = Packages.software.amazon.awssdk.core.sync.RequestBody.fromBytes(
-      java.lang.String(documentContents).getBytes()
+      documentContents
     );
 
     result = client.putObject(putRequest, requestBody);


### PR DESCRIPTION
Ticket: #[1350](https://github.com/metriport/metriport-internal/issues/1350)

### Description

- patching string conversion issues resulting in messed up pdfs and tiffs. Now, we decode b64 from DocumentReference into bytes and dont touch it and then write it back into the file on s3. 
- file size computed without filtering for utf-8, since tiffs and pdfs raw bytes filled with non utf-8
- preserving the fileType determination logic since it seems like it works 

### Testing

_[Regular PRs:]_

- Local
  - [x] created identical patients in local and staging. uploaded xml, pdf, tiff to patient on staging, then did: mirth outbound -> mirthInbound PD, DQ, DRs and looked at the downloaded files in the local patients s3 bucket and all the files downloaded fine

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
- [ ] IHE gateway coordination  

