### PR TITLE
fix(api): added patient matching on the outbound pd response

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway/poll-outbound-results.ts
+++ b/packages/core/src/external/carequality/ihe-gateway/poll-outbound-results.ts
@@ -107,13 +107,13 @@ async function pollResults({
 
     if (raceResult && allGWsCompleted) {
       console.log(
-        `${raceResult}. Got ${iheGatewayResults.length} successes out of ${numOfGateways} gateways for ${resultsTable}. RequestID: ${requestId}`
+        `${raceResult}. Got ${iheGatewayResults.length} responses out of ${numOfGateways} gateways for ${resultsTable}. RequestID: ${requestId}`
       );
       raceControl.isRaceInProgress = false;
     } else if (!allGWsCompleted) {
       const msg = `IHE gateway results are incomplete.`;
       console.log(
-        `${msg}. Got ${iheGatewayResults.length} successes out of ${numOfGateways} gateways for ${resultsTable}. RequestID: ${requestId}`
+        `${msg}. Got ${iheGatewayResults.length} responses out of ${numOfGateways} gateways for ${resultsTable}. RequestID: ${requestId}`
       );
 
       capture.message(msg, {

--- a/packages/ihe-gateway-sdk/src/index.ts
+++ b/packages/ihe-gateway-sdk/src/index.ts
@@ -40,6 +40,7 @@ export {
   inboundPatientDiscoveryRespSchema,
   OutboundPatientDiscoveryResp,
   outboundPatientDiscoveryRespSchema,
+  isOutboundPDRespSuccessful,
 } from "./models/patient-discovery/patient-discovery-responses";
 export {
   BaseErrorResponse,

--- a/packages/ihe-gateway-sdk/src/models/patient-discovery/patient-discovery-responses.ts
+++ b/packages/ihe-gateway-sdk/src/models/patient-discovery/patient-discovery-responses.ts
@@ -1,14 +1,39 @@
 import * as z from "zod";
 import {
   baseResponseSchema,
+  BaseResponse,
   baseErrorResponseSchema,
   externalGatewayPatientSchema,
   XCPDGatewaySchema,
 } from "../shared";
 
+// TODO: Test that this schema is correct for the patientResource in the IHE response
+const patientSchema = z.object({
+  resourceType: z.literal("Patient"),
+  active: z.boolean(),
+  name: z.array(
+    z.object({
+      family: z.string(),
+      given: z.array(z.string()),
+    })
+  ),
+  gender: z.string(),
+  birthDate: z.string(),
+  address: z.array(
+    z.object({
+      line: z.array(z.string()),
+      city: z.string(),
+      state: z.string(),
+      postalCode: z.string(),
+      country: z.string(),
+    })
+  ),
+});
+
+export type Patient = z.infer<typeof patientSchema>;
+
 const patientDiscoveryRespSuccessfulDefaultSchema = baseResponseSchema.extend({
   patientMatch: z.literal(true),
-  patientResource: z.object({}),
   gatewayHomeCommunityId: z.string(),
 });
 
@@ -16,6 +41,7 @@ const patientDiscoveryRespSuccessfulDefaultSchema = baseResponseSchema.extend({
 const inboundPatientDiscoveryRespSuccessfulSchema =
   patientDiscoveryRespSuccessfulDefaultSchema.extend({
     patientMatchDegree: z.number().optional(),
+    patientResource: z.object({}),
     externalGatewayPatient: externalGatewayPatientSchema,
   });
 
@@ -43,8 +69,15 @@ const outboundPatientDiscoveryRespDefaultSchema = baseResponseSchema.extend({
   patientId: z.string(),
 });
 
-const outboundPatientDiscoveryRespSuccessfulSchema =
-  outboundPatientDiscoveryRespDefaultSchema.merge(patientDiscoveryRespSuccessfulDefaultSchema);
+const outboundPatientDiscoveryRespSuccessfulSchema = outboundPatientDiscoveryRespDefaultSchema
+  .merge(patientDiscoveryRespSuccessfulDefaultSchema)
+  .extend({
+    patientResource: patientSchema.optional(),
+  });
+
+export type OutboundPatientDiscoveryRespSuccessful = z.infer<
+  typeof outboundPatientDiscoveryRespSuccessfulSchema
+>;
 
 const outboundPatientDiscoveryRespFaultSchema = outboundPatientDiscoveryRespDefaultSchema.extend({
   patientMatch: z.literal(false).or(z.literal(null)),
@@ -56,3 +89,9 @@ export const outboundPatientDiscoveryRespSchema = z.union([
 ]);
 
 export type OutboundPatientDiscoveryResp = z.infer<typeof outboundPatientDiscoveryRespSchema>;
+
+export function isOutboundPDRespSuccessful(
+  obj: BaseResponse
+): obj is OutboundPatientDiscoveryRespSuccessful & { patientResource: Patient } {
+  return "patientResource" in obj;
+}


### PR DESCRIPTION
refs. metriport/metriport-internal#1350

### Description

- When PD completes, we check that the patient information from the gateways matches what we have on file for the CX patient entry to avoid cross-polination of patient data

### Testing

- Local
  - [x] Tested this with Innovar and Epic: 
     Results: 
        - Innovar returns a patient with different demos -> no match and we don't DQ them 
        - Epic returns correct demos -> match and successful DQ
  - [ ] Test with the other test partners
- Production
  - [ ] ⚠️  Run a DQ for a real patient and see if the schemas work as expected

### Release Plan

- [ ] Release NPM packages
- [ ] Merge this

