### PR TITLE
fix(ihe): handle progress when there are no results

### DIFF
--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -53,16 +53,33 @@ export async function processOutboundDocumentQueryResps({
 
     log(`I have ${docsToDownload.length} docs to download (${convertibleDocCount} convertible)`);
 
+    if (docsToDownload.length === 0) {
+      log(`No new documents to download.`);
+
+      await setDocQueryProgress({
+        patient: { id: patientId, cxId: cxId },
+        downloadProgress: { status: "completed" },
+        requestId,
+        source: MedicalDataSource.CAREQUALITY,
+      });
+
+      return;
+    }
+
     await setDocQueryProgress({
       patient: { id: patientId, cxId: cxId },
       downloadProgress: {
         status: "processing",
         total: docsToDownload.length,
       },
-      convertProgress: {
-        status: "processing",
-        total: convertibleDocCount,
-      },
+      ...(convertibleDocCount > 0
+        ? {
+            convertProgress: {
+              status: "processing",
+              total: convertibleDocCount,
+            },
+          }
+        : {}),
       requestId,
       source: MedicalDataSource.CAREQUALITY,
     });

--- a/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
@@ -29,6 +29,33 @@ export async function processOutboundDocumentRetrievalResps({
     let issuesWithGateway = 0;
     let successDocsCount = 0;
 
+    if (results.length === 0) {
+      const msg = `No results received to process.`;
+
+      log(`${msg}`);
+
+      await setDocQueryProgress({
+        patient: { id: patientId, cxId: cxId },
+        downloadProgress: { status: "completed" },
+        convertProgress: { status: "completed" },
+        requestId,
+        source: MedicalDataSource.CAREQUALITY,
+      });
+
+      capture.message(msg, {
+        extra: {
+          context: `cq.processOutboundDocumentRetrievalResps`,
+          patientId: patientId,
+          requestId,
+          cxId,
+          results,
+        },
+        level: "warning",
+      });
+
+      return;
+    }
+
     for (const docRetrievalResp of results) {
       newDocRefCount += docRetrievalResp.documentReference?.length ?? 0;
     }

--- a/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
@@ -30,18 +30,9 @@ export async function processOutboundDocumentRetrievalResps({
     let successDocsCount = 0;
 
     if (results.length === 0) {
-      const msg = `No results received to process.`;
+      const msg = `Received DR result without entries.`;
 
       log(`${msg}`);
-
-      await setDocQueryProgress({
-        patient: { id: patientId, cxId: cxId },
-        downloadProgress: { status: "completed" },
-        convertProgress: { status: "completed" },
-        requestId,
-        source: MedicalDataSource.CAREQUALITY,
-      });
-
       capture.message(msg, {
         extra: {
           context: `cq.processOutboundDocumentRetrievalResps`,
@@ -51,6 +42,14 @@ export async function processOutboundDocumentRetrievalResps({
           results,
         },
         level: "warning",
+      });
+
+      await setDocQueryProgress({
+        patient: { id: patientId, cxId: cxId },
+        downloadProgress: { status: "completed" },
+        convertProgress: { status: "completed" },
+        requestId,
+        source: MedicalDataSource.CAREQUALITY,
       });
 
       return;


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: #1350

### Dependencies

- Upstream: none
- Downstream:  none

### Description

Be able to adjust the progress status if we dont receive any results from IHE GW

### Testing

- Staging
  - [ ] Hit endpoint with no results
- Production
  - [ ] Monitor progresses

### Release Plan

- [ ] Merge this
