### PR TITLE
PATCH: set correct doc total

### DIFF
--- a/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
@@ -26,7 +26,7 @@ export async function processOutboundDocumentRetrievalResps({
   );
   try {
     let successDocsRetrievedCount = 0;
-    let issuesWithGateway = 0;
+    let issuesWithExternalGateway = 0;
 
     if (results.length === 0) {
       const msg = `Received DR result without entries.`;
@@ -58,14 +58,14 @@ export async function processOutboundDocumentRetrievalResps({
       if (docRetrievalResp.documentReference) {
         successDocsRetrievedCount += docRetrievalResp.documentReference.length;
       } else if (docRetrievalResp.operationOutcome?.issue) {
-        issuesWithGateway += docRetrievalResp.operationOutcome.issue.length;
+        issuesWithExternalGateway += docRetrievalResp.operationOutcome.issue.length;
       }
     }
 
     await setDocQueryProgress({
       patient: { id: patientId, cxId: cxId },
       downloadProgress: {
-        total: successDocsRetrievedCount + issuesWithGateway,
+        total: successDocsRetrievedCount + issuesWithExternalGateway,
         status: "processing",
       },
       convertProgress: {
@@ -107,7 +107,7 @@ export async function processOutboundDocumentRetrievalResps({
       patient: { id: patientId, cxId: cxId },
       progress: {
         successful: successDocsRetrievedCount,
-        errors: issuesWithGateway,
+        errors: issuesWithExternalGateway,
       },
       type: "download",
       requestId,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: #1350

### Dependencies

- Upstream: none
- Downstream: none 

### Description

There are 2 issues being resolved here:
- First if no results are present we set the progresses to completed but dont update the total 
- The second issue is when we tally the total for download progress were only doing so for results that return success doc refs and not the ones that errored leading to a false total.

### Testing

- Production
  - [ ] Monitor the warning messages in the alerts

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
