### PR TITLE
1350 patch xcpd failed doc progresses

### DIFF
--- a/packages/api/src/external/carequality/command/update-patient-discovery-status.ts
+++ b/packages/api/src/external/carequality/command/update-patient-discovery-status.ts
@@ -46,7 +46,7 @@ export async function updatePatientDiscoveryStatus({
       const scheduledDocQueryRequestId = getCQData(externalData)?.scheduledDocQueryRequestId;
 
       if (scheduledDocQueryRequestId) {
-        // TODO: define the data to be updated on the patient in setDocQueryProgress, so we could call it here too.
+        // TODO: define the data to be updated on the patient in setDocQueryProgress so we could call it here too.
         await setDocQueryProgress({
           patient,
           requestId: scheduledDocQueryRequestId,

--- a/packages/api/src/external/carequality/command/update-patient-discovery-status.ts
+++ b/packages/api/src/external/carequality/command/update-patient-discovery-status.ts
@@ -46,7 +46,8 @@ export async function updatePatientDiscoveryStatus({
       const scheduledDocQueryRequestId = getCQData(externalData)?.scheduledDocQueryRequestId;
 
       if (scheduledDocQueryRequestId) {
-        setDocQueryProgress({
+        // TODO: define the data to be updated on the patient in setDocQueryProgress, so we could call it here too.
+        await setDocQueryProgress({
           patient,
           requestId: scheduledDocQueryRequestId,
           source: MedicalDataSource.CAREQUALITY,

--- a/packages/api/src/external/carequality/command/update-patient-discovery-status.ts
+++ b/packages/api/src/external/carequality/command/update-patient-discovery-status.ts
@@ -43,6 +43,7 @@ export async function updatePatientDiscoveryStatus({
       docQueryRequestIdToTrigger = getCQData(externalData)?.scheduledDocQueryRequestId;
       newScheduledDocQueryRequestId = undefined;
     } else if (status === "failed") {
+      newScheduledDocQueryRequestId = getCQData(externalData)?.scheduledDocQueryRequestId;
       patientDiscoverFailed = true;
     } else {
       newScheduledDocQueryRequestId = getCQData(externalData)?.scheduledDocQueryRequestId;


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: #1350

### Dependencies

- Upstream: none
- Downstream: none

### Description

[Context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1710264483494489?thread_ts=1710262426.705439&cid=C04GEQ1GH9D) - If there is a doc progress scheduled but xcpd fails it stays in progress

### Testing

- Production
  - [ ] Monitor logs

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
