### PR TITLE
feat(patch): explictly set content type

### DIFF
--- a/packages/ihe-gateway/server/CodeTemplates/Common Library/Write document to AWS S3 bucket/Write document to AWS S3 bucket.js
+++ b/packages/ihe-gateway/server/CodeTemplates/Common Library/Write document to AWS S3 bucket/Write document to AWS S3 bucket.js
@@ -1,11 +1,3 @@
-/**
-	Writes the content of the XCA ITI-39 document to a file
-
-	@param {String} path - the file path
-	@param {String} documentContents - Base64 encoded document
-	@param {Object} metadata - file metadata
-	@return {String} return write result or error string
-*/
 function xcaWriteToFile(path, documentContents, metadata) {
   var result = null;
 
@@ -15,14 +7,21 @@ function xcaWriteToFile(path, documentContents, metadata) {
 
     // Specify file's metadata
     var meta = java.util.HashMap();
+    var contentType = "application/octet-stream"; // Default content type
     for (var key in metadata) {
-      if ("url" !== key.toString()) meta.put(key.toString(), String(metadata[key]));
+      if ("url" !== key.toString()) {
+        meta.put(key.toString(), String(metadata[key]));
+        if (key.toString() === "contentType") {
+          contentType = String(metadata[key]);
+        }
+      }
     }
 
     const putRequest = Packages.software.amazon.awssdk.services.s3.model.PutObjectRequest.builder()
       .bucket(bucketName)
       .key(path.toString())
       .metadata(meta)
+      .contentType(contentType)
       .build();
     const requestBody =
       Packages.software.amazon.awssdk.core.sync.RequestBody.fromBytes(documentContents);


### PR DESCRIPTION
Refs: #[1350](https://github.com/metriport/metriport-internal/issues/1350)

### Description

- explicitly set content type when writing to s3. 

### Testing

- Local
  - [x] tested on all different kinds of files local 

### Release Plan

- [ ] Merge this
