### PR TITLE
PATCH RELEASE Limit amount of chars on WH error details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29683,7 +29683,10 @@
     "packages/shared": {
       "name": "@metriport/shared",
       "version": "0.4.8",
-      "license": "MIT"
+      "license": "MIT",
+      "devDependencies": {
+        "@faker-js/faker": "^8.0.2"
+      }
     },
     "packages/utils": {
       "version": "1.10.8",

--- a/packages/api/src/models/_default.ts
+++ b/packages/api/src/models/_default.ts
@@ -11,6 +11,8 @@ import { BaseDomain, BaseDomainNoId } from "@metriport/core/domain/base-domain";
 import VersionMismatchError from "../errors/version-mismatch";
 import { Util } from "../shared/util";
 
+export const MAX_VARCHAR_LENGTH = 255;
+
 export type ModelSetup = (sequelize: Sequelize) => void;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,5 +50,8 @@
     "prettier-fix": "npx prettier '**/*.ts' --write",
     "test": "jest --runInBand --detectOpenHandles --passWithNoTests",
     "test:e2e": "E2E=true jest --runInBand --detectOpenHandles --passWithNoTests"
+  },
+  "devDependencies": {
+    "@faker-js/faker": "^8.0.2"
   }
 }

--- a/packages/shared/src/common/__tests__/string.test.ts
+++ b/packages/shared/src/common/__tests__/string.test.ts
@@ -1,0 +1,69 @@
+import { faker } from "@faker-js/faker";
+import { limitStringLength } from "../string";
+
+describe("limitStringLength", () => {
+  it("returns undefined when it gets undefined", async () => {
+    const resp = limitStringLength(undefined);
+    expect(resp).toBeUndefined();
+  });
+
+  it("returns empty when it gets empty", async () => {
+    const expected = "";
+    const resp = limitStringLength(expected);
+    expect(resp).toEqual(expected);
+  });
+
+  it("returns input when it gets one char string", async () => {
+    const expected = faker.string.alphanumeric(1);
+    const resp = limitStringLength(expected);
+    expect(resp).toEqual(expected);
+  });
+
+  it("returns input when it gets multiple char string", async () => {
+    const stringLength = faker.number.int({ min: 2, max: 254 });
+    const expected = faker.string.alphanumeric(stringLength);
+    const resp = limitStringLength(expected);
+    expect(resp).toEqual(expected);
+  });
+
+  it("returns input when it gets max char string", async () => {
+    const expected = faker.string.alphanumeric(255);
+    const resp = limitStringLength(expected);
+    expect(resp).toEqual(expected);
+  });
+
+  it("does not cap string if length < suffix", async () => {
+    const expected = faker.string.alphanumeric(2);
+    const resp = limitStringLength(expected, 1);
+    expect(resp).toEqual(expected);
+  });
+
+  it("caps string if length > max", async () => {
+    const expected = "123456";
+    const resp = limitStringLength(expected, 5);
+    expect(resp).not.toContain(expected);
+    expect(resp).toContain("12");
+  });
+
+  it("defaults max chars to 255", async () => {
+    const input = faker.string.alphanumeric(256);
+    const expected = input.substring(0, 252) + "...";
+    const resp = limitStringLength(input);
+    expect(resp).toEqual(expected);
+  });
+
+  it("defaults suffix to three dots", async () => {
+    const expected = "123456";
+    const resp = limitStringLength(expected, 5);
+    expect(resp).not.toContain(expected);
+    expect(resp).toContain("12...");
+  });
+
+  it("uses custom suffix when provided", async () => {
+    const expected = "123456";
+    const customSuffix = "!!!";
+    const resp = limitStringLength(expected, 5, customSuffix);
+    expect(resp).not.toContain(expected);
+    expect(resp).toContain("12" + customSuffix);
+  });
+});

--- a/packages/shared/src/common/string.ts
+++ b/packages/shared/src/common/string.ts
@@ -1,0 +1,10 @@
+export function limitStringLength(
+  value: string | undefined,
+  max = 255,
+  suffix = "..."
+): string | undefined {
+  if (!value) return value;
+  return value.length > max && value.length > suffix.length
+    ? value.substring(0, max - suffix.length) + suffix
+    : value;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,3 +6,5 @@ export { executeWithRetries, executeWithRetriesOrFail } from "./common/retry";
 export { sleep } from "./common/sleep";
 export { AtLeastOne, stringToBoolean } from "./common/types";
 export { validateNPI } from "./common/validate-npi";
+export { limitStringLength } from "./common/string";
+export { errorToString } from "./common/error";


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Description

Limit amount of chars on WH error details - [context](https://metriport.slack.com/archives/C0553DYC95L/p1710447978924019).

### Testing

- Local
  - [x] Unit test for the `limitStringLength` function
  - [x] Limits chars on WH details column if force Zod error to be stored
  - [x] Stores generic invalid payload when response is invalid
  - [x] Saves WH URL when valid
- Production
  - [ ] Saves WH URL when valid

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
