### PR TITLE
fix(api): add retries when upserting to fhir

### DIFF
--- a/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
@@ -274,7 +274,7 @@ async function handleDocReferences(
     }
   }
 
-  await upsertDocumentsToFHIRServer(cxId, transactionBundle);
+  await upsertDocumentsToFHIRServer(cxId, transactionBundle, log);
 
   await setDocQueryProgress({
     patient: { id: patientId, cxId: cxId },

--- a/packages/api/src/external/fhir/document/save-document-reference.ts
+++ b/packages/api/src/external/fhir/document/save-document-reference.ts
@@ -1,6 +1,10 @@
 import { DocumentReference, Bundle } from "@medplum/fhirtypes";
+import { executeWithRetriesOrFail } from "@metriport/shared";
 import { errorToString } from "../../../shared/log";
 import { makeFhirApi } from "../api/api-factory";
+
+const NUM_RETRIES = 3;
+const WAIT_TIME = 1000;
 
 export const upsertDocumentToFHIRServer = async (
   cxId: string,
@@ -9,10 +13,16 @@ export const upsertDocumentToFHIRServer = async (
 ): Promise<void> => {
   const fhir = makeFhirApi(cxId);
   try {
-    await fhir.updateResource({
-      id: docRef.id,
-      ...docRef,
-    });
+    await executeWithRetriesOrFail(
+      async () =>
+        await fhir.updateResource({
+          id: docRef.id,
+          ...docRef,
+        }),
+      NUM_RETRIES,
+      WAIT_TIME,
+      log
+    );
   } catch (err) {
     log(`Error upserting the doc ref on FHIR server: ${docRef.id} - ${errorToString(err)}`);
     throw err;
@@ -21,8 +31,18 @@ export const upsertDocumentToFHIRServer = async (
 
 export const upsertDocumentsToFHIRServer = async (
   cxId: string,
-  transactionBundle: Bundle
+  transactionBundle: Bundle,
+  log = console.log
 ): Promise<void> => {
   const fhir = makeFhirApi(cxId);
-  await fhir.executeBatch(transactionBundle);
+  try {
+    await executeWithRetriesOrFail(
+      async () => await fhir.executeBatch(transactionBundle),
+      NUM_RETRIES,
+      WAIT_TIME
+    );
+  } catch (error) {
+    log(`Error executing batch for the doc ref bundle on FHIR server: ${errorToString(error)}`);
+    throw error;
+  }
 };

--- a/packages/api/src/external/fhir/document/save-document-reference.ts
+++ b/packages/api/src/external/fhir/document/save-document-reference.ts
@@ -39,7 +39,8 @@ export const upsertDocumentsToFHIRServer = async (
     await executeWithRetriesOrFail(
       async () => await fhir.executeBatch(transactionBundle),
       NUM_RETRIES,
-      WAIT_TIME
+      WAIT_TIME,
+      log
     );
   } catch (error) {
     log(`Error executing batch for the doc ref bundle on FHIR server: ${errorToString(error)}`);

--- a/packages/api/src/external/fhir/document/save-document-reference.ts
+++ b/packages/api/src/external/fhir/document/save-document-reference.ts
@@ -3,8 +3,8 @@ import { executeWithRetriesOrFail } from "@metriport/shared";
 import { errorToString } from "../../../shared/log";
 import { makeFhirApi } from "../api/api-factory";
 
-const NUM_RETRIES = 3;
-const WAIT_TIME = 1000;
+const NUM_RETRIES = 5;
+const WAIT_TIME = 200;
 
 export const upsertDocumentToFHIRServer = async (
   cxId: string,
@@ -14,11 +14,7 @@ export const upsertDocumentToFHIRServer = async (
   const fhir = makeFhirApi(cxId);
   try {
     await executeWithRetriesOrFail(
-      async () =>
-        await fhir.updateResource({
-          id: docRef.id,
-          ...docRef,
-        }),
+      async () => await fhir.updateResource(docRef),
       NUM_RETRIES,
       WAIT_TIME,
       log


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: https://github.com/metriport/metriport-internal/issues/1561

### Dependencies

- Upstream: none
- Downstream: none

### Description

Add retries when upserting to FHIR

### Testing

- Local
  - [x] Able to upload to FHIR
- Staging
  - [X] Able to upload to FHIR
- Production
  - [ ] Monitor logs

### Release Plan

- [ ] Merge this
