### PR TITLE
1350 Add index on patient DOB

### DIFF
--- a/packages/api/src/sequelize/migrations/2024-03-19_00_alter-patient-add-index-dob-gender.ts
+++ b/packages/api/src/sequelize/migrations/2024-03-19_00_alter-patient-add-index-dob-gender.ts
@@ -1,0 +1,23 @@
+import { Sequelize } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "patient";
+const indexName = "patient_dob_index";
+
+// Use 'Promise.all' when changes are independent of each other
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    // https://github.com/sequelize/sequelize/issues/5155#issuecomment-417189558
+    await queryInterface.addIndex(tableName, {
+      name: indexName,
+      fields: [Sequelize.literal("((data->>'dob'))")],
+      transaction,
+    });
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.removeIndex(tableName, indexName, { transaction });
+  });
+};

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -175,6 +175,7 @@ export class APIStack extends Stack {
         vpc: this.vpc,
         instanceType: new InstanceType("serverless"),
         enablePerformanceInsights: true,
+        parameterGroup,
       },
       credentials: dbCreds,
       defaultDatabaseName: dbName,

--- a/packages/infra/lib/ihe-stack/ihe-db-construct.ts
+++ b/packages/infra/lib/ihe-stack/ihe-db-construct.ts
@@ -61,6 +61,7 @@ export default class IHEDBConstruct extends Construct {
         vpc,
         instanceType: new ec2.InstanceType("serverless"),
         enablePerformanceInsights: true,
+        parameterGroup,
       },
       credentials: dbCreds,
       defaultDatabaseName: dbName,


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1350

### Dependencies

none

### Description

- Add index on patient DOB
- Add access log to API GW
- Set param group on DB instances too (was only setting on the cluster)

#### DB Index data

Amount of records on patient table: `200,025` records

Query

```sql
SELECT "id", "created_at" AS "createdAt", "updated_at" AS "updatedAt", "version", "cx_id" AS "cxId",
       "facility_ids" AS "facilityIds", "external_id" AS "externalId", "data", "created_at", "updated_at" 
FROM "patient" AS "PatientModel" WHERE (data->>'dob' = '1999-10-30');
```

Without index

<img width="1184" alt="image" src="https://github.com/metriport/metriport/assets/2132564/1ee74491-eb11-4eca-91bb-e0245b48bea1">


With index

<img width="1184" alt="image" src="https://github.com/metriport/metriport/assets/2132564/409a06dd-b311-4d98-b4a8-4083950d3502">


### Testing

- Local
  - [x] MPI query uses the patient's DOB index
- Staging
  - [ ] App working fine w/ DB
  - [ ] OSS DB instances w/ new, dedicated param group
  - [ ] IHE GHW DB instances w/ new, dedicated param group
  - [ ] API Gateway logs populated as we access the API
- Sandbox
  - [ ] App working fine w/ DB
- Production
  - [ ] App working fine w/ DB
  - [ ] OSS DB instances w/ new, dedicated param group
  - [ ] IHE GHW DB instances w/ new, dedicated param group
  - [ ] API Gateway logs populated as we access the API

### Release Plan

- :warning: This contains a DB migration
- [ ] Merge this
