### PR TITLE
1350 scheduled directory rebuilder

### DIFF
--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -118,6 +118,9 @@ export type EnvConfig = {
      */
     scheduleExpressions: string | string[];
   };
+  cqDirectoryRebuilder?: {
+    scheduleExpressions: string | string[];
+  };
 } & (
   | {
       environmentType: EnvType.staging | EnvType.production;

--- a/packages/infra/lib/api-stack/cq-directory-rebuilder.ts
+++ b/packages/infra/lib/api-stack/cq-directory-rebuilder.ts
@@ -34,7 +34,7 @@ function getSettings(
 
 export function createCqDirectoryRebuilder(props: CqDirectoryRebuilderProps): Lambda | undefined {
   const config = getConfig();
-  if (!config.docQueryChecker) return;
+  if (!config.cqDirectoryRebuilder) return;
 
   const {
     stack,
@@ -48,7 +48,7 @@ export function createCqDirectoryRebuilder(props: CqDirectoryRebuilderProps): La
     scheduleExpression,
     url,
     httpTimeout,
-  } = getSettings(props, config.docQueryChecker);
+  } = getSettings(props, config.cqDirectoryRebuilder);
 
   const lambda = createScheduledLambda({
     stack,

--- a/packages/infra/lib/api-stack/cq-directory-rebuilder.ts
+++ b/packages/infra/lib/api-stack/cq-directory-rebuilder.ts
@@ -1,0 +1,72 @@
+import { Duration } from "aws-cdk-lib";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { IVpc } from "aws-cdk-lib/aws-ec2";
+import { Function as Lambda, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+import { EnvConfig } from "../../config/env-config";
+import { getConfig } from "../shared/config";
+import { LambdaLayers } from "../shared/lambda-layers";
+import { createScheduledLambda } from "../shared/lambda-scheduled";
+
+export type CqDirectoryRebuilderProps = {
+  stack: Construct;
+  lambdaLayers: LambdaLayers;
+  vpc: IVpc;
+  apiAddress: string;
+  alarmSnsAction?: SnsAction;
+};
+
+function getSettings(
+  props: CqDirectoryRebuilderProps,
+  config: NonNullable<EnvConfig["cqDirectoryRebuilder"]>
+) {
+  return {
+    ...props,
+    name: "ScheduledCqDirectoryRebuilder",
+    lambdaMemory: 256,
+    lambdaTimeout: Duration.seconds(900), // How long can the lambda run for, max is 900 seconds (15 minutes)
+    runtime: Runtime.NODEJS_18_X,
+    scheduleExpression: config.scheduleExpressions, // See: https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html
+    url: `http://${props.apiAddress}/internal/carequality/directory/rebuild`,
+    httpTimeout: Duration.seconds(3),
+  };
+}
+
+export function createCqDirectoryRebuilder(props: CqDirectoryRebuilderProps): Lambda | undefined {
+  const config = getConfig();
+  if (!config.docQueryChecker) return;
+
+  const {
+    stack,
+    lambdaLayers,
+    vpc,
+    runtime,
+    alarmSnsAction,
+    name,
+    lambdaMemory,
+    lambdaTimeout,
+    scheduleExpression,
+    url,
+    httpTimeout,
+  } = getSettings(props, config.docQueryChecker);
+
+  const lambda = createScheduledLambda({
+    stack,
+    layers: [lambdaLayers.shared],
+    name,
+    vpc,
+    scheduleExpression,
+    url,
+    runtime,
+    memory: lambdaMemory,
+    timeout: lambdaTimeout,
+    alarmSnsAction,
+    envType: config.environmentType,
+    envVars: {
+      TIMEOUT_MILLIS: String(httpTimeout.toMilliseconds()),
+      ...(config.lambdasSentryDSN ? { SENTRY_DSN: config.lambdasSentryDSN } : {}),
+    },
+  });
+
+  return lambda;
+}

--- a/packages/infra/lib/api-stack/cq-directory-rebuilder.ts
+++ b/packages/infra/lib/api-stack/cq-directory-rebuilder.ts
@@ -1,7 +1,7 @@
 import { Duration } from "aws-cdk-lib";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import { IVpc } from "aws-cdk-lib/aws-ec2";
-import { Function as Lambda, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Function as Lambda } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import { EnvConfig } from "../../config/env-config";
 import { getConfig } from "../shared/config";
@@ -24,11 +24,10 @@ function getSettings(
     ...props,
     name: "ScheduledCqDirectoryRebuilder",
     lambdaMemory: 256,
-    lambdaTimeout: Duration.seconds(900), // How long can the lambda run for, max is 900 seconds (15 minutes)
-    runtime: Runtime.NODEJS_18_X,
+    lambdaTimeout: Duration.seconds(60), // How long can the lambda run for, max is 900 seconds (15 minutes)
     scheduleExpression: config.scheduleExpressions, // See: https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html
     url: `http://${props.apiAddress}/internal/carequality/directory/rebuild`,
-    httpTimeout: Duration.seconds(3),
+    httpTimeout: Duration.seconds(5),
   };
 }
 
@@ -40,7 +39,6 @@ export function createCqDirectoryRebuilder(props: CqDirectoryRebuilderProps): La
     stack,
     lambdaLayers,
     vpc,
-    runtime,
     alarmSnsAction,
     name,
     lambdaMemory,
@@ -57,7 +55,6 @@ export function createCqDirectoryRebuilder(props: CqDirectoryRebuilderProps): La
     vpc,
     scheduleExpression,
     url,
-    runtime,
     memory: lambdaMemory,
     timeout: lambdaTimeout,
     alarmSnsAction,


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1350

### Dependencies
- Upstream: https://github.com/metriport/metriport-internal/pull/1623

### Description

- Added a scheduled lambda to rebuild the CQ directory in Prod on a daily basis (at 10pm)

### Testing
- Staging
  - [ ] Made sure that the lambda was triggered and successfully rebuilt the cq directory

### Release Plan
- [ ] Upstream dependencies are met
- [ ] Merge this
