### PR TITLE
Patching Regex Issues on Inbound DQ

### DIFF
--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-38 Inbound Interface/sourceConnector-transformer-step-4-get-query-parameters.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-38 Inbound Interface/sourceConnector-transformer-step-4-get-query-parameters.js
@@ -8,7 +8,8 @@ try {
 	var namespaces = msg.namespaceDeclarations();
 	namespaces = namespaces.concat(queryRequest.namespaceDeclarations());
 
-	queryRequest = String(queryRequest).replace(/xmlns(?:.*?)?=\".*?\"/g, '');
+	var regexNamespaces = RegExp('xmlns="[^"]*"(?=[^<>]*>)', "g");
+	queryRequest = String(queryRequest).replace(regexNamespaces, '');
 
 	namespaces.forEach(function(entry) {
 		var regex = new RegExp(entry.prefix + ':', "g");
@@ -23,6 +24,11 @@ try {
 	if ('ObjectRef' == payload.ResponseOption.@returnType) channelMap.put('OBJECTREF', true);
 
 	request.id = payload.@id.toString()
+	if (!request.id) {
+		var msgId = msg.*::Header.*::MessageID.toString();
+		msgId = msgId.replace(/^urn:uuid:/, '');
+		request.id = msgId;
+	}
 	request.timestamp = DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss");
 	request.samlAttributes = saml;
 


### PR DESCRIPTION
Refs: #[1350](https://github.com/metriport/metriport-internal/issues/1350)

### Description

- regex on xml to remove namespaces was removing more than the namespace, causing invalid xml 
- added logic to get msgId from the header if it doesnt exist where its supposed to be in the body too 

### Testing

- Local
  - [x] reproed error and got working with patch + staging lambdas


### Release Plan

- :warning: Points to `master`
- [ ] Merge this
