### PR TITLE
Missing Namespace on Inbound DQ

### DIFF
--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-38 Inbound Interface/sourceConnector-transformer-step-4-get-query-parameters.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-38 Inbound Interface/sourceConnector-transformer-step-4-get-query-parameters.js
@@ -7,6 +7,7 @@ try {
 	// Remove namespaces
 	var namespaces = msg.namespaceDeclarations();
 	namespaces = namespaces.concat(queryRequest.namespaceDeclarations());
+	namespaces = namespaces.concat(queryRequest.*::AdhocQuery.namespaceDeclarations());
 
 	var regexNamespaces = RegExp('xmlns="[^"]*"(?=[^<>]*>)', "g");
 	queryRequest = String(queryRequest).replace(regexNamespaces, '');

--- a/packages/ihe-gateway/server/CodeTemplates/XCA Library - Inbound/Process XCA ITI-38 AdhocQueryRequest/Process XCA ITI-38 AdhocQueryRequest.js
+++ b/packages/ihe-gateway/server/CodeTemplates/XCA Library - Inbound/Process XCA ITI-38 AdhocQueryRequest/Process XCA ITI-38 AdhocQueryRequest.js
@@ -28,7 +28,7 @@ function getAdhocQueryRequestOptionFn() {
 				// First, decode any HTML entities
 				var decodedValue = slot.ValueList.Value.toString().replace(/&amp;/g, "&");
 				// Then, remove unwanted characters
-				var cleanedValue = decodedValue.replace(/['"]/g, "");
+				var cleanedValue = decodedValue.replace(/['"]/g, "").trim();
 				// Split by '^', expecting the format to be id^^^system&000&ISO
 				var parts = cleanedValue.split("^");
 				var id = parts[0];


### PR DESCRIPTION
Refs: #[1350](https://github.com/metriport/metriport-internal/issues/1350)

### Description

- Inbound DQs errored because we weren't replacing all namespaces, and so the AdHocQuery slots werent getting pulled into the lambda request, so the lambda request was missing the patientID, and it was throwing errors. 
- the patient Id also had a newline infront of it causing other errors. 
- [context](https://metriport.slack.com/archives/C04T256DQPQ/p1710977023609959)

### Testing

- Local
  - [x] local + lambda on staging 

### Release Plan

- [ ] Merge this
