### PR TITLE
PATCH RELEASE 1631 Filter out not ready docrefs

### DIFF
--- a/packages/api/src/external/fhir/document/index.ts
+++ b/packages/api/src/external/fhir/document/index.ts
@@ -58,9 +58,26 @@ const authorTypesMap: Record<AuthorTypes["resourceType"], AuthorTypes["resourceT
 };
 const authorTypes = Object.values(authorTypesMap);
 
+export function isDocStatusReady(doc: DocumentReference): boolean {
+  return !isDocStatusPreliminary(doc) && !isDocStatusEnteredInError(doc);
+}
+export function isDocStatusFinal(doc: DocumentReference): boolean {
+  return doc.docStatus === "final";
+}
+export function isDocStatusAmended(doc: DocumentReference): boolean {
+  return doc.docStatus === "amended";
+}
+export function isDocStatusPreliminary(doc: DocumentReference): boolean {
+  return doc.docStatus === "preliminary";
+}
+export function isDocStatusEnteredInError(doc: DocumentReference): boolean {
+  return doc.docStatus === "entered-in-error";
+}
+
 // HIEs probably don't have records before the year 1800 :)
 const earliestPossibleYear = 1800;
 
+// TODO move to external/commonwell/document
 export function getBestDateFromCWDocRef(content: DocumentContent): string {
   const date = dayjs(content.indexed);
   const period = content.context.period;

--- a/packages/api/src/external/fhir/document/search-documents.ts
+++ b/packages/api/src/external/fhir/document/search-documents.ts
@@ -1,8 +1,9 @@
 import { DocumentReference } from "@medplum/fhirtypes";
-import { uniqBy } from "lodash";
-import { isMetriportExtension } from "@metriport/core/external/fhir/shared/extensions/metriport";
 import { isCarequalityExtension } from "@metriport/core/external/carequality/extension";
 import { isCommonwellExtension } from "@metriport/core/external/commonwell/extension";
+import { isMetriportExtension } from "@metriport/core/external/fhir/shared/extensions/metriport";
+import { uniqBy } from "lodash";
+import { isDocStatusReady } from ".";
 import { Config } from "../../../shared/config";
 import { capture } from "../../../shared/notifications";
 import { makeSearchServiceQuery } from "../../opensearch/file-search-connector-factory";
@@ -34,7 +35,8 @@ export async function searchDocuments({
   }
 
   const unique = uniqBy(success, "id");
-  return unique;
+  const ready = unique.filter(isDocStatusReady);
+  return ready;
 }
 
 async function searchOnDocumentReferences(


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1631

### Dependencies

none

### Description

- Filter out not ready docrefs

### Testing

- Local
  - [x] filter out doc refs w/ `docStatus` preliminary
  - [x] returns doc refs that are ready

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
