### PR TITLE
Downgrading CW CQ Duplicates

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
@@ -42,6 +42,18 @@ export async function getOrganizationsWithXCPD(): Promise<CQDirectoryEntryModel[
   });
 }
 
+export async function getCQDirectoryEntryById(
+  id: string | undefined
+): Promise<CQDirectoryEntryModel | undefined> {
+  if (!id) return undefined;
+  const result = await CQDirectoryEntryModel.findOne({
+    where: {
+      id: id,
+    },
+  });
+  return result ?? undefined;
+}
+
 export async function getRecordLocatorServiceOrganizations(): Promise<CQDirectoryEntryModel[]> {
   const rls: CQDirectoryEntryModel[] = await CQDirectoryEntryModel.findAll({
     where: {

--- a/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
@@ -42,18 +42,6 @@ export async function getOrganizationsWithXCPD(): Promise<CQDirectoryEntryModel[
   });
 }
 
-export async function getCQDirectoryEntryById(
-  id: string | undefined
-): Promise<CQDirectoryEntryModel | undefined> {
-  if (!id) return undefined;
-  const result = await CQDirectoryEntryModel.findOne({
-    where: {
-      id: id,
-    },
-  });
-  return result ?? undefined;
-}
-
 export async function getRecordLocatorServiceOrganizations(): Promise<CQDirectoryEntryModel[]> {
   const rls: CQDirectoryEntryModel[] = await CQDirectoryEntryModel.findAll({
     where: {

--- a/packages/api/src/external/carequality/command/cq-directory/get-organizations-for-xcpd.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/get-organizations-for-xcpd.ts
@@ -16,7 +16,7 @@ function sortOrgsByNearbyOrder(orgs: CQDirectoryEntryModel[], orderMap: Map<stri
 }
 
 export async function getAllCQOrgsIds(): Promise<Set<string>> {
-  const orgs = await Promise.all([getOrganizationsWithXCPD()]);
+  const orgs = await getOrganizationsWithXCPD();
   const orgsFlat: CQDirectoryEntryModel[] = orgs.flat();
   const orgsSet: Set<string> = new Set();
   orgsFlat.forEach(org => {

--- a/packages/api/src/external/carequality/command/cq-directory/get-organizations-for-xcpd.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/get-organizations-for-xcpd.ts
@@ -3,6 +3,7 @@ import {
   getRecordLocatorServiceOrganizations,
   getStandaloneOrganizations,
   getSublinkOrganizations,
+  getOrganizationsWithXCPD,
 } from "./cq-gateways";
 
 function sortOrgsByNearbyOrder(orgs: CQDirectoryEntryModel[], orderMap: Map<string, number>) {
@@ -12,6 +13,16 @@ function sortOrgsByNearbyOrder(orgs: CQDirectoryEntryModel[], orderMap: Map<stri
 
     return orderA - orderB;
   });
+}
+
+export async function getAllCQOrgsIds(): Promise<Set<string>> {
+  const orgs = await Promise.all([getOrganizationsWithXCPD()]);
+  const orgsFlat: CQDirectoryEntryModel[] = orgs.flat();
+  const orgsSet: Set<string> = new Set();
+  orgsFlat.forEach(org => {
+    orgsSet.add(org.id);
+  });
+  return orgsSet;
 }
 
 export async function getOrganizationsForXCPD(

--- a/packages/api/src/external/commonwell/admin/patch-patient-duplicates.ts
+++ b/packages/api/src/external/commonwell/admin/patch-patient-duplicates.ts
@@ -22,7 +22,8 @@ export async function patchDuplicatedPersonsForPatient(
   cxId: string,
   patientId: string,
   chosenPersonId: string,
-  unenrollByDemographics = false
+  unenrollByDemographics = false,
+  orgIdExcludeList: Set<string>
 ): Promise<void> {
   const context = "patchDuplicatedPersonsForPatient";
   const { log } = Util.out(`${context} ${patientId}`);
@@ -57,7 +58,14 @@ export async function patchDuplicatedPersonsForPatient(
   // link the chosen person to the patient...
   await commonWell.addPatientLink(queryMeta, chosenPersonId, cwPatientUri);
   // ...and upgrade the network links w/ that person's patients
-  await autoUpgradeNetworkLinks(commonWell, queryMeta, cwPatientId, chosenPersonId, context);
+  await autoUpgradeNetworkLinks(
+    commonWell,
+    queryMeta,
+    cwPatientId,
+    chosenPersonId,
+    context,
+    orgIdExcludeList
+  );
 
   // update Metriport's DB
   await setCommonwellId({

--- a/packages/api/src/external/commonwell/admin/recreate-patients-at-hies.ts
+++ b/packages/api/src/external/commonwell/admin/recreate-patients-at-hies.ts
@@ -9,6 +9,7 @@ import { makeCommonWellAPI } from "../api";
 import { create, getCWData } from "../patient";
 import { getPatientData } from "../patient-shared";
 import { isCWEnabledForCx } from "../../aws/appConfig";
+import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
 
 export type RecreateResultOfPatient = {
   originalCWPatientId: string | undefined;
@@ -102,9 +103,11 @@ export async function recreatePatientAtCW(
     const commonWell = makeCommonWellAPI(orgName, oid(orgOID));
     const queryMeta = organizationQueryMeta(orgName, { npi: facilityNPI });
 
+    const orgIdExcludeList = await getAllCQOrgsIds();
+
     // create new patient, including linkint to person and network link to other patients
     log(`Creating new patient at CW...`);
-    const cwIds = await create(patient, facilityId, {
+    const cwIds = await create(patient, facilityId, orgIdExcludeList, {
       organization,
       facility,
     });

--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-api-local.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-api-local.ts
@@ -20,11 +20,15 @@ const WAIT_BETWEEN_LINKING_AND_DOC_QUERY = dayjs.duration({ seconds: 30 });
  * the API.
  */
 export class CoverageEnhancerApiLocal extends CoverageEnhancerLocal {
-  constructor(cwManagementApi: CommonWellManagementAPI, prefix?: string | undefined) {
+  constructor(
+    cwManagementApi: CommonWellManagementAPI,
+    orgIdExcludeList: Set<string>,
+    prefix?: string | undefined
+  ) {
     super(
       cwManagementApi,
       new PatientLoaderLocal(),
-      new PatientUpdaterCommonWell(),
+      new PatientUpdaterCommonWell(orgIdExcludeList),
       new ECUpdaterLocal(),
       capture,
       prefix

--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-factory.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-factory.ts
@@ -17,6 +17,7 @@ export function makeCoverageEnhancer(): CoverageEnhancer | undefined {
   }
   const cookieManager = new CookieManagerOnSecrets(cookieArn, Config.getAWSRegion());
   const cwManagementApi = makeApi({ cookieManager, baseUrl: cwManagementUrl });
+  // #TODO we are passing an empty exclude list to accelerate development. All this code should be deprecated soon anyway and this shouldnt be a problem.
   const orgIdExcludeList = new Set<string>();
   return new CoverageEnhancerApiLocal(cwManagementApi, orgIdExcludeList);
 }

--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-factory.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-factory.ts
@@ -17,5 +17,6 @@ export function makeCoverageEnhancer(): CoverageEnhancer | undefined {
   }
   const cookieManager = new CookieManagerOnSecrets(cookieArn, Config.getAWSRegion());
   const cwManagementApi = makeApi({ cookieManager, baseUrl: cwManagementUrl });
-  return new CoverageEnhancerApiLocal(cwManagementApi);
+  const orgIdExcludeList = new Set<string>();
+  return new CoverageEnhancerApiLocal(cwManagementApi, orgIdExcludeList);
 }

--- a/packages/api/src/external/commonwell/link/create.ts
+++ b/packages/api/src/external/commonwell/link/create.ts
@@ -15,7 +15,8 @@ export const create = async (
   personId: string,
   patientId: string,
   cxId: string,
-  facilityId: string
+  facilityId: string,
+  orgIdExcludeList: Set<string>
 ): Promise<void> => {
   if (!(await isCWEnabledForCx(cxId))) {
     console.log(`CW is disabled for cxId: ${cxId}`);
@@ -71,7 +72,14 @@ export const create = async (
       throw new Error("Link has no href");
     }
 
-    await autoUpgradeNetworkLinks(commonWell, queryMeta, cwPatientId, personId, context);
+    await autoUpgradeNetworkLinks(
+      commonWell,
+      queryMeta,
+      cwPatientId,
+      personId,
+      context,
+      orgIdExcludeList
+    );
   } catch (error) {
     const msg = `Failed to create CW person link`;
     console.log(`${msg}. Cause: ${error}`);

--- a/packages/api/src/external/commonwell/link/shared.ts
+++ b/packages/api/src/external/commonwell/link/shared.ts
@@ -87,13 +87,13 @@ export async function autoUpgradeNetworkLinks(
       .flatMap(filterTruthy)
       .filter(isLOLA2 || isLOLA3);
 
-    console.log(`lola1Links: ${JSON.stringify(lola1Links, null, 2)}`);
-    console.log(`lola2or3Links: ${JSON.stringify(lola2or3Links, null, 2)}`);
+    console.log(`lola1Links: ${JSON.stringify(lola1Links)}`);
+    console.log(`lola2or3Links: ${JSON.stringify(lola2or3Links)}`);
     const lola2or3LinksToDowngrade = lola2or3Links.filter(link =>
       isInsideOrgExcludeList(link, orgIdExcludeList)
     );
     const downgradeRequests: Promise<NetworkLink>[] = [];
-    console.log(`lola2or3LinksToDowngrade: ${JSON.stringify(lola2or3LinksToDowngrade, null, 2)}`);
+    console.log(`lola2or3LinksToDowngrade: ${JSON.stringify(lola2or3LinksToDowngrade)}`);
     lola2or3LinksToDowngrade.forEach(async link => {
       if (link._links?.downgrade?.href) {
         downgradeRequests.push(
@@ -133,7 +133,7 @@ export async function autoUpgradeNetworkLinks(
       link => !isInsideOrgExcludeList(link, orgIdExcludeList)
     );
     const upgradeRequests: Promise<NetworkLink>[] = [];
-    console.log(`lola1LinksToUpgrade: ${JSON.stringify(lola1LinksToUpgrade, null, 2)}`);
+    console.log(`lola1LinksToUpgrade: ${JSON.stringify(lola1LinksToUpgrade)}`);
     lola1LinksToUpgrade.forEach(async link => {
       if (link._links?.upgrade?.href) {
         upgradeRequests.push(

--- a/packages/api/src/external/commonwell/link/shared.ts
+++ b/packages/api/src/external/commonwell/link/shared.ts
@@ -60,7 +60,7 @@ async function shouldDowngradeLink(link: NetworkLink): Promise<boolean> {
   return results.includes(true); // true if any of the checks are true
 }
 
-async function assessCWCQDuplicatesAndDowngrade(
+async function assessIfCWCQDuplicatesAndDowngrade(
   link: NetworkLink,
   commonWell: CommonWellAPI,
   queryMeta: RequestMetadata,
@@ -118,7 +118,7 @@ export async function autoUpgradeNetworkLinks(
       .filter(isLOLA2 || isLOLA3);
 
     const downgradeRequests: Promise<NetworkLink | undefined>[] = lola2or3Links.map(link =>
-      assessCWCQDuplicatesAndDowngrade(
+      assessIfCWCQDuplicatesAndDowngrade(
         link,
         commonWell,
         queryMeta,

--- a/packages/api/src/external/commonwell/link/shared.ts
+++ b/packages/api/src/external/commonwell/link/shared.ts
@@ -18,6 +18,8 @@ import { filterTruthy } from "../../../shared/filter-map-utils";
 import { capture } from "../../../shared/notifications";
 import { PatientDataCommonwell } from "../patient-shared";
 
+const urnOidRegex = /^urn:oid:/;
+
 export const commonwellPersonLinks = (persons: Person[]): Person[] => {
   return persons.flatMap<Person>(filterTruthy);
 };
@@ -49,7 +51,7 @@ export function patientWithCWData(
 function isInsideOrgExcludeList(link: NetworkLink, orgIdExcludeList: Set<string>): boolean {
   const identifiers = link.patient?.identifier || [];
   return identifiers.some(id => {
-    const idSystem = id.system?.replace(/^urn:oid:/, "");
+    const idSystem = id.system?.replace(urnOidRegex, "");
     if (idSystem && orgIdExcludeList.has(idSystem)) {
       console.log(`OrgID ${idSystem} is in the exclude list.`);
       return true;
@@ -115,7 +117,7 @@ export async function autoUpgradeNetworkLinks(
       } else {
         capture.message(`Missing downgrade link for network link`, {
           extra: {
-            link: JSON.stringify(link, null, 2),
+            link: link,
             commonwellPatientId,
             commonwellPersonId,
             context: executionContext,

--- a/packages/api/src/external/commonwell/link/shared.ts
+++ b/packages/api/src/external/commonwell/link/shared.ts
@@ -85,6 +85,8 @@ export async function autoUpgradeNetworkLinks(
       .flatMap(filterTruthy)
       .filter(isLOLA2 || isLOLA3);
 
+    console.log(`lola1Links: ${JSON.stringify(lola1Links, null, 2)}`);
+    console.log(`lola2or3Links: ${JSON.stringify(lola2or3Links, null, 2)}`);
     const lola2or3LinksToDowngrade = lola2or3Links.filter(link =>
       isInsideOrgExcludeList(link, orgIdExcludeList)
     );
@@ -129,6 +131,7 @@ export async function autoUpgradeNetworkLinks(
       link => !isInsideOrgExcludeList(link, orgIdExcludeList)
     );
     const upgradeRequests: Promise<NetworkLink>[] = [];
+    console.log(`lola1LinksToUpgrade: ${JSON.stringify(lola1LinksToUpgrade, null, 2)}`);
     lola1LinksToUpgrade.forEach(async link => {
       if (link._links?.upgrade?.href) {
         upgradeRequests.push(

--- a/packages/api/src/external/commonwell/patient-updater-commonwell.ts
+++ b/packages/api/src/external/commonwell/patient-updater-commonwell.ts
@@ -13,6 +13,13 @@ const maxNumberOfParallelRequestsToCW = 10;
  * Implementation of the PatientUpdater that executes the logic on CommonWell.
  */
 export class PatientUpdaterCommonWell extends PatientUpdater {
+  private orgIdExcludeList: Set<string>;
+
+  constructor(orgIdExcludeList: Set<string>) {
+    super();
+    this.orgIdExcludeList = orgIdExcludeList;
+  }
+
   public async updateAll(
     cxId: string,
     patientIds?: string[]
@@ -27,7 +34,8 @@ export class PatientUpdaterCommonWell extends PatientUpdater {
     const updatePatient = async (patient: Patient) => {
       try {
         const facilityId = getFacilityIdOrFail(patient);
-        await cwCommands.patient.update(patient, facilityId);
+        // Use the cqOrgs from the constructor instead of fetching them here
+        await cwCommands.patient.update(patient, facilityId, this.orgIdExcludeList);
       } catch (error) {
         failedUpdateCount++;
         const msg = `Failed to update CW patient`;

--- a/packages/api/src/external/commonwell/patient-updater-commonwell.ts
+++ b/packages/api/src/external/commonwell/patient-updater-commonwell.ts
@@ -34,7 +34,6 @@ export class PatientUpdaterCommonWell extends PatientUpdater {
     const updatePatient = async (patient: Patient) => {
       try {
         const facilityId = getFacilityIdOrFail(patient);
-        // Use the cqOrgs from the constructor instead of fetching them here
         await cwCommands.patient.update(patient, facilityId, this.orgIdExcludeList);
       } catch (error) {
         failedUpdateCount++;


### PR DESCRIPTION
Refs: #[1608](https://github.com/metriport/metriport-internal/issues/1608)

### Description

- filter out duplicates with fast DB lookups of CQ directory entries using the id index + downgrading links


### Testing

- prod

### Release Plan

- [ ] Merge this
- [ ] Because CW integration env is down, this will need to be tested on prod using FFs
- [ ] TODO: Follow on PR to remove logs once tested in Prod
