### PR TITLE
fix(api): process subsequent pd results

### DIFF
--- a/packages/api/src/external/carequality/command/outbound-resp/get-outbound-patient-discovery-resp.ts
+++ b/packages/api/src/external/carequality/command/outbound-resp/get-outbound-patient-discovery-resp.ts
@@ -1,0 +1,11 @@
+import { OutboundPatientDiscoveryRespModel } from "../../models/outbound-patient-discovery-resp";
+
+export async function getOutboundPatientDiscoveryResp(
+  requestId: string
+): Promise<OutboundPatientDiscoveryRespModel[]> {
+  return await OutboundPatientDiscoveryRespModel.findAll({
+    where: {
+      requestId,
+    },
+  });
+}

--- a/packages/api/src/external/carequality/process-subsequent-outbound-patient-discovery-resps.ts
+++ b/packages/api/src/external/carequality/process-subsequent-outbound-patient-discovery-resps.ts
@@ -1,0 +1,67 @@
+import { out } from "@metriport/core/util/log";
+import { Patient } from "@metriport/core/domain/patient";
+import { capture } from "@metriport/core/util/notifications";
+import { errorToString } from "@metriport/shared/common/error";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import { makeOutboundResultPoller } from "../ihe-gateway/outbound-result-poller-factory";
+import { updatePatientDiscoveryStatus } from "./command/update-patient-discovery-status";
+import { getCQData } from "./patient";
+import { getPatientOrFail } from "../../command/medical/patient/get-patient";
+import { gatherXCPDGateways } from "./patient";
+import { getOutboundPatientDiscoveryResp } from "./command/outbound-resp/get-outbound-patient-discovery-resp";
+
+dayjs.extend(duration);
+
+const context = "cq.patient.subsequent.discover";
+const resultPoller = makeOutboundResultPoller();
+
+export async function processSubsequentOutboundPatientDiscoveryResps({
+  requestId,
+  patientId,
+  cxId,
+}: {
+  patientId: string;
+  requestId: string;
+  cxId: string;
+}): Promise<void> {
+  const baseLogMessage = `CQ PD Processing subsequent results - patientId ${patientId}`;
+  const { log } = out(`${baseLogMessage}, requestId: ${requestId}`);
+  const { log: outerLog } = out(baseLogMessage);
+
+  try {
+    const patient = await getPatientOrFail({ id: patientId, cxId });
+    const discoveryStatus = getCQData(patient.data.externalData)?.discoveryStatus;
+
+    if (discoveryStatus !== "processing") {
+      log(`Kicking off subsequent patient discovery`);
+      const leftoverGateways = await calculateLeftoverGateways(patient);
+      await updatePatientDiscoveryStatus({ patient, status: "processing" });
+
+      await resultPoller.pollOutboundPatientDiscoveryResults({
+        requestId: requestId,
+        patientId: patient.id,
+        cxId: patient.cxId,
+        numOfGateways: leftoverGateways,
+      });
+    }
+  } catch (error) {
+    const msg = `Error on Processing Subsequent Outbound Patient Discovery Responses`;
+    outerLog(`${msg} - ${errorToString(error)}`);
+    await updatePatientDiscoveryStatus({ patient: { id: patientId, cxId }, status: "failed" });
+    capture.error(msg, {
+      extra: {
+        patientId,
+        context,
+        error,
+      },
+    });
+  }
+}
+
+async function calculateLeftoverGateways(patient: Patient): Promise<number> {
+  const { xcpdGateways } = await gatherXCPDGateways(patient);
+  const results = await getOutboundPatientDiscoveryResp(patient.id);
+
+  return xcpdGateways.length - results.length;
+}

--- a/packages/api/src/external/carequality/process-subsequent-outbound-patient-discovery-resps.ts
+++ b/packages/api/src/external/carequality/process-subsequent-outbound-patient-discovery-resps.ts
@@ -12,7 +12,7 @@ dayjs.extend(duration);
 
 const context = "cq.patient.post-response.discover";
 const resultPoller = makeOutboundResultPoller();
-const MAX_SAFE_GWS = 10000;
+const MAX_SAFE_GWS = 100000;
 
 export async function processPostRespOutboundPatientDiscoveryResps({
   requestId,

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -2,6 +2,7 @@ import BadRequestError from "@metriport/core/util/error/bad-request";
 import NotFoundError from "@metriport/core/util/error/not-found";
 import { capture } from "@metriport/core/util/notifications";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
+import { emptyFunction } from "@metriport/shared";
 import {
   isSuccessfulOutboundDocQueryResponse,
   isSuccessfulOutboundDocRetrievalResponse,
@@ -35,7 +36,7 @@ import {
   getPDResultStatus,
 } from "../../external/carequality/ihe-result";
 import { processOutboundPatientDiscoveryResps } from "../../external/carequality/process-outbound-patient-discovery-resps";
-import { processSubsequentOutboundPatientDiscoveryResps } from "../../external/carequality/process-subsequent-outbound-patient-discovery-resps";
+import { processPostRespOutboundPatientDiscoveryResps } from "../../external/carequality/process-subsequent-outbound-patient-discovery-resps";
 import { cqOrgDetailsSchema } from "../../external/carequality/shared";
 import { Config } from "../../shared/config";
 import { asyncHandler, getFrom, getFromQueryAsBoolean } from "../util";
@@ -165,11 +166,11 @@ router.post(
     });
 
     if (response.patientId && response.cxId) {
-      await processSubsequentOutboundPatientDiscoveryResps({
+      processPostRespOutboundPatientDiscoveryResps({
         requestId: response.id,
         patientId: response.patientId,
         cxId: response.cxId,
-      });
+      }).catch(emptyFunction);
     }
 
     return res.sendStatus(httpStatus.OK);

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -35,6 +35,7 @@ import {
   getPDResultStatus,
 } from "../../external/carequality/ihe-result";
 import { processOutboundPatientDiscoveryResps } from "../../external/carequality/process-outbound-patient-discovery-resps";
+import { processSubsequentOutboundPatientDiscoveryResps } from "../../external/carequality/process-subsequent-outbound-patient-discovery-resps";
 import { cqOrgDetailsSchema } from "../../external/carequality/shared";
 import { Config } from "../../shared/config";
 import { asyncHandler, getFrom, getFromQueryAsBoolean } from "../util";
@@ -162,6 +163,14 @@ router.post(
       status,
       response,
     });
+
+    if (response.patientId && response.cxId) {
+      await processSubsequentOutboundPatientDiscoveryResps({
+        requestId: response.id,
+        patientId: response.patientId,
+        cxId: response.cxId,
+      });
+    }
 
     return res.sendStatus(httpStatus.OK);
   })


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: #1350
### Dependencies

- Upstream: none
- Downstream: none

### Description

Process the subsequent request again if the discoveryStstus was completed so we  dont lose links

### Testing

_[Regular PRs:]_

- Local
  - [x] hit internal endpoint and see if runs with completed status
- Staging
  - [ ] hit internal endpoint and see if runs with completed status
- Production
  - [ ] monitor 

### Release Plan

- [ ] Merge this
