### PR TITLE
1636 Disable the release step on CICD

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -1,5 +1,8 @@
 name: Reusable Release workflow
 
+# Not being used as of 2024-04-23
+# Left here so we can use it when ready to address https://github.com/metriport/metriport-internal/issues/1636
+
 on:
   workflow_call: # called by other workflows
     secrets:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -187,18 +187,13 @@ jobs:
       IHE_GW_KEYSTORE_STOREPASS: ${{ secrets.IHE_GW_KEYSTORE_STOREPASS_PRODUCTION }}
       IHE_GW_KEYSTORE_KEYPASS: ${{ secrets.IHE_GW_KEYSTORE_KEYPASS_PRODUCTION }}
 
-  release:
-    uses: ./.github/workflows/_release.yml
+  e2e-tests:
+    uses: ./.github/workflows/_e2e-tests.yml
     needs: [api-sandbox, infra-api-lambdas-sandbox, infra-ihe-gw, ihe-gw-server]
     # run even if one of the dependencies didn't
     # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."
     # can't use ${{ ! failure() && contains(needs.*.result, 'success') }} because if anything that came before succeeded, even if not a direct dependency, it will run
     if: ${{ !failure() && (needs.api-sandbox.result == 'success' || needs.infra-api-lambdas-sandbox.result == 'success' || needs.infra-ihe-gw.result == 'success' || needs.ihe-gw-server.result == 'success') }}
-    secrets: inherit
-
-  e2e-tests:
-    uses: ./.github/workflows/_e2e-tests.yml
-    needs: release
     with:
       deploy_env: "production"
       api_url: ${{ vars.API_URL_PRODUCTION }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -153,18 +153,13 @@ jobs:
       IHE_GW_KEYSTORE_STOREPASS: ${{ secrets.IHE_GW_KEYSTORE_STOREPASS_STAGING }}
       IHE_GW_KEYSTORE_KEYPASS: ${{ secrets.IHE_GW_KEYSTORE_KEYPASS_STAGING }}
 
-  release:
-    uses: ./.github/workflows/_release.yml
+  e2e-tests:
+    uses: ./.github/workflows/_e2e-tests.yml
     needs: [api, infra-api-lambdas, infra-ihe-gw, ihe-gw-server]
     # run even if one of the dependencies didn't
     # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."
     # can't use ${{ ! failure() && contains(needs.*.result, 'success') }} because if anything that came before succeeded, even if not a direct dependency, it will run
     if: ${{ !failure() && (needs.api.result == 'success' || needs.infra-api-lambdas.result == 'success' || needs.infra-ihe-gw.result == 'success' || needs.ihe-gw-server.result == 'success') }}
-    secrets: inherit
-
-  e2e-tests:
-    uses: ./.github/workflows/_e2e-tests.yml
-    needs: release
     with:
       deploy_env: "staging"
       api_url: ${{ vars.API_URL_STAGING }}

--- a/packages/core/src/external/carequality/ihe-gateway/poll-outbound-results.ts
+++ b/packages/core/src/external/carequality/ihe-gateway/poll-outbound-results.ts
@@ -113,7 +113,7 @@ async function pollResults({
       console.log(`${raceResult}. ${details}`);
       raceControl.isRaceInProgress = false;
     } else if (!allGWsCompleted) {
-      const msg = `IHE GW results are incomplete for ${context}}`;
+      const msg = `IHE GW results are incomplete for ${context}`;
       console.log(`${msg}. ${details}`);
       capture.message(msg, {
         extra: {


### PR DESCRIPTION
Ref. metriport/metriport-internal#1636

### Dependencies

none

### Description

Disable the release step on CICD. This will essentially stop creating the releases @ GH: https://github.com/metriport/metriport/releases

### Testing

- Local
  - none
- Staging
  - [ ] CICD works
  - [ ] regular deployment works
  - [ ] branch to staging works
- Sandbox
  - [ ] CICD works
- Production
  - [ ] CICD works

### Release Plan

- [ ] Merge this
