### PR TITLE
1040 Simplify FFs

### DIFF
--- a/packages/api/src/external/aws/appConfig.ts
+++ b/packages/api/src/external/aws/appConfig.ts
@@ -63,16 +63,15 @@ function getFeatureFlagValueLocal(featureFlagName: keyof FeatureFlagDatastore) {
 /**
  * Returns the list of customers that are enabled for the given feature flag.
  *
- * @returns Array of cxIds or cxIdsAndLimits
+ * @returns Array of string values
  */
 async function getCxsWithFeatureFlagEnabled(
   featureFlagName: keyof FeatureFlagDatastore
 ): Promise<string[]> {
   try {
     const featureFlag = await getFeatureFlagValueLocal(featureFlagName);
-    if (featureFlag.enabled) {
-      if (featureFlag.cxIds) return featureFlag.cxIds;
-      if (featureFlag.cxIdsAndLimits) return featureFlag.cxIdsAndLimits;
+    if (featureFlag.enabled && featureFlag.values) {
+      return featureFlag.values;
     }
   } catch (error) {
     const msg = `Failed to get Feature Flag Value`;

--- a/packages/core/src/external/aws/appConfig.ts
+++ b/packages/core/src/external/aws/appConfig.ts
@@ -8,31 +8,23 @@ function makeAppConfigClient(region: string): AWS.AppConfig {
   return new AppConfig({ region });
 }
 
-export type CustomerIdsFF = {
+export type StringValuesFF = {
   enabled: boolean;
-  cxIds: string[];
-  cxIdsAndLimits: never;
-};
-
-export type SandboxLimitFF = {
-  enabled: boolean;
-  cxIdsAndLimits: string[];
-  cxIds: never;
+  values: string[];
 };
 
 export type BooleanFF = {
   enabled: boolean;
-  cxIds: never;
-  cxIdsAndLimits: never;
+  values: never;
 };
 
 export type FeatureFlagDatastore = {
-  cxsWithEnhancedCoverageFeatureFlag: CustomerIdsFF;
-  cxsWithCQDirectFeatureFlag: CustomerIdsFF;
-  cxsWithCWFeatureFlag: CustomerIdsFF;
-  cxsWithADHDMRFeatureFlag: CustomerIdsFF;
-  cxsWithNoWebhookPongFeatureFlag: CustomerIdsFF;
-  cxsWithIncreasedSandboxLimitFeatureFlag: SandboxLimitFF;
+  cxsWithEnhancedCoverageFeatureFlag: StringValuesFF;
+  cxsWithCQDirectFeatureFlag: StringValuesFF;
+  cxsWithCWFeatureFlag: StringValuesFF;
+  cxsWithADHDMRFeatureFlag: StringValuesFF;
+  cxsWithNoWebhookPongFeatureFlag: StringValuesFF;
+  cxsWithIncreasedSandboxLimitFeatureFlag: StringValuesFF;
   commonwellFeatureFlag: BooleanFF;
   carequalityFeatureFlag: BooleanFF;
 };
@@ -60,8 +52,8 @@ export async function getFeatureFlagValue<T extends keyof FeatureFlagDatastore>(
   );
   if (configContent && config.ContentType && config.ContentType === "application/json") {
     const configContentValue = JSON.parse(configContent.toString());
-    if (configContentValue.values && configContentValue.values[featureFlagName]) {
-      return configContentValue.values[featureFlagName];
+    if (configContentValue && configContentValue[featureFlagName]) {
+      return configContentValue[featureFlagName];
     } else {
       throw new MetriportError(`Feature Flag not found in config`, undefined, { featureFlagName });
     }

--- a/packages/lambdas/src/fhir-to-medical-record.ts
+++ b/packages/lambdas/src/fhir-to-medical-record.ts
@@ -208,7 +208,7 @@ async function getCxsWithADHDFeatureFlagValue(): Promise<string[]> {
       "cxsWithADHDMRFeatureFlag"
     );
 
-    if (featureFlag?.enabled && featureFlag?.cxIds) return featureFlag.cxIds;
+    if (featureFlag?.enabled && featureFlag?.values) return featureFlag.values;
   } catch (error) {
     const msg = `Failed to get Feature Flag Value`;
     const extra = { featureFlagName: "cxsWithADHDMRFeatureFlag" };


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Description

Simplify FFs. Currently, there's an unnecessary structure of types on the FFs' payload, and a distinction on how we name the property that holds each FF value.

I propose we:
- remove the types from the payload
- have all props to store the value named the same

### Testing

- Local
  - none
- Staging
  - [ ] `commonwellFeatureFlag` FF work
  - [ ] `carequalityFeatureFlag` FF work
  - [ ] `cxsWithCWFeatureFlag` FF work
  - [ ] `cxsWithCQDirectFeatureFlag` FF work
  - [ ] `cxsWithNoWebhookPongFeatureFlag` FF work
  - [ ] `cxsWithADHDMRFeatureFlag` FF work
- Sandbox
  - [ ] `cxsWithIncreasedSandboxLimitFeatureFlag` FF work
- Production
  - none

### Release Plan

- [x] Update FFs' payload
    - [x] remove the types
    - [x] move FFs to main level (move the out of `values`)
    - [x] rename `cxIds` and `cxIdsAndLimits` to `values`
- [ ] Merge this
