### PR TITLE
1608 Adjust how we filter CQ orgs to filter CW links

### DIFF
--- a/packages/api/src/command/medical/hie.ts
+++ b/packages/api/src/command/medical/hie.ts
@@ -1,0 +1,5 @@
+import { getOrganizationIds } from "../../external/carequality/command/cq-directory/cq-gateways";
+
+export async function getCqOrgIdsToDenyOnCw() {
+  return getOrganizationIds(["CommonWell"]);
+}

--- a/packages/api/src/command/medical/patient/create-patient.ts
+++ b/packages/api/src/command/medical/patient/create-patient.ts
@@ -3,11 +3,11 @@ import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { processAsyncError } from "../../../errors";
 import { isCarequalityEnabled, isCommonwellEnabled } from "../../../external/aws/appConfig";
 import cqCommands from "../../../external/carequality";
-import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
 import cwCommands from "../../../external/commonwell";
 import { PatientModel } from "../../../models/medical/patient";
 import { Config } from "../../../shared/config";
 import { getFacilityOrFail } from "../facility/get-facility";
+import { getCqOrgIdsToDenyOnCw } from "../hie";
 import { addCoordinatesToAddresses } from "./add-coordinates";
 import { getPatientByDemo } from "./get-patient";
 import { sanitize, validate } from "./shared";
@@ -62,7 +62,7 @@ export const createPatient = async (
   if (commonwellEnabled || forceCommonwell || Config.isSandbox()) {
     // Intentionally asynchronous
     cwCommands.patient
-      .create(newPatient, facilityId, getAllCQOrgsIds)
+      .create(newPatient, facilityId, getCqOrgIdsToDenyOnCw)
       .catch(processAsyncError(`cw.patient.create`));
   }
 

--- a/packages/api/src/command/medical/patient/update-patient.ts
+++ b/packages/api/src/command/medical/patient/update-patient.ts
@@ -42,19 +42,21 @@ export async function updatePatient(
   const fhirPatient = toFHIR(result);
   await upsertPatientToFHIRServer(patientUpdate.cxId, fhirPatient);
 
-  const orgIdExcludeList = await getAllCQOrgsIds();
+  // TODO move these to the respective "commands" files so this is fully async
+  const [commonwellEnabled, carequalityEnabled] = await Promise.all([
+    isCommonwellEnabled(),
+    isCarequalityEnabled(),
+  ]);
 
-  // Intentionally asynchronous
-  const commonwellEnabled = await isCommonwellEnabled();
   if (commonwellEnabled || forceCommonwell || Config.isSandbox()) {
+    // Intentionally asynchronous
     cwCommands.patient
-      .update(result, facilityId, orgIdExcludeList)
+      .update(result, facilityId, getAllCQOrgsIds)
       .catch(processAsyncError(`cw.patient.update`));
   }
 
-  // Intentionally asynchronous
-  const carequalityEnabled = await isCarequalityEnabled();
   if (carequalityEnabled || forceCarequality) {
+    // Intentionally asynchronous
     cqCommands.patient
       .discover(result, facility.data.npi)
       .catch(processAsyncError(`cq.patient.update`));

--- a/packages/api/src/command/medical/patient/update-patient.ts
+++ b/packages/api/src/command/medical/patient/update-patient.ts
@@ -12,10 +12,10 @@ import { validateVersionForUpdate } from "../../../models/_default";
 import { Config } from "../../../shared/config";
 import { BaseUpdateCmdWithCustomer } from "../base-update-command";
 import { getFacilityOrFail } from "../facility/get-facility";
+import { getCqOrgIdsToDenyOnCw } from "../hie";
 import { addCoordinatesToAddresses } from "./add-coordinates";
 import { getPatientOrFail } from "./get-patient";
 import { sanitize, validate } from "./shared";
-import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
 
 type PatientNoExternalData = Omit<PatientData, "externalData">;
 export type PatientUpdateCmd = BaseUpdateCmdWithCustomer &
@@ -51,7 +51,7 @@ export async function updatePatient(
   if (commonwellEnabled || forceCommonwell || Config.isSandbox()) {
     // Intentionally asynchronous
     cwCommands.patient
-      .update(result, facilityId, getAllCQOrgsIds)
+      .update(result, facilityId, getCqOrgIdsToDenyOnCw)
       .catch(processAsyncError(`cw.patient.update`));
   }
 

--- a/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
@@ -1,37 +1,20 @@
-import { capture } from "@metriport/core/util/notifications";
 import { Op, Sequelize } from "sequelize";
 import { CQDirectoryEntryModel } from "../../models/cq-directory";
 
-export async function updateCQGateways(gatewayOids: string[]): Promise<void> {
-  console.log(`Found ${gatewayOids.length} gateways in the CQ directory. Updating...`);
-  await Promise.allSettled(
-    gatewayOids.map(gatewayOid =>
-      updateCQGateway(gatewayOid).catch(error => {
-        const msg = `Failed to update gateway ${gatewayOid} in the CQ directory. Skipping...`;
-        console.log(`${msg}. Cause: ${error}`);
-        capture.error(msg, { extra: { context: `cq.directory.updateCQGateways`, error } });
-        throw error;
-      })
-    )
-  );
-}
-
-export async function updateCQGateway(gatewayOid: string): Promise<void> {
+export async function setEntriesAsGateway(oids: string[]): Promise<void> {
+  console.log(`Found ${oids.length} gateways in the CQ directory. Updating...`);
   await CQDirectoryEntryModel.update(
     {
       gateway: true,
     },
     {
-      where: {
-        id: gatewayOid,
-        urlXCPD: {
-          [Op.ne]: "",
-        },
-      },
+      where: { id: { [Op.in]: oids } },
     }
   );
 }
 
+// move this to a function that queries entries not from CW, only need the OID
+// check the json ramil sent to find if we can use the managing_org (name) to filter non-CW entries, or whether its a multi-level recursive structure
 export async function getOrganizationsWithXCPD(): Promise<CQDirectoryEntryModel[]> {
   return CQDirectoryEntryModel.findAll({
     where: {

--- a/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
@@ -13,16 +13,17 @@ export async function setEntriesAsGateway(oids: string[]): Promise<void> {
   );
 }
 
-// move this to a function that queries entries not from CW, only need the OID
-// check the json ramil sent to find if we can use the managing_org (name) to filter non-CW entries, or whether its a multi-level recursive structure
-export async function getOrganizationsWithXCPD(): Promise<CQDirectoryEntryModel[]> {
-  return CQDirectoryEntryModel.findAll({
+export async function getOrganizationIds(excludeManagingOrgs: string[]): Promise<string[]> {
+  const entries = await CQDirectoryEntryModel.findAll({
+    attributes: ["id"],
     where: {
-      urlXCPD: {
-        [Op.ne]: "",
+      managingOrganization: {
+        [Op.notIn]: excludeManagingOrgs,
       },
     },
   });
+  const ids = entries.map(entry => entry.id);
+  return ids;
 }
 
 export async function getRecordLocatorServiceOrganizations(): Promise<CQDirectoryEntryModel[]> {

--- a/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
@@ -1,8 +1,9 @@
+import { out } from "@metriport/core/util/log";
 import { Op, Sequelize } from "sequelize";
 import { CQDirectoryEntryModel } from "../../models/cq-directory";
 
 export async function setEntriesAsGateway(oids: string[]): Promise<void> {
-  console.log(`Found ${oids.length} gateways in the CQ directory. Updating...`);
+  out(`setEntriesAsGateway`).log(`Found ${oids.length} gateways in the CQ directory. Updating...`);
   await CQDirectoryEntryModel.update(
     {
       gateway: true,

--- a/packages/api/src/external/carequality/command/cq-directory/create-cq-directory-entry.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/create-cq-directory-entry.ts
@@ -81,5 +81,6 @@ export async function bulkInsertCQDirectoryEntries(
   await sequelize.query(query, {
     replacements: flattenedData,
     type: QueryTypes.INSERT,
+    logging: false,
   });
 }

--- a/packages/api/src/external/carequality/command/cq-directory/create-cq-directory-entry.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/create-cq-directory-entry.ts
@@ -81,6 +81,5 @@ export async function bulkInsertCQDirectoryEntries(
   await sequelize.query(query, {
     replacements: flattenedData,
     type: QueryTypes.INSERT,
-    logging: false,
   });
 }

--- a/packages/api/src/external/carequality/command/cq-directory/create-cq-directory-entry.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/create-cq-directory-entry.ts
@@ -1,7 +1,6 @@
 import { QueryTypes, Sequelize } from "sequelize";
 import { CQDirectoryEntryData } from "../../cq-directory";
 import { CQDirectoryEntryModel } from "../../models/cq-directory";
-import { cqDirectoryEntryTemp } from "./shared";
 
 const keys = createKeys();
 const number_of_keys = keys.split(",").length;
@@ -50,7 +49,8 @@ function createKeys(): string {
 
 export async function bulkInsertCQDirectoryEntries(
   sequelize: Sequelize,
-  orgDataArray: CQDirectoryEntryData[]
+  orgDataArray: CQDirectoryEntryData[],
+  tableName: string
 ): Promise<void> {
   if (orgDataArray.length === 0) return;
   const placeholders = orgDataArray
@@ -77,7 +77,7 @@ export async function bulkInsertCQDirectoryEntries(
     entry.lastUpdatedAtCQ ?? null,
   ]);
 
-  const query = `INSERT INTO ${cqDirectoryEntryTemp} (${keys}) VALUES ${placeholders};`;
+  const query = `INSERT INTO ${tableName} (${keys}) VALUES ${placeholders};`;
   await sequelize.query(query, {
     replacements: flattenedData,
     type: QueryTypes.INSERT,

--- a/packages/api/src/external/carequality/command/cq-directory/get-organizations-for-xcpd.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/get-organizations-for-xcpd.ts
@@ -3,7 +3,6 @@ import {
   getRecordLocatorServiceOrganizations,
   getStandaloneOrganizations,
   getSublinkOrganizations,
-  getOrganizationsWithXCPD,
 } from "./cq-gateways";
 
 function sortOrgsByNearbyOrder(orgs: CQDirectoryEntryModel[], orderMap: Map<string, number>) {
@@ -13,16 +12,6 @@ function sortOrgsByNearbyOrder(orgs: CQDirectoryEntryModel[], orderMap: Map<stri
 
     return orderA - orderB;
   });
-}
-
-export async function getAllCQOrgsIds(): Promise<Set<string>> {
-  const orgs = await getOrganizationsWithXCPD();
-  const orgsFlat: CQDirectoryEntryModel[] = orgs.flat();
-  const orgsSet: Set<string> = new Set();
-  orgsFlat.forEach(org => {
-    orgsSet.add(org.id);
-  });
-  return orgsSet;
 }
 
 export async function getOrganizationsForXCPD(

--- a/packages/api/src/external/carequality/command/cq-directory/parse-cq-directory-entry.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/parse-cq-directory-entry.ts
@@ -115,7 +115,8 @@ function isValidUrl(url: string | undefined): boolean {
 }
 
 function getCoordinates(address: Address[]): Coordinates | undefined {
-  const orgPosition = address.find(a => a.extension?.url === ORG_POSITION);
+  const addressArray = Array.isArray(address) ? address : [address];
+  const orgPosition = addressArray.find(a => a.extension?.url === ORG_POSITION);
   const position = orgPosition?.extension?.valueCodeableConcept?.coding?.value?.position;
   if (!position) return;
   const lat = parseFloat(position.latitude.value);

--- a/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory.ts
@@ -85,6 +85,7 @@ export async function rebuildCQDirectory(failGracefully = false): Promise<void> 
 }
 
 async function createTempCQDirectoryTable(): Promise<void> {
+  await deleteTempCQDirectoryTable();
   const query = `CREATE TABLE IF NOT EXISTS ${cqDirectoryEntryTemp} (LIKE ${cqDirectoryEntry} INCLUDING ALL)`;
   await sequelize.query(query, {
     type: QueryTypes.INSERT,

--- a/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory.ts
@@ -1,13 +1,15 @@
+import { initDBPool } from "@metriport/core/util/sequelize";
 import { sleep } from "@metriport/core/util/sleep";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
-import { QueryTypes, Sequelize } from "sequelize";
+import { QueryTypes } from "sequelize";
 import { executeOnDBTx } from "../../../../models/transaction-wrapper";
+import { addUpdatedAtTrigger } from "../../../../sequelize/migrations-shared";
 import { Config } from "../../../../shared/config";
 import { capture } from "../../../../shared/notifications";
 import { makeCarequalityManagementAPI } from "../../api";
 import { CQDirectoryEntryModel } from "../../models/cq-directory";
-import { updateCQGateways } from "./cq-gateways";
+import { setEntriesAsGateway } from "./cq-gateways";
 import { bulkInsertCQDirectoryEntries } from "./create-cq-directory-entry";
 import { parseCQDirectoryEntries } from "./parse-cq-directory-entry";
 import { cqDirectoryEntry, cqDirectoryEntryBackup, cqDirectoryEntryTemp } from "./shared";
@@ -16,13 +18,12 @@ dayjs.extend(duration);
 const BATCH_SIZE = 1000;
 const SLEEP_TIME = dayjs.duration({ milliseconds: 750 });
 
-const sqlDBCreds = Config.getDBCreds();
-const dbCreds = JSON.parse(sqlDBCreds);
-
-const sequelize = new Sequelize(dbCreds.dbname, dbCreds.username, dbCreds.password, {
-  host: dbCreds.host,
-  port: dbCreds.port,
-  dialect: dbCreds.engine,
+const dbCreds = Config.getDBCreds();
+const sequelize = initDBPool(dbCreds, {
+  max: 10,
+  min: 1,
+  acquire: 30000,
+  idle: 10000,
 });
 
 export async function rebuildCQDirectory(failGracefully = false): Promise<void> {
@@ -48,7 +49,7 @@ export async function rebuildCQDirectory(failGracefully = false): Promise<void> 
         console.log(
           `Adding ${parsedOrgs.length} CQ directory entries... Total fetched: ${currentPosition}`
         );
-        await bulkInsertCQDirectoryEntries(sequelize, parsedOrgs);
+        await bulkInsertCQDirectoryEntries(sequelize, parsedOrgs, cqDirectoryEntryTemp);
         await sleep(SLEEP_TIME.asMilliseconds());
       } catch (error) {
         isDone = true;
@@ -69,7 +70,7 @@ export async function rebuildCQDirectory(failGracefully = false): Promise<void> 
   }
   try {
     await renameCQDirectoryTablesAndUpdateIndexes();
-    await updateCQGateways(Array.from(gatewaysSet));
+    await setEntriesAsGateway(Array.from(gatewaysSet));
     console.log("CQ directory successfully rebuilt! :)");
   } catch (error) {
     const msg = `Failed the last step of CQ directory rebuild`;
@@ -84,7 +85,7 @@ export async function rebuildCQDirectory(failGracefully = false): Promise<void> 
 }
 
 async function createTempCQDirectoryTable(): Promise<void> {
-  const query = `CREATE TABLE IF NOT EXISTS ${cqDirectoryEntryTemp} AS SELECT * FROM ${cqDirectoryEntry} WHERE 1=0;`;
+  const query = `CREATE TABLE IF NOT EXISTS ${cqDirectoryEntryTemp} (LIKE ${cqDirectoryEntry} INCLUDING ALL)`;
   await sequelize.query(query, {
     type: QueryTypes.INSERT,
   });
@@ -102,32 +103,24 @@ async function renameCQDirectoryTablesAndUpdateIndexes(): Promise<void> {
     const dropBackupQuery = `DROP TABLE IF EXISTS ${cqDirectoryEntryBackup};`;
     await sequelize.query(dropBackupQuery, {
       type: QueryTypes.DELETE,
-      logging: false,
       transaction,
     });
 
     const lockTablesQuery = `LOCK TABLE ${cqDirectoryEntry} IN ACCESS EXCLUSIVE MODE;`;
     await sequelize.query(lockTablesQuery, {
       type: QueryTypes.RAW,
-      logging: false,
       transaction,
     });
 
     const renameTablesQuery = `
-    ALTER TABLE ${cqDirectoryEntry} RENAME TO ${cqDirectoryEntryBackup};
-    ALTER TABLE ${cqDirectoryEntryTemp} RENAME TO ${cqDirectoryEntry};
-    ALTER INDEX IF EXISTS cq_directory_entry_pkey RENAME TO cq_directory_entry_backup_pkey;`;
+      ALTER TABLE ${cqDirectoryEntry} RENAME TO ${cqDirectoryEntryBackup};
+      ALTER TABLE ${cqDirectoryEntryTemp} RENAME TO ${cqDirectoryEntry};
+    `;
     await sequelize.query(renameTablesQuery, {
       type: QueryTypes.UPDATE,
-      logging: false,
       transaction,
     });
 
-    const createIndexQuery = `CREATE INDEX IF NOT EXISTS cq_directory_entry_pkey ON ${cqDirectoryEntry} (id);`;
-    await sequelize.query(createIndexQuery, {
-      type: QueryTypes.INSERT,
-      logging: false,
-      transaction,
-    });
+    await addUpdatedAtTrigger(sequelize.getQueryInterface(), transaction, cqDirectoryEntry);
   });
 }

--- a/packages/api/src/external/commonwell/admin/patch-patient-duplicates.ts
+++ b/packages/api/src/external/commonwell/admin/patch-patient-duplicates.ts
@@ -23,7 +23,7 @@ export async function patchDuplicatedPersonsForPatient(
   patientId: string,
   chosenPersonId: string,
   unenrollByDemographics = false,
-  orgIdExcludeList: Set<string>
+  orgIdExcludeList: () => Promise<Set<string>>
 ): Promise<void> {
   const context = "patchDuplicatedPersonsForPatient";
   const { log } = Util.out(`${context} ${patientId}`);

--- a/packages/api/src/external/commonwell/admin/patch-patient-duplicates.ts
+++ b/packages/api/src/external/commonwell/admin/patch-patient-duplicates.ts
@@ -23,7 +23,7 @@ export async function patchDuplicatedPersonsForPatient(
   patientId: string,
   chosenPersonId: string,
   unenrollByDemographics = false,
-  orgIdExcludeList: () => Promise<Set<string>>
+  orgIdExcludeList: () => Promise<string[]>
 ): Promise<void> {
   const context = "patchDuplicatedPersonsForPatient";
   const { log } = Util.out(`${context} ${patientId}`);

--- a/packages/api/src/external/commonwell/admin/recreate-patients-at-hies.ts
+++ b/packages/api/src/external/commonwell/admin/recreate-patients-at-hies.ts
@@ -1,15 +1,15 @@
 import { organizationQueryMeta } from "@metriport/commonwell-sdk";
 import { oid } from "@metriport/core/domain/oid";
-import { groupBy } from "lodash";
 import { Patient } from "@metriport/core/domain/patient";
+import { groupBy } from "lodash";
+import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
 import { PatientModel } from "../../../models/medical/patient";
 import { capture } from "../../../shared/notifications";
 import { Util } from "../../../shared/util";
+import { isCWEnabledForCx } from "../../aws/appConfig";
 import { makeCommonWellAPI } from "../api";
 import { create, getCWData } from "../patient";
 import { getPatientData } from "../patient-shared";
-import { isCWEnabledForCx } from "../../aws/appConfig";
-import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
 
 export type RecreateResultOfPatient = {
   originalCWPatientId: string | undefined;
@@ -45,15 +45,13 @@ export async function recreatePatientsAtCW(cxId?: string): Promise<RecreateResul
   }
   const patientsByCustomer = groupBy(patients, "cxId");
 
-  const orgIdExcludeList = await getAllCQOrgsIds();
-
   const res: RecreateResult = {};
   for (const [cxId, patients] of Object.entries(patientsByCustomer)) {
     log(`Found ${patients.length} patients for cxId ${cxId}`);
     const cxRes: Record<string, RecreateResultOfPatient | undefined> = {};
     // TODO consider moving this to Promise.all()
     for (const patient of patients) {
-      cxRes[patient.id] = await recreatePatientAtCW(patient, orgIdExcludeList);
+      cxRes[patient.id] = await recreatePatientAtCW(patient, getAllCQOrgsIds);
     }
     res[cxId] = cxRes;
   }
@@ -63,7 +61,7 @@ export async function recreatePatientsAtCW(cxId?: string): Promise<RecreateResul
 
 export async function recreatePatientAtCW(
   patient: Patient,
-  orgIdExcludeList: Set<string>
+  getOrgIdExcludeList: () => Promise<Set<string>>
 ): Promise<RecreateResultOfPatient | undefined> {
   const { log } = Util.out(`recreatePatientAtCW - ${patient.id}`);
 
@@ -108,7 +106,7 @@ export async function recreatePatientAtCW(
 
     // create new patient, including linkint to person and network link to other patients
     log(`Creating new patient at CW...`);
-    const cwIds = await create(patient, facilityId, orgIdExcludeList, {
+    const cwIds = await create(patient, facilityId, getOrgIdExcludeList, {
       organization,
       facility,
     });

--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-api-local.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-api-local.ts
@@ -22,13 +22,13 @@ const WAIT_BETWEEN_LINKING_AND_DOC_QUERY = dayjs.duration({ seconds: 30 });
 export class CoverageEnhancerApiLocal extends CoverageEnhancerLocal {
   constructor(
     cwManagementApi: CommonWellManagementAPI,
-    orgIdExcludeList: () => Promise<Set<string>>,
+    getOrgIdExcludeList: () => Promise<string[]>,
     prefix?: string | undefined
   ) {
     super(
       cwManagementApi,
       new PatientLoaderLocal(),
-      new PatientUpdaterCommonWell(orgIdExcludeList),
+      new PatientUpdaterCommonWell(getOrgIdExcludeList),
       new ECUpdaterLocal(),
       capture,
       prefix

--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-api-local.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-api-local.ts
@@ -22,7 +22,7 @@ const WAIT_BETWEEN_LINKING_AND_DOC_QUERY = dayjs.duration({ seconds: 30 });
 export class CoverageEnhancerApiLocal extends CoverageEnhancerLocal {
   constructor(
     cwManagementApi: CommonWellManagementAPI,
-    orgIdExcludeList: Set<string>,
+    orgIdExcludeList: () => Promise<Set<string>>,
     prefix?: string | undefined
   ) {
     super(

--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-factory.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-factory.ts
@@ -18,6 +18,6 @@ export function makeCoverageEnhancer(): CoverageEnhancer | undefined {
   const cookieManager = new CookieManagerOnSecrets(cookieArn, Config.getAWSRegion());
   const cwManagementApi = makeApi({ cookieManager, baseUrl: cwManagementUrl });
   // #TODO we are passing an empty exclude list to accelerate development. All this code should be deprecated soon anyway and this shouldnt be a problem.
-  const orgIdExcludeList = new Set<string>();
+  const orgIdExcludeList = async () => new Set<string>();
   return new CoverageEnhancerApiLocal(cwManagementApi, orgIdExcludeList);
 }

--- a/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-factory.ts
+++ b/packages/api/src/external/commonwell/cq-bridge/coverage-enhancer-factory.ts
@@ -18,6 +18,6 @@ export function makeCoverageEnhancer(): CoverageEnhancer | undefined {
   const cookieManager = new CookieManagerOnSecrets(cookieArn, Config.getAWSRegion());
   const cwManagementApi = makeApi({ cookieManager, baseUrl: cwManagementUrl });
   // #TODO we are passing an empty exclude list to accelerate development. All this code should be deprecated soon anyway and this shouldnt be a problem.
-  const orgIdExcludeList = async () => new Set<string>();
-  return new CoverageEnhancerApiLocal(cwManagementApi, orgIdExcludeList);
+  const getOrgIdExcludeList = async () => [];
+  return new CoverageEnhancerApiLocal(cwManagementApi, getOrgIdExcludeList);
 }

--- a/packages/api/src/external/commonwell/index.ts
+++ b/packages/api/src/external/commonwell/index.ts
@@ -1,11 +1,29 @@
+import * as link from "./link";
 import * as organization from "./organization";
 import * as patient from "./patient";
-import * as link from "./link";
 
 const cwCommands = {
-  organization,
-  patient,
-  link,
+  organization: {
+    create: organization.create,
+    update: organization.update,
+    initCQOrgIncludeList: organization.initCQOrgIncludeList,
+    organizationToCommonwell: organization.organizationToCommonwell,
+  },
+  patient: {
+    create: patient.create,
+    update: patient.update,
+    remove: patient.remove,
+    getCWData: patient.getCWData,
+    getLinkStatusCQ: patient.getLinkStatusCQ,
+    getLinkStatusCW: patient.getLinkStatusCW,
+  },
+  link: {
+    create: link.create,
+    get: link.get,
+    reset: link.reset,
+    findAllPotentialLinks: link.findAllPotentialLinks,
+    findCurrentLink: link.findCurrentLink,
+  },
 };
 
 export default cwCommands;

--- a/packages/api/src/external/commonwell/link/create.ts
+++ b/packages/api/src/external/commonwell/link/create.ts
@@ -16,7 +16,7 @@ export const create = async (
   patientId: string,
   cxId: string,
   facilityId: string,
-  getOrgIdExcludeList: () => Promise<Set<string>>
+  getOrgIdExcludeList: () => Promise<string[]>
 ): Promise<void> => {
   if (!(await isCWEnabledForCx(cxId))) {
     console.log(`CW is disabled for cxId: ${cxId}`);

--- a/packages/api/src/external/commonwell/link/create.ts
+++ b/packages/api/src/external/commonwell/link/create.ts
@@ -1,13 +1,13 @@
 import { CommonWellAPI, organizationQueryMeta } from "@metriport/commonwell-sdk";
+import { oid } from "@metriport/core/domain/oid";
 import { reset } from ".";
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 import { capture } from "../../../shared/notifications";
-import { oid } from "@metriport/core/domain/oid";
+import { isCWEnabledForCx } from "../../aws/appConfig";
 import { makeCommonWellAPI } from "../api";
 import { setCommonwellId } from "../patient-external-data";
 import { getPatientData } from "../patient-shared";
 import { autoUpgradeNetworkLinks, patientWithCWData } from "./shared";
-import { isCWEnabledForCx } from "../../aws/appConfig";
 
 const context = "cw.link.create";
 
@@ -16,7 +16,7 @@ export const create = async (
   patientId: string,
   cxId: string,
   facilityId: string,
-  orgIdExcludeList: Set<string>
+  getOrgIdExcludeList: () => Promise<Set<string>>
 ): Promise<void> => {
   if (!(await isCWEnabledForCx(cxId))) {
     console.log(`CW is disabled for cxId: ${cxId}`);
@@ -78,7 +78,7 @@ export const create = async (
       cwPatientId,
       personId,
       context,
-      orgIdExcludeList
+      getOrgIdExcludeList
     );
   } catch (error) {
     const msg = `Failed to create CW person link`;

--- a/packages/api/src/external/commonwell/link/create.ts
+++ b/packages/api/src/external/commonwell/link/create.ts
@@ -1,5 +1,6 @@
 import { CommonWellAPI, organizationQueryMeta } from "@metriport/commonwell-sdk";
 import { oid } from "@metriport/core/domain/oid";
+import { out } from "@metriport/core/util/log";
 import { reset } from ".";
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 import { capture } from "../../../shared/notifications";
@@ -11,15 +12,17 @@ import { autoUpgradeNetworkLinks, patientWithCWData } from "./shared";
 
 const context = "cw.link.create";
 
-export const create = async (
+export async function create(
   personId: string,
   patientId: string,
   cxId: string,
   facilityId: string,
   getOrgIdExcludeList: () => Promise<string[]>
-): Promise<void> => {
+): Promise<void> {
+  const { log } = out(context);
+
   if (!(await isCWEnabledForCx(cxId))) {
-    console.log(`CW is disabled for cxId: ${cxId}`);
+    log(`CW is disabled for cxId: ${cxId}`);
     return undefined;
   }
 
@@ -82,11 +85,11 @@ export const create = async (
     );
   } catch (error) {
     const msg = `Failed to create CW person link`;
-    console.log(`${msg}. Cause: ${error}`);
+    log(`${msg}. Cause: ${error}`);
     capture.message(msg, {
       extra: { cwPatientId, personId, cwReference: commonWell?.lastReferenceHeader, context },
       level: "error",
     });
     throw error;
   }
-};
+}

--- a/packages/api/src/external/commonwell/link/reset.ts
+++ b/packages/api/src/external/commonwell/link/reset.ts
@@ -1,15 +1,17 @@
 import { organizationQueryMeta } from "@metriport/commonwell-sdk";
-import { makeCommonWellAPI } from "../api";
 import { oid } from "@metriport/core/domain/oid";
-import { setCommonwellId } from "../patient-external-data";
-import { patientWithCWData } from "./shared";
-import { getPatientData } from "../patient-shared";
+import { out } from "@metriport/core/util/log";
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 import { isCWEnabledForCx } from "../../aws/appConfig";
+import { makeCommonWellAPI } from "../api";
+import { setCommonwellId } from "../patient-external-data";
+import { getPatientData } from "../patient-shared";
+import { patientWithCWData } from "./shared";
 
-export const reset = async (patientId: string, cxId: string, facilityId: string) => {
+export async function reset(patientId: string, cxId: string, facilityId: string) {
+  const { log } = out("cw.link.reset");
   if (!(await isCWEnabledForCx(cxId))) {
-    console.log(`CW is disabled for cxId: ${cxId}`);
+    log(`CW is disabled for cxId: ${cxId}`);
     return undefined;
   }
 
@@ -45,8 +47,7 @@ export const reset = async (patientId: string, cxId: string, facilityId: string)
     });
   } catch (error) {
     const msg = `Failure resetting`;
-    console.log(`${msg} - patient id:`, patient.id);
-    console.log(msg, error);
+    log(`${msg} - patient id:`, patient.id);
     throw new Error(msg, { cause: error });
   }
-};
+}

--- a/packages/api/src/external/commonwell/link/shared.ts
+++ b/packages/api/src/external/commonwell/link/shared.ts
@@ -7,13 +7,13 @@ import {
   Person,
   RequestMetadata,
 } from "@metriport/commonwell-sdk";
-import { MedicalDataSource } from "@metriport/core/external/index";
 import {
   Patient,
   PatientData,
   PatientExternalData,
   PatientExternalDataEntry,
 } from "@metriport/core/domain/patient";
+import { MedicalDataSource } from "@metriport/core/external/index";
 import { filterTruthy } from "../../../shared/filter-map-utils";
 import { capture } from "../../../shared/notifications";
 import { PatientDataCommonwell } from "../patient-shared";
@@ -48,11 +48,11 @@ export function patientWithCWData(
   return patientWithCW;
 }
 
-function isInsideOrgExcludeList(link: NetworkLink, orgIdExcludeList: Set<string>): boolean {
+function isInsideOrgExcludeList(link: NetworkLink, orgIdExcludeList: string[]): boolean {
   const identifiers = link.patient?.identifier || [];
   return identifiers.some(id => {
     const idSystem = id.system?.replace(urnOidRegex, "");
-    if (idSystem && orgIdExcludeList.has(idSystem)) {
+    if (idSystem && orgIdExcludeList.includes(idSystem)) {
       console.log(`OrgID ${idSystem} is in the exclude list.`);
       return true;
     }
@@ -79,7 +79,7 @@ export async function autoUpgradeNetworkLinks(
   commonwellPatientId: string,
   commonwellPersonId: string,
   executionContext: string,
-  getOrgIdExcludeList: () => Promise<Set<string>>
+  getOrgIdExcludeList: () => Promise<string[]>
 ) {
   const [networkLinks, orgIdExcludeList] = await Promise.all([
     commonWell.getNetworkLinks(queryMeta, commonwellPatientId),

--- a/packages/api/src/external/commonwell/link/shared.ts
+++ b/packages/api/src/external/commonwell/link/shared.ts
@@ -65,11 +65,13 @@ function isInsideOrgExcludeList(link: NetworkLink, orgIdExcludeList: Set<string>
  * for a given patient to LOLA 2.
  *
  * @param commonWell - The CommonWell API object
- * @param queryMeta - RequestMetadata - this is the metadata that is passed in from
- * the client.  It contains the user's session token, the user's organization, and the user's userId.
+ * @param queryMeta - RequestMetadata - this is the metadata that is passed in from the client.
+ *    It contains the user's session token, the user's organization, and the user's userId.
  * @param commonwellPatientId - The patient ID in the CommonWell system
  * @param commonwellPersonId - The CommonWell Person ID of the patient
  * @param executionContext - The execution context of the current request.
+ * @param getOrgIdExcludeList - Function to get the list of organization IDs to exclude from
+ *    network links
  */
 export async function autoUpgradeNetworkLinks(
   commonWell: CommonWellAPI,
@@ -77,9 +79,12 @@ export async function autoUpgradeNetworkLinks(
   commonwellPatientId: string,
   commonwellPersonId: string,
   executionContext: string,
-  orgIdExcludeList: Set<string>
+  getOrgIdExcludeList: () => Promise<Set<string>>
 ) {
-  const networkLinks = await commonWell.getNetworkLinks(queryMeta, commonwellPatientId);
+  const [networkLinks, orgIdExcludeList] = await Promise.all([
+    commonWell.getNetworkLinks(queryMeta, commonwellPatientId),
+    getOrgIdExcludeList(),
+  ]);
 
   if (networkLinks._embedded && networkLinks._embedded.networkLink?.length) {
     const lola1Links = networkLinks._embedded.networkLink.flatMap(filterTruthy).filter(isLOLA1);

--- a/packages/api/src/external/commonwell/patient-updater-commonwell.ts
+++ b/packages/api/src/external/commonwell/patient-updater-commonwell.ts
@@ -13,7 +13,7 @@ const maxNumberOfParallelRequestsToCW = 10;
  * Implementation of the PatientUpdater that executes the logic on CommonWell.
  */
 export class PatientUpdaterCommonWell extends PatientUpdater {
-  constructor(private readonly orgIdExcludeList: () => Promise<Set<string>>) {
+  constructor(private readonly orgIdExcludeList: () => Promise<string[]>) {
     super();
     this.orgIdExcludeList = orgIdExcludeList;
   }

--- a/packages/api/src/external/commonwell/patient-updater-commonwell.ts
+++ b/packages/api/src/external/commonwell/patient-updater-commonwell.ts
@@ -1,11 +1,11 @@
 import { PatientUpdater } from "@metriport/core/command/patient-updater";
-import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { Patient } from "@metriport/core/domain/patient";
-import { getFacilityIdOrFail } from "../../domain/medical/patient-facility";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import cwCommands from ".";
+import { getPatients } from "../../command/medical/patient/get-patient";
+import { getFacilityIdOrFail } from "../../domain/medical/patient-facility";
 import { errorToString } from "../../shared/log";
 import { capture } from "../../shared/notifications";
-import { getPatients } from "../../command/medical/patient/get-patient";
 
 const maxNumberOfParallelRequestsToCW = 10;
 
@@ -13,9 +13,7 @@ const maxNumberOfParallelRequestsToCW = 10;
  * Implementation of the PatientUpdater that executes the logic on CommonWell.
  */
 export class PatientUpdaterCommonWell extends PatientUpdater {
-  private orgIdExcludeList: Set<string>;
-
-  constructor(orgIdExcludeList: Set<string>) {
+  constructor(private readonly orgIdExcludeList: () => Promise<Set<string>>) {
     super();
     this.orgIdExcludeList = orgIdExcludeList;
   }

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -96,7 +96,7 @@ function getStoreIdsFn(
 export async function create(
   patient: Patient,
   facilityId: string,
-  orgIdExcludeList: Set<string>,
+  getOrgIdExcludeList: () => Promise<Set<string>>,
   patientData?: {
     organization: Organization;
     facility: Facility;
@@ -142,7 +142,7 @@ export async function create(
       commonwellPatientId,
       patientRefLink,
       storeIds,
-      orgIdExcludeList,
+      getOrgIdExcludeList,
     });
 
     return { commonwellPatientId, personId };
@@ -166,7 +166,7 @@ export async function create(
 export async function update(
   patient: Patient,
   facilityId: string,
-  orgIdExcludeList: Set<string>
+  getOrgIdExcludeList: () => Promise<Set<string>>
 ): Promise<void> {
   let commonWell: CommonWellAPI | undefined;
   try {
@@ -182,7 +182,7 @@ export async function update(
       capture.message("Could not find external data on Patient, creating it @ CW", {
         extra: { patientId: patient.id, context: updateContext },
       });
-      await create(patient, facilityId, orgIdExcludeList);
+      await create(patient, facilityId, getOrgIdExcludeList);
       return;
     }
     const { queryMeta, commonwellPatient, commonwellPatientId, personId } = updateData;
@@ -205,7 +205,7 @@ export async function update(
         commonwellPatientId,
         patientRefLink,
         storeIds: getStoreIdsFn(patient.id, patient.cxId),
-        orgIdExcludeList,
+        getOrgIdExcludeList,
       });
       return;
     }
@@ -241,7 +241,7 @@ export async function update(
           commonwellPatientId,
           patientRefLink,
           storeIds: getStoreIdsFn(patient.id, patient.cxId),
-          orgIdExcludeList,
+          getOrgIdExcludeList,
         });
         return;
       }
@@ -290,7 +290,7 @@ export async function update(
       commonwellPatientId,
       personId,
       createContext,
-      orgIdExcludeList
+      getOrgIdExcludeList
     );
   } catch (error) {
     console.error(`Failed to update patient ${patient.id} @ CW: ${errorToString(error)}`);
@@ -380,7 +380,7 @@ async function findOrCreatePersonAndLink({
   commonwellPatientId,
   patientRefLink,
   storeIds,
-  orgIdExcludeList,
+  getOrgIdExcludeList,
 }: {
   commonWell: CommonWellAPI;
   queryMeta: RequestMetadata;
@@ -388,7 +388,7 @@ async function findOrCreatePersonAndLink({
   commonwellPatientId: string;
   patientRefLink: string;
   storeIds: StoreIdsFunction;
-  orgIdExcludeList: Set<string>;
+  getOrgIdExcludeList: () => Promise<Set<string>>;
 }): Promise<string> {
   const { log, debug } = Util.out(
     `CW findOrCreatePersonAndLink - CW patientId ${commonwellPatientId}`
@@ -434,7 +434,7 @@ async function findOrCreatePersonAndLink({
     commonwellPatientId,
     personId,
     createContext,
-    orgIdExcludeList
+    getOrgIdExcludeList
   );
 
   return personId;

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -96,7 +96,7 @@ function getStoreIdsFn(
 export async function create(
   patient: Patient,
   facilityId: string,
-  getOrgIdExcludeList: () => Promise<Set<string>>,
+  getOrgIdExcludeList: () => Promise<string[]>,
   patientData?: {
     organization: Organization;
     facility: Facility;
@@ -166,7 +166,7 @@ export async function create(
 export async function update(
   patient: Patient,
   facilityId: string,
-  getOrgIdExcludeList: () => Promise<Set<string>>
+  getOrgIdExcludeList: () => Promise<string[]>
 ): Promise<void> {
   let commonWell: CommonWellAPI | undefined;
   try {
@@ -388,7 +388,7 @@ async function findOrCreatePersonAndLink({
   commonwellPatientId: string;
   patientRefLink: string;
   storeIds: StoreIdsFunction;
-  getOrgIdExcludeList: () => Promise<Set<string>>;
+  getOrgIdExcludeList: () => Promise<string[]>;
 }): Promise<string> {
   const { log, debug } = Util.out(
     `CW findOrCreatePersonAndLink - CW patientId ${commonwellPatientId}`

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -16,6 +16,7 @@ import duration from "dayjs/plugin/duration";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import httpStatus from "http-status";
+import { uniqBy } from "lodash";
 import multer from "multer";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
 import { makeCarequalityManagementAPI } from "../../external/carequality/api";
@@ -95,8 +96,11 @@ router.post(
         gatewaysSet.add(org.managingOrganizationId);
       }
     }
-    console.log(`Adding ${parsedOrgs.length} CQ directory entries...`);
-    await bulkInsertCQDirectoryEntries(sequelize, parsedOrgs, cqDirectoryEntry);
+
+    // TODO remove this with https://github.com/metriport/metriport-internal/issues/1638
+    const nonDup = uniqBy(parsedOrgs, "id");
+    console.log(`Adding ${nonDup.length} CQ directory entries...`);
+    await bulkInsertCQDirectoryEntries(sequelize, nonDup, cqDirectoryEntry);
 
     await setEntriesAsGateway(Array.from(gatewaysSet));
 

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -1,8 +1,8 @@
 import BadRequestError from "@metriport/core/util/error/bad-request";
 import NotFoundError from "@metriport/core/util/error/not-found";
 import { capture } from "@metriport/core/util/notifications";
+import { initDBPool } from "@metriport/core/util/sequelize";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
-import { emptyFunction } from "@metriport/shared";
 import {
   isSuccessfulOutboundDocQueryResponse,
   isSuccessfulOutboundDocRetrievalResponse,
@@ -10,13 +10,17 @@ import {
   outboundDocumentRetrievalRespSchema,
   outboundPatientDiscoveryRespSchema,
 } from "@metriport/ihe-gateway-sdk";
+import { emptyFunction } from "@metriport/shared";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import httpStatus from "http-status";
+import multer from "multer";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
 import { makeCarequalityManagementAPI } from "../../external/carequality/api";
+import { setEntriesAsGateway } from "../../external/carequality/command/cq-directory/cq-gateways";
+import { bulkInsertCQDirectoryEntries } from "../../external/carequality/command/cq-directory/create-cq-directory-entry";
 import { createOrUpdateCQOrganization } from "../../external/carequality/command/cq-directory/create-or-update-cq-organization";
 import { parseCQDirectoryEntries } from "../../external/carequality/command/cq-directory/parse-cq-directory-entry";
 import { rebuildCQDirectory } from "../../external/carequality/command/cq-directory/rebuild-cq-directory";
@@ -25,6 +29,7 @@ import {
   searchCQDirectoriesAroundPatientAddresses,
   toBasicOrgAttributes,
 } from "../../external/carequality/command/cq-directory/search-cq-directory";
+import { cqDirectoryEntry } from "../../external/carequality/command/cq-directory/shared";
 import { createOutboundDocumentQueryResp } from "../../external/carequality/command/outbound-resp/create-outbound-document-query-resp";
 import { createOutboundDocumentRetrievalResp } from "../../external/carequality/command/outbound-resp/create-outbound-document-retrieval-resp";
 import { createOutboundPatientDiscoveryResp } from "../../external/carequality/command/outbound-resp/create-outbound-patient-discovery-resp";
@@ -43,6 +48,8 @@ import { asyncHandler, getFrom, getFromQueryAsBoolean } from "../util";
 
 dayjs.extend(duration);
 const router = Router();
+const upload = multer();
+const sequelize = initDBPool(Config.getDBCreds());
 
 /**
  * POST /internal/carequality/directory/rebuild
@@ -54,6 +61,45 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     if (Config.isSandbox()) return res.sendStatus(httpStatus.NOT_IMPLEMENTED);
     await rebuildCQDirectory();
+    return res.sendStatus(httpStatus.OK);
+  })
+);
+
+/**
+ * POST /internal/carequality/directory/insert
+ *
+ * Inserts organizations from a Carequality Directory bundle into our database.
+ * @param req.file The Carequality Directory to insert, in JSON format; it should include an array
+ *    of Organization resources, property `Bundle.entry` from the original CQ directory payload.
+ */
+router.post(
+  "/directory/insert",
+  upload.single("file"),
+  asyncHandler(async (req: Request, res: Response) => {
+    const file = req.file;
+    if (!file) {
+      throw new BadRequestError("File must be provided");
+    }
+    const bundle = JSON.parse(file.buffer.toString());
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const orgs = bundle.map((e: any) => e.resource.Organization);
+    console.log(`Got ${orgs.length} orgs`);
+
+    const parsedOrgs = parseCQDirectoryEntries(orgs);
+    console.log(`Parsed ${parsedOrgs.length} orgs`);
+
+    const gatewaysSet = new Set<string>();
+    for (const org of parsedOrgs) {
+      if (org.managingOrganizationId) {
+        gatewaysSet.add(org.managingOrganizationId);
+      }
+    }
+    console.log(`Adding ${parsedOrgs.length} CQ directory entries...`);
+    await bulkInsertCQDirectoryEntries(sequelize, parsedOrgs, cqDirectoryEntry);
+
+    await setEntriesAsGateway(Array.from(gatewaysSet));
+
     return res.sendStatus(httpStatus.OK);
   })
 );

--- a/packages/core/src/external/carequality/ihe-gateway/poll-outbound-results.ts
+++ b/packages/core/src/external/carequality/ihe-gateway/poll-outbound-results.ts
@@ -10,7 +10,7 @@ import { MetriportError } from "../../../util/error/metriport-error";
 import { errorToString } from "../../../util/error/shared";
 import { capture } from "../../../util/notifications";
 import { checkIfRaceIsComplete, controlDuration, RaceControl } from "../../../util/race-control";
-import { initSequelizeForLambda } from "../../../util/sequelize";
+import { initDBPool } from "../../../util/sequelize";
 import {
   OutboundDocumentQueryRespTableEntry,
   OutboundDocumentRetrievalRespTableEntry,
@@ -85,7 +85,7 @@ async function pollResults({
   resultsTable: string;
   context: string;
 }): Promise<object[]> {
-  const sequelize = initSequelizeForLambda(dbCreds);
+  const sequelize = initDBPool(dbCreds);
   const raceControl: RaceControl = { isRaceInProgress: true };
   const maxTimeout = maxPollingDuration ?? CONTROL_TIMEOUT.asMilliseconds();
 

--- a/packages/core/src/external/carequality/ihe-gateway/poll-outbound-results.ts
+++ b/packages/core/src/external/carequality/ihe-gateway/poll-outbound-results.ts
@@ -113,7 +113,7 @@ async function pollResults({
       console.log(`${raceResult}. ${details}`);
       raceControl.isRaceInProgress = false;
     } else if (!allGWsCompleted) {
-      const msg = `IHE GW results are incomplete for ${context}}`;
+      const msg = `IHE GW results are incomplete for ${context}`;
       console.log(`${msg}. ${details}`);
       capture.message(msg, {
         extra: {

--- a/packages/core/src/external/carequality/pd/get-xcpd-statistics.ts
+++ b/packages/core/src/external/carequality/pd/get-xcpd-statistics.ts
@@ -6,7 +6,7 @@ import { QueryTypes } from "sequelize";
 import z from "zod";
 import { MPIMetriportAPI } from "../../../mpi/patient-mpi-metriport-api";
 import { executeAsynchronously } from "../../../util/concurrency";
-import { initSequelizeForLambda } from "../../../util/sequelize";
+import { initDBPool } from "../../../util/sequelize";
 import { mapPatientResourceToPatientData } from "./process-inbound-pd";
 
 const MAX_NUMBER_OF_PARALLEL_XCPD_PROCESSING_REQUESTS = 20;
@@ -49,7 +49,7 @@ export async function getXcpdStatisticsForPatient(
 ): Promise<string> {
   console.log("Starting XCPD statistics calculation...");
   const mpi = new MPIMetriportAPI(apiUrl);
-  const sequelize = initSequelizeForLambda(sqlDBCreds, false);
+  const sequelize = initDBPool(sqlDBCreds);
 
   let query = `
   SELECT * FROM patient_discovery_result

--- a/packages/core/src/util/sequelize.ts
+++ b/packages/core/src/util/sequelize.ts
@@ -1,4 +1,4 @@
-import { Sequelize } from "sequelize";
+import { PoolOptions, Sequelize } from "sequelize";
 import { z } from "zod";
 
 export const dbCredsSchema = z.object({
@@ -11,9 +11,18 @@ export const dbCredsSchema = z.object({
 });
 
 /**
- * This function is used to initialize sequelize for lambda functions.
+ * This function is used to initialize the DB pool for raw queries that can't rely on Models.
  */
-export function initSequelizeForLambda(dbCreds: string, logging = true) {
+export function initDBPool(
+  dbCreds: string,
+  poolOptions: PoolOptions = {
+    max: 5,
+    min: 1,
+    acquire: 30000,
+    idle: 10000,
+  },
+  logging = false
+) {
   const sqlDBCreds = JSON.parse(dbCreds);
   const parsedDbCreds = dbCredsSchema.parse(sqlDBCreds);
 
@@ -25,12 +34,7 @@ export function initSequelizeForLambda(dbCreds: string, logging = true) {
       host: parsedDbCreds.host,
       port: parsedDbCreds.port,
       dialect: parsedDbCreds.engine,
-      pool: {
-        max: 5,
-        min: 1,
-        acquire: 30000,
-        idle: 10000,
-      },
+      pool: poolOptions,
       logging,
     }
   );


### PR DESCRIPTION
Ref. metriport/metriport-internal#1608

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1801

### Description

- Adjust how we determine/obtain CQ exclude IDs for CW network links
- Fix CQ directory table to keep its structure across rebuilds
- Move get orgs to exclude to be awaited on CW code
- Refactor CW commands so we can use VSCode's `find all references`

Follow up ticket to load the list of CQ org ids in memory: https://github.com/metriport/metriport-internal/issues/1640

### Testing

- Local
  - [x] Rebuild CQ directory
  - [x] Filter CQ org IDs based on CW top-level org
- Staging
  - none
- Sandbox
  - none
- Production
  - [ ] Update a patient with network links to CQ org and see that ling being downgraded to LOLA1
  - [ ] CQ directory rebuild

### Release Plan

- [ ] Merge this
