### PR TITLE
fix(api): set convert 0 if no succ docs

### DIFF
--- a/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
@@ -82,7 +82,9 @@ export async function processOutboundDocumentRetrievalResps({
               status: "processing",
             },
           }
-        : {}),
+        : {
+            convertProgress: { total: 0, status: "completed" },
+          }),
       requestId,
       source: MedicalDataSource.CAREQUALITY,
     });


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: #1350

### Dependencies

- Upstream: none
- Downstream: none

### Description

There is an issue where if we set the conversion progress before the doc retrieval to a certain # but then we dont receive any successful doc entries then since we only change if it has at least one it will stay at the previous #. Now if its 0 we set the total to 0 and mark complete. - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1711459850269839)

### Testing

- Local
  - [x] Update patient progress and send request to results endpoint to see if its changes.
- Staging
  - [ ] Update patient progress and send request to results endpoint to see if its changes.
- Production
  - [ ] monitor logs 

### Release Plan

- [ ] Merge this
