### PR TITLE
Patch datetime inbound

### DIFF
--- a/packages/ihe-gateway/server/CodeTemplates/XCPD Library - Inbound/Generate HL7v3 Subject from FHIR Patient /Generate HL7v3 Subject from FHIR Patient .js
+++ b/packages/ihe-gateway/server/CodeTemplates/XCPD Library - Inbound/Generate HL7v3 Subject from FHIR Patient /Generate HL7v3 Subject from FHIR Patient .js
@@ -84,7 +84,7 @@ function getXCPDResponseSubject(lambda) {
 
 	// The date and time this person was born 
 	if (patientResource.hasOwnProperty('birthDate')) try {
-		patient.appendChild(new XML('<birthTime value="' + DateUtil.convertDate('yyyy-MM-dd', 'yyyyMMdd', patientResource.birthDate.toString().substring(0, 9)) +  '"/>'))
+		patient.appendChild(new XML('<birthTime value="' + DateUtil.convertDate('yyyy-MM-dd', 'yyyyMMdd', patientResource.birthDate.toString().substring(0, 10)) +  '"/>'))
 	} catch(ex) {
 		if (globalMap.containsKey('TEST_MODE')) logger.error('Code Template: XCPD Inbound - getXCPDResponseSubject() - birthDate: ' + ex);
 	}


### PR DESCRIPTION
Ticket: #[1350](https://github.com/metriport/metriport-internal/issues/1350)

### Description

- every single date we have been returning on inbound patient discovery has been missing the last digit and wrong 🤯 . there are 10 values in a string, and substring(start,end) is exclusive so it misses the 10th digit if we just index (0,9)

### Testing

- Local
  - [x] locally testing javascript code 
  - [x] locally testing mirth

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
