### PR TITLE
1643 delete patient

### DIFF
--- a/packages/api/src/command/medical/patient/delete-patient.ts
+++ b/packages/api/src/command/medical/patient/delete-patient.ts
@@ -31,9 +31,11 @@ export const deletePatient = async (patientDelete: PatientDeleteCmd): Promise<vo
     // These need to run before the Patient is deleted (need patient data from the DB)
     await Promise.all([
       cwCommands.patient.remove(patient, facilityId).catch(err => {
-        if (err.response?.status !== 404) throw err;
-        console.log(`Patient not found @ CW when deleting ${patient.id} , continuing...`);
-        processAsyncError(deleteContext);
+        if (err.response?.status === 404) {
+          console.log(`Patient not found @ CW when deleting ${patient.id} , continuing...`);
+          return;
+        }
+        processAsyncError(deleteContext)(err);
       }),
       fhirApi.deleteResource("Patient", patient.id).catch(processAsyncError(deleteContext)),
       cqCommands.patient.remove(patient).catch(processAsyncError(deleteContext)),

--- a/packages/api/src/command/medical/patient/delete-patient.ts
+++ b/packages/api/src/command/medical/patient/delete-patient.ts
@@ -4,7 +4,6 @@ import cqCommands from "../../../external/carequality";
 import cwCommands from "../../../external/commonwell";
 import { makeFhirApi } from "../../../external/fhir/api/api-factory";
 import { validateVersionForUpdate } from "../../../models/_default";
-import { Config } from "../../../shared/config";
 import { capture } from "../../../shared/notifications";
 import { BaseUpdateCmdWithCustomer } from "../base-update-command";
 import { getPatientOrFail } from "./get-patient";
@@ -19,43 +18,36 @@ export type DeleteOptions = {
   allEnvs?: boolean;
 };
 
-export const deletePatient = async (
-  patientDelete: PatientDeleteCmd,
-  options: DeleteOptions = {}
-): Promise<void> => {
+export const deletePatient = async (patientDelete: PatientDeleteCmd): Promise<void> => {
   const { id, cxId, facilityId: facilityIdParam, eTag } = patientDelete;
 
   const patient = await getPatientOrFail({ id, cxId });
   validateVersionForUpdate(patient, eTag);
 
   const facilityId = getFacilityIdOrFail(patient, facilityIdParam);
+  const fhirApi = makeFhirApi(cxId);
 
-  if (options.allEnvs || Config.isSandbox()) {
-    const fhirApi = makeFhirApi(cxId);
-
-    try {
-      // These need to run before the Patient is deleted (need patient data from the DB)
-      await Promise.all([
-        cwCommands.patient.remove(patient, facilityId).catch(err => {
-          if (err.response?.status !== 404) throw err;
-          console.log(`Patient not found @ CW when deleting ${patient.id} , continuing...`);
-          processAsyncError(deleteContext);
-        }),
-        fhirApi.deleteResource("Patient", patient.id).catch(processAsyncError(deleteContext)),
-        cqCommands.patient.remove(patient).catch(processAsyncError(deleteContext)),
-      ]);
-      await patient.destroy();
-    } catch (error) {
-      capture.error("Failed to delete patient", {
-        extra: {
-          context: deleteContext,
-          patientId: patient.id,
-          facilityId,
-          options,
-          error,
-        },
-      });
-      throw error;
-    }
+  try {
+    // These need to run before the Patient is deleted (need patient data from the DB)
+    await Promise.all([
+      cwCommands.patient.remove(patient, facilityId).catch(err => {
+        if (err.response?.status !== 404) throw err;
+        console.log(`Patient not found @ CW when deleting ${patient.id} , continuing...`);
+        processAsyncError(deleteContext);
+      }),
+      fhirApi.deleteResource("Patient", patient.id).catch(processAsyncError(deleteContext)),
+      cqCommands.patient.remove(patient).catch(processAsyncError(deleteContext)),
+    ]);
+    await patient.destroy();
+  } catch (error) {
+    capture.error("Failed to delete patient", {
+      extra: {
+        context: deleteContext,
+        patientId: patient.id,
+        facilityId,
+        error,
+      },
+    });
+    throw error;
   }
 };

--- a/packages/api/src/routes/medical/internal-patient.ts
+++ b/packages/api/src/routes/medical/internal-patient.ts
@@ -185,7 +185,7 @@ router.delete(
       cxId,
       facilityId,
     };
-    await deletePatient(patientDeleteCmd, { allEnvs: true });
+    await deletePatient(patientDeleteCmd);
 
     return res.sendStatus(status.NO_CONTENT);
   })

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -181,7 +181,7 @@ router.delete(
       cxId,
       facilityId,
     };
-    await deletePatient(patientDeleteCmd);
+    await deletePatient(patientDeleteCmd, { allEnvs: true });
 
     return res.sendStatus(status.NO_CONTENT);
   })

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -181,7 +181,7 @@ router.delete(
       cxId,
       facilityId,
     };
-    await deletePatient(patientDeleteCmd, { allEnvs: true });
+    await deletePatient(patientDeleteCmd);
 
     return res.sendStatus(status.NO_CONTENT);
   })


### PR DESCRIPTION
Ticket: #[1643](https://github.com/metriport/metriport-internal/issues/1643)

### Description

- patient deletion hasn't been working for months? Delete patient always gets passed an empty allEnvs before which means the patient deletion never happens: https://github.com/metriport/metriport/blob/61e55d5885d22000f74328cb88883b81c5f30428/packages/api/src/command/medical/patient/delete-patient.ts#L24

### Testing

- Local
  - [x] patient deletion flow local

### Release Plan

- [ ] Merge this
