### PR TITLE
fix(api): trigger schedule query no cw links

### DIFF
--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -12,7 +12,7 @@ import { calculateConversionProgress } from "../../../domain/medical/conversion-
 import { validateOptionalFacilityId } from "../../../domain/medical/patient-facility";
 import { isCarequalityEnabled, isCommonwellEnabled } from "../../../external/aws/appConfig";
 import { getDocumentsFromCQ } from "../../../external/carequality/document/query-documents";
-import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
+import { getAllCQOrgsIds } from "../../../../src/external/carequality/command/cq-directory/get-organizations-for-xcpd";
 import { queryAndProcessDocuments as getDocumentsFromCW } from "../../../external/commonwell/document/document-query";
 import { resetDocQueryProgress } from "../../../external/hie/reset-doc-query-progress";
 import { PatientModel } from "../../../models/medical/patient";

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -12,6 +12,7 @@ import { calculateConversionProgress } from "../../../domain/medical/conversion-
 import { validateOptionalFacilityId } from "../../../domain/medical/patient-facility";
 import { isCarequalityEnabled, isCommonwellEnabled } from "../../../external/aws/appConfig";
 import { getDocumentsFromCQ } from "../../../external/carequality/document/query-documents";
+import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
 import { queryAndProcessDocuments as getDocumentsFromCW } from "../../../external/commonwell/document/document-query";
 import { resetDocQueryProgress } from "../../../external/hie/reset-doc-query-progress";
 import { PatientModel } from "../../../models/medical/patient";
@@ -21,7 +22,6 @@ import { Util } from "../../../shared/util";
 import { getPatientOrFail } from "../patient/get-patient";
 import { storeQueryInit } from "../patient/query-init";
 import { areDocumentsProcessing } from "./document-status";
-import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
 
 export function isProgressEqual(a?: Progress, b?: Progress): boolean {
   return (
@@ -88,13 +88,15 @@ export async function queryDocumentsAcrossHIEs({
 
   const commonwellEnabled = await isCommonwellEnabled();
   if (commonwellEnabled || forceCommonwell || Config.isSandbox()) {
+    const orgIdExcludeList = await getAllCQOrgsIds();
+
     getDocumentsFromCW({
       patient,
       facilityId,
       forceDownload: override,
       forceQuery,
       requestId,
-      getAllCQOrgsIds,
+      orgIdExcludeList,
     }).catch(emptyFunction);
   }
 

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -21,7 +21,7 @@ import { Util } from "../../../shared/util";
 import { getPatientOrFail } from "../patient/get-patient";
 import { storeQueryInit } from "../patient/query-init";
 import { areDocumentsProcessing } from "./document-status";
-import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
+import { getCqOrgIdsToDenyOnCw } from "../hie";
 
 export function isProgressEqual(a?: Progress, b?: Progress): boolean {
   return (
@@ -94,7 +94,7 @@ export async function queryDocumentsAcrossHIEs({
       forceDownload: override,
       forceQuery,
       requestId,
-      getAllCQOrgsIds,
+      getOrgIdExcludeList: getCqOrgIdsToDenyOnCw,
     }).catch(emptyFunction);
   }
 

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -21,6 +21,7 @@ import { Util } from "../../../shared/util";
 import { getPatientOrFail } from "../patient/get-patient";
 import { storeQueryInit } from "../patient/query-init";
 import { areDocumentsProcessing } from "./document-status";
+import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
 
 export function isProgressEqual(a?: Progress, b?: Progress): boolean {
   return (
@@ -93,6 +94,7 @@ export async function queryDocumentsAcrossHIEs({
       forceDownload: override,
       forceQuery,
       requestId,
+      getAllCQOrgsIds,
     }).catch(emptyFunction);
   }
 

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -12,7 +12,6 @@ import { calculateConversionProgress } from "../../../domain/medical/conversion-
 import { validateOptionalFacilityId } from "../../../domain/medical/patient-facility";
 import { isCarequalityEnabled, isCommonwellEnabled } from "../../../external/aws/appConfig";
 import { getDocumentsFromCQ } from "../../../external/carequality/document/query-documents";
-import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
 import { queryAndProcessDocuments as getDocumentsFromCW } from "../../../external/commonwell/document/document-query";
 import { resetDocQueryProgress } from "../../../external/hie/reset-doc-query-progress";
 import { PatientModel } from "../../../models/medical/patient";
@@ -22,6 +21,7 @@ import { Util } from "../../../shared/util";
 import { getPatientOrFail } from "../patient/get-patient";
 import { storeQueryInit } from "../patient/query-init";
 import { areDocumentsProcessing } from "./document-status";
+import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
 
 export function isProgressEqual(a?: Progress, b?: Progress): boolean {
   return (
@@ -88,15 +88,13 @@ export async function queryDocumentsAcrossHIEs({
 
   const commonwellEnabled = await isCommonwellEnabled();
   if (commonwellEnabled || forceCommonwell || Config.isSandbox()) {
-    const orgIdExcludeList = await getAllCQOrgsIds();
-
     getDocumentsFromCW({
       patient,
       facilityId,
       forceDownload: override,
       forceQuery,
       requestId,
-      orgIdExcludeList,
+      getAllCQOrgsIds,
     }).catch(emptyFunction);
   }
 

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -12,7 +12,7 @@ import { calculateConversionProgress } from "../../../domain/medical/conversion-
 import { validateOptionalFacilityId } from "../../../domain/medical/patient-facility";
 import { isCarequalityEnabled, isCommonwellEnabled } from "../../../external/aws/appConfig";
 import { getDocumentsFromCQ } from "../../../external/carequality/document/query-documents";
-import { getAllCQOrgsIds } from "../../../../src/external/carequality/command/cq-directory/get-organizations-for-xcpd";
+import { getAllCQOrgsIds } from "../../../external/carequality/command/cq-directory/get-organizations-for-xcpd";
 import { queryAndProcessDocuments as getDocumentsFromCW } from "../../../external/commonwell/document/document-query";
 import { resetDocQueryProgress } from "../../../external/hie/reset-doc-query-progress";
 import { PatientModel } from "../../../models/medical/patient";

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -15,7 +15,7 @@ import { getCQPatientData } from "../command/cq-patient-data/get-cq-data";
 import { CQLink } from "../cq-patient-data";
 import { getCQData } from "../patient";
 import { createOutboundDocumentQueryRequests } from "./create-outbound-document-query-req";
-import { scheduleDocQuery } from "./schedule-document-query";
+import { scheduleDocQuery } from "../../hie/schedule-document-query";
 
 const iheGateway = makeIheGatewayAPIForDocQuery();
 const resultPoller = makeOutboundResultPoller();
@@ -43,7 +43,7 @@ export async function getDocumentsFromCQ({
 
     // If DQ is triggered while the PD is in progress, schedule it to be done when PD is completed
     if (getCQData(patient.data.externalData)?.discoveryStatus === "processing") {
-      await scheduleDocQuery({ requestId, patient });
+      await scheduleDocQuery({ requestId, patient, source: MedicalDataSource.CAREQUALITY });
       return;
     }
     if (!cqPatientData || cqPatientData.data.links.length <= 0) {

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -39,14 +39,13 @@ export async function getDocumentsFromCQ({
     const [organization, cqPatientData] = await Promise.all([
       getOrganizationOrFail({ cxId }),
       getCQPatientData({ id: patient.id, cxId }),
+      setDocQueryProgress({
+        patient: { id: patient.id, cxId: patient.cxId },
+        downloadProgress: { status: "processing" },
+        requestId,
+        source: MedicalDataSource.CAREQUALITY,
+      }),
     ]);
-
-    await setDocQueryProgress({
-      patient: { id: patient.id, cxId: patient.cxId },
-      downloadProgress: { status: "processing" },
-      requestId,
-      source: MedicalDataSource.CAREQUALITY,
-    });
 
     // If DQ is triggered while the PD is in progress, schedule it to be done when PD is completed
     if (getCQData(patient.data.externalData)?.discoveryStatus === "processing") {

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -41,6 +41,13 @@ export async function getDocumentsFromCQ({
       getCQPatientData({ id: patient.id, cxId }),
     ]);
 
+    await setDocQueryProgress({
+      patient: { id: patient.id, cxId: patient.cxId },
+      downloadProgress: { status: "processing" },
+      requestId,
+      source: MedicalDataSource.CAREQUALITY,
+    });
+
     // If DQ is triggered while the PD is in progress, schedule it to be done when PD is completed
     if (getCQData(patient.data.externalData)?.discoveryStatus === "processing") {
       await scheduleDocQuery({ requestId, patient, source: MedicalDataSource.CAREQUALITY });

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -92,7 +92,7 @@ export async function queryAndProcessDocuments({
   ignoreDocRefOnFHIRServer,
   ignoreFhirConversionAndUpsert,
   requestId,
-  getAllCQOrgsIds,
+  getOrgIdExcludeList,
 }: {
   patient: Patient;
   facilityId?: string | undefined;
@@ -101,7 +101,7 @@ export async function queryAndProcessDocuments({
   ignoreDocRefOnFHIRServer?: boolean;
   ignoreFhirConversionAndUpsert?: boolean;
   requestId: string;
-  getAllCQOrgsIds?: () => Promise<Set<string>>;
+  getOrgIdExcludeList: () => Promise<string[]>;
 }): Promise<void> {
   const { id: patientId, cxId } = patientParam;
   const { log } = Util.out(`CW queryDocuments: ${requestId} - M patient ${patientId}`);
@@ -131,16 +131,14 @@ export async function queryAndProcessDocuments({
     // If patient has no links in CW then we want to schedule a doc query
     // and to prevent infinite loops we need to check if the patient has any CQ orgs
     // as its only called the first time
-    if (hasNoCWStatus && getAllCQOrgsIds) {
+    if (hasNoCWStatus && getOrgIdExcludeList) {
       await scheduleDocQuery({
         requestId,
         patient: { id: patientId, cxId },
         source: MedicalDataSource.COMMONWELL,
       });
 
-      const orgIdExcludeList = await getAllCQOrgsIds();
-
-      await updatePatient(patientParam, facility.id, orgIdExcludeList);
+      await updatePatient(patientParam, facility.id, getOrgIdExcludeList);
       return;
     }
 

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -92,7 +92,7 @@ export async function queryAndProcessDocuments({
   ignoreDocRefOnFHIRServer,
   ignoreFhirConversionAndUpsert,
   requestId,
-  getAllCQOrgsIds,
+  orgIdExcludeList,
 }: {
   patient: Patient;
   facilityId?: string | undefined;
@@ -101,7 +101,7 @@ export async function queryAndProcessDocuments({
   ignoreDocRefOnFHIRServer?: boolean;
   ignoreFhirConversionAndUpsert?: boolean;
   requestId: string;
-  getAllCQOrgsIds?: () => Promise<Set<string>>;
+  orgIdExcludeList?: Set<string>;
 }): Promise<void> {
   const { id: patientId, cxId } = patientParam;
   const { log } = Util.out(`CW queryDocuments: ${requestId} - M patient ${patientId}`);
@@ -131,14 +131,12 @@ export async function queryAndProcessDocuments({
     // If patient has no links in CW then we want to schedule a doc query
     // and to prevent infinite loops we need to check if the patient has any CQ orgs
     // as its only called the first time
-    if (hasNoCWStatus && getAllCQOrgsIds) {
+    if (hasNoCWStatus && orgIdExcludeList) {
       await scheduleDocQuery({
         requestId,
         patient: { id: patientId, cxId },
         source: MedicalDataSource.COMMONWELL,
       });
-
-      const orgIdExcludeList = await getAllCQOrgsIds();
 
       await updatePatient(patientParam, facility.id, orgIdExcludeList);
       return;

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -101,8 +101,7 @@ export async function queryAndProcessDocuments({
   ignoreDocRefOnFHIRServer?: boolean;
   ignoreFhirConversionAndUpsert?: boolean;
   requestId: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  orgIdExcludeList?: any;
+  orgIdExcludeList?: Set<string>;
 }): Promise<void> {
   const { id: patientId, cxId } = patientParam;
   const { log } = Util.out(`CW queryDocuments: ${requestId} - M patient ${patientId}`);

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -101,7 +101,8 @@ export async function queryAndProcessDocuments({
   ignoreDocRefOnFHIRServer?: boolean;
   ignoreFhirConversionAndUpsert?: boolean;
   requestId: string;
-  orgIdExcludeList?: Set<string>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  orgIdExcludeList?: any;
 }): Promise<void> {
   const { id: patientId, cxId } = patientParam;
   const { log } = Util.out(`CW queryDocuments: ${requestId} - M patient ${patientId}`);

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -92,7 +92,7 @@ export async function queryAndProcessDocuments({
   ignoreDocRefOnFHIRServer,
   ignoreFhirConversionAndUpsert,
   requestId,
-  orgIdExcludeList,
+  getAllCQOrgsIds,
 }: {
   patient: Patient;
   facilityId?: string | undefined;
@@ -101,7 +101,7 @@ export async function queryAndProcessDocuments({
   ignoreDocRefOnFHIRServer?: boolean;
   ignoreFhirConversionAndUpsert?: boolean;
   requestId: string;
-  orgIdExcludeList?: Set<string>;
+  getAllCQOrgsIds?: () => Promise<Set<string>>;
 }): Promise<void> {
   const { id: patientId, cxId } = patientParam;
   const { log } = Util.out(`CW queryDocuments: ${requestId} - M patient ${patientId}`);
@@ -131,12 +131,14 @@ export async function queryAndProcessDocuments({
     // If patient has no links in CW then we want to schedule a doc query
     // and to prevent infinite loops we need to check if the patient has any CQ orgs
     // as its only called the first time
-    if (hasNoCWStatus && orgIdExcludeList) {
+    if (hasNoCWStatus && getAllCQOrgsIds) {
       await scheduleDocQuery({
         requestId,
         patient: { id: patientId, cxId },
         source: MedicalDataSource.COMMONWELL,
       });
+
+      const orgIdExcludeList = await getAllCQOrgsIds();
 
       await updatePatient(patientParam, facility.id, orgIdExcludeList);
       return;

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -127,9 +127,9 @@ export async function queryAndProcessDocuments({
 
     const patientCWData = getCWData(patientParam.data.externalData);
     const hasNoCWStatus = !patientCWData || !patientCWData.status;
-    const isLinking = patientCWData?.status === "processing";
+    const isProcessing = patientCWData?.status === "processing";
 
-    if (hasNoCWStatus || isLinking) {
+    if (hasNoCWStatus || isProcessing) {
       await scheduleDocQuery({
         requestId,
         patient: { id: patientId, cxId },

--- a/packages/api/src/external/commonwell/patient-external-data.ts
+++ b/packages/api/src/external/commonwell/patient-external-data.ts
@@ -10,7 +10,6 @@ import { executeOnDBTx } from "../../models/transaction-wrapper";
 import { LinkStatus } from "../patient-link";
 import { getCWData, getLinkStatusCQ } from "./patient";
 import { CQLinkStatus, PatientDataCommonwell } from "./patient-shared";
-import { queryAndProcessDocuments } from "./document/document-query";
 
 dayjs.extend(duration);
 
@@ -103,19 +102,13 @@ export async function resetPatientScheduledDocQueryRequestId({
   patient,
 }: {
   patient: Patient;
-}): Promise<void> {
+}): Promise<Patient> {
   const patientFilter = {
     id: patient.id,
     cxId: patient.cxId,
   };
 
-  const scheduledDocQueryRequestId = getCWData(
-    patient.data.externalData
-  )?.scheduledDocQueryRequestId;
-
-  if (!scheduledDocQueryRequestId) return;
-
-  const updatedPatient = await executeOnDBTx(PatientModel.prototype, async transaction => {
+  return await executeOnDBTx(PatientModel.prototype, async transaction => {
     const existingPatient = await getPatientOrFail({
       ...patientFilter,
       lock: true,
@@ -146,10 +139,5 @@ export async function resetPatientScheduledDocQueryRequestId({
     });
 
     return updatedPatient;
-  });
-
-  queryAndProcessDocuments({
-    patient: updatedPatient,
-    requestId: scheduledDocQueryRequestId,
   });
 }

--- a/packages/api/src/external/commonwell/patient-external-data.ts
+++ b/packages/api/src/external/commonwell/patient-external-data.ts
@@ -148,7 +148,6 @@ export async function updatePatientScheduledQueryRequestId({
     queryAndProcessDocuments({
       patient: updatedPatient,
       requestId: scheduledDocQueryRequestId,
-      scheduledDocQuery: true,
     });
   });
 }

--- a/packages/api/src/external/commonwell/patient-external-data.ts
+++ b/packages/api/src/external/commonwell/patient-external-data.ts
@@ -99,7 +99,7 @@ export const setCommonwellId = async ({
   });
 };
 
-export async function updatePatientScheduledQueryRequestId({
+export async function resetPatientScheduledDocQueryRequestId({
   patient,
 }: {
   patient: Patient;
@@ -115,7 +115,7 @@ export async function updatePatientScheduledQueryRequestId({
 
   if (!scheduledDocQueryRequestId) return;
 
-  await executeOnDBTx(PatientModel.prototype, async transaction => {
+  const updatedPatient = await executeOnDBTx(PatientModel.prototype, async transaction => {
     const existingPatient = await getPatientOrFail({
       ...patientFilter,
       lock: true,
@@ -145,9 +145,11 @@ export async function updatePatientScheduledQueryRequestId({
       transaction,
     });
 
-    queryAndProcessDocuments({
-      patient: updatedPatient,
-      requestId: scheduledDocQueryRequestId,
-    });
+    return updatedPatient;
+  });
+
+  queryAndProcessDocuments({
+    patient: updatedPatient,
+    requestId: scheduledDocQueryRequestId,
   });
 }

--- a/packages/api/src/external/commonwell/patient-shared.ts
+++ b/packages/api/src/external/commonwell/patient-shared.ts
@@ -34,7 +34,8 @@ export class PatientDataCommonwell extends PatientExternalDataEntry {
     public patientId: string,
     public personId?: string | undefined,
     public status?: LinkStatus | undefined,
-    public cqLinkStatus?: CQLinkStatus
+    public cqLinkStatus?: CQLinkStatus,
+    public scheduledDocQueryRequestId?: string | undefined
   ) {
     super();
   }

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -22,7 +22,7 @@ import { LinkStatus } from "../patient-link";
 import { makeCommonWellAPI } from "./api";
 import { autoUpgradeNetworkLinks } from "./link/shared";
 import { makePersonForPatient, patientToCommonwell } from "./patient-conversion";
-import { setCommonwellId } from "./patient-external-data";
+import { setCommonwellId, updatePatientScheduledQueryRequestId } from "./patient-external-data";
 import {
   CQLinkStatus,
   findOrCreatePerson,
@@ -292,6 +292,10 @@ export async function update(
       createContext,
       orgIdExcludeList
     );
+
+    // Update the scheduled query request ID if it exists
+    // and retrigger the scheduled query
+    await updatePatientScheduledQueryRequestId({ patient });
   } catch (error) {
     console.error(`Failed to update patient ${patient.id} @ CW: ${errorToString(error)}`);
     capture.error(error, {

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -22,7 +22,7 @@ import { LinkStatus } from "../patient-link";
 import { makeCommonWellAPI } from "./api";
 import { autoUpgradeNetworkLinks } from "./link/shared";
 import { makePersonForPatient, patientToCommonwell } from "./patient-conversion";
-import { setCommonwellId, updatePatientScheduledQueryRequestId } from "./patient-external-data";
+import { setCommonwellId, resetPatientScheduledDocQueryRequestId } from "./patient-external-data";
 import {
   CQLinkStatus,
   findOrCreatePerson,
@@ -293,9 +293,7 @@ export async function update(
       getOrgIdExcludeList
     );
 
-    // Update the scheduled query request ID if it exists
-    // and retrigger the scheduled query
-    await updatePatientScheduledQueryRequestId({ patient });
+    await resetPatientScheduledDocQueryRequestId({ patient });
   } catch (error) {
     console.error(`Failed to update patient ${patient.id} @ CW: ${errorToString(error)}`);
     capture.error(error, {
@@ -343,6 +341,14 @@ export async function remove(patient: Patient, facilityId: string): Promise<void
     });
     throw err;
   }
+}
+
+export async function linkPatientToCW(
+  patient: Patient,
+  facilityId: string,
+  getOrgIdExcludeList: () => Promise<string[]>
+) {
+  await update(patient, facilityId, getOrgIdExcludeList);
 }
 
 async function setupUpdate(

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -360,7 +360,7 @@ export async function linkPatientToCW(
   patient: Patient,
   facilityId: string,
   getOrgIdExcludeList: () => Promise<string[]>
-) {
+): Promise<void> {
   await update(patient, facilityId, getOrgIdExcludeList);
 }
 

--- a/packages/api/src/external/hie/schedule-document-query.ts
+++ b/packages/api/src/external/hie/schedule-document-query.ts
@@ -1,8 +1,9 @@
+import { MedicalDataSource } from "@metriport/core/external/index";
 import { Patient } from "@metriport/core/domain/patient";
 import { out } from "@metriport/core/util/log";
-import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
-import { PatientModel } from "../../../models/medical/patient";
-import { executeOnDBTx } from "../../../models/transaction-wrapper";
+import { getPatientOrFail } from "../../command/medical/patient/get-patient";
+import { PatientModel } from "../../models/medical/patient";
+import { executeOnDBTx } from "../../models/transaction-wrapper";
 
 /**
  * Stores the requestId as the scheduled document query to be executed when the patient discovery
@@ -11,13 +12,15 @@ import { executeOnDBTx } from "../../../models/transaction-wrapper";
 export async function scheduleDocQuery({
   requestId,
   patient,
+  source,
 }: {
   requestId: string;
   patient: Pick<Patient, "id" | "cxId">;
+  source: MedicalDataSource;
 }) {
-  const { log } = out(`CQ DQ - requestId ${requestId}, patient ${patient.id}`);
+  const { log } = out(`${source} DQ - requestId ${requestId}, patient ${patient.id}`);
 
-  log(`Scheduling document query to be executed when PD is completed`);
+  log(`Scheduling document query to be executed`);
 
   const patientFilter = {
     id: patient.id,
@@ -35,8 +38,8 @@ export async function scheduleDocQuery({
 
     const updatedExternalData = {
       ...externalData,
-      CAREQUALITY: {
-        ...externalData.CAREQUALITY,
+      [source]: {
+        ...externalData[source],
         scheduledDocQueryRequestId: requestId,
       },
     };


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

### Dependencies

- Upstream:  none
- Downstream: none 

### Description

Trigger a scheduled doc query for when a patient does not have CW data

### Testing

- Local
  - [x] Run doc query for patient with no CW external data
- Staging
  - [ ] Run doc query for patient with no CW external data
- Production
  - [ ] Monitor

### Release Plan

- [ ] Merge this
