### PR TITLE
fix(api): add download progress before schedule doc query

### DIFF
--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -125,6 +125,13 @@ export async function queryAndProcessDocuments({
       facilityId
     );
 
+    await setDocQueryProgress({
+      patient: { id: patientId, cxId },
+      downloadProgress: { status: "processing" },
+      requestId,
+      source: MedicalDataSource.COMMONWELL,
+    });
+
     const patientCWData = getCWData(patientParam.data.externalData);
     const hasNoCWStatus = !patientCWData || !patientCWData.status;
     const isProcessing = patientCWData?.status === "processing";


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: #1350

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1821
- Downstream: none

### Description

Left over from upstream PR needed to call doc query progress before schedule doc query

### Testing

_[Regular PRs:]_

- Local
  - [x] Run doc query for patient with no CW external data sets to processing before schedule
- Staging
  - [ ] Run doc query for patient with no CW external data sets to processing before schedule
- Production
  - [ ] Monitor

### Release Plan

- [ ] Merge this
