### PR TITLE
PATCH reset only source doc progress

### DIFF
--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -80,7 +80,12 @@ export async function processOutboundDocumentQueryResps({
               total: convertibleDocCount,
             },
           }
-        : {}),
+        : {
+            convertProgress: {
+              status: "completed",
+              total: 0,
+            },
+          }),
       requestId,
       source: MedicalDataSource.CAREQUALITY,
     });

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -42,6 +42,7 @@ export async function getDocumentsFromCQ({
       setDocQueryProgress({
         patient: { id: patient.id, cxId: patient.cxId },
         downloadProgress: { status: "processing" },
+        convertProgress: { status: "processing" },
         requestId,
         source: MedicalDataSource.CAREQUALITY,
       }),

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -128,6 +128,7 @@ export async function queryAndProcessDocuments({
     await setDocQueryProgress({
       patient: { id: patientId, cxId },
       downloadProgress: { status: "processing" },
+      convertProgress: { status: "processing" },
       requestId,
       source: MedicalDataSource.COMMONWELL,
     });

--- a/packages/api/src/external/hie/reset-doc-query-progress.ts
+++ b/packages/api/src/external/hie/reset-doc-query-progress.ts
@@ -3,6 +3,7 @@ import { Patient } from "@metriport/core/domain/patient";
 import { PatientModel } from "../../models/medical/patient";
 import { executeOnDBTx } from "../../models/transaction-wrapper";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
+import { aggregateAndSetHIEProgresses } from "./set-doc-query-progress";
 
 /**
  * Resets the doc query progress for the given HIE
@@ -57,6 +58,13 @@ export async function resetDocQueryProgress({
         ...externalData[source],
         documentQueryProgress: {},
       };
+
+      const aggregatedDocProgresses = aggregateAndSetHIEProgresses(
+        existingPatient,
+        resetExternalData
+      );
+
+      updatedPatient.data.documentQueryProgress = aggregatedDocProgresses;
     }
 
     await PatientModel.update(updatedPatient, {

--- a/packages/api/src/external/hie/reset-doc-query-progress.ts
+++ b/packages/api/src/external/hie/reset-doc-query-progress.ts
@@ -32,35 +32,32 @@ export async function resetDocQueryProgress({
 
     const resetExternalData = { ...externalData };
 
-    if (source === MedicalDataSource.COMMONWELL) {
-      resetExternalData.COMMONWELL = {
-        ...externalData.COMMONWELL,
-        documentQueryProgress: {},
-      };
-    } else if (source === MedicalDataSource.CAREQUALITY) {
-      resetExternalData.CAREQUALITY = {
-        ...externalData.CAREQUALITY,
-        documentQueryProgress: {},
-      };
-    } else {
-      resetExternalData.COMMONWELL = {
-        ...externalData.COMMONWELL,
-        documentQueryProgress: {},
-      };
-      resetExternalData.CAREQUALITY = {
-        ...externalData.CAREQUALITY,
-        documentQueryProgress: {},
-      };
-    }
-
     const updatedPatient = {
       ...existingPatient,
       data: {
         ...existingPatient.data,
         externalData: resetExternalData,
-        documentQueryProgress: {},
       },
     };
+
+    if (source === MedicalDataSource.ALL) {
+      resetExternalData.COMMONWELL = {
+        ...externalData.COMMONWELL,
+        documentQueryProgress: {},
+      };
+
+      resetExternalData.CAREQUALITY = {
+        ...externalData.CAREQUALITY,
+        documentQueryProgress: {},
+      };
+
+      updatedPatient.data.documentQueryProgress = {};
+    } else {
+      resetExternalData[source] = {
+        ...externalData[source],
+        documentQueryProgress: {},
+      };
+    }
 
     await PatientModel.update(updatedPatient, {
       where: patientFilter,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: #1350

### Dependencies

- Upstream: NONE
- Downstream: NONE

### Description

Only reset overall doc progress when explicitly passing medicaldatasource all

### Testing

- Production
  - [] monitor logs

### Release Plan

- :warning: Points to `master`
