### PR TITLE
PATCH RELEASE Guardrails on bulk insert

### DIFF
--- a/packages/api/src/external/commonwell/organization.ts
+++ b/packages/api/src/external/commonwell/organization.ts
@@ -1,11 +1,11 @@
 import { Organization as CWOrganization } from "@metriport/commonwell-sdk";
 import { OID_PREFIX } from "@metriport/core/domain/oid";
-import { getOrgsByPrio } from "@metriport/core/external/commonwell/cq-bridge/get-orgs";
 import { Organization } from "@metriport/core/domain/organization";
+import { getOrgsByPrio } from "@metriport/core/external/commonwell/cq-bridge/get-orgs";
 import { Config, getEnvVarOrFail } from "../../shared/config";
-import { isCWEnabledForCx } from "../aws/appConfig";
 import { capture } from "../../shared/notifications";
 import { Util } from "../../shared/util";
+import { isCWEnabledForCx, isEnhancedCoverageEnabledForCx } from "../aws/appConfig";
 import {
   getCertificate,
   makeCommonWellAPI,
@@ -90,8 +90,10 @@ export const create = async (org: Organization): Promise<void> => {
     );
     debug(`resp respAddCert: `, JSON.stringify(respAddCert));
 
-    // update the CQ bridge include list
-    await initCQOrgIncludeList(org.oid);
+    if (await isEnhancedCoverageEnabledForCx(org.cxId)) {
+      // update the CQ bridge include list
+      await initCQOrgIncludeList(org.oid);
+    }
   } catch (error) {
     const msg = `Failure creating Org @ CW`;
     log(msg, error);


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Description

- Guardrails on bulk insert
- Don't init CW CQ bridge if EC is not enabled for cx - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1711587454137239)

### Testing

- Local
  - [x] bulk insert patients
  - [x] internal endpoint checks EC is enabled or not
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
