### PR TITLE
Explicit Namespace Declaration for Extrinsic Object

### DIFF
--- a/packages/core/src/external/carequality/dq/create-metadata-xml.ts
+++ b/packages/core/src/external/carequality/dq/create-metadata-xml.ts
@@ -56,7 +56,7 @@ export function createExtrinsicObjectXml({
   const organizationName = organization?.name || ORGANIZATION_NAME_DEFAULT;
   const organizationId = organization?.id || METRIPORT_HOME_COMMUNITY_ID_NO_PREFIX;
 
-  const metadataXml = `<ExtrinsicObject home="${METRIPORT_HOME_COMMUNITY_ID}" id="${documentUUID}" isOpaque="false" mimeType="${mimeType}" objectType="urn:uuid:34268e47-fdf5-41a6-ba33-82133c465248" status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved">
+  const metadataXml = `<ExtrinsicObject xmlns="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" home="${METRIPORT_HOME_COMMUNITY_ID}" id="${documentUUID}" isOpaque="false" mimeType="${mimeType}" objectType="urn:uuid:34268e47-fdf5-41a6-ba33-82133c465248" status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved">
 
     <Slot name="creationTime">
       <ValueList>


### PR DESCRIPTION
Refs: #[1350](https://github.com/metriport/metriport-internal/issues/1350)

### Description

- explicitly adding namespace 

### Testing

_[Regular PRs:]_

- Local
  - [x] manually modified s3 file for test patient and then did DQ local and got a response without an empty namespace 
  
### Release Plan

- :warning: Points to `master`
- [x] Merge this
