### PR TITLE
Document Retrieve Wrong URL

### DIFF
--- a/packages/infra/lib/ihe-stack/ihe-gateway.ts
+++ b/packages/infra/lib/ihe-stack/ihe-gateway.ts
@@ -111,7 +111,7 @@ export function createIHEGateway(stack: Construct, props: IHEGatewayProps): void
     }),
   });
   apiGateway.addRoutes({
-    path: "/v1/document-retrieval",
+    path: "/v1/document-retrieve",
     integration: new HttpAlbIntegration(`IHEGWDRIntegration`, drListener, {
       vpcLink,
       parameterMapping: new apigwv2.ParameterMapping().overwritePath(


### PR DESCRIPTION
Refs: #[1350](https://github.com/metriport/metriport-internal/issues/1350)

### Description

- misnamed path in cdk. doesnt match CQ directory 🤯 

### Release Plan

- [ ] Merge this
