### PR TITLE
1040 Move some logs to out.log and remove multi-lines

### DIFF
--- a/packages/core/src/external/commonwell/management/api-impl.ts
+++ b/packages/core/src/external/commonwell/management/api-impl.ts
@@ -106,7 +106,7 @@ export class CommonWellManagementAPIImpl implements CommonWellManagementAPI {
         statusText: resp.statusText,
         data: safeStringify(resp.data),
       };
-      log(msg, additionalData);
+      log(msg + " - " + JSON.stringify(additionalData));
       throw new MetriportError(msg, undefined, additionalData);
     }
     log("Response", result.join(", "));
@@ -163,7 +163,7 @@ export class CommonWellManagementAPIImpl implements CommonWellManagementAPI {
         statusText: resp.statusText,
         data: safeStringify(resp.data),
       };
-      log(msg, additionalData);
+      log(msg + " - " + JSON.stringify(additionalData));
       throw new MetriportError(msg, undefined, additionalData);
     }
     debug(


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Move some logs to out.log and remove some multi-line logs.

### Testing

- Local
  - none
- Staging
  - CW Integration is down
- Sandbox
  - CW Integration is down
- Production
  - [ ] Org update works

### Release Plan

- [ ] Merge this
