### PR TITLE
PATCH add creation date to docref

### DIFF
--- a/packages/api/src/external/carequality/document/shared.ts
+++ b/packages/api/src/external/carequality/document/shared.ts
@@ -74,7 +74,7 @@ export const cqToFHIR = (
     content: generateCQFHIRContent(baseAttachment, contentExtension, docRef.url),
     extension: [cqExtension],
     contained: dedupeContainedResources(contained),
-    date: docRef.date ? formatDate(docRef.date) : undefined,
+    ...(docRef.creation ? { date: formatDate(docRef.creation) } : {}),
     // TODO: #1612 (internal) Add author reference
   };
   if (docRef.title) updatedDocRef.description = docRef.title;


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

### Dependencies

- Upstream: none
- Downstream: none

### Description

Add creation date to docRef

### Testing

_[Regular PRs:]_

- Local
  - [x]  able to add the fhir data accordingly with creation date
- Staging
  - [ ] able to add the fhir data accordingly with creation date
- Production
  - [ ] monitor

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
