### PR TITLE
fix(api): create patient if cw or patient id doesnt exist

### DIFF
--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -388,6 +388,8 @@ async function setupUpdate(
   const commonwellPatientId = commonwellData.patientId;
   const personId = commonwellData.personId;
 
+  if (!commonwellPatientId || !personId) return undefined;
+
   const { organization, facility } = await getPatientData(patient, facilityId);
   const orgName = organization.data.name;
   const orgOID = organization.oid;


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

### Dependencies

- Upstream: none
- Downstream: none

### Description

Issue because of the scheduled doc query in CW because when we go to create the patient in CW we have data just not personId so when we go to update its undefined. -[context](https://metriport-inc.sentry.io/issues/4973939488/?alert_rule_id=14031186&alert_type=issue&environment=production&notification_uuid=4aa3c9c8-77f9-4540-92ac-d69e961ec3a0&project=4504912884924416&referrer=slack)

### Testing

- Production
  - [ ] monitor

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
