### PR TITLE
Adding Namespace to Soap Body

### DIFF
--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-39 Inbound Interface/destinationConnector-AWS Lambda Interface-responseTransformer-step-0-Process response.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Inbound/XCA ITI-39 Inbound Interface/destinationConnector-AWS Lambda Interface-responseTransformer-step-0-Process response.js
@@ -1,5 +1,5 @@
 // Generate SOAP Envelope
-var soapTemplate = getSOAPTemplate();
+var soapTemplate = getITI39SOAPTemplate();
 var soap = soapTemplate.namespace('soap');
 var wsa = soapTemplate.namespace('wsa');
 soapTemplate.soap::Header.wsa::Action = 'urn:ihe:iti:2007:CrossGatewayRetrieveResponse';

--- a/packages/ihe-gateway/server/CodeTemplates/Common Library/Get SOAP Template or Fault message/Get SOAP Template or Fault message.js
+++ b/packages/ihe-gateway/server/CodeTemplates/Common Library/Get SOAP Template or Fault message/Get SOAP Template or Fault message.js
@@ -49,3 +49,18 @@ function getSOAPTemplate() {
 	return soap;
 }
 
+
+function getITI39SOAPTemplate() {
+
+	var soap = <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+				  <soap:Header>
+				    <wsa:To soap:mustUnderstand="true">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+				    <wsa:Action soap:mustUnderstand="true"></wsa:Action>
+				    <wsa:MessageID soap:mustUnderstand="true">{'urn:uuid:' + UUIDGenerator.getUUID()}</wsa:MessageID>
+				    <wsa:RelatesTo soap:mustUnderstand="true"></wsa:RelatesTo>
+				  </soap:Header>
+				  <soap:Body xmlns="urn:ihe:iti:xds-b:2007" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+				</soap:Envelope>;
+
+	return soap;
+}

--- a/packages/ihe-gateway/server/CodeTemplates/XCA Library - Inbound/Get XCA ITI-39 RetrieveDocumentSetResponse/Get XCA ITI-39 RetrieveDocumentSetResponse.js
+++ b/packages/ihe-gateway/server/CodeTemplates/XCA Library - Inbound/Get XCA ITI-39 RetrieveDocumentSetResponse/Get XCA ITI-39 RetrieveDocumentSetResponse.js
@@ -19,7 +19,7 @@ function getXCAITI39QueryResponse(request, operationOutcome, mtom) {
                 
                 var doc64 = xcaReadFromFileB64(entry.urn.toString());
                 
-				var docResponse = <DocumentResponse>
+				var docResponse = <DocumentResponse xmlns="urn:ihe:iti:xds-b:2007">
                                     <HomeCommunityId>{'urn:oid:' + entry.homeCommunityId.toString()}</HomeCommunityId>
                                     <RepositoryUniqueId>{entry.repositoryUniqueId.toString()}</RepositoryUniqueId>
                                     <DocumentUniqueId>{entry.docUniqueId.toString()}</DocumentUniqueId>


### PR DESCRIPTION
Refs: #[1350](https://github.com/metriport/metriport-internal/issues/1350)

### Description

- invalid xml due to missing namespace in soap body 

### Testing

- Local
  - [x] responses generate on local with staging lambdas
  - [x] passes schema validators 

### Release Plan

- [ ] Merge this
