### PR TITLE
PATCH cq pd processing

### DIFF
--- a/packages/api/src/command/medical/patient/create-patient.ts
+++ b/packages/api/src/command/medical/patient/create-patient.ts
@@ -59,14 +59,14 @@ export const createPatient = async (
 
   const newPatient = await PatientModel.create(patientCreate);
 
-  // TODO move these to the respective "commands" files so this is fully async
+  // TODO #1661: move these to the respective "commands" files so this is fully async
   const [commonwellEnabled, carequalityEnabled] = await Promise.all([
     isCommonwellEnabled(),
     isCarequalityEnabled(),
   ]);
 
   if (commonwellEnabled || forceCommonwell || Config.isSandbox()) {
-    // TODO: AWAIT HIE LOGIC AND MAKE INNER LOGIC ASYNC
+    // TODO #1661: AWAIT HIE LOGIC AND MAKE INNER LOGIC ASYNC
     const baseLogMessage = `CQ PD - patientId ${newPatient.id}`;
     const { log: outerLog } = out(baseLogMessage);
     const shouldRun = await shouldRunDiscovery(cxId, iheGateway, outerLog);

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -48,7 +48,7 @@ export async function discover(patient: Patient, facilityNPI: string): Promise<v
     const { log } = out(`${baseLogMessage}, requestId: ${pdRequest.id}`);
 
     log(`Kicking off patient discovery`);
-    // TODO: ADD THIS BACK IN WHEN CODE IS SYNCHRONOUS
+    // TODO #1661: ADD THIS BACK IN WHEN CODE IS SYNCHRONOUS
     // await processPatientDiscoveryProgress({ patient, status: "processing" });
     await iheGateway.startPatientDiscovery(pdRequest);
 
@@ -73,7 +73,7 @@ export async function discover(patient: Patient, facilityNPI: string): Promise<v
   }
 }
 
-// TODO: REMOVE THIS WHEN CODE IS SYNCHRONOUS
+// TODO #1661: REMOVE THIS WHEN CODE IS SYNCHRONOUS
 export async function shouldRunDiscovery(
   cxId: string,
   iheGateway: IHEGateway | undefined,

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -1,4 +1,5 @@
 import { Patient, PatientExternalData } from "@metriport/core/domain/patient";
+import { IHEGateway } from "@metriport/ihe-gateway-sdk";
 import { Organization } from "@metriport/core/domain/organization";
 import { toFHIR } from "@metriport/core/external/fhir/patient/index";
 import { MedicalDataSource } from "@metriport/core/external/index";
@@ -47,7 +48,8 @@ export async function discover(patient: Patient, facilityNPI: string): Promise<v
     const { log } = out(`${baseLogMessage}, requestId: ${pdRequest.id}`);
 
     log(`Kicking off patient discovery`);
-    await processPatientDiscoveryProgress({ patient, status: "processing" });
+    // TODO: ADD THIS BACK IN WHEN CODE IS SYNCHRONOUS
+    // await processPatientDiscoveryProgress({ patient, status: "processing" });
     await iheGateway.startPatientDiscovery(pdRequest);
 
     await resultPoller.pollOutboundPatientDiscoveryResults({
@@ -69,6 +71,24 @@ export async function discover(patient: Patient, facilityNPI: string): Promise<v
       },
     });
   }
+}
+
+// TODO: REMOVE THIS WHEN CODE IS SYNCHRONOUS
+export async function shouldRunDiscovery(
+  cxId: string,
+  iheGateway: IHEGateway | undefined,
+  outerLog: typeof console.log
+): Promise<boolean> {
+  if (!iheGateway) {
+    outerLog(`IHE GW not available, skipping PD`);
+    return false;
+  }
+  if (!(await isCQDirectEnabledForCx(cxId))) {
+    outerLog(`CQ disabled for cx ${cxId}, skipping PD`);
+    return false;
+  }
+
+  return true;
 }
 
 export function getCQData(


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: #_[ticket-number]_

### Dependencies

- Upstream: _[this PR points to another PR or depends on its release]_
- Downstream: _[PRs that depend on this one, either point to this or can only be released after this one is released]_

### Description

PD processing sometimes happens after DQ has been started. Need to set it as early as possible.  - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1711741669809139)

### Testing

- Production
  - [ ] monitor

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
