### PR TITLE
fix(api): revert cw back to normal patient create

### DIFF
--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -42,7 +42,7 @@ export async function discover(
   const { log: outerLog } = out(baseLogMessage);
   const { cxId } = patient;
 
-  const enabledIHEGW = await validatePDEnabled(cxId, forceEnabled, outerLog);
+  const enabledIHEGW = await validatePDEnabledAndInitGW(cxId, forceEnabled, outerLog);
 
   if (enabledIHEGW) {
     await processPatientDiscoveryProgress({ patient, status: "processing" });
@@ -54,7 +54,7 @@ export async function discover(
   }
 }
 
-async function validatePDEnabled(
+async function validatePDEnabledAndInitGW(
   cxId: string,
   forceEnabled: boolean,
   outerLog: typeof console.log

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -30,7 +30,6 @@ import { PatientDataCarequality } from "./patient-shared";
 dayjs.extend(duration);
 
 const context = "cq.patient.discover";
-const iheGateway = makeIheGatewayAPIForPatientDiscovery();
 const resultPoller = makeOutboundResultPoller();
 
 export async function discover(
@@ -60,6 +59,7 @@ async function validatePDEnabledAndInitGW(
   outerLog: typeof console.log
 ): Promise<IHEGateway | undefined> {
   try {
+    const iheGateway = makeIheGatewayAPIForPatientDiscovery();
     const isCQEnabled = await isCarequalityEnabled();
     const isCQDirectEnabled = await isCQDirectEnabledForCx(cxId);
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

### Dependencies

- Upstream: none
- Downstream: none

### Description

revet cw to original state and make CQ async

### Testing

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
