### PR TITLE
1040 merge master into develop

### DIFF
--- a/packages/api/src/external/carequality/document/shared.ts
+++ b/packages/api/src/external/carequality/document/shared.ts
@@ -74,7 +74,7 @@ export const cqToFHIR = (
     content: generateCQFHIRContent(baseAttachment, contentExtension, docRef.url),
     extension: [cqExtension],
     contained: dedupeContainedResources(contained),
-    date: docRef.date ? formatDate(docRef.date) : undefined,
+    ...(docRef.creation ? { date: formatDate(docRef.creation) } : {}),
     // TODO: #1612 (internal) Add author reference
   };
   if (docRef.title) updatedDocRef.description = docRef.title;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-0-Process response.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-0-Process response.js
@@ -7,29 +7,16 @@ var 	queryResponseCode = '',
 	soapReason = null;
 
 try {
+  xml = msg.*::Body.*::AdhocQueryResponse;
 
-	var soap = msg.toString();
-
-	// SOAP level error
-	if (soap.indexOf('Fault') > 0) {
-		
-		channelMap.put('QACK', 'SOAP_FAULT');
-		// Stop further processing
-		return;
-		
-	} else {
-
-		xml = new XML(soap);
-		xml = xml.*::Body.*::AdhocQueryResponse;
-
-		// The status attribute reflects the status of the operation and shall be one of the following values:
-		// urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success
-		// urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure
-		// urn:ihe:iti:2007:ResponseStatusType:PartialSuccess
-		queryResponseCode = xml.@status.toString().split(':').pop();
-		
-		channelMap.put('QACK', queryResponseCode.toString());
-	}
+	// The status attribute reflects the status of the operation and shall be one of the following values:
+	// urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success
+	// urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure
+	// urn:ihe:iti:2007:ResponseStatusType:PartialSuccess
+	queryResponseCode = xml.@status.toString().split(':').pop();
+	
+	channelMap.put('QACK', queryResponseCode.toString());
+	
 	
 } catch(ex) {
 	if (globalMap.containsKey('TEST_MODE')) logger.error('XCA ITI-39 Processor: Response - ' + ex);

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-0-Process response.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-0-Process response.js
@@ -12,27 +12,15 @@ var 	queryResponseCode = '',
 	soapReason = null;
 
 try {
-	var soap = msg.toString();
-	
-	// SOAP level error
-	if (soap.indexOf('Fault') > 0) {
-		
-		channelMap.put('QACK', 'SOAP_FAULT');
-		// Stop further processing
-		return;
-		
-	} else {
+	xml = msg.*::Body.*::RetrieveDocumentSetResponse;
 
-		xml = new XML(soap);
-		xml = xml.*::Body.*::RetrieveDocumentSetResponse;
+	// The status attribute reflects the status of the operation and shall be one of the following values:
+	// urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success
+	// urn:ihe:iti:2007:ResponseStatusType:PartialSuccess
+	// urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure
+	queryResponseCode = xml.*::RegistryResponse.@status.toString().split(':').pop();		
+	channelMap.put('QACK', queryResponseCode.toString());
 
-		// The status attribute reflects the status of the operation and shall be one of the following values:
-		// urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success
-		// urn:ihe:iti:2007:ResponseStatusType:PartialSuccess
-		// urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure
-		queryResponseCode = xml.*::RegistryResponse.@status.toString().split(':').pop();		
-		channelMap.put('QACK', queryResponseCode.toString());
-	}
 	
 } catch(ex) {
 	if (globalMap.containsKey('TEST_MODE')) logger.error('XCA ITI-39 Processor: Response - ' + ex);

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor/destinationConnector-XCPD Endpoint-responseTransformer-step-0-Process response.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor/destinationConnector-XCPD Endpoint-responseTransformer-step-0-Process response.js
@@ -19,34 +19,23 @@ var 	ack = '',
 	soapReason = null;
 
 try {
-	var soap = msg.toString();
+	xml = msg.*::Body.*::PRPA_IN201306UV02;
 
-	// SOAP level error
-	if (soap.indexOf('Fault') > 0) {
+	// Acknowledgement code as described in HL7 message processing rules
+	// AA - Receiving application successfully processed message
+	// AE - Receiving application found error in processing message. Sending error response with additional error detail information
+	// AR - Receiving application failed to process message for reason unrelated to content or format
+	ack = xml.*::acknowledgement.*::typeCode.@code.toString();
+	channelMap.put('ACK', ack.toString());
 
-		channelMap.put('ACK', 'SOAP_FAULT');
-		return;
-		
-	} else {
-
-		xml = new XML(soap);
-		xml = xml.*::Body.*::PRPA_IN201306UV02;
-
-		// Acknowledgement code as described in HL7 message processing rules
-		// AA - Receiving application successfully processed message
-		// AE - Receiving application found error in processing message. Sending error response with additional error detail information
-		// AR - Receiving application failed to process message for reason unrelated to content or format
-		ack = xml.*::acknowledgement.*::typeCode.@code.toString();
-		channelMap.put('ACK', ack.toString());
-
-		// The result status of the query
-		// OK - Query reponse data found for 1 or more result sets matching the query request specification
-		// NF - No errors, but no data was found matching the query request specification
-		// AE - Query or application error
-		// QE - Problem with input Parmeters error
-		queryResponseCode = xml.*::controlActProcess.*::queryAck.*::queryResponseCode.@code.toString();
-		channelMap.put('QACK', queryResponseCode.toString());
-	}
+	// The result status of the query
+	// OK - Query reponse data found for 1 or more result sets matching the query request specification
+	// NF - No errors, but no data was found matching the query request specification
+	// AE - Query or application error
+	// QE - Problem with input Parmeters error
+	queryResponseCode = xml.*::controlActProcess.*::queryAck.*::queryResponseCode.@code.toString();
+	channelMap.put('QACK', queryResponseCode.toString());
+	
 	
 } catch(ex) {
 	if (globalMap.containsKey('TEST_MODE')) logger.error('XCPD ITI-55 Processor: Response - ' + ex);


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport/pull/1350

### Dependencies

- related: https://github.com/metriport/metriport/pull/1859

### Description

Merge `master` into `develop` and fix conflicts.

Since `soap` was only used to string search, removing it to save some memory. :) Tested local and it works, `msg` is the actual XML.

### Testing

- Local
  - [x] PD works
  - [x] DQ works
  - [x] DR works
- Staging
  - [ ] PD works
  - [ ] DQ works
  - [ ] DR works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
