### PR TITLE
Patch Inbound DQ: Org OID and Stable Object Type

### DIFF
--- a/packages/core/src/external/carequality/dq/create-metadata-xml.ts
+++ b/packages/core/src/external/carequality/dq/create-metadata-xml.ts
@@ -54,7 +54,8 @@ export function createExtrinsicObjectXml({
     healthcareFacilityTypeCode?.coding?.[0]?.code || DEFAULT_HEALTHCARE_FACILITY_TYPE_CODE_NODE;
 
   const organizationName = organization?.name || ORGANIZATION_NAME_DEFAULT;
-  const organizationId = organization?.id || METRIPORT_HOME_COMMUNITY_ID_NO_PREFIX;
+  const organizationId =
+    organization?.identifier?.[0]?.value || METRIPORT_HOME_COMMUNITY_ID_NO_PREFIX;
 
   const metadataXml = `<ExtrinsicObject xmlns="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" home="${METRIPORT_HOME_COMMUNITY_ID}" id="${documentUUID}" isOpaque="false" mimeType="${mimeType}" objectType="urn:uuid:34268e47-fdf5-41a6-ba33-82133c465248" status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved">
 

--- a/packages/core/src/external/carequality/dq/create-metadata-xml.ts
+++ b/packages/core/src/external/carequality/dq/create-metadata-xml.ts
@@ -55,9 +55,13 @@ export function createExtrinsicObjectXml({
 
   const organizationName = organization?.name || ORGANIZATION_NAME_DEFAULT;
   const organizationId =
-    organization?.identifier?.[0]?.value || METRIPORT_HOME_COMMUNITY_ID_NO_PREFIX;
+    organization?.identifier?.find(identifier =>
+      identifier.value?.startsWith(METRIPORT_HOME_COMMUNITY_ID_NO_PREFIX)
+    )?.value || METRIPORT_HOME_COMMUNITY_ID_NO_PREFIX;
 
-  const metadataXml = `<ExtrinsicObject xmlns="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" home="${METRIPORT_HOME_COMMUNITY_ID}" id="${documentUUID}" isOpaque="false" mimeType="${mimeType}" objectType="urn:uuid:34268e47-fdf5-41a6-ba33-82133c465248" status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved">
+  const stableDocumentId = "urn:uuid:7edca82f-054d-47f2-a032-9b2a5b5186c1";
+
+  const metadataXml = `<ExtrinsicObject xmlns="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" home="${METRIPORT_HOME_COMMUNITY_ID}" id="${documentUUID}" isOpaque="false" mimeType="${mimeType}" objectType="${stableDocumentId}" status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved">
 
     <Slot name="creationTime">
       <ValueList>


### PR DESCRIPTION
Ticket: #[1350](https://github.com/metriport/metriport-internal/issues/1350)

### Description

- wrong id being used for organization when constructing responses. Using their orgId instead of their OID
- On Demand Document being used instead of Stable Document, so we are changing to stable to see if it fixes anything


### Release Plan

- :warning: Points to `master`
- [ ] Merge this
