### PR TITLE
PATCH pd cw processing

### DIFF
--- a/packages/api/src/external/commonwell/patient-external-data.ts
+++ b/packages/api/src/external/commonwell/patient-external-data.ts
@@ -2,7 +2,6 @@ import { MetriportError } from "@metriport/core/util/error/metriport-error";
 import { executeWithRetries } from "@metriport/shared";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
-import { cloneDeep } from "lodash";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
 import { Patient } from "@metriport/core/domain/patient";
 import { PatientModel } from "../../models/medical/patient";
@@ -73,28 +72,47 @@ export const setCommonwellId = async ({
   commonwellStatus?: LinkStatus | undefined;
   cqLinkStatus?: CQLinkStatus | undefined;
 }): Promise<Patient> => {
+  const patientFilter = {
+    id: patientId,
+    cxId,
+  };
+
   return executeOnDBTx(PatientModel.prototype, async transaction => {
-    const updatedPatient = await getPatientOrFail({
-      id: patientId,
-      cxId,
+    const existingPatient = await getPatientOrFail({
+      ...patientFilter,
       lock: true,
       transaction,
     });
 
-    const updatedCQLinkStatus = cqLinkStatus ?? getLinkStatusCQ(updatedPatient.data.externalData);
+    const updatedCQLinkStatus = cqLinkStatus ?? getLinkStatusCQ(existingPatient.data.externalData);
 
-    const updatedData = cloneDeep(updatedPatient.data);
-    updatedData.externalData = {
-      ...updatedData.externalData,
-      COMMONWELL: new PatientDataCommonwell(
-        commonwellPatientId,
-        commonwellPersonId,
-        commonwellStatus,
-        updatedCQLinkStatus
-      ),
+    const externalData = existingPatient.data.externalData ?? {};
+
+    const updateCWExternalData = {
+      ...externalData,
+      COMMONWELL: {
+        ...externalData.COMMONWELL,
+        patientId: commonwellPatientId,
+        personId: commonwellPersonId,
+        status: commonwellStatus,
+        cqLinkStatus: updatedCQLinkStatus,
+      },
     };
 
-    return updatedPatient.update({ data: updatedData }, { transaction });
+    const updatedPatient = {
+      ...existingPatient.dataValues,
+      data: {
+        ...existingPatient.data,
+        externalData: updateCWExternalData,
+      },
+    };
+
+    await PatientModel.update(updatedPatient, {
+      where: patientFilter,
+      transaction,
+    });
+
+    return updatedPatient;
   });
 };
 

--- a/packages/api/src/external/commonwell/patient-external-data.ts
+++ b/packages/api/src/external/commonwell/patient-external-data.ts
@@ -92,10 +92,10 @@ export const setCommonwellId = async ({
       ...externalData,
       COMMONWELL: {
         ...externalData.COMMONWELL,
-        patientId: commonwellPatientId,
-        personId: commonwellPersonId,
-        status: commonwellStatus,
-        cqLinkStatus: updatedCQLinkStatus,
+        ...(commonwellPatientId && { patientId: commonwellPatientId }),
+        ...(commonwellPersonId && { personId: commonwellPersonId }),
+        ...(commonwellStatus && { status: commonwellStatus }),
+        ...(updatedCQLinkStatus && { cqLinkStatus: updatedCQLinkStatus }),
       },
     };
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: #_[ticket-number]_

### Dependencies

- Upstream: none
- Downstream:  none

### Description

Current way of setting CW data overrides all previous values. This way we do not ovveride leading to progress not being present when scheduling doc query.

### Testing

- Production
  - [ ] Monitor

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
