### PR TITLE
135 Parse non-base64 decoded content

### DIFF
--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-1-Case 1 - Success or PartialSuccess.js
@@ -50,7 +50,11 @@ if ('Success' == queryResponseCode.toString() || 'PartialSuccess' == queryRespon
 				if (newDocumentUniqueId) attachment.newDocumentUniqueId = newDocumentUniqueId.toString();
 
 				var documentEncoded = entry.*::Document;
-				var parsedFile = parseFileFromString(documentEncoded, false);
+				var parsedFile = parseFileFromString(documentEncoded);
+				if (!parsedFile) {
+					logError("Error parsing file, result is undefined");
+					continue;
+				}
 				var detectedExtension = parsedFile.extension;
 				var detectedFileType = parsedFile.mimeType;
 				var decodedAsString = parsedFile.decodedString;

--- a/packages/ihe-gateway/server/Channels/Default Group/Tester XML/destinationConnector-Destination 1.js
+++ b/packages/ihe-gateway/server/Channels/Default Group/Tester XML/destinationConnector-Destination 1.js
@@ -4,11 +4,11 @@ const msg = channelMap.get("REQ_BODY");
 
 logger.info("[Tester] Got: " + msg.toString());
 
-const res = parseFileFromString(msg.toString(), false);
+const res = parseFileFromString(msg.toString());
 logger.info("[Tester] >>> res: " + JSON.stringify(res));
 
 const fileName = new Date().toISOString();
 const s3Res = xcaWriteToFile("nonXMLBody/" + fileName + res.extension, res.decodedBytes, {});
 
 logger.info("[Tester] Returning...");
-return xml;
+return res.decodedString;

--- a/packages/ihe-gateway/server/CodeTemplates/Common Library/File type/File type.js
+++ b/packages/ihe-gateway/server/CodeTemplates/Common Library/File type/File type.js
@@ -69,7 +69,7 @@ function isASCIIChar(char) {
   );
 }
 
-function isLikelyTextFile(fileBuffer) {
+function isLikelyText(fileBuffer) {
   var readableChars = 0;
   var nonReadableChars = 0;
   for (let i = 0; i < fileBuffer.length; i++) {
@@ -93,11 +93,11 @@ function isLikelyTextFile(fileBuffer) {
  *
  * @param fileBuffer - The contents as bytes.
  * @param decodedString - The contents as string.
- * @param isNonXmlBody - Whether it is a nonXNLBody
+ * @param isNonXmlBody - Whether it is a nonXmlBody, if already known
  * @returns returns a string representing the detected file type.
  */
 function detectFileType(decodedBytes, decodedString, isNonXmlBody) {
-  let fileBuffer = new Array(6).fill(0).map((_, i) => decodedBytes[i] & 0xFF);
+  let fileBuffer = new Array(6).fill(0).map((_, i) => decodedBytes[i] & 0xff);
   if (
     (fileBuffer[0] === TIFF_MAGIC_NUMBER_1 &&
       fileBuffer[1] === TIFF_MAGIC_NUMBER_2 &&
@@ -150,7 +150,7 @@ function detectFileType(decodedBytes, decodedString, isNonXmlBody) {
     return [JPEG_MIME_TYPE, JPEG_FILE_EXTENSION];
   } else if (fileBuffer[0] === BMP_MAGIC_NUMBER_1 && fileBuffer[1] === BMP_MAGIC_NUMBER_2) {
     return [BMP_MIME_TYPE, BMP_FILE_EXTENSION];
-  } else if (isNonXmlBody && isLikelyTextFile(decodedString)) {
+  } else if (isNonXmlBody && isLikelyText(decodedString)) {
     return [TXT_MIME_TYPE, TXT_FILE_EXTENSION];
   } else {
     return [OCTET_MIME_TYPE, OCTET_FILE_EXTENSION];

--- a/packages/ihe-gateway/server/CodeTemplates/Common Library/parseFileFromString/parseFileFromString.js
+++ b/packages/ihe-gateway/server/CodeTemplates/Common Library/parseFileFromString/parseFileFromString.js
@@ -9,30 +9,41 @@
  * Takes a file content as string and returns the file type, extension and decoded string and bytes.
  *
  * @param {String} fileAsString - the file content as string
- * @param {Boolean} - Whether it is a nonXNLBody
+ * @param {Boolean} isNonXmlBody - Whether it is a nonXmlBody, if known
  * @return {ParsedFile} returns the file type, extension and decoded string and bytes
  */
 function parseFileFromString(fileAsString, isNonXmlBody) {
-	// logger.info("[parseFileFromString] decodedString: " + decodedString);
+  if (isNonXmlBody === undefined) isNonXmlBody = false;
+
   let decodedBytes = null;
+  let decodedString = null;
   // We don't know upfront if the file is base64 encoded, so we try to decode it and if it fails
   // we use the original content.
   try {
     const byteDecoder = java.util.Base64.getDecoder();
-    decodedBytes = byteDecoder.decode(fileAsString);
+    decodedBytes = byteDecoder.decode(String(fileAsString).trim());
+    decodedString = String(new Packages.java.lang.String(decodedBytes));
   } catch (ex) {
-    // intentionally left empty
+    logger.info("[parseFileFromString] Got a non-base64 document! ");
+    decodedBytes = java.lang.String(fileAsString).trim().getBytes();
+    decodedString = String(fileAsString).trim();
   }
-  if (!decodedBytes) return;
+  if (!decodedBytes) {
+    logger.error("[parseFileFromString] Error decoding file content - missing decodedBytes");
+    return;
+  };
+  if (!decodedString) {
+    logger.error("[parseFileFromString] Error decoding file content - missing decodedString");
+    return;
+  };
 
-  const decodedString = String(new Packages.java.lang.String(decodedBytes));
-  const type = detectFileType(decodedBytes, decodedString, isNonXmlBody);
-  const mimeType = type[0];
-  const extension = type[1];
+  var type = detectFileType(decodedBytes, decodedString, isNonXmlBody);
+  var mimeType = type[0];
+  var extension = type[1];
 
   if (mimeType === XML_TXT_MIME_TYPE || mimeType === XML_APP_MIME_TYPE) {
     // If the file is XML, it might contain an attachment (nonXMLBody) that we need to extract
-    const cda = new XML(decodedString);
+    var cda = new XML(decodedString);
 		var nonXMLBody = cda.*::component.*::nonXMLBody;
 		if (nonXMLBody.length() > 0 && nonXMLBody.*::text.length() > 0) {
 			return parseFileFromString(nonXMLBody.*::text.toString(), true);


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

### Dependencies

none

### Description

`parseFileFromString()` to parse non-base64 decoded content - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1712113884942059?thread_ts=1712078581.090989&cid=C0616FCPAKZ)

### Testing

- Local
  - [x] Using Texter XML channel, parse CCDA w/ attached TXT
  - [x] Using Texter XML channel, parse CCDA w/ attached PDF
  - [x] Using Texter XML channel, parse regular CCDA w/o attachment
- Staging
  - [ ] DR works
- Sandbox
  - none
- Production
  - [ ] Trigger a couple of DR

### Release Plan

- [ ] Merge this
