### PR TITLE
1040 Add index to patient discovery result

### DIFF
--- a/packages/api/src/sequelize/migrations/2024-04-03_00_alter-patient-discovery-result-add-index-patient-id.ts
+++ b/packages/api/src/sequelize/migrations/2024-04-03_00_alter-patient-discovery-result-add-index-patient-id.ts
@@ -1,0 +1,22 @@
+import type { Migration } from "..";
+
+const tableName = "patient_discovery_result";
+const indexName = "patient_discovery_result_patientid_index";
+const fieldName = "patient_id";
+
+// Use 'Promise.all' when changes are independent of each other
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.addIndex(tableName, {
+      name: indexName,
+      fields: [fieldName],
+      transaction,
+    });
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.removeIndex(tableName, indexName, { transaction });
+  });
+};


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1866
- Downstream: none

### Description

- Add index to the `patient_discovery_result` table
- Remove the PK (constraint/index), keeping the `id` column

Reason being:
- it takes +20s to query that table by `patientId`, and when we're investigating we usually don't have the PD req ID easily at hand
- by adding this index it will allow us to query/join with other tables, like so:
    ```sql
      select p.cx_id, p.id, p.data, pd.data, r.data
      from patient p
        join cq_patient_data pd on pd.id = p.id
        join patient_discovery_result r on r.patient_id::text = p.id
      where p.id = '...'
        and r.data->>'patientMatch' = 'true'
      order by r.created_at desc;
    ```
- we don't use the ID for direct access - that allows us to switch one index for another without all the impact of just adding a new index

### Testing

- Prepare the `patient_discovery_result ` table with enough data (27MM records)
   ```sql
      -- Remove indexes to help loading the data into the table
      DROP INDEX public.patient_discovery_result_request_id;
      ALTER TABLE public.patient_discovery_result DROP CONSTRAINT patient_discovery_result_pkey;

      -- Load the data
      insert into patient_discovery_result (id, request_id, patient_id, status, data)
      WITH thePatient AS (
        SELECT generate_series(1, 300) -- how many patients
      ),
      thePatient_uuid as (
        select gen_random_uuid()::text as id
        from thePatient
      ),
      theRequest AS (
        SELECT generate_series(1, 2) -- how many requests by patient
      ),
      theRequed_uuid AS (
        SELECT thePatient_uuid.id as patient_id, gen_random_uuid()::text as id
        FROM thePatient_uuid, theRequest
      ),
      theRecords AS (
        SELECT generate_series(1, 150) -- how many records by tuple (patient,request)
      ),
      theRecords_uuid AS (
        SELECT thePatient_uuid.id as patient_id, theRequed_uuid.id as request_id, gen_random_uuid()::text as record_id
        FROM thePatient_uuid, theRequed_uuid, theRecords
      )
      SELECT gen_random_uuid()::text, uuids.request_id::uuid, uuids.patient_id::uuid, 'success', ('{"some": "property"}')::json
      from theRecords_uuid as uuids
      order by uuids.record_id;

    -- Recreate the indexes
    CREATE INDEX patient_discovery_result_request_id ON public.patient_discovery_result USING btree (request_id);
    CREATE UNIQUE INDEX patient_discovery_result_pkey ON public.patient_discovery_result USING btree (id);
   ```
- Time to execute create the index on my computer:
   - 28s through API/Sequelize (14-17s on subsequent runs)
   - 12s directly on the DB


- Local
  - [x] add index
  - [x] rollback index
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- :warning: This contains a DB migration
   - We might need to run this off hours b/c building this index might temporarily hammer the DB
- [ ] Merge this
- `production`
   - Try to merge this off-hours