### PR TITLE
PATCH add scheduled check for create

### DIFF
--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -222,7 +222,7 @@ export async function registerAndLinkPatientInCW(
       getOrgIdExcludeList,
     });
 
-    await queryDocsAgainIfScheduled(patient, getOrgIdExcludeList);
+    await queryDocsIfScheduled(patient, getOrgIdExcludeList);
 
     return { commonwellPatientId, personId };
   } catch (error) {
@@ -378,7 +378,7 @@ export async function update(
       getOrgIdExcludeList
     );
 
-    await queryDocsAgainIfScheduled(patient, getOrgIdExcludeList);
+    await queryDocsIfScheduled(patient, getOrgIdExcludeList);
   } catch (error) {
     console.error(`Failed to update patient ${patient.id} @ CW: ${errorToString(error)}`);
     capture.error(error, {
@@ -394,7 +394,7 @@ export async function update(
   }
 }
 
-async function queryDocsAgainIfScheduled(
+async function queryDocsIfScheduled(
   patient: Patient,
   getOrgIdExcludeList: () => Promise<string[]>
 ): Promise<void> {


### PR DESCRIPTION
Ref. metriport/metriport-internal#1350

Ticket: #_[ticket-number]_

### Dependencies

- Upstream: none
- Downstream: none

### Description

When checking to see if doc progress is triggered we need to also check after create not just update.

### Testing

- Production
  - [ ] Monitor

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
