### PR TITLE
1040 Remove PK from patient_discovery_result

### DIFF
--- a/packages/api/src/sequelize/migrations/2024-04-03_00_alter-patient-discovery-result-add-index-patient-id.ts
+++ b/packages/api/src/sequelize/migrations/2024-04-03_00_alter-patient-discovery-result-add-index-patient-id.ts
@@ -1,15 +1,20 @@
 import type { Migration } from "..";
 
 const tableName = "patient_discovery_result";
-const indexName = "patient_discovery_result_patientid_index";
-const fieldName = "patient_id";
+const indexToCreate = "patient_discovery_result_patientid_index";
+const indexToCreateFieldName = "patient_id";
+const constraintToRemove = "patient_discovery_result_pkey";
+const constraintToRemoveFieldName = "id";
 
 // Use 'Promise.all' when changes are independent of each other
 export const up: Migration = async ({ context: queryInterface }) => {
   await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.removeConstraint(tableName, constraintToRemove, {
+      transaction,
+    });
     await queryInterface.addIndex(tableName, {
-      name: indexName,
-      fields: [fieldName],
+      name: indexToCreate,
+      fields: [indexToCreateFieldName],
       transaction,
     });
   });
@@ -17,6 +22,11 @@ export const up: Migration = async ({ context: queryInterface }) => {
 
 export const down: Migration = ({ context: queryInterface }) => {
   return queryInterface.sequelize.transaction(async transaction => {
-    await queryInterface.removeIndex(tableName, indexName, { transaction });
+    await queryInterface.removeIndex(tableName, indexToCreate, { transaction });
+    await queryInterface.addIndex(tableName, {
+      name: constraintToRemove,
+      fields: [constraintToRemoveFieldName],
+      transaction,
+    });
   });
 };


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1869
- Downstream: none

### Description

Follow-up to https://github.com/metriport/metriport/pull/1869, this does the removing of the table's PK (constraint, index).

### Testing

Upstream PR

### Release Plan

Upstream PR
