### PR TITLE
fix(api): move request logger to individual routes

### DIFF
--- a/packages/api/src/routes/helpers/request-analytics.ts
+++ b/packages/api/src/routes/helpers/request-analytics.ts
@@ -1,4 +1,5 @@
 import { Request } from "express";
+import QueryString from "qs";
 import { Product } from "../../domain/product";
 import { analytics, EventTypes } from "../../shared/analytics";
 import { getCxId, getCxIdFromHeaders } from "../util";
@@ -23,11 +24,15 @@ export const analyzeRoute = ({
   req,
   method,
   url,
+  params,
+  query,
   duration,
 }: {
   req: Request;
   method: string;
   url: string;
+  params: Record<string, string> | undefined;
+  query: QueryString.ParsedQs | undefined;
   duration: number;
 }): void => {
   const reqCxId = getCxId(req);
@@ -37,15 +42,16 @@ export const analyzeRoute = ({
   const isMedical = medicalRoutes.some(route => url.includes(route));
   const isDevices = devicesRoutes.some(route => url.includes(route));
 
-  const distinctId = cxId ?? "not-available";
-  if (!isDevices) {
+  if (!isDevices && cxId) {
     analytics({
       event: EventTypes.query,
-      distinctId,
+      distinctId: cxId,
       properties: {
         method,
         url,
         duration,
+        ...params,
+        ...query,
       },
       apiType: isMedical ? Product.medical : "internal",
     });

--- a/packages/api/src/routes/helpers/request-logger.ts
+++ b/packages/api/src/routes/helpers/request-logger.ts
@@ -5,19 +5,6 @@ import { analyzeRoute } from "./request-analytics";
 
 const asyncLocalStorage = getLocalStorage("reqId");
 
-// TODO: 1411 - remove the DAPI-related routes when DAPI is fully discontinued
-const blackListedRoutes = [
-  "/internal/carequality/document-query/response",
-  "/internal/carequality/document-retrieval/response",
-  "/internal/carequality/patient-discovery/response",
-  "/internal/mpi/patient",
-  "/webhook/tenovi",
-  "/webhook/fitbit",
-  "/webhook/withings",
-  "/webhook/garmin",
-  "/webhook/apple",
-];
-
 export const requestLogger = (req: Request, res: Response, next: NextFunction): void => {
   const reqId = nanoid();
   asyncLocalStorage.run(reqId, () => {
@@ -25,10 +12,6 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction): 
     const url = req.baseUrl;
     const query = req.query && Object.keys(req.query).length ? req.query : undefined;
     const params = req.params && Object.keys(req.params).length ? req.params : undefined;
-
-    if (isBlackListed(url)) {
-      return next();
-    }
 
     console.log(
       "%s ..........Begins %s %s %s %s",
@@ -62,10 +45,6 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction): 
     next();
   });
 };
-
-function isBlackListed(url: string): boolean {
-  return blackListedRoutes.some(route => url.includes(route));
-}
 
 function toString(obj: unknown): string {
   return obj ? ` ${JSON.stringify(obj)}` : "";

--- a/packages/api/src/routes/helpers/request-logger.ts
+++ b/packages/api/src/routes/helpers/request-logger.ts
@@ -22,7 +22,7 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction): 
   const reqId = nanoid();
   asyncLocalStorage.run(reqId, () => {
     const method = req.method;
-    const url = req.baseUrl + req.path;
+    const url = req.baseUrl;
     const query = req.query && Object.keys(req.query).length ? req.query : undefined;
     const params = req.params && Object.keys(req.params).length ? req.params : undefined;
 
@@ -53,7 +53,11 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction): 
         elapsedTimeInMs
       );
 
-      analyzeRoute({ req, method, url, duration: elapsedTimeInMs });
+      const isSuccessful = res.statusCode >= 200 && res.statusCode < 300;
+
+      if (isSuccessful) {
+        analyzeRoute({ req, method, url, params, query, duration: elapsedTimeInMs });
+      }
     });
     next();
   });

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -4,7 +4,6 @@ import biometrics from "./biometrics";
 import body from "./body";
 import connect from "./connect";
 import { reportClientErrors } from "./helpers/report-client-errors";
-import { requestLogger } from "./helpers/request-logger";
 import internal from "./internal";
 import medical from "./medical";
 import fhirRouter from "./medical/fhir-r4-proxy";
@@ -18,8 +17,6 @@ import user from "./user";
 import webhook from "./webhook";
 
 export default (app: Application) => {
-  app.use(requestLogger);
-
   // internal only routes, should be disabled at API Gateway
   app.use("/webhook", reportClientErrors, webhook);
   app.use("/internal", internal);

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -109,7 +109,6 @@ router.delete(
  */
 router.post(
   "/populate-fhir-server",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").optional();
     const allCustomers = getFrom("query").optional("allCustomers", req) === "true";
@@ -165,7 +164,6 @@ router.get(
  */
 router.post(
   "/cq-include-list/reset",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     if (!(await isEnhancedCoverageEnabledForCx(cxId))) {
@@ -184,7 +182,6 @@ router.post(
  */
 router.get(
   "/cx-data",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const org = await getOrganizationOrFail({ cxId });
@@ -218,7 +215,6 @@ router.get(
  */
 router.post(
   "/check-api-quota",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxsWithLowQuota = await checkApiQuota();
     return res.status(httpStatus.OK).json({ cxsWithLowQuota });
@@ -232,7 +228,6 @@ router.post(
  */
 router.post(
   "/db-maintenance",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const result = await dbMaintenance();
     console.log(`DB Maintenance Result: ${JSON.stringify(result)}`);
@@ -247,7 +242,6 @@ router.post(
  */
 router.post(
   "/references-from-fhir",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
 

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -25,6 +25,7 @@ import mpiRoutes from "./medical/internal-mpi";
 import patientRoutes from "./medical/internal-patient";
 import { getUUIDFrom } from "./schemas/uuid";
 import { asyncHandler, getFrom } from "./util";
+import { requestLogger } from "./helpers/request-logger";
 
 const router = Router();
 
@@ -45,6 +46,7 @@ router.use("/mpi", mpiRoutes);
  */
 router.post(
   "/mapi-access",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const outcome = await allowMapiAccess(cxId);
@@ -62,6 +64,7 @@ router.post(
  */
 router.get(
   "/mapi-access",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const hasMapi = await hasMapiAccess(cxId);
@@ -79,6 +82,7 @@ router.get(
  */
 router.delete(
   "/mapi-access",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     await revokeMapiAccess(cxId);
@@ -105,6 +109,7 @@ router.delete(
  */
 router.post(
   "/populate-fhir-server",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").optional();
     const allCustomers = getFrom("query").optional("allCustomers", req) === "true";
@@ -145,6 +150,7 @@ router.post(
  */
 router.get(
   "/count-fhir-resources",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const result = await countResources({ patient: { cxId } });
@@ -159,6 +165,7 @@ router.get(
  */
 router.post(
   "/cq-include-list/reset",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     if (!(await isEnhancedCoverageEnabledForCx(cxId))) {
@@ -177,6 +184,7 @@ router.post(
  */
 router.get(
   "/cx-data",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const org = await getOrganizationOrFail({ cxId });
@@ -210,6 +218,7 @@ router.get(
  */
 router.post(
   "/check-api-quota",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxsWithLowQuota = await checkApiQuota();
     return res.status(httpStatus.OK).json({ cxsWithLowQuota });
@@ -223,6 +232,7 @@ router.post(
  */
 router.post(
   "/db-maintenance",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const result = await dbMaintenance();
     console.log(`DB Maintenance Result: ${JSON.stringify(result)}`);
@@ -237,6 +247,7 @@ router.post(
  */
 router.post(
   "/references-from-fhir",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
 

--- a/packages/api/src/routes/medical/document.ts
+++ b/packages/api/src/routes/medical/document.ts
@@ -25,7 +25,7 @@ import { optionalDateSchema } from "../schemas/date";
 import { asyncHandler, getCxIdOrFail, getFrom, getFromQueryOrFail } from "../util";
 import { toDTO } from "./dtos/documentDTO";
 import { docConversionTypeSchema, docFileNameSchema } from "./schemas/documents";
-
+import { requestLogger } from "../helpers/request-logger";
 import { cxRequestMetadataSchema } from "./schemas/request-metadata";
 
 const router = Router();
@@ -58,6 +58,7 @@ const getDocSchema = z.object({
  */
 router.get(
   "/",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const patientId = getFromQueryOrFail("patientId", req);
@@ -87,6 +88,7 @@ router.get(
  */
 router.get(
   "/query",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const patientId = getFromQueryOrFail("patientId", req);
@@ -108,6 +110,7 @@ router.get(
  */
 router.post(
   "/query",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const patientId = getFromQueryOrFail("patientId", req);
@@ -168,6 +171,7 @@ async function getDownloadUrl(req: Request): Promise<string> {
  */
 router.get(
   "/downloadUrl",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const url = await getDownloadUrl(req);
     return res.status(OK).json({ url });
@@ -185,6 +189,7 @@ router.get(
  */
 router.get(
   "/download-url",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const url = await getDownloadUrl(req);
     return res.status(OK).json({ url });
@@ -203,6 +208,7 @@ router.get(
 
 router.post(
   "/download-url/bulk",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const patientId = getFromQueryOrFail("patientId", req);
@@ -264,6 +270,7 @@ async function getUploadUrlAndCreateDocRef(req: Request): Promise<UploadDocument
  */
 router.post(
   "/upload-url",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const resp = await getUploadUrlAndCreateDocRef(req);
     const url = resp.uploadUrl;
@@ -285,6 +292,7 @@ router.post(
  */
 router.post(
   "/upload",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const resp = await getUploadUrlAndCreateDocRef(req);
     return res.status(httpStatus.OK).json(resp);

--- a/packages/api/src/routes/medical/facility.ts
+++ b/packages/api/src/routes/medical/facility.ts
@@ -9,6 +9,7 @@ import { getETag } from "../../shared/http";
 import { asyncHandler, getCxIdOrFail, getFromParamsOrFail } from "../util";
 import { dtoFromModel } from "./dtos/facilityDTO";
 import { facilityCreateSchema, facilityUpdateSchema } from "./schemas/facility";
+import { requestLogger } from "../helpers/request-logger";
 
 const router = Router();
 
@@ -21,6 +22,7 @@ const router = Router();
  */
 router.post(
   "/",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const facilityData = facilityCreateSchema.parse(req.body);
@@ -47,6 +49,7 @@ router.post(
  */
 router.put(
   "/:id",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const facilityId = getFromParamsOrFail("id", req);
@@ -74,6 +77,7 @@ router.put(
  */
 router.get(
   "/",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
 
@@ -93,6 +97,7 @@ router.get(
  */
 router.get(
   "/:id",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const facilityId = getFromParamsOrFail("id", req);

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -202,7 +202,6 @@ router.get(
  */
 router.post(
   "/patient-discovery/response",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const response = outboundPatientDiscoveryRespSchema.parse(req.body);
 
@@ -257,7 +256,6 @@ router.post(
  */
 router.post(
   "/document-query/response",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const response = outboundDocumentQueryRespSchema.parse(req.body);
 
@@ -310,7 +308,6 @@ router.post(
  */
 router.post(
   "/document-retrieval/response",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const response = outboundDocumentRetrievalRespSchema.parse(req.body);
 

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -46,6 +46,7 @@ import { processPostRespOutboundPatientDiscoveryResps } from "../../external/car
 import { cqOrgDetailsSchema } from "../../external/carequality/shared";
 import { Config } from "../../shared/config";
 import { asyncHandler, getFrom, getFromQueryAsBoolean } from "../util";
+import { requestLogger } from "../helpers/request-logger";
 
 dayjs.extend(duration);
 const router = Router();
@@ -59,6 +60,7 @@ const sequelize = initDBPool(Config.getDBCreds());
  */
 router.post(
   "/directory/rebuild",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     if (Config.isSandbox()) return res.sendStatus(httpStatus.NOT_IMPLEMENTED);
     await rebuildCQDirectory();
@@ -76,6 +78,7 @@ router.post(
 router.post(
   "/directory/insert",
   upload.single("file"),
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const file = req.file;
     if (!file) {
@@ -117,6 +120,7 @@ router.post(
  */
 router.get(
   "/directory/organization/:oid",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     if (Config.isSandbox()) return res.sendStatus(httpStatus.NOT_IMPLEMENTED);
     const cq = makeCarequalityManagementAPI();
@@ -147,6 +151,7 @@ router.get(
  */
 router.post(
   "/directory/organization",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const body = req.body;
     const orgDetails = cqOrgDetailsSchema.parse(body);
@@ -168,6 +173,7 @@ router.post(
  */
 router.get(
   "/directory/nearby-organizations",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getFrom("query").orFail("cxId", req);
     const patientId = getFrom("query").orFail("patientId", req);
@@ -196,6 +202,7 @@ router.get(
  */
 router.post(
   "/patient-discovery/response",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const response = outboundPatientDiscoveryRespSchema.parse(req.body);
 
@@ -234,6 +241,7 @@ router.post(
  */
 router.post(
   "/patient-discovery/results",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     // TODO validate the request with the Zod schema, its mostly based on outboundPatientDiscoveryRespSchema
     processOutboundPatientDiscoveryResps(req.body);
@@ -249,6 +257,7 @@ router.post(
  */
 router.post(
   "/document-query/response",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const response = outboundDocumentQueryRespSchema.parse(req.body);
 
@@ -285,6 +294,7 @@ router.post(
  */
 router.post(
   "/document-query/results",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     // TODO validate the request with the Zod schema, its mostly based on outboundDocumentQueryRespSchema
     processOutboundDocumentQueryResps(req.body);
@@ -300,6 +310,7 @@ router.post(
  */
 router.post(
   "/document-retrieval/response",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const response = outboundDocumentRetrievalRespSchema.parse(req.body);
 
@@ -336,6 +347,7 @@ router.post(
  */
 router.post(
   "/document-retrieval/results",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     // TODO validate the request with the Zod schema, its mostly based on outboundDocumentRetrievalRespSchema
     processOutboundDocumentRetrievalResps(req.body);

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -60,7 +60,6 @@ const sequelize = initDBPool(Config.getDBCreds());
  */
 router.post(
   "/directory/rebuild",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     if (Config.isSandbox()) return res.sendStatus(httpStatus.NOT_IMPLEMENTED);
     await rebuildCQDirectory();
@@ -78,7 +77,6 @@ router.post(
 router.post(
   "/directory/insert",
   upload.single("file"),
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const file = req.file;
     if (!file) {
@@ -120,7 +118,6 @@ router.post(
  */
 router.get(
   "/directory/organization/:oid",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     if (Config.isSandbox()) return res.sendStatus(httpStatus.NOT_IMPLEMENTED);
     const cq = makeCarequalityManagementAPI();
@@ -151,7 +148,6 @@ router.get(
  */
 router.post(
   "/directory/organization",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const body = req.body;
     const orgDetails = cqOrgDetailsSchema.parse(body);

--- a/packages/api/src/routes/medical/internal-docs.ts
+++ b/packages/api/src/routes/medical/internal-docs.ts
@@ -44,6 +44,7 @@ import { getUUIDFrom } from "../schemas/uuid";
 import { asyncHandler, getFrom, getFromQueryAsArray, getFromQueryAsBoolean } from "../util";
 import { getFromQueryOrFail } from "./../util";
 import { cxRequestMetadataSchema } from "./schemas/request-metadata";
+import { requestLogger } from "../helpers/request-logger";
 
 const router = Router();
 const upload = multer();
@@ -81,6 +82,7 @@ const requestIdEmptyOverride = "empty-override";
  */
 router.post(
   "/re-convert",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const patientIds = getFromQueryAsArray("patientIds", req) ?? [];
@@ -129,6 +131,7 @@ const convertResultSchema = z.enum(convertResult);
  */
 router.post(
   "/conversion-status",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const patientId = getFrom("query").orFail("patientId", req);
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
@@ -192,6 +195,7 @@ router.post(
  */
 router.post(
   "/override-progress",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const patientId = getFrom("query").orFail("patientId", req);
@@ -234,6 +238,7 @@ router.post(
  */
 router.post(
   "/check-doc-queries",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const patientIds = getFromQueryAsArray("patientIds", req) ?? [];
     checkDocumentQueries(patientIds);
@@ -274,6 +279,7 @@ const uploadDocSchema = z.object({
 router.post(
   "/upload",
   upload.single("file"),
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const patientId = getUUIDFrom("query", req, "patientId").orFail();
@@ -326,6 +332,7 @@ router.post(
  */
 router.post(
   "/doc-ref",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     console.log("Updating the DocRef on a CX-uploaded file...");
     const cxId = getFromQueryOrFail("cxId", req);
@@ -352,6 +359,7 @@ router.post(
  */
 router.get(
   "/query",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const patientId = getUUIDFrom("query", req, "patientId").orFail();
@@ -374,6 +382,7 @@ router.get(
  */
 router.post(
   "/query",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getFrom("query").orFail("cxId", req);
     const patientId = getFrom("query").orFail("patientId", req);
@@ -406,6 +415,7 @@ export default router;
  */
 router.post(
   "/triggerBulkDownloadWebhook",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getFrom("query").orFail("cxId", req);
     const patientId = getFrom("query").orFail("patientId", req);

--- a/packages/api/src/routes/medical/internal-mpi.ts
+++ b/packages/api/src/routes/medical/internal-mpi.ts
@@ -9,7 +9,6 @@ import { asyncHandler, getFrom } from "../util";
 import { dtoFromModel } from "./dtos/patientDTO";
 import { createPatientUniqueId } from "@metriport/core/external/carequality/shared";
 import { Patient } from "@metriport/core/domain/patient";
-import { requestLogger } from "../helpers/request-logger";
 
 dayjs.extend(duration);
 
@@ -32,7 +31,6 @@ const patientLoader = new PatientLoaderLocal();
  */
 router.get(
   "/patient",
-  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const dob = getFrom("query").orFail("dob", req);
     const genderAtBirth = genderAtBirthSchema.parse(getFrom("query").orFail("genderAtBirth", req));

--- a/packages/api/src/routes/medical/internal-mpi.ts
+++ b/packages/api/src/routes/medical/internal-mpi.ts
@@ -9,6 +9,7 @@ import { asyncHandler, getFrom } from "../util";
 import { dtoFromModel } from "./dtos/patientDTO";
 import { createPatientUniqueId } from "@metriport/core/external/carequality/shared";
 import { Patient } from "@metriport/core/domain/patient";
+import { requestLogger } from "../helpers/request-logger";
 
 dayjs.extend(duration);
 
@@ -31,6 +32,7 @@ const patientLoader = new PatientLoaderLocal();
  */
 router.get(
   "/patient",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const dob = getFrom("query").orFail("dob", req);
     const genderAtBirth = genderAtBirthSchema.parse(getFrom("query").orFail("genderAtBirth", req));

--- a/packages/api/src/routes/medical/internal-patient.ts
+++ b/packages/api/src/routes/medical/internal-patient.ts
@@ -63,6 +63,7 @@ import { dtoFromCW, PatientLinksDTO } from "./dtos/linkDTO";
 import { dtoFromModel } from "./dtos/patientDTO";
 import { getResourcesQueryParam } from "./schemas/fhir";
 import { linkCreateSchema } from "./schemas/link";
+import { requestLogger } from "../helpers/request-logger";
 
 dayjs.extend(duration);
 
@@ -81,6 +82,7 @@ const patientLoader = new PatientLoaderLocal();
  */
 router.get(
   "/ids",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const facilityId = getFrom("query").optional("facilityId", req);
@@ -101,6 +103,7 @@ router.get(
  */
 router.get(
   "/states",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const patientIds = getFromQueryAsArrayOrFail("patientIds", req);
@@ -126,6 +129,7 @@ const updateAllSchema = z.object({
  */
 router.post(
   "/update-all/commonwell",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const { patientIds } = updateAllSchema.parse(req.body);
@@ -151,6 +155,7 @@ router.post(
  */
 router.post(
   "/update-all/carequality",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const { patientIds } = updateAllSchema.parse(req.body);
@@ -172,6 +177,7 @@ router.post(
  */
 router.delete(
   "/:id",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const id = getFromParamsOrFail("id", req);
@@ -202,6 +208,7 @@ router.delete(
  */
 router.post(
   "/:patientId/link/:source",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const patientId = getFromParamsOrFail("patientId", req);
@@ -239,6 +246,7 @@ router.post(
  */
 router.delete(
   "/:patientId/link/:source",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const patientId = getFromParamsOrFail("patientId", req);
@@ -267,6 +275,7 @@ router.delete(
  */
 router.get(
   "/:patientId/link",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const patientId = getFromParamsOrFail("patientId", req);
@@ -301,6 +310,7 @@ router.get(
  */
 router.get(
   "/duplicates",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").optional();
     const result = await findDuplicatedPersons(cxId);
@@ -339,6 +349,7 @@ const patchDuplicatesSchema = z.record(
  */
 router.patch(
   "/duplicates",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const unenrollByDemographics = stringToBoolean(
       getFrom("query").optional("unenrollByDemographics", req)
@@ -388,6 +399,7 @@ router.patch(
  */
 router.post(
   "/recreate-at-hies",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").optional();
     const resultCW = await recreatePatientsAtCW(cxId);
@@ -419,6 +431,7 @@ const initEnhancedCoverageSchema = z.object({
  */
 router.post(
   "/enhance-coverage",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const { cxId, patientIds, fromOrgPos } = initEnhancedCoverageSchema.parse(req.query);
 
@@ -475,6 +488,7 @@ const cqLinkStatusSchema = z.enum(cqLinkStatus);
  */
 router.post(
   "/enhance-coverage/set-cq-link-statuses",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const patientIds = getFromQueryAsArrayOrFail("patientIds", req);
@@ -502,6 +516,7 @@ const updateECAfterIncludeListSchema = z.object({
  */
 router.post(
   "/enhance-coverage/after-include-list",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const { ecId, cxId, patientIds, cqOrgIds } = updateECAfterIncludeListSchema.parse(req.query);
     if (patientIds && !patientIds.length) throw new BadRequestError(`Patient IDs are required`);
@@ -533,6 +548,7 @@ const updateECAfterDocQuerySchema = z.object({
  */
 router.post(
   "/enhance-coverage/after-doc-query",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const { ecId, cxId, patientId, docsFound } = updateECAfterDocQuerySchema.parse(req.query);
     if (docsFound < 0) {
@@ -572,6 +588,7 @@ const consolidationConversionTypeSchema = z.enum(consolidationConversionType);
  */
 router.get(
   "/consolidated",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const patientId = getFrom("query").orFail("patientId", req);
@@ -607,6 +624,7 @@ router.get(
  */
 router.post(
   "/trigger-update",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const patients = await getPatients({ cxId });
@@ -661,6 +679,7 @@ router.post(
  */
 router.get(
   "/",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const dob = getFrom("query").orFail("dob", req);
@@ -693,6 +712,7 @@ router.get(
  */
 router.get(
   "/:id",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const id = getFromParamsOrFail("id", req);

--- a/packages/api/src/routes/medical/organization.ts
+++ b/packages/api/src/routes/medical/organization.ts
@@ -18,6 +18,7 @@ import { getETag } from "../../shared/http";
 import { asyncHandler, getCxIdOrFail, getFromParamsOrFail } from "../util";
 import { dtoFromModel } from "./dtos/organizationDTO";
 import { organizationCreateSchema, organizationUpdateSchema } from "./schemas/organization";
+import { requestLogger } from "../helpers/request-logger";
 
 const router = Router();
 
@@ -31,6 +32,7 @@ const router = Router();
  */
 router.post(
   "/",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
 
@@ -61,6 +63,7 @@ router.post(
  */
 router.put(
   "/:id",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const id = getFromParamsOrFail("id", req);
@@ -95,6 +98,7 @@ router.put(
  */
 router.get(
   "/",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
 

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -47,6 +47,7 @@ import {
 } from "./schemas/patient";
 import { cxRequestMetadataSchema } from "./schemas/request-metadata";
 import { stringToBoolean } from "@metriport/shared";
+import { requestLogger } from "../helpers/request-logger";
 
 const router = Router();
 const MAX_RESOURCE_POST_COUNT = 50;
@@ -64,6 +65,7 @@ const MAX_CONTENT_LENGTH_BYTES = 1_000_000;
  */
 router.post(
   "/",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const facilityId = getFromQueryOrFail("facilityId", req);
@@ -107,6 +109,7 @@ router.post(
  */
 router.put(
   "/:id",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const id = getFromParamsOrFail("id", req);
@@ -150,6 +153,7 @@ router.put(
  */
 router.get(
   "/:id",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const patientId = getFromParamsOrFail("id", req);
@@ -170,6 +174,7 @@ router.get(
  */
 router.delete(
   "/:id",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const id = getFromParamsOrFail("id", req);
@@ -198,6 +203,7 @@ router.delete(
  */
 router.get(
   "/",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const facilityId = getFrom("query").optional("facilityId", req);
@@ -225,6 +231,7 @@ router.get(
  */
 router.get(
   "/:id/consolidated",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const patientId = getFrom("params").orFail("id", req);
@@ -256,6 +263,7 @@ router.get(
  */
 router.get(
   "/:id/consolidated/query",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const patientId = getFrom("params").orFail("id", req);
@@ -289,6 +297,7 @@ const consolidationConversionTypeSchema = z.enum(consolidationConversionType);
  */
 router.post(
   "/:id/consolidated/query",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const patientId = getFrom("params").orFail("id", req);
@@ -328,6 +337,7 @@ router.post(
  */
 router.get(
   "/:id/medical-record",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const patientId = getFrom("params").orFail("id", req);
@@ -351,6 +361,7 @@ router.get(
  */
 router.get(
   "/:id/medical-record-status",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const patientId = getFrom("params").orFail("id", req);
@@ -436,6 +447,7 @@ async function putConsolidated(req: Request, res: Response) {
  */
 router.get(
   "/:id/consolidated/count",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const patientId = getFrom("params").orFail("id", req);

--- a/packages/api/src/routes/settings.ts
+++ b/packages/api/src/routes/settings.ts
@@ -10,6 +10,7 @@ import { retryFailedRequests } from "../command/webhook/retry-failed";
 import BadRequestError from "../errors/bad-request";
 import { Settings } from "../models/settings";
 import { asyncHandler, getCxIdOrFail } from "./util";
+import { requestLogger } from "./helpers/request-logger";
 
 const router = Router();
 const webhookURLIncludeBlacklist = [
@@ -98,6 +99,7 @@ class WebhookStatusDTO {
  */
 router.get(
   "/",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const id = getCxIdOrFail(req);
     let settings = await getSettings({ id });
@@ -125,6 +127,7 @@ const updateSettingsSchema = z
  */
 router.post(
   "/",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     const { webhookUrl } = updateSettingsSchema.parse(req.body);
@@ -154,6 +157,7 @@ router.post(
  */
 router.get(
   "/webhook",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const id = getCxIdOrFail(req);
     const settings = await getSettingsOrFail({ id });
@@ -180,6 +184,7 @@ router.get(
  */
 router.post(
   "/webhook/retry",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
     await retryFailedRequests(cxId);

--- a/packages/api/src/shared/analytics.ts
+++ b/packages/api/src/shared/analytics.ts
@@ -28,6 +28,9 @@ export const analytics = (params: EventMessageV1 & { apiType: Product | "interna
       environment: Config.getEnvType(),
       platform: "oss-api",
       apiType: params.apiType,
+      $set_once: {
+        cxId: params.distinctId,
+      },
     };
 
     posthog.capture(params);


### PR DESCRIPTION
Ref. metriport/metriport-internal#1669

Ticket: #1669

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1685

### Description

Move the request logs to the individual routes in order to extract the params from the URL's

### Testing

_[Regular PRs:]_

- Local
  - [x] Test sending events to posthog
- Staging
  - [ ] Test sending events to posthog
- Production
  - [ ]Monitor

### Release Plan

- [ ] Upstream dependencies are met/released
- [ ] Merge this
