### PR TITLE
PATCH RELEASE 1679 Add patient overview at HIEs

### DIFF
--- a/packages/api/src/command/medical/admin/hie-overview.ts
+++ b/packages/api/src/command/medical/admin/hie-overview.ts
@@ -1,0 +1,240 @@
+import { GenderAtBirth, PatientData } from "@metriport/core/domain/patient";
+import { genderMapping } from "@metriport/core/external/fhir/patient/index";
+import { initReadonlyDBPool } from "@metriport/core/util/sequelize";
+import { OutboundPatientDiscoveryResp } from "@metriport/ihe-gateway-sdk";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import distance from "jaro-winkler";
+import { partition } from "lodash";
+import { QueryTypes } from "sequelize";
+import { CQLink } from "../../../external/carequality/cq-patient-data";
+import { Config } from "../../../shared/config";
+
+dayjs.extend(duration);
+
+const readOnlyDBPool = initReadonlyDBPool(Config.getDBCreds(), Config.getDBReadReplicaEndpoint());
+
+type DebugLevel = "info" | "success" | "error";
+
+type HieGateway = {
+  name: string;
+  oid: string;
+  url: string | undefined;
+};
+
+type HiePatient = {
+  name: {
+    family: string | undefined;
+    given: string | undefined;
+  }[];
+  gender: string | undefined;
+  birthDate: string | undefined;
+  address: {
+    line: string | undefined;
+    city: string | undefined;
+    state: string | undefined;
+    postalCode: string | undefined;
+    country: string | undefined;
+  }[];
+};
+
+type CqPdSuccessResponse = {
+  gateway: HieGateway;
+  patient: HiePatient;
+};
+
+type CqPdErrorConsolidated = {
+  error: string;
+  gatewayNames: string[];
+};
+
+type HiePatientOverview = {
+  cxId: string;
+  patientId: string;
+  patientData: PatientData;
+  carequality: {
+    links: CQLink[];
+    success: CqPdSuccessResponse[];
+    errors: CqPdErrorConsolidated[];
+  };
+};
+
+type DbQueryResponseRecord = {
+  cx_id: string;
+  id: string;
+  patient_data: PatientData;
+  cq_links: { links: CQLink[] };
+  response_data: OutboundPatientDiscoveryResp | undefined;
+  name: string | undefined | null;
+};
+
+export async function getHieOverview(
+  patientId: string,
+  debugLevel: DebugLevel
+): Promise<HiePatientOverview | undefined> {
+  const queryResp: DbQueryResponseRecord[] = await getDataFromDb(patientId, debugLevel);
+  const [respErrors, respSuccess] = partition(
+    queryResp,
+    r => r.response_data?.patientMatch === false
+  );
+  const patientData = respSuccess[0]?.patient_data;
+
+  const errors: CqPdErrorConsolidated[] = respErrors.reduce(
+    (acc: CqPdErrorConsolidated[], row: DbQueryResponseRecord) => {
+      const rowErrorDetail = (
+        row.response_data?.operationOutcome?.issue[0]?.details as { text: string | undefined }
+      )?.text;
+      if (!rowErrorDetail) return acc;
+      const gatewayName = getGatewayName(row);
+      const existingErrorEntry = acc.find(a => a.error === rowErrorDetail);
+      if (existingErrorEntry) {
+        existingErrorEntry.gatewayNames.push(gatewayName);
+        return acc;
+      }
+      acc.push({
+        error: rowErrorDetail,
+        gatewayNames: [gatewayName],
+      });
+      return acc;
+    },
+    new Array<CqPdErrorConsolidated>()
+  );
+
+  const hieOverview = respSuccess.reduce(
+    (acc: HiePatientOverview | undefined, row: DbQueryResponseRecord) => {
+      if (!row.response_data) return acc;
+      const patientOfSuccessfulResp = responseToPatient(row.response_data, patientData);
+      if (!patientOfSuccessfulResp) {
+        console.log(`Skipping response with missing patient data: ${row.response_data.id}`);
+        return acc;
+      }
+      const gatewayName = getGatewayName(row);
+      const gateway = responseToGateway(row.response_data, gatewayName);
+      const success = {
+        patient: patientOfSuccessfulResp,
+        gateway,
+      };
+      if (acc) {
+        acc.carequality.success.push(success);
+        return acc;
+      }
+      const cqLinks = responseToCqLinks(row);
+      return {
+        cxId: row.cx_id,
+        patientId: row.id,
+        patientData,
+        carequality: {
+          links: cqLinks,
+          success: [success],
+          errors,
+        },
+      };
+    },
+    undefined
+  );
+  return hieOverview;
+}
+
+async function getDataFromDb(
+  patientId: string,
+  debugLevel: DebugLevel
+): Promise<DbQueryResponseRecord[]> {
+  const matchQuery = debugLevel === "success" ? `and r.data->>'patientMatch' = 'true'` : "";
+  const query =
+    debugLevel !== "info"
+      ? `
+          select p.cx_id, p.id, p.data as patient_data, pd.data as cq_links, r.data as response_data, d.name as gateway_name
+          from patient p
+            left outer join cq_patient_data pd on pd.id = p.id
+            left join patient_discovery_result r on r.patient_id::text = p.id ${matchQuery}
+            left join cq_directory_entry d on d.id = r.data->>'gatewayHomeCommunityId'
+          where p.id = ':patientId'
+        `
+      : `
+        select p.cx_id, p.id, p.data as patient_data, pd.data as cq_links, null as response_data, null as gateway_name
+        from patient p
+          left outer join cq_patient_data pd on pd.id = p.id
+        where p.id = ':patientId'
+      `;
+  const replacements = {
+    patientId,
+  };
+  const queryResp: DbQueryResponseRecord[] = await readOnlyDBPool.query(query, {
+    replacements,
+    type: QueryTypes.SELECT,
+  });
+  return queryResp;
+}
+
+function responseToPatient(
+  resp: OutboundPatientDiscoveryResp,
+  patientOnMetriport: PatientData
+): HiePatient | undefined {
+  if (!resp.patientMatch) return undefined;
+  const patientOnExternalGw = resp.patientResource;
+  if (!patientOnExternalGw) return undefined;
+  return {
+    name:
+      patientOnExternalGw.name?.map(name => ({
+        family: addStringDiff(name.family, patientOnMetriport.lastName),
+        given: (name.given ?? [])
+          .map(g => addStringDiff(g, patientOnMetriport.firstName))
+          .join(", "),
+      })) ?? [],
+    gender: addGenderDiff(patientOnExternalGw.gender, patientOnMetriport.genderAtBirth),
+    birthDate: addDobDiff(patientOnExternalGw.birthDate, patientOnMetriport.dob),
+    address:
+      patientOnExternalGw.address?.map(addr => ({
+        line: addr.line?.join(", "),
+        city: addr.city,
+        state: addr.state,
+        postalCode: addr.postalCode,
+        country: addr.country,
+      })) ?? [],
+  };
+}
+
+function addStringDiff(
+  name: string | undefined,
+  referenceName: string | undefined
+): string | undefined {
+  const nameAdj = name?.trim().toLowerCase();
+  const referenceNameAdj = referenceName?.trim().toLowerCase();
+  if (!nameAdj || !referenceNameAdj) return name;
+  const dist = distance(nameAdj, referenceNameAdj);
+  const suffix = dist === 1 ? "same" : dist.toString();
+  return `${name} (${suffix})`;
+}
+
+function addGenderDiff(
+  gender: string | undefined,
+  referenceGender: GenderAtBirth
+): string | undefined {
+  const genderAdj = gender?.trim();
+  if (!genderAdj) return undefined;
+  const referenceGenderAdj = genderMapping[referenceGender];
+  if (genderAdj === referenceGenderAdj) return `${genderAdj} (same)`;
+  return `${genderAdj} (diff)`;
+}
+
+function addDobDiff(dob: string | undefined, referenceDob: string): string | undefined {
+  const dobAdj = dob?.trim();
+  if (dayjs(dobAdj).isSame(referenceDob)) return `${dobAdj} (same)`;
+  return `${dobAdj} (diff)`;
+}
+
+function responseToGateway(resp: OutboundPatientDiscoveryResp, name: string): HieGateway {
+  return {
+    name,
+    oid: resp.gateway.oid,
+    url: resp.gateway.url,
+  };
+}
+
+function getGatewayName(row: DbQueryResponseRecord): string {
+  return row.name || "Unknown";
+}
+
+function responseToCqLinks(resp: DbQueryResponseRecord): CQLink[] {
+  return resp.cq_links.links;
+}

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -21,6 +21,7 @@ import { OrganizationModel } from "../models/medical/organization";
 import userRoutes from "./devices/internal-user";
 import carequalityRoutes from "./medical/internal-cq";
 import docsRoutes from "./medical/internal-docs";
+import hieRoutes from "./medical/internal-hie";
 import mpiRoutes from "./medical/internal-mpi";
 import patientRoutes from "./medical/internal-patient";
 import { getUUIDFrom } from "./schemas/uuid";
@@ -33,6 +34,7 @@ router.use("/patient", patientRoutes);
 router.use("/user", userRoutes);
 router.use("/carequality", carequalityRoutes);
 router.use("/mpi", mpiRoutes);
+router.use("/hie", hieRoutes);
 
 /** ---------------------------------------------------------------------------
  * POST /internal/mapi-access

--- a/packages/api/src/routes/medical/internal-hie.ts
+++ b/packages/api/src/routes/medical/internal-hie.ts
@@ -1,0 +1,39 @@
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import { Request, Response } from "express";
+import Router from "express-promise-router";
+import httpStatus from "http-status";
+import { z } from "zod";
+import { getHieOverview } from "../../command/medical/admin/hie-overview";
+import { getUUIDFrom } from "../schemas/uuid";
+import { asyncHandler } from "../util";
+
+dayjs.extend(duration);
+
+const router = Router();
+
+const debugLevelSchema = z.enum(["info", "success", "error"]).optional();
+
+/**
+ * GET /internal/hie/patient/overview
+ *
+ * Retrieves the overall status of a patient across HIEs.
+ *
+ * @param req.query.patientId - The patient's ID.
+ * @param req.query.debugLevel - The level of details to include in the overview:
+ *    - info: Only the basic information about the patient's status in the HIEs (default).
+ *    - success: Include the successful responses from HIEs (useful to enhance the Patient's demographics).
+ *    - error: Include the failed transactions in the overview (useful to diagnose why the patient didn't
+ *              get linked to a certain external gateway).
+ */
+router.get(
+  "/patient/overview",
+  asyncHandler(async (req: Request, res: Response) => {
+    const patientId = getUUIDFrom("query", req, "patientId").orFail();
+    const debugLevel = debugLevelSchema.parse(req.query.debugLevel) ?? "info";
+    const response = await getHieOverview(patientId, debugLevel);
+    return res.status(httpStatus.OK).json(response);
+  })
+);
+
+export default router;

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -122,6 +122,10 @@ export class Config {
     return getEnvVarOrFail("DB_CREDS");
   }
 
+  static getDBReadReplicaEndpoint(): string {
+    return getEnvVarOrFail("DB_READ_REPLICA_ENDPOINT");
+  }
+
   static getCronometerClientId(): string {
     return getEnvVarOrFail("CRONOMETER_CLIENT_ID");
   }

--- a/packages/core/src/util/sequelize.ts
+++ b/packages/core/src/util/sequelize.ts
@@ -9,12 +9,52 @@ export const dbCredsSchema = z.object({
   port: z.number(),
   engine: z.literal("postgres"),
 });
+export type DbCreds = z.infer<typeof dbCredsSchema>;
+
+export const dbReadReplicaEndpointSchema = z.object({
+  host: z.string(),
+  port: z.number(),
+});
+export type DbReadReplicaEndpoint = z.infer<typeof dbCredsSchema>;
+
+/**
+ * This function is used to initialize the readonly DB pool for queries that require the read replica.
+ *
+ * Note that this is a workaround while we don't have https://github.com/metriport/metriport-internal/issues/1174
+ * in place.
+ */
+export function initReadonlyDBPool(
+  dbCreds: string,
+  dbReadReplicaEndpoint: string,
+  poolOptions?: PoolOptions,
+  logging?: boolean
+) {
+  const dbCredsRaw = JSON.parse(dbCreds);
+  const parsedDbCreds = dbCredsSchema.parse(dbCredsRaw);
+
+  const dbReadReplicaEndpointRaw = JSON.parse(dbReadReplicaEndpoint);
+  const parsedDbReadReplicaEndpoint = dbReadReplicaEndpointSchema.parse(dbReadReplicaEndpointRaw);
+
+  parsedDbCreds.host = parsedDbReadReplicaEndpoint.host;
+  parsedDbCreds.port = parsedDbReadReplicaEndpoint.port;
+
+  return initDBPoolFromCreds(parsedDbCreds, poolOptions, logging);
+}
 
 /**
  * This function is used to initialize the DB pool for raw queries that can't rely on Models.
  */
-export function initDBPool(
-  dbCreds: string,
+export function initDBPool(dbCreds: string, poolOptions?: PoolOptions, logging?: boolean) {
+  const sqlDBCreds = JSON.parse(dbCreds);
+  const parsedDbCreds = dbCredsSchema.parse(sqlDBCreds);
+  return initDBPoolFromCreds(parsedDbCreds, poolOptions, logging);
+}
+
+/**
+ * This function is used to initialize the DB pool for raw queries that can't rely on Models.
+ */
+function initDBPoolFromCreds(
+  dbCreds: DbCreds,
   poolOptions: PoolOptions = {
     max: 5,
     min: 1,
@@ -23,20 +63,12 @@ export function initDBPool(
   },
   logging = false
 ) {
-  const sqlDBCreds = JSON.parse(dbCreds);
-  const parsedDbCreds = dbCredsSchema.parse(sqlDBCreds);
-
-  const sequelize = new Sequelize(
-    parsedDbCreds.dbname,
-    parsedDbCreds.username,
-    parsedDbCreds.password,
-    {
-      host: parsedDbCreds.host,
-      port: parsedDbCreds.port,
-      dialect: parsedDbCreds.engine,
-      pool: poolOptions,
-      logging,
-    }
-  );
+  const sequelize = new Sequelize(dbCreds.dbname, dbCreds.username, dbCreds.password, {
+    host: dbCreds.host,
+    port: dbCreds.port,
+    dialect: dbCreds.engine,
+    pool: poolOptions,
+    logging,
+  });
   return sequelize;
 }

--- a/packages/ihe-gateway-sdk/src/index.ts
+++ b/packages/ihe-gateway-sdk/src/index.ts
@@ -39,6 +39,7 @@ export {
   InboundPatientDiscoveryResp,
   inboundPatientDiscoveryRespSchema,
   OutboundPatientDiscoveryResp,
+  OutboundPatientDiscoveryRespSuccessfulSchema,
   outboundPatientDiscoveryRespSchema,
   InboundPatientResource,
   inboundPatientResourceSchema,

--- a/packages/ihe-gateway-sdk/src/models/patient-discovery/patient-discovery-responses.ts
+++ b/packages/ihe-gateway-sdk/src/models/patient-discovery/patient-discovery-responses.ts
@@ -1,9 +1,9 @@
 import * as z from "zod";
 import {
-  XCPDGatewaySchema,
   baseErrorResponseSchema,
   baseResponseSchema,
   externalGatewayPatientSchema,
+  XCPDGatewaySchema,
 } from "../shared";
 
 export const inboundPatientResourceSchema = z.object({
@@ -72,6 +72,9 @@ const outboundPatientDiscoveryRespSuccessfulSchema = outboundPatientDiscoveryRes
   .extend({
     patientResource: inboundPatientResourceSchema.optional(),
   });
+export type OutboundPatientDiscoveryRespSuccessfulSchema = z.infer<
+  typeof outboundPatientDiscoveryRespSuccessfulSchema
+>;
 
 const outboundPatientDiscoveryRespFaultSchema = outboundPatientDiscoveryRespDefaultSchema.extend({
   patientMatch: z.literal(false).or(z.literal(null)),

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -425,6 +425,7 @@ export class APIStack extends Stack {
       secrets,
       vpc: this.vpc,
       dbCredsSecret,
+      dbReadReplicaEndpoint: dbCluster.clusterReadEndpoint,
       dynamoDBTokenTable,
       alarmAction: slackNotification?.alarmAction,
       dnsZones,

--- a/packages/infra/lib/ihe-stack.ts
+++ b/packages/infra/lib/ihe-stack.ts
@@ -1,5 +1,5 @@
-import { Stack, StackProps } from "aws-cdk-lib";
-import { CfnOutput } from "aws-cdk-lib";
+import { CfnOutput, Stack, StackProps } from "aws-cdk-lib";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
 import * as cert from "aws-cdk-lib/aws-certificatemanager";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
@@ -12,7 +12,6 @@ import { Construct } from "constructs";
 import { EnvConfig } from "../config/env-config";
 import { createIHEGateway } from "./ihe-stack/ihe-gateway";
 import { createLambda } from "./shared/lambda";
-import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
 import { LambdaLayers, setupLambdasLayers } from "./shared/lambda-layers";
 
 interface IHEStackProps extends StackProps {


### PR DESCRIPTION
Ref. metriport/metriport-internal#1679

### Dependencies

- Original PR: https://github.com/metriport/metriport/pull/1890

### Description

⚠️ This is a patch to master with a cherry-pick from the original PR above, so we can ship this before the release train on Saturday.

Add internal endpoint to return the patient's overview across HIEs:
- `info`: basic information about links
- `success`: includes info about patient demographics from successful links
   - indicates whether the demographics on responses from external GW are the same or different from what we have on our DB
- `error`: includes "success" and errors
   - groups gateways by error description

More details/examples on https://metriport.slack.com/archives/C04DMKE9DME/p1712879705213539

### Testing

- Local
  - [x] it returns just basic info
  - [x] it returns successful responses
  - [x] it returns all responses, including errors
- Staging
  - [ ] it returns just basic info
  - [ ] it returns successful responses
  - [ ] it returns all responses, including errors
- Sandbox
  - none
- Production
  - [ ] it returns just basic info
  - [ ] it returns successful responses
  - [ ] it returns all responses, including errors

### Release Plan

- ⚠️ This is pointing to `master`
- [ ] Merge this
