### PR TITLE
1679 Fix DB replica ECS env var

### DIFF
--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -113,7 +113,7 @@ export function createAPIService({
   const coverageEnhancementConfig = props.config.commonwell.coverageEnhancement;
   const dbReadReplicaEndpointAsString = JSON.stringify({
     host: dbReadReplicaEndpoint.hostname,
-    port: dbReadReplicaEndpoint.port.toString(),
+    port: dbReadReplicaEndpoint.port,
   });
   // Run some servers on fargate containers
   const fargateService = new ecs_patterns.NetworkLoadBalancedFargateService(


### PR DESCRIPTION
Ref. metriport/metriport-internal#1679

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1890

### Description

Fix DB replica ECS env var. It was being created w/ the port as string instead of number and failing to start the ECS task.

### Testing

- Staging
  - [ ] ECS task loads
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
