### PR TITLE
Fix typo on docs and move sqs-to-converter's cleanup fn to external

### DIFF
--- a/docs/home/api-info/webhooks.mdx
+++ b/docs/home/api-info/webhooks.mdx
@@ -44,7 +44,7 @@ When Metriport sends a webhook message, it includes an `x-metriport-signature` h
 
 At a high level, an HMAC works by taking a secret key and a message, and performing iterative hashes of the two to create 
 a signature. That signature is compared against the signature in the header for equality. If the signatures are equal, you can trust the webhook 
-payload is authentic and has not been tampered with. If they aren't equal, you should throw it awasy. 
+payload is authentic and has not been tampered with. If they aren't equal, you should throw it away. 
 
 You can use this header to verify that the webhook messages sent to your endpoint are from Metriport. Here's an example of how you can do this in Node.js:
 

--- a/packages/lambdas/src/__tests__/sqs-to-converter.test.ts
+++ b/packages/lambdas/src/__tests__/sqs-to-converter.test.ts
@@ -1,0 +1,20 @@
+import { cleanUpPayload } from "../sqs-to-converter/cleanup";
+
+describe("sqs-to-converter", () => {
+  describe("cleanUpPayload", () => {
+    it("returns original xml when no UNK and no nullFlavor", async () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+                  <ClinicalDocument>
+                    <component typeCode="COMP" contextConductionInd="true">
+                      <nonXMLBody classCode="DOCBODY" moodCode="EVN">
+                        <text mediaType="application/pdf" representation="B64">
+                          abc123
+                        </text>
+                      </nonXMLBody>
+                    </component>
+                  </ClinicalDocument>`;
+      const res = cleanUpPayload(xml);
+      expect(res).toEqual(xml);
+    });
+  });
+});

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -10,6 +10,7 @@ import { Log, prefixedLog } from "./shared/log";
 import { apiClient } from "./shared/oss-api";
 import { S3Utils } from "./shared/s3";
 import { SQSUtils } from "./shared/sqs";
+import { cleanUpPayload } from "./sqs-to-converter/cleanup";
 
 // Keep this as early on the file as possible
 capture.init();
@@ -390,21 +391,4 @@ async function sendConversionResult(
     },
   };
   await sqsUtils.sqs.sendMessage(sendParams).promise();
-}
-function cleanUpPayload(payloadRaw: string): string {
-  const payloadNoCDUNK = removeCDUNK(payloadRaw);
-  const payloadNoNullFlavor = removeNullFlavor(payloadNoCDUNK);
-  return payloadNoNullFlavor;
-}
-
-function removeCDUNK(payloadRaw: string): string {
-  const stringToReplace = /xsi:type="CD UNK"/g;
-  const replacement = `xsi:type="CD"`;
-  return payloadRaw.replace(stringToReplace, replacement);
-}
-
-function removeNullFlavor(payloadRaw: string): string {
-  const stringToReplace = /<id\s*nullFlavor\s*=\s*".*?"\s*\/>/g;
-  const replacement = `<id extension="1" root="1"/>`;
-  return payloadRaw.replace(stringToReplace, replacement);
 }

--- a/packages/lambdas/src/sqs-to-converter/cleanup.ts
+++ b/packages/lambdas/src/sqs-to-converter/cleanup.ts
@@ -1,0 +1,17 @@
+export function cleanUpPayload(payloadRaw: string): string {
+  const payloadNoCDUNK = removeCDUNK(payloadRaw);
+  const payloadNoNullFlavor = removeNullFlavor(payloadNoCDUNK);
+  return payloadNoNullFlavor;
+}
+
+function removeCDUNK(payloadRaw: string): string {
+  const stringToReplace = /xsi:type="CD UNK"/g;
+  const replacement = `xsi:type="CD"`;
+  return payloadRaw.replace(stringToReplace, replacement);
+}
+
+function removeNullFlavor(payloadRaw: string): string {
+  const stringToReplace = /<id\s*nullFlavor\s*=\s*".*?"\s*\/>/g;
+  const replacement = `<id extension="1" root="1"/>`;
+  return payloadRaw.replace(stringToReplace, replacement);
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1698

### Dependencies

none

### Description

- fix typo on docs
- move sqs-to-converter's cleanup fn to external and add simplest test
   - didn't get to fix it b/c it seems to require more time and the issue doesn't seem to be so critical

### Testing

- Local
  - [x] add some unit test
- Staging
  - [ ] download and convert one file
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
