### PR TITLE
PATCH empty address on patient create

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28425,7 +28425,7 @@
       }
     },
     "packages/api": {
-      "version": "1.13.8",
+      "version": "1.13.9",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -28506,11 +28506,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.12.5",
+      "version": "7.12.6",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.8",
-        "@metriport/shared": "^0.4.8",
+        "@metriport/commonwell-sdk": "^4.12.9",
+        "@metriport/shared": "^0.4.9",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28566,11 +28566,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
-        "@metriport/core": "^1.9.8",
-        "@metriport/ihe-gateway-sdk": "^0.5.2"
+        "@metriport/core": "^1.9.9",
+        "@metriport/ihe-gateway-sdk": "^0.5.3"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -28578,7 +28578,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -28588,10 +28588,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.13.8",
+      "version": "1.13.9",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.8",
+        "@metriport/commonwell-sdk": "^4.12.9",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -28630,10 +28630,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.10.8",
+      "version": "1.10.9",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.12.8",
+        "@metriport/commonwell-sdk": "^4.12.9",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -28665,7 +28665,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.12.8",
+      "version": "4.12.9",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",
@@ -28715,7 +28715,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.9.8",
+      "version": "1.9.9",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -28787,17 +28787,17 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.4.8",
+        "@metriport/shared": "^0.4.9",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.8.8",
+      "version": "1.8.9",
       "dependencies": {
         "aws-cdk-lib": "^2.122.0",
         "constructs": "^10.2.69",
@@ -28845,7 +28845,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.8.8",
+      "version": "1.8.9",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -29872,14 +29872,14 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^8.0.2"
       }
     },
     "packages/utils": {
-      "version": "1.10.8",
+      "version": "1.10.9",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.12.5",
+  "version": "7.12.6",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -56,8 +56,8 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.8",
-    "@metriport/shared": "^0.4.8",
+    "@metriport/commonwell-sdk": "^4.12.9",
+    "@metriport/shared": "^0.4.9",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/src/medical/models/demographics.ts
+++ b/packages/api-sdk/src/medical/models/demographics.ts
@@ -57,7 +57,7 @@ export const demographicsSchema = z.object({
   dob: defaultDateString,
   genderAtBirth: genderAtBirthSchema,
   personalIdentifiers: z.array(personalIdentifierSchema).optional(),
-  address: z.array(addressSchema).or(addressSchema),
+  address: z.array(addressSchema).nonempty().or(addressSchema),
   contact: z.array(contactSchema).optional().or(contactSchema.optional()),
 });
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.13.8",
+  "version": "1.13.9",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/core": "^1.9.8",
-    "@metriport/ihe-gateway-sdk": "^0.5.2"
+    "@metriport/core": "^1.9.9",
+    "@metriport/ihe-gateway-sdk": "^0.5.3"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.13.8",
+  "version": "1.13.9",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.8",
+    "@metriport/commonwell-sdk": "^4.12.9",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.10.8",
+  "version": "1.10.9",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.12.8",
+    "@metriport/commonwell-sdk": "^4.12.9",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.12.8",
+  "version": "4.12.9",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -55,7 +55,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.4.8",
+    "@metriport/shared": "^0.4.9",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.10.8",
+  "version": "1.10.9",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ticket: #799

### Dependencies

- Upstream: none
- Downstream: none

### Description

Dont allow for empty addresses on patient create - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1713268382878429)

### Testing

- Local
  - [x] Make sure schema throws error if empty 
- Production
  - [ ] Monitor

### Release Plan

- :warning: Points to `master`
- [x] Release NPM packages
- [ ] Merge this
