### PR TITLE
1040 Add basic address validation to domain

### DIFF
--- a/packages/api/src/command/medical/patient/__tests__/validate.test.ts
+++ b/packages/api/src/command/medical/patient/__tests__/validate.test.ts
@@ -1,0 +1,40 @@
+import { makeAddressStrict } from "../../../../domain/medical/__tests__/location-address";
+import { makePatientCreate } from "../../../../domain/medical/__tests__/patient";
+import { validate } from "../shared";
+
+describe("validate", () => {
+  it("returns true when patient is valid", async () => {
+    const patient = makePatientCreate();
+    const resp = validate(patient);
+    expect(resp).toBeTruthy();
+  });
+
+  describe("address", () => {
+    it("returns false if address is empty", async () => {
+      const patient = makePatientCreate({ address: [] });
+      const resp = validate(patient);
+      expect(resp).toBeFalsy();
+    });
+
+    it("returns false if address is undefined", async () => {
+      const patient = makePatientCreate();
+      patient.address = undefined as unknown as any; //eslint-disable-line @typescript-eslint/no-explicit-any
+      const resp = validate(patient);
+      expect(resp).toBeFalsy();
+    });
+
+    it("returns true if address has one element", async () => {
+      const patient = makePatientCreate({ address: [makeAddressStrict()] });
+      const resp = validate(patient);
+      expect(resp).toBeTruthy();
+    });
+
+    it("returns true if address has multiple elements", async () => {
+      const patient = makePatientCreate({
+        address: [makeAddressStrict(), makeAddressStrict(), makeAddressStrict()],
+      });
+      const resp = validate(patient);
+      expect(resp).toBeTruthy();
+    });
+  });
+});

--- a/packages/api/src/command/medical/patient/shared.ts
+++ b/packages/api/src/command/medical/patient/shared.ts
@@ -12,6 +12,7 @@ export function sanitize<T extends PatientCreateCmd | PatientUpdateCmd>(patient:
 }
 
 export function validate<T extends PatientCreateCmd | PatientUpdateCmd>(patient: T): boolean {
+  if (!patient.address || patient.address.length < 1) return false;
   patient.personalIdentifiers?.forEach(pid => pid.period && validatePeriod(pid.period));
   return true;
 }

--- a/packages/api/src/domain/medical/__tests__/patient.ts
+++ b/packages/api/src/domain/medical/__tests__/patient.ts
@@ -1,19 +1,21 @@
 import { faker } from "@faker-js/faker";
 import { USState } from "@metriport/core/domain/geographic-locations";
+import { Patient, PatientData, PersonalIdentifier } from "@metriport/core/domain/patient";
 import dayjs from "dayjs";
+import { PatientCreateCmd } from "../../../command/medical/patient/create-patient";
 import { ISO_DATE } from "../../../shared/date";
 import { makeBaseDomain } from "../../__tests__/base-domain";
-import { Patient, PatientData, PersonalIdentifier } from "@metriport/core/domain/patient";
 import { makeAddressStrict } from "./location-address";
 
-export const makePersonalIdentifier = (): PersonalIdentifier => {
+export function makePersonalIdentifier(): PersonalIdentifier {
   return {
     type: "driversLicense",
     value: faker.string.uuid(),
     state: faker.helpers.arrayElement(Object.values(USState)),
   };
-};
-export const makePatientData = (data: Partial<PatientData> = {}): PatientData => {
+}
+
+export function makePatientData(data: Partial<PatientData> = {}): PatientData {
   return {
     firstName: data.firstName ?? faker.person.firstName(),
     lastName: data.lastName ?? faker.person.lastName(),
@@ -25,8 +27,9 @@ export const makePatientData = (data: Partial<PatientData> = {}): PatientData =>
     cxDocumentRequestMetadata: data.cxDocumentRequestMetadata,
     cxConsolidatedRequestMetadata: data.cxConsolidatedRequestMetadata,
   };
-};
-export const makePatient = (params: Partial<Patient> = {}): Patient => {
+}
+
+export function makePatient(params: Partial<Patient> = {}): Patient {
   return {
     ...makeBaseDomain(),
     ...(params.id ? { id: params.id } : {}),
@@ -34,4 +37,13 @@ export const makePatient = (params: Partial<Patient> = {}): Patient => {
     facilityIds: params.facilityIds ?? [faker.string.uuid()],
     data: makePatientData(params.data),
   };
-};
+}
+
+export function makePatientCreate(params: Partial<PatientCreateCmd> = {}): PatientCreateCmd {
+  return {
+    ...makeBaseDomain(),
+    cxId: params.cxId ?? faker.string.uuid(),
+    facilityId: params.facilityId ?? faker.string.uuid(),
+    ...makePatientData(params),
+  };
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Add basic address validation to domain - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1713281789791799?thread_ts=1713268382.878429&cid=C04T256DQPQ)

### Testing

- Local
  - [ ] Unit test
- Staging
  - [ ] Create Patient
  - [ ] Update Patient
- Sandbox
  - [ ] Create Patient
  - [ ] Update Patient
- Production
  - none

### Release Plan

- [ ] Merge this
