### PR TITLE
799 Manually specify FHIRToMedicalRecord lambda node runtime

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1423,6 +1423,10 @@ export class APIStack extends Stack {
       stack: this,
       name: "FhirToMedicalRecord",
       runtime: lambda.Runtime.NODEJS_16_X,
+      // TODO https://github.com/metriport/metriport-internal/issues/1672
+      runtimeManagementMode: lambda.RuntimeManagementMode.manual(
+        "arn:aws:lambda:us-west-1::runtime:0163909785ec2e11db2b64bb2636ada67bb348dd5764aa83e7eb011bc0f365d8"
+      ),
       entry: "fhir-to-medical-record",
       envType,
       envVars: {

--- a/packages/infra/lib/shared/lambda.ts
+++ b/packages/infra/lib/shared/lambda.ts
@@ -11,6 +11,7 @@ import {
   Function as Lambda,
   ILayerVersion,
   Runtime,
+  RuntimeManagementMode,
   SingletonFunction,
 } from "aws-cdk-lib/aws-lambda";
 import * as lambda_node from "aws-cdk-lib/aws-lambda-nodejs";
@@ -53,6 +54,7 @@ export interface LambdaProps extends StackProps {
   readonly maxEventAge?: Duration;
   readonly alarmSnsAction?: SnsAction;
   readonly runtime?: Runtime;
+  readonly runtimeManagementMode?: RuntimeManagementMode;
   readonly architecture?: Architecture;
   readonly layers: ILayerVersion[];
   readonly version?: string | undefined;
@@ -62,6 +64,7 @@ export function createLambda(props: LambdaProps): Lambda {
   const lambda = new Lambda(props.stack, props.name, {
     functionName: props.name + "Lambda",
     runtime: props.runtime ?? Runtime.NODEJS_18_X,
+    runtimeManagementMode: props.runtimeManagementMode,
     // TODO move our lambdas to use layers, quicker to deploy and execute them
     code: Code.fromAsset(`${pathToLambdas}/dist`),
     handler: props.entry + ".handler",


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Dependencies

none

### Description

Manually specify FHIRToMedicalRecord lambda node runtime - [context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1713389424007909?thread_ts=1713373431.617089&cid=C04GEQ1GH9D)

### Testing

This is setting on CDK/infra something we already validated in `prod`.

- Local
  - none
- Staging
  - [ ] FhirToMedicalRecordLambda works
- Sandbox
  - none
- Production
  - [ ] FhirToMedicalRecordLambda works

### Release Plan

- [ ] Merge this
