### PR TITLE
799 Move FhirToLambda runtime lambda to config

### DIFF
--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -9,7 +9,7 @@ import { IHEStack } from "../lib/ihe-stack";
 import { LocationServicesStack } from "../lib/location-services-stack";
 import { SecretsStack } from "../lib/secrets-stack";
 import { initConfig } from "../lib/shared/config";
-import { getEnvVar } from "../lib/shared/util";
+import { getEnvVar, isSandbox } from "../lib/shared/util";
 
 const app = new cdk.App();
 
@@ -61,7 +61,7 @@ async function deploy(config: EnvConfig) {
   //---------------------------------------------------------------------------------
   // 5. Deploy the Connect widget stack.
   //---------------------------------------------------------------------------------
-  if (config.connectWidget) {
+  if (!isSandbox(config)) {
     new ConnectWidgetStack(app, config.connectWidget.stackName, {
       env: { ...env, region: config.connectWidget.region },
       config: { ...config, connectWidget: config.connectWidget },

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -14,7 +14,8 @@ export type CWCoverageEnhancementConfig = {
   codeChallengeNotificationUrl: string;
 };
 
-export type EnvConfig = {
+type EnvConfigBase = {
+  environmentType: EnvType;
   stackName: string;
   secretsStackName: string;
   region: string;
@@ -122,17 +123,20 @@ export type EnvConfig = {
   cqDirectoryRebuilder?: {
     scheduleExpressions: string | string[];
   };
-} & (
-  | {
-      environmentType: EnvType.staging | EnvType.production;
-      connectWidget: ConnectWidgetConfig;
-      connectWidgetUrl?: never;
-      sandboxSeedDataBucketName?: never;
-    }
-  | {
-      environmentType: EnvType.sandbox;
-      connectWidget?: never;
-      connectWidgetUrl: string;
-      sandboxSeedDataBucketName: string;
-    }
-);
+};
+
+export type EnvConfigNonSandbox = EnvConfigBase & {
+  environmentType: EnvType.staging | EnvType.production;
+  fhirToMedicalLambda: {
+    nodeRuntimeArn: string;
+  };
+  connectWidget: ConnectWidgetConfig;
+};
+
+export type EnvConfigSandbox = EnvConfigBase & {
+  environmentType: EnvType.sandbox;
+  connectWidgetUrl: string;
+  sandboxSeedDataBucketName: string;
+};
+
+export type EnvConfig = EnvConfigSandbox | EnvConfigNonSandbox;

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -1,7 +1,7 @@
 import { EnvType } from "../lib/env-type";
-import { EnvConfig } from "./env-config";
+import { EnvConfigNonSandbox } from "./env-config";
 
-export const config: EnvConfig = {
+export const config: EnvConfigNonSandbox = {
   stackName: "MetriportInfraStack",
   secretsStackName: "MetriportSecretsStack",
   environmentType: EnvType.production,
@@ -13,6 +13,9 @@ export const config: EnvConfig = {
   dbName: "my_db",
   dbUsername: "my_db_user",
   loadBalancerDnsName: "<your-load-balancer-dns-name>",
+  fhirToMedicalLambda: {
+    nodeRuntimeArn: "arn:aws:lambda:<region>::runtime:<id>",
+  },
   fhirServerUrl: "http://localhost:8888",
   systemRootOID: "2.16.840.1.113883.3.999999",
   systemRootOrgName: "Name of the Organization",
@@ -44,13 +47,6 @@ export const config: EnvConfig = {
     CW_GATEWAY_AUTHORIZATION_CLIENT_ID: "CW_GATEWAY_AUTHORIZATION_CLIENT_ID",
     CW_GATEWAY_AUTHORIZATION_CLIENT_SECRET: "CW_GATEWAY_AUTHORIZATION_CLIENT_SECRET",
   },
-  // TODO 1377 Update this
-  // iheGateway: {
-  //   vpcId: "<your-vpc-id>",
-  //   certArn: "<your-cert-arn>",
-  //   subdomain: "ihe",
-  //   snsTopicArn: "<your-sns-topic-arn>",
-  // },
   connectWidget: {
     stackName: "MetriportConnectInfraStack",
     region: "us-east-1",

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -29,7 +29,7 @@ import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import * as sns from "aws-cdk-lib/aws-sns";
 import { ITopic } from "aws-cdk-lib/aws-sns";
 import { Construct } from "constructs";
-import { EnvConfig } from "../config/env-config";
+import { EnvConfig, EnvConfigSandbox } from "../config/env-config";
 import { AlarmSlackBot } from "./api-stack/alarm-slack-chatbot";
 import { createScheduledAPIQuotaChecker } from "./api-stack/api-quota-checker";
 import { createAPIService } from "./api-stack/api-service";
@@ -301,20 +301,24 @@ export class APIStack extends Stack {
       alarmSnsAction: slackNotification?.alarmAction,
     });
 
-    const existingSandboxSeedDataBucket = props.config.sandboxSeedDataBucketName
-      ? s3.Bucket.fromBucketName(
+    const getSandboxSeedDataBucket = (sandboxConfig: EnvConfigSandbox) => {
+      const seedBucketCfnName = "APISandboxSeedDataBucket";
+      try {
+        return s3.Bucket.fromBucketName(
           this,
-          "APISandboxSeedDataBucket",
-          props.config.sandboxSeedDataBucketName
-        )
-      : undefined;
-    const sandboxSeedDataBucket = props.config.sandboxSeedDataBucketName
-      ? existingSandboxSeedDataBucket ??
-        new s3.Bucket(this, "APISandboxSeedDataBucket", {
-          bucketName: props.config.sandboxSeedDataBucketName,
+          seedBucketCfnName,
+          sandboxConfig.sandboxSeedDataBucketName
+        );
+      } catch (error) {
+        return new s3.Bucket(this, seedBucketCfnName, {
+          bucketName: sandboxConfig.sandboxSeedDataBucketName,
           publicReadAccess: false,
           encryption: s3.BucketEncryption.S3_MANAGED,
-        })
+        });
+      }
+    };
+    const sandboxSeedDataBucket = isSandbox(props.config)
+      ? getSandboxSeedDataBucket(props.config)
       : undefined;
 
     const fhirServerQueue = fhirServerConnector.createConnector({
@@ -396,6 +400,7 @@ export class APIStack extends Stack {
           appId: appConfigAppId,
           configId: appConfigConfigId,
         },
+        ...props.config.fhirToMedicalLambda,
       });
     }
 
@@ -1395,6 +1400,7 @@ export class APIStack extends Stack {
   }
 
   private setupFhirToMedicalRecordLambda(ownProps: {
+    nodeRuntimeArn: string;
     lambdaLayers: LambdaLayers;
     vpc: ec2.IVpc;
     medicalDocumentsBucket: s3.Bucket;
@@ -1407,6 +1413,7 @@ export class APIStack extends Stack {
     };
   }): Lambda {
     const {
+      nodeRuntimeArn,
       lambdaLayers,
       vpc,
       sentryDsn,
@@ -1424,9 +1431,7 @@ export class APIStack extends Stack {
       name: "FhirToMedicalRecord",
       runtime: lambda.Runtime.NODEJS_16_X,
       // TODO https://github.com/metriport/metriport-internal/issues/1672
-      runtimeManagementMode: lambda.RuntimeManagementMode.manual(
-        "arn:aws:lambda:us-west-1::runtime:0163909785ec2e11db2b64bb2636ada67bb348dd5764aa83e7eb011bc0f365d8"
-      ),
+      runtimeManagementMode: lambda.RuntimeManagementMode.manual(nodeRuntimeArn),
       entry: "fhir-to-medical-record",
       envType,
       envVars: {

--- a/packages/infra/lib/shared/util.ts
+++ b/packages/infra/lib/shared/util.ts
@@ -1,4 +1,4 @@
-import { EnvConfig } from "../../config/env-config";
+import { EnvConfig, EnvConfigSandbox } from "../../config/env-config";
 import { EnvType } from "../env-type";
 
 export function isStagingEnv(env: EnvType): boolean {
@@ -17,7 +17,7 @@ export function isStaging(config: EnvConfig): boolean {
 export function isProd(config: EnvConfig): boolean {
   return isProdEnv(config.environmentType);
 }
-export function isSandbox(config: EnvConfig): boolean {
+export function isSandbox(config: EnvConfig): config is EnvConfigSandbox {
   return isSandboxEnv(config.environmentType);
 }
 export function isLocalEnvironment(): boolean {


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1703
- Downstream: none

### Description

- move FhirToLambda runtime lambda to config
- revamp EnvConfig type structure

### Testing

- Local
  - none
- Staging
  - [ ] Deploys successfully
  - [ ] FhirToMericalRecord lambda works
- Sandbox
  - none
- Production
  - [ ] FhirToMericalRecord lambda works

### Release Plan

- [ ] Merge upstream
- [ ] Merge this
