### PR TITLE
1706 Add internal endpoint to create OBO Facility @ CQ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29029,7 +29029,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.6.4",
+      "version": "0.6.6-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",

--- a/packages/api/src/external/carequality/command/cq-directory/create-or-update-cq-organization.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/create-or-update-cq-organization.ts
@@ -1,4 +1,5 @@
 import { CarequalityManagementAPI } from "@metriport/carequality-sdk";
+import { Organization } from "@metriport/carequality-sdk/models/organization";
 import { errorToString } from "@metriport/shared/common/error";
 import { makeCarequalityManagementAPI } from "../../api";
 import { CQOrganization } from "../../organization";
@@ -25,6 +26,12 @@ async function doesOrganizationExistInCQ(
     return true;
   }
   return false;
+}
+
+export async function getCqOrganization(oid: string): Promise<Organization> {
+  if (!cq) throw new Error("Carequality API not initialized");
+  const organizations = await cq.listOrganizations({ count: 1, oid });
+  return organizations[0];
 }
 
 async function updateCQOrganization(

--- a/packages/api/src/external/carequality/command/cq-directory/create-or-update-cq-organization.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/create-or-update-cq-organization.ts
@@ -1,20 +1,19 @@
 import { CarequalityManagementAPI } from "@metriport/carequality-sdk";
+import { errorToString } from "@metriport/shared/common/error";
 import { makeCarequalityManagementAPI } from "../../api";
 import { CQOrganization } from "../../organization";
 import { CQOrgDetails } from "../../shared";
 
 const cq = makeCarequalityManagementAPI();
 
-export async function createOrUpdateCQOrganization(orgDetails: CQOrgDetails): Promise<void> {
+export async function createOrUpdateCQOrganization(orgDetails: CQOrgDetails): Promise<string> {
   if (!cq) throw new Error("Carequality API not initialized");
   const org = CQOrganization.fromDetails(orgDetails);
-  console.log("ORG IS", org.getXmlString());
-  // const orgExists = await doesOrganizationExistInCQ(cq, org.oid);
-  // if (orgExists) {
-  //   await updateCQOrganization(cq, org);
-  // } else {
-  //   await registerOrganization(cq, org);
-  // }
+  const orgExists = await doesOrganizationExistInCQ(cq, org.oid);
+  if (orgExists) {
+    return updateCQOrganization(cq, org);
+  }
+  return registerOrganization(cq, org);
 }
 
 async function doesOrganizationExistInCQ(
@@ -31,12 +30,14 @@ async function doesOrganizationExistInCQ(
 async function updateCQOrganization(
   cq: CarequalityManagementAPI,
   cqOrg: CQOrganization
-): Promise<void> {
+): Promise<string> {
   console.log(`Updating organization in the CQ Directory with OID: ${cqOrg.oid}...`);
   try {
-    await cq.updateOrganization(cqOrg.getXmlString(), cqOrg.oid);
+    return await cq.updateOrganization(cqOrg.getXmlString(), cqOrg.oid);
   } catch (error) {
-    console.log(`Failed to update organization in the CQ Directory. Cause: ${error}`);
+    console.log(
+      `Failed to update organization in the CQ Directory. Cause: ${errorToString(error)}`
+    );
     throw error;
   }
 }
@@ -44,12 +45,14 @@ async function updateCQOrganization(
 async function registerOrganization(
   cq: CarequalityManagementAPI,
   cqOrg: CQOrganization
-): Promise<void> {
+): Promise<string> {
   try {
     console.log(`Registering organization in the CQ Directory with OID: ${cqOrg.oid}...`);
-    await cq.registerOrganization(cqOrg.getXmlString());
+    return await cq.registerOrganization(cqOrg.getXmlString());
   } catch (error) {
-    console.log(`Failed to register organization in the CQ Directory. Cause: ${error}`);
+    console.log(
+      `Failed to register organization in the CQ Directory. Cause: ${errorToString(error)}`
+    );
     throw error;
   }
 }

--- a/packages/api/src/external/carequality/command/cq-directory/create-or-update-cq-organization.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/create-or-update-cq-organization.ts
@@ -28,7 +28,7 @@ async function doesOrganizationExistInCQ(
   return false;
 }
 
-export async function getCqOrganization(oid: string): Promise<Organization> {
+export async function getCqOrganization(oid: string): Promise<Organization | undefined> {
   if (!cq) throw new Error("Carequality API not initialized");
   const organizations = await cq.listOrganizations({ count: 1, oid });
   return organizations[0];

--- a/packages/api/src/external/carequality/command/cq-directory/create-or-update-cq-organization.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/create-or-update-cq-organization.ts
@@ -8,12 +8,13 @@ const cq = makeCarequalityManagementAPI();
 export async function createOrUpdateCQOrganization(orgDetails: CQOrgDetails): Promise<void> {
   if (!cq) throw new Error("Carequality API not initialized");
   const org = CQOrganization.fromDetails(orgDetails);
-  const orgExists = await doesOrganizationExistInCQ(cq, org.oid);
-  if (orgExists) {
-    await updateCQOrganization(cq, org);
-  } else {
-    await registerOrganization(cq, org);
-  }
+  console.log("ORG IS", org.getXmlString());
+  // const orgExists = await doesOrganizationExistInCQ(cq, org.oid);
+  // if (orgExists) {
+  //   await updateCQOrganization(cq, org);
+  // } else {
+  //   await registerOrganization(cq, org);
+  // }
 }
 
 async function doesOrganizationExistInCQ(

--- a/packages/api/src/external/carequality/constants.ts
+++ b/packages/api/src/external/carequality/constants.ts
@@ -1,0 +1,1 @@
+export const metriportEmail = "engineering+carequality@metriport.com";

--- a/packages/api/src/external/carequality/organization-template.ts
+++ b/packages/api/src/external/carequality/organization-template.ts
@@ -27,7 +27,7 @@ export function buildXmlStringFromTemplate(orgDetails: CQOrgDetailsWithUrls) {
     phone,
     email,
     role,
-    hostOrgOID,
+    parentOrgOid,
   } = orgDetails;
 
   const urnOid = "urn:oid:" + oid;
@@ -100,7 +100,7 @@ export function buildXmlStringFromTemplate(orgDetails: CQOrgDetailsWithUrls) {
             </valueCodeableConcept>
         </extension>
     </address>
-    ${getPartOf(hostOrgOID)}
+    ${getPartOf(parentOrgOid)}
     ${endpoints}
     <managingOrg>
         <reference value="org.sequoiaproject.fhir.stu3/Organization/${metriportName}">
@@ -202,8 +202,8 @@ function getEndpoint(oid: string, urlType: ChannelUrl, url?: string) {
 `;
 }
 
-function getPartOf(hostOrgOid?: string): string {
-  const oid = hostOrgOid ?? metriportOid;
+function getPartOf(parentOrgOid?: string): string {
+  const oid = parentOrgOid ?? metriportOid;
   return `<partOf>
         <identifier>
             <use value="official"/>

--- a/packages/api/src/external/carequality/organization.ts
+++ b/packages/api/src/external/carequality/organization.ts
@@ -24,7 +24,7 @@ export class CQOrganization {
     public phone: string,
     public email: string,
     public role: "Implementer" | "Connection",
-    public hostOrgOID?: string,
+    public parentOrgOid?: string,
     public urlXCPD?: string,
     public urlDQ?: string,
     public urlDR?: string
@@ -44,7 +44,7 @@ export class CQOrganization {
       orgDetails.phone,
       orgDetails.email,
       orgDetails.role,
-      orgDetails.hostOrgOID
+      orgDetails.parentOrgOid
     );
 
     this.addUrls(organization);
@@ -71,7 +71,7 @@ export class CQOrganization {
       phone: this.phone,
       email: this.email,
       role: this.role,
-      hostOrgOID: this.hostOrgOID,
+      parentOrgOid: this.parentOrgOid,
     };
   }
 

--- a/packages/api/src/external/carequality/shared.ts
+++ b/packages/api/src/external/carequality/shared.ts
@@ -6,6 +6,7 @@ import { makeIheGatewayAPIForPatientDiscovery } from "../ihe-gateway/api";
 import { isCarequalityEnabled } from "../aws/appConfig";
 import { errorToString } from "@metriport/shared/common/error";
 import { capture } from "@metriport/core/util/notifications";
+import { AddressStrictSchema } from "../../routes/medical/schemas/address";
 
 // TODO: adjust when we support multiple POUs
 export function createPurposeOfUse() {
@@ -66,10 +67,13 @@ export type CQOrgUrls = z.infer<typeof cqOrgUrlsSchema>;
 export const cqOrgDetailsSchema = z.object({
   name: z.string(),
   oid: z.string(),
+  // address: AddressStrictSchema, // TODO: uncomment this
+  // TODO: remove these and deal with consequences of replacing with this ^
   addressLine1: z.string(),
   city: z.string(),
   state: z.string(),
   postalCode: z.string(),
+  // up to here ^
   lat: z.string(),
   lon: z.string(),
   contactName: z.string(),
@@ -81,6 +85,20 @@ export const cqOrgDetailsSchema = z.object({
 
 export type CQOrgDetails = z.infer<typeof cqOrgDetailsSchema>;
 export type CQOrgDetailsWithUrls = CQOrgDetails & CQOrgUrls;
+
+export const cqOboOrgDetailsSchema = z.object({
+  healthcareItVendorOrgName: z.string().optional(),
+  cqOboOid: z.string().optional(),
+  cqActive: z.boolean().optional(),
+});
+
+export type CqOboOrgDetails = z.infer<typeof cqOboOrgDetailsSchema>;
+
+export const cqOboFullOrgDetailsSchema = cqOrgDetailsSchema
+  .omit({ oid: true })
+  .merge(z.object({ oid: z.string().optional() }))
+  .merge(cqOboOrgDetailsSchema);
+export type CqOboFullOrgDetails = z.infer<typeof cqOboFullOrgDetailsSchema>;
 
 export function formatDate(dateString: string | undefined): string | undefined {
   if (!dateString) return undefined;

--- a/packages/api/src/external/carequality/shared.ts
+++ b/packages/api/src/external/carequality/shared.ts
@@ -1,12 +1,10 @@
-import { PurposeOfUse } from "@metriport/shared";
-import z from "zod";
-import { IHEGateway } from "@metriport/ihe-gateway-sdk";
-import { isCQDirectEnabledForCx } from "../aws/appConfig";
-import { makeIheGatewayAPIForPatientDiscovery } from "../ihe-gateway/api";
-import { isCarequalityEnabled } from "../aws/appConfig";
-import { errorToString } from "@metriport/shared/common/error";
 import { capture } from "@metriport/core/util/notifications";
-import { AddressStrictSchema } from "../../routes/medical/schemas/address";
+import { IHEGateway } from "@metriport/ihe-gateway-sdk";
+import { PurposeOfUse } from "@metriport/shared";
+import { errorToString } from "@metriport/shared/common/error";
+import z from "zod";
+import { isCarequalityEnabled, isCQDirectEnabledForCx } from "../aws/appConfig";
+import { makeIheGatewayAPIForPatientDiscovery } from "../ihe-gateway/api";
 
 // TODO: adjust when we support multiple POUs
 export function createPurposeOfUse() {
@@ -67,13 +65,10 @@ export type CQOrgUrls = z.infer<typeof cqOrgUrlsSchema>;
 export const cqOrgDetailsSchema = z.object({
   name: z.string(),
   oid: z.string(),
-  // address: AddressStrictSchema, // TODO: uncomment this
-  // TODO: remove these and deal with consequences of replacing with this ^
   addressLine1: z.string(),
   city: z.string(),
   state: z.string(),
   postalCode: z.string(),
-  // up to here ^
   lat: z.string(),
   lon: z.string(),
   contactName: z.string(),
@@ -85,20 +80,6 @@ export const cqOrgDetailsSchema = z.object({
 
 export type CQOrgDetails = z.infer<typeof cqOrgDetailsSchema>;
 export type CQOrgDetailsWithUrls = CQOrgDetails & CQOrgUrls;
-
-export const cqOboOrgDetailsSchema = z.object({
-  healthcareItVendorOrgName: z.string().optional(),
-  cqOboOid: z.string().optional(),
-  cqActive: z.boolean().optional(),
-});
-
-export type CqOboOrgDetails = z.infer<typeof cqOboOrgDetailsSchema>;
-
-export const cqOboFullOrgDetailsSchema = cqOrgDetailsSchema
-  .omit({ oid: true })
-  .merge(z.object({ oid: z.string().optional() }))
-  .merge(cqOboOrgDetailsSchema);
-export type CqOboFullOrgDetails = z.infer<typeof cqOboFullOrgDetailsSchema>;
 
 export function formatDate(dateString: string | undefined): string | undefined {
   if (!dateString) return undefined;

--- a/packages/api/src/external/carequality/shared.ts
+++ b/packages/api/src/external/carequality/shared.ts
@@ -75,7 +75,7 @@ export const cqOrgDetailsSchema = z.object({
   phone: z.string(),
   email: z.string(),
   role: z.enum(["Implementer", "Connection"]),
-  hostOrgOID: z.string().optional(),
+  parentOrgOid: z.string().optional(),
 });
 
 export type CQOrgDetails = z.infer<typeof cqOrgDetailsSchema>;

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -24,6 +24,7 @@ import docsRoutes from "./medical/internal-docs";
 import hieRoutes from "./medical/internal-hie";
 import mpiRoutes from "./medical/internal-mpi";
 import patientRoutes from "./medical/internal-patient";
+import facilityRoutes from "./medical/internal-facility";
 import { getUUIDFrom } from "./schemas/uuid";
 import { asyncHandler, getFrom } from "./util";
 import { requestLogger } from "./helpers/request-logger";
@@ -32,6 +33,7 @@ const router = Router();
 
 router.use("/docs", docsRoutes);
 router.use("/patient", patientRoutes);
+router.use("/facility", facilityRoutes);
 router.use("/user", userRoutes);
 router.use("/carequality", carequalityRoutes);
 router.use("/mpi", mpiRoutes);

--- a/packages/api/src/routes/medical/internal-facility.ts
+++ b/packages/api/src/routes/medical/internal-facility.ts
@@ -1,0 +1,64 @@
+import { Request, Response } from "express";
+import Router from "express-promise-router";
+import httpStatus from "http-status";
+import { getOrganizationOrFail } from "../../command/medical/organization/get-organization";
+import { createOrUpdateCQOrganization } from "../../external/carequality/command/cq-directory/create-or-update-cq-organization";
+import { cqOboFullOrgDetailsSchema } from "../../external/carequality/shared";
+import { requestLogger } from "../helpers/request-logger";
+import { getUUIDFrom } from "../schemas/uuid";
+import { asyncHandler, getFromParamsOrFail } from "../util";
+
+const router = Router();
+
+/** ---------------------------------------------------------------------------
+ *
+ * POST /internal/facility/
+ *
+ * TODO: Add description.
+ *
+ * @return {FacilityDTO} The updated facility.
+ */
+router.post(
+  "/",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").orFail();
+    const facilityId = getFromParamsOrFail("id", req);
+
+    // TODO: Fix the logic to create the facility in the DB
+    // const facilityData = facilityCreateSchema.parse(req.body); // TODO: Combine the two schemas into one.
+
+    // const facility = await createFacility({
+    //   cxId,
+    //   data: {
+    //     ...facilityData,
+    //     tin: facilityData.tin ?? undefined,
+    //     active: facilityData.active ?? undefined,
+    //   },
+    // });
+
+    const cxOrg = await getOrganizationOrFail({ cxId });
+
+    const body = req.body;
+    const orgDetails = cqOboFullOrgDetailsSchema.parse(body);
+    const vendorName = orgDetails.healthcareItVendorOrgName ?? cxOrg.dataValues.data?.name;
+
+    // if (!orgDetails.cqOboOid && !orgDetails.oid) throw new Error("Missing OID");
+
+    if (orgDetails.cqActive && orgDetails.cqOboOid) {
+      const orgName = buildOrgName(vendorName, orgDetails.name, orgDetails.cqOboOid);
+      orgDetails.oid = orgDetails.cqOboOid;
+      orgDetails.name = orgName;
+      orgDetails.hostOrgOID = cxOrg.dataValues.oid;
+      await createOrUpdateCQOrganization(orgDetails);
+    }
+
+    return res.sendStatus(httpStatus.OK);
+  })
+);
+
+function buildOrgName(vendorName: string, orgName: string, oid: string) {
+  return `${vendorName} - ${orgName} #OBO# ${oid}`;
+}
+
+export default router;

--- a/packages/api/src/routes/medical/internal-facility.ts
+++ b/packages/api/src/routes/medical/internal-facility.ts
@@ -64,7 +64,7 @@ router.put(
     const facilityInput = facilityOboDetailsSchema.parse(req.body);
     // TODO 1706 search existing facility by NPI, cqOboOid, and cwOboOid (individually), and update if exists
 
-    let facilityName: string | undefined;
+    let cqFacilityName: string | undefined;
     if (facilityInput.cqOboOid) {
       const existingFacility = await getCqOrganization(facilityInput.cqOboOid);
       if (!existingFacility) {
@@ -72,7 +72,10 @@ router.put(
           .status(httpStatus.BAD_REQUEST)
           .send("CQ OBO organization with the specified CQ OBO OID was not found");
       }
-      facilityName = existingFacility.name?.value ?? undefined;
+      const existingFacilityName = existingFacility.name?.value;
+      if (!existingFacilityName)
+        return res.status(httpStatus.NOT_FOUND).send("CQ OBO organization has no name");
+      cqFacilityName = existingFacilityName;
     }
 
     const facility = await createFacility({
@@ -104,7 +107,7 @@ router.put(
       const vendorName = cxOrg.dataValues.data?.name;
       const orgName = buildCqOboOrgName(
         vendorName,
-        facilityName ?? facilityInput.name,
+        cqFacilityName as string,
         facilityInput.cqOboOid
       );
       const addressLine = facilityInput.addressLine2

--- a/packages/api/src/routes/medical/schemas/facility.ts
+++ b/packages/api/src/routes/medical/schemas/facility.ts
@@ -15,3 +15,5 @@ export const facilityCreateSchema = z.object({
 });
 
 export const facilityUpdateSchema = facilityCreateSchema;
+
+// TODO: export extended schema for facilityCreateSchema + OBO CQ fields + OBO CW fields

--- a/packages/api/src/routes/medical/schemas/facility.ts
+++ b/packages/api/src/routes/medical/schemas/facility.ts
@@ -15,5 +15,3 @@ export const facilityCreateSchema = z.object({
 });
 
 export const facilityUpdateSchema = facilityCreateSchema;
-
-// TODO: export extended schema for facilityCreateSchema + OBO CQ fields + OBO CW fields

--- a/packages/api/src/routes/schemas/shared.ts
+++ b/packages/api/src/routes/schemas/shared.ts
@@ -25,3 +25,18 @@ export const stringIntegerSchema = z
   .string()
   .regex(/^\d+$/, { message: "Invalid integer" })
   .transform(Number);
+
+export function required<T>(dependent: keyof T) {
+  return {
+    when: (dependency: keyof T) => {
+      return (val: T) => {
+        if (val[dependency])
+          return (
+            val[dependent] !== undefined &&
+            (typeof val[dependent] === "string" ? (val[dependent] as string).trim() !== "" : true)
+          );
+        return true;
+      };
+    },
+  };
+}

--- a/packages/api/src/sequelize/migrations/2024-04-03_00_alter-patient-discovery-result-add-index-patient-id.ts
+++ b/packages/api/src/sequelize/migrations/2024-04-03_00_alter-patient-discovery-result-add-index-patient-id.ts
@@ -23,9 +23,10 @@ export const up: Migration = async ({ context: queryInterface }) => {
 export const down: Migration = ({ context: queryInterface }) => {
   return queryInterface.sequelize.transaction(async transaction => {
     await queryInterface.removeIndex(tableName, indexToCreate, { transaction });
-    await queryInterface.addIndex(tableName, {
+    await queryInterface.addConstraint(tableName, {
       name: constraintToRemove,
       fields: [constraintToRemoveFieldName],
+      type: "primary key",
       transaction,
     });
   });

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.6.4",
+  "version": "0.6.6-alpha.0",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/carequality-sdk/src/client/carequality.ts
+++ b/packages/carequality-sdk/src/client/carequality.ts
@@ -170,6 +170,7 @@ export class CarequalityManagementAPIImpl implements CarequalityManagementAPI {
 
     const url = `${CarequalityManagementAPIImpl.ORG_ENDPOINT}?${queryString}`;
     const resp = await this.sendGetRequest(url, { "Content-Type": "application/json" });
+    if (!resp.data.Bundle) return [];
     const bundle: STU3Bundle = stu3BundleSchema.parse(resp.data.Bundle);
     const orgs = bundle.entry.map(e => e.resource.Organization);
     return orgs;

--- a/packages/shared/src/domain/metriport.ts
+++ b/packages/shared/src/domain/metriport.ts
@@ -1,0 +1,9 @@
+// AKA Metriport, info
+export const metriportCompanyDetails = {
+  name: "Metriport",
+  address: "1234 Metriport St",
+  city: "San Francisco",
+  state: "CA",
+  postalCode: "12345",
+  phone: "415-941-3282",
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,3 +8,4 @@ export { AtLeastOne, stringToBoolean } from "./common/types";
 export { validateNPI } from "./common/validate-npi";
 export { limitStringLength } from "./common/string";
 export { errorToString } from "./common/error";
+export { metriportCompanyDetails } from "./domain/metriport";


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1706

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1928
- Downstream: none

### Description

Adds internal endpoint to create (and later update) facilities enabled for OBO.

### Testing

- Local
  - [x] Creates facility on local DB
  - [x] Creates facility on CQ directory
  - [x] Fails to create facility if `cqActive` is `true` and `cqOboOid` is empty or missing
- Staging
  - [x] Creates facility on local DB
  - [x] Creates facility on CQ directory
- Sandbox
  - none
- Production
  - [ ] creates actual cx's facilities

### Release Plan

- [ ] Merge upstream
- [ ] Merge this
