### PR TITLE
fix(api): add requestid to webhooks

### DIFF
--- a/packages/api/src/command/medical/document/document-conversion-status.ts
+++ b/packages/api/src/command/medical/document/document-conversion-status.ts
@@ -70,7 +70,7 @@ export async function calculateDocumentConversionStatus({
     });
 
     if (isConversionCompleted) {
-      const startedAt = externalData?.documentQueryProgress?.startedAt;
+      const startedAt = updatedPatient.data.documentQueryProgress?.startedAt;
 
       analytics({
         distinctId: cxId,

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -22,6 +22,7 @@ import { getPatientOrFail } from "../patient/get-patient";
 import { storeQueryInit } from "../patient/query-init";
 import { areDocumentsProcessing } from "./document-status";
 import { getCqOrgIdsToDenyOnCw } from "../hie";
+import { analytics, EventTypes } from "../../../shared/analytics";
 
 export function isProgressEqual(a?: Progress, b?: Progress): boolean {
   return (
@@ -86,6 +87,15 @@ export async function queryDocumentsAcrossHIEs({
     cmd: {
       documentQueryProgress: { requestId, startedAt, download: { status: "processing" } },
       cxDocumentRequestMetadata,
+    },
+  });
+
+  analytics({
+    event: EventTypes.documentQuery,
+    distinctId: cxId,
+    properties: {
+      requestId,
+      patientId,
     },
   });
 

--- a/packages/api/src/command/medical/document/document-webhook.ts
+++ b/packages/api/src/command/medical/document/document-webhook.ts
@@ -79,7 +79,7 @@ export const processPatientDocumentRequest = async (
       await processRequest(
         webhookRequest,
         settings,
-        undefined,
+        requestId ? { requestId } : undefined,
         patient.data.cxDocumentRequestMetadata
       );
     } else {

--- a/packages/api/src/command/medical/patient/consolidated-get.ts
+++ b/packages/api/src/command/medical/patient/consolidated-get.ts
@@ -42,7 +42,7 @@ export type GetConsolidatedFilters = {
 
 export type GetConsolidatedParams = {
   patient: Pick<Patient, "id" | "cxId" | "data">;
-  requestId: string;
+  requestId?: string;
   documentIds?: string[];
 } & GetConsolidatedFilters;
 

--- a/packages/api/src/command/medical/patient/consolidated-get.ts
+++ b/packages/api/src/command/medical/patient/consolidated-get.ts
@@ -1,4 +1,5 @@
 import { OperationOutcomeError } from "@medplum/core";
+import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import {
   Bundle,
   BundleEntry,
@@ -41,6 +42,7 @@ export type GetConsolidatedFilters = {
 
 export type GetConsolidatedParams = {
   patient: Pick<Patient, "id" | "cxId" | "data">;
+  requestId: string;
   documentIds?: string[];
 } & GetConsolidatedFilters;
 
@@ -67,7 +69,17 @@ export async function startConsolidatedQuery({
   }
 
   const startedAt = new Date();
+  const requestId = uuidv7();
   const progress: QueryProgress = { status: "processing", startedAt };
+
+  analytics({
+    distinctId: patient.cxId,
+    event: EventTypes.consolidatedQuery,
+    properties: {
+      patientId: patient.id,
+      requestId,
+    },
+  });
 
   const updatedPatient = await storeQueryInit({
     id: patient.id,
@@ -84,18 +96,20 @@ export async function startConsolidatedQuery({
     dateFrom,
     dateTo,
     conversionType,
+    requestId,
   }).catch(emptyFunction);
 
   return progress;
 }
 
 async function getConsolidatedAndSendToCx(params: GetConsolidatedParams): Promise<void> {
-  const { patient, resources, dateFrom, dateTo, conversionType } = params;
+  const { patient, requestId, resources, dateFrom, dateTo, conversionType } = params;
   try {
     const { bundle, filters } = await getConsolidated(params);
     // trigger WH call
     processConsolidatedDataWebhook({
       patient,
+      requestId,
       status: "completed",
       bundle,
       filters,
@@ -103,6 +117,7 @@ async function getConsolidatedAndSendToCx(params: GetConsolidatedParams): Promis
   } catch (error) {
     processConsolidatedDataWebhook({
       patient,
+      requestId,
       status: "failed",
       filters: {
         resources: resources ? resources.join(", ") : undefined,

--- a/packages/api/src/command/medical/patient/consolidated-webhook.ts
+++ b/packages/api/src/command/medical/patient/consolidated-webhook.ts
@@ -81,8 +81,10 @@ export const processConsolidatedDataWebhook = async ({
         requestId,
       };
 
-      if (bundle)
-        additionalWHRequestMeta.bundleLength = bundle.entry?.length?.toString() ?? "unknown";
+      if (bundle) {
+        additionalWHRequestMeta.bundleLength =
+          optionalToString(bundle.entry?.length ?? bundle.total) ?? "unknown";
+      }
 
       await processRequest(
         webhookRequest,

--- a/packages/api/src/command/medical/patient/consolidated-webhook.ts
+++ b/packages/api/src/command/medical/patient/consolidated-webhook.ts
@@ -45,7 +45,7 @@ export const processConsolidatedDataWebhook = async ({
 }: {
   patient: Pick<Patient, "id" | "cxId" | "externalId">;
   status: ConsolidatedWebhookStatus;
-  requestId: string;
+  requestId?: string;
   bundle?: Bundle<Resource>;
   filters?: Filters;
 }): Promise<void> => {
@@ -77,9 +77,9 @@ export const processConsolidatedDataWebhook = async ({
         payload,
       });
 
-      const additionalWHRequestMeta: Record<string, string> = {
-        requestId,
-      };
+      const additionalWHRequestMeta: Record<string, string> = {};
+
+      if (requestId) additionalWHRequestMeta.requestId = requestId;
 
       if (bundle) {
         additionalWHRequestMeta.bundleLength =

--- a/packages/api/src/command/medical/patient/consolidated-webhook.ts
+++ b/packages/api/src/command/medical/patient/consolidated-webhook.ts
@@ -39,11 +39,13 @@ type PayloadWithoutMeta = Omit<Payload, "meta">;
 export const processConsolidatedDataWebhook = async ({
   patient,
   status,
+  requestId,
   bundle,
   filters,
 }: {
   patient: Pick<Patient, "id" | "cxId" | "externalId">;
   status: ConsolidatedWebhookStatus;
+  requestId: string;
   bundle?: Bundle<Resource>;
   filters?: Filters;
 }): Promise<void> => {
@@ -75,14 +77,17 @@ export const processConsolidatedDataWebhook = async ({
         payload,
       });
 
+      const additionalWHRequestMeta: Record<string, string> = {
+        requestId,
+      };
+
+      if (bundle)
+        additionalWHRequestMeta.bundleLength = bundle.entry?.length?.toString() ?? "unknown";
+
       await processRequest(
         webhookRequest,
         settings,
-        bundle
-          ? {
-              bundleLength: optionalToString(bundle.entry?.length ?? bundle.total) ?? "unknown",
-            }
-          : undefined,
+        additionalWHRequestMeta,
         currentPatient.data.cxConsolidatedRequestMetadata
       );
     } else {


### PR DESCRIPTION
Ref. metriport/metriport-internal#1669

Ticket: #1889 

### Dependencies

- Upstream: none
- Downstream: none

### Description

Add requestIid to webhooks

### Testing

- Local
  - [x] Send webhook see in logs
- Staging
  - [ ] See logs in posthog
- Production
  - [ ] Monitor logs

Check each PR.

### Release Plan

- [ ] Merge this
