### PR TITLE
1040 Fix DB auto rollback

### DIFF
--- a/packages/api/src/external/commonwell/proxy/cw-fhir-proxy.ts
+++ b/packages/api/src/external/commonwell/proxy/cw-fhir-proxy.ts
@@ -3,6 +3,7 @@ import Router from "express-promise-router";
 import { asyncHandler } from "../../../routes/util";
 import { processRequest } from "./cw-process-request";
 import { fhirServerUrl } from "./shared";
+import { requestLogger } from "../../../routes/helpers/request-logger";
 
 /**
  * Endpoints to process CW's Document Query (DQ) requests.
@@ -23,6 +24,7 @@ import { fhirServerUrl } from "./shared";
 const fhirRouter = Router();
 fhirRouter.get(
   "/DocumentReference",
+  requestLogger,
   asyncHandler(async (req, res) => {
     const bundle = await processRequest(req);
     return res.status(200).json(bundle);
@@ -38,6 +40,7 @@ fhirRouter.all(
 const dummyRouter = Router();
 dummyRouter.all(
   "/*",
+  requestLogger,
   asyncHandler(async () => {
     throw new NotFoundError(`FHIR server for CW is disabled`);
   })

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -113,6 +113,7 @@ router.delete(
  */
 router.post(
   "/populate-fhir-server",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").optional();
     const allCustomers = getFrom("query").optional("allCustomers", req) === "true";
@@ -168,6 +169,7 @@ router.get(
  */
 router.post(
   "/cq-include-list/reset",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     if (!(await isEnhancedCoverageEnabledForCx(cxId))) {
@@ -186,6 +188,7 @@ router.post(
  */
 router.get(
   "/cx-data",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const org = await getOrganizationOrFail({ cxId });
@@ -219,6 +222,7 @@ router.get(
  */
 router.post(
   "/check-api-quota",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxsWithLowQuota = await checkApiQuota();
     return res.status(httpStatus.OK).json({ cxsWithLowQuota });
@@ -232,6 +236,7 @@ router.post(
  */
 router.post(
   "/db-maintenance",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const result = await dbMaintenance();
     console.log(`DB Maintenance Result: ${JSON.stringify(result)}`);
@@ -246,6 +251,7 @@ router.post(
  */
 router.post(
   "/references-from-fhir",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
 

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -60,6 +60,7 @@ const sequelize = initDbPool(Config.getDBCreds());
  */
 router.post(
   "/directory/rebuild",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     if (Config.isSandbox()) return res.sendStatus(httpStatus.NOT_IMPLEMENTED);
     await rebuildCQDirectory();
@@ -118,6 +119,7 @@ router.post(
  */
 router.get(
   "/directory/organization/:oid",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     if (Config.isSandbox()) return res.sendStatus(httpStatus.NOT_IMPLEMENTED);
     const cq = makeCarequalityManagementAPI();
@@ -148,6 +150,7 @@ router.get(
  */
 router.post(
   "/directory/organization",
+  requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const body = req.body;
     const orgDetails = cqOrgDetailsSchema.parse(body);
@@ -198,6 +201,7 @@ router.get(
  */
 router.post(
   "/patient-discovery/response",
+  // no requestLogger here because we get too many requests
   asyncHandler(async (req: Request, res: Response) => {
     const response = outboundPatientDiscoveryRespSchema.parse(req.body);
 
@@ -252,6 +256,7 @@ router.post(
  */
 router.post(
   "/document-query/response",
+  // no requestLogger here because we get too many requests
   asyncHandler(async (req: Request, res: Response) => {
     const response = outboundDocumentQueryRespSchema.parse(req.body);
 
@@ -304,6 +309,7 @@ router.post(
  */
 router.post(
   "/document-retrieval/response",
+  // no requestLogger here because we get too many requests
   asyncHandler(async (req: Request, res: Response) => {
     const response = outboundDocumentRetrievalRespSchema.parse(req.body);
 

--- a/packages/api/src/routes/medical/internal-mpi.ts
+++ b/packages/api/src/routes/medical/internal-mpi.ts
@@ -31,6 +31,7 @@ const patientLoader = new PatientLoaderLocal();
  */
 router.get(
   "/patient",
+  // no requestLogger here because we get too many requests (inbound CQ)
   asyncHandler(async (req: Request, res: Response) => {
     const dob = getFrom("query").orFail("dob", req);
     const genderAtBirth = genderAtBirthSchema.parse(getFrom("query").orFail("genderAtBirth", req));

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -374,7 +374,7 @@ router.get(
  * POST /patient/:id/consolidated
  * @deprecated use the PUT version of this endpoint
  */
-router.post("/:id/consolidated", asyncHandler(putConsolidated));
+router.post("/:id/consolidated", requestLogger, asyncHandler(putConsolidated));
 /** ---------------------------------------------------------------------------
  * PUT /patient/:id/consolidated
  *
@@ -385,7 +385,7 @@ router.post("/:id/consolidated", asyncHandler(putConsolidated));
  * @param req.body The FHIR Bundle to create or update resources.
  * @return FHIR Bundle with operation outcome.
  */
-router.put("/:id/consolidated", asyncHandler(putConsolidated));
+router.put("/:id/consolidated", requestLogger, asyncHandler(putConsolidated));
 async function putConsolidated(req: Request, res: Response) {
   // Limit the payload size that can be created
   const contentLength = req.headers["content-length"];

--- a/packages/api/src/sequelize/index.ts
+++ b/packages/api/src/sequelize/index.ts
@@ -1,6 +1,6 @@
 import { MetriportError } from "@metriport/core/util/error/metriport-error";
 import { QueryInterface, Sequelize } from "sequelize";
-import { MigrationMeta, MigrationParams, SequelizeStorage, Umzug } from "umzug";
+import { MigrationError, MigrationMeta, MigrationParams, SequelizeStorage, Umzug } from "umzug";
 import { Config } from "../shared/config";
 
 let umzug: Umzug<QueryInterface> | undefined = undefined;
@@ -9,7 +9,7 @@ const migrationsPath = Config.isCloudEnv()
   ? "packages/api/dist/sequelize/migrations/*.js"
   : "src/sequelize/migrations/*.ts";
 
-export const getUmzug = (sequelize: Sequelize): Umzug<QueryInterface> => {
+export function getUmzug(sequelize: Sequelize): Umzug<QueryInterface> {
   if (!umzug) {
     umzug = new Umzug({
       migrations: { glob: migrationsPath },
@@ -19,17 +19,16 @@ export const getUmzug = (sequelize: Sequelize): Umzug<QueryInterface> => {
     });
   }
   return umzug;
-};
+}
 
-export const getUmzugWithMeta = async (
-  sequelize: Sequelize
-): Promise<{
+export async function getUmzugWithMeta(sequelize: Sequelize): Promise<{
   umzug: Umzug<QueryInterface>;
   migrations: number;
   executed: number;
   pending: number;
   lastExecuted: string | undefined;
-}> => {
+  rollbackTo: string | undefined;
+}> {
   const queryInterface = sequelize.getQueryInterface();
   const umzug = getUmzug(sequelize);
   const migrations = await umzug.migrations(queryInterface);
@@ -41,41 +40,43 @@ export const getUmzugWithMeta = async (
     executed: executed.length,
     pending: pending.length,
     lastExecuted: executed[executed.length - 1]?.name,
+    rollbackTo: pending.length > 1 ? pending[0]?.name : undefined,
   };
-};
+}
 
 // export the type helper exposed by umzug, which will have the `context` argument typed correctly
 export type Migration = (params: MigrationParams<QueryInterface>) => Promise<unknown>;
 
-const updateDB = async (sequelize: Sequelize): Promise<MigrationMeta[]> => {
+async function updateDB(sequelize: Sequelize): Promise<MigrationMeta[]> {
   const prefix = `[--- SEQUELIZE ---] `;
-  const { umzug, migrations, executed, pending, lastExecuted } = await getUmzugWithMeta(sequelize);
+  const { umzug, migrations, executed, pending, lastExecuted, rollbackTo } = await getUmzugWithMeta(
+    sequelize
+  );
   console.log(
     `${prefix}Migrations: ${executed} executed, ${pending} pending, ` +
-      `${migrations} total, last executed: ${lastExecuted}`
+      `${migrations} total, last executed: ${lastExecuted}, rollback to: ${rollbackTo}`
   );
   try {
     // Execute all migrations that are not yet executed
     return await umzug.up();
   } catch (error) {
     const mainMsg = `${prefix}Error running migrations`;
-    if (lastExecuted) {
-      console.error(`${mainMsg}, rolling back to last executed migration: ${lastExecuted}`);
-      try {
-        await umzug.down({ to: lastExecuted });
-      } catch (error2) {
-        const msg = `${prefix}ERROR rolling back to last executed migration`;
-        console.error(`${msg}: ${lastExecuted}`, error2);
-        throw new MetriportError(msg, error2, {
-          originalError: String(error),
-          additionalContext: msg,
-        });
-      }
-    } else {
-      console.error(`${mainMsg}, nothing to rolling back to`);
+    const rollbackInfo = rollbackTo ? `, rolling back to last executed migration` : "";
+    console.error(`${mainMsg}${rollbackInfo}`);
+    const failedMigration = error instanceof MigrationError ? error.migration.name : undefined;
+    try {
+      if (rollbackTo && rollbackTo !== failedMigration) await umzug.down({ to: rollbackTo });
+      else console.error(`${mainMsg}, nothing to rolling back to`);
+    } catch (error2) {
+      const msg = `${prefix}ERROR rolling back to last executed migration`;
+      console.error(`${msg}: ${lastExecuted}`, error2);
+      throw new MetriportError(msg, error2, {
+        originalError: String(error),
+        additionalContext: msg,
+      });
     }
     throw error;
   }
-};
+}
 
 export default updateDB;


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

- Related: https://github.com/metriport/metriport-internal/pull/1709

### Description

- Fix DB migration auto rollback 
- Add requestLogger to endpoints missing it 

### Testing

- Local
  - [x] API starts w/ no migration
  - [x] API starts w/ 1 migration
  - [x] API starts w/ 2 migrations
  - [x] Rolls back 0 migration when it has 1 and it fails
  - [x] Rolls back 0 migration when it has 2 and the first one fails
  - [x] Rolls back 1 migration when it has 2 and the last one fails
- Staging
  - [ ] API starts
- Sandbox
  - [ ] API starts
- Production
  - [ ] API starts

### Release Plan

- [ ] Merge this
