### PR TITLE
feat(api): improved consolidated query to send url to json file

### DIFF
--- a/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
+++ b/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
@@ -9,12 +9,12 @@ data from the FHIR repository.
 
 Once the data is consolidated and ready for consumption, a [Webhook request](/medical-api/more-info/webhooks#patient-consolidated-data)
 is sent to [your configured URL](/home/api-reference/settings/post-settings) containing the Patient's
-data in FHIR-compliant format, based on the filters used to trigger the query.
+data in FHIR-compliant format, based on the [parameters](#query-params) used to trigger the query.
 
 You can check the status of the data query by calling [get consolidated data query](/medical-api/api-reference/fhir/consolidated-data-query-get).
 
-This endpoint also provides the ability to render a medical record summary from the FHIR bundle as a
-PDF or HTML document. This will be returned [via a webook](/medical-api/more-info/webhooks#medical-record)
+This endpoint also provides the ability to render a [Medical Record Summary](/medical-api/more-info/medical-record-summary)
+from the FHIR bundle as a PDF or HTML document. This will be returned [via a webook](/medical-api/more-info/webhooks#medical-record)
 as a FHIR bundle with a [DocumentReference](/medical-api/fhir/resources/documentreference) resource
 that will contain a URL to retrieve the data from.
 
@@ -53,14 +53,15 @@ that will contain a URL to retrieve the data from.
   ISO 8601. If not provided, no end date filter will be applied.
 </ParamField>
 
-<ParamField query="conversionType" type="string">
-  The output format of the resulting . Can be one of `pdf`, `html`, or `json`. 
+<ParamField query="conversionType" type="string" optional>
+  The format of the resulting data. Can be one of `pdf`, `html`, or `json`.
 
   If provided, the Webhook will contain a URL to the file of chosen type. The URL is active for 3 minutes.
   
-  Otherwise, the data will be returned in JSON format in the Webhook payload.
+  Otherwise, the data will be returned in JSON format in the Webhook payload (default).
 
-  <Info>This parameter is to indicate how the medical record should be rendered.</Info>
+  <Info>Providing `pdf` or `html` results in a
+  [Medical Record Summary](/medical-api/more-info/webhooks#medical-record) being sent.</Info>
 </ParamField>
 
 <Info>

--- a/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
+++ b/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
@@ -55,11 +55,12 @@ that will contain a URL to retrieve the data from.
 
 <ParamField query="conversionType" type="string">
   The output format of the resulting . Can be one of `pdf`, `html`, or `json`. 
-  If provided, the Webhook will contain a URL to the file of chosen type. Otherwise, the data will
-  be returned in JSON format in the Webhook payload.
+
+  If provided, the Webhook will contain a URL to the file of chosen type. The URL is active for 3 minutes.
+  
+  Otherwise, the data will be returned in JSON format in the Webhook payload.
 
   <Info>This parameter is to indicate how the medical record should be rendered.</Info>
-  <Info>The URL is active for 3 minutes.</Info>
 </ParamField>
 
 <Info>

--- a/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
+++ b/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
@@ -4,16 +4,19 @@ description: "Trigger a consolidated data query for the given patient"
 api: "POST /medical/v1/patient/{id}/consolidated/query"
 ---
 
-When executed, this endpoint triggers an asynchronous query to retrieve a Patient's consolidated data from
-the FHIR repository.
+When executed, this endpoint triggers an asynchronous query to retrieve a Patient's consolidated
+data from the FHIR repository.
 
 Once the data is consolidated and ready for consumption, a [Webhook request](/medical-api/more-info/webhooks#patient-consolidated-data)
-is sent to your configured URL containing the Patient's data in FHIR-compliant format, based on the filters used to trigger the query.
+is sent to [your configured URL](/home/api-reference/settings/post-settings) containing the Patient's
+data in FHIR-compliant format, based on the filters used to trigger the query.
 
 You can check the status of the data query by calling [get consolidated data query](/medical-api/api-reference/fhir/consolidated-data-query-get).
 
-This endpoint also provides the ability to render a medical record summary from the FHIR bundle as a PDF or HTML document.
-This will be returned [via a webook](/medical-api/more-info/webhooks#medical-record) as a FHIR bundle with a DocumentReference resource that will contain a url to retrieve the data from.
+This endpoint also provides the ability to render a medical record summary from the FHIR bundle as a
+PDF or HTML document. This will be returned [via a webook](/medical-api/more-info/webhooks#medical-record)
+as a FHIR bundle with a [DocumentReference](/medical-api/fhir/resources/documentreference) resource
+that will contain a URL to retrieve the data from.
 
 ## Path Params
 
@@ -51,9 +54,9 @@ This will be returned [via a webook](/medical-api/more-info/webhooks#medical-rec
 </ParamField>
 
 <ParamField query="conversionType" type="string">
-  The doc type to convert to. Can be one of "pdf", "html", or "json". 
+  The output format of the resulting . Can be one of `pdf`, `html`, or `json`. 
   If provided, the Webhook will contain a URL to the file of chosen type. Otherwise, the data will
-  be returned in json format in the Webhook payload.
+  be returned in JSON format in the Webhook payload.
 
   <Info>This parameter is to indicate how the medical record should be rendered.</Info>
   <Info>The URL is active for 3 minutes.</Info>

--- a/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
+++ b/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
@@ -51,14 +51,11 @@ This will be returned [via a webook](/medical-api/more-info/webhooks#medical-rec
 </ParamField>
 
 <ParamField query="conversionType" type="string">
-  The doc type to convert to. Either `html` or `pdf`.
+  The doc type to convert to. Can be one of "pdf", "html", or "json". 
+  If provided, the Webhook will contain a URL to the file of chosen type. Otherwise, the data will
+  be returned in json format in the Webhook payload.
 
   <Info>This parameter is to indicate how the medical record should be rendered.</Info>
-</ParamField>
-
-<ParamField query="getUrl" type="boolean">
-  If set to true, the Webhook response will contain a signed URL to the file containing the FHIR
-  bundle.
 </ParamField>
 
 <Info>

--- a/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
+++ b/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
@@ -56,6 +56,11 @@ This will be returned [via a webook](/medical-api/more-info/webhooks#medical-rec
   <Info>This parameter is to indicate how the medical record should be rendered.</Info>
 </ParamField>
 
+<ParamField query="getUrl" type="boolean">
+  If set to true, the Webhook response will contain a signed URL to the file containing the FHIR
+  bundle.
+</ParamField>
+
 <Info>
   You can scroll to the bottom of the page to view all [available
   resources](/medical-api/api-reference/fhir/get-patient-consolidated#available-fhir-resources).

--- a/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
+++ b/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
@@ -56,6 +56,7 @@ This will be returned [via a webook](/medical-api/more-info/webhooks#medical-rec
   be returned in json format in the Webhook payload.
 
   <Info>This parameter is to indicate how the medical record should be rendered.</Info>
+  <Info>The URL is active for 3 minutes.</Info>
 </ParamField>
 
 <Info>

--- a/docs/medical-api/more-info/webhooks.mdx
+++ b/docs/medical-api/more-info/webhooks.mdx
@@ -311,9 +311,12 @@ The format follows:
 
 When querying for a Patient's consolidated data, you can also request this information in PDF or HTML format.
 
-The following is the result of the [previous section](#patient-consolidated-data), but with the `Bundle` containing a document reference to a rendered medical record that represents the resulting FHIR bundle.
+The following is the result of the [previous section](#patient-consolidated-data), but with the `Bundle`
+containing a document reference to a rendered [Medical Record Summary](/medical-api/more-info/medical-record-summary)
+that represents the resulting FHIR bundle.
 
-Inside the `Bundle` you'll find a `DocumentReference` resource with the first item in the `content` array containing an attachment with a `url` which can be used to download the rendered medical record.
+Inside the `Bundle` you'll find a `DocumentReference` resource with the first item in the `content` array containing
+an attachment with a `url` which can be used to download the rendered medical record.
 
 Example payload:
 

--- a/packages/api/src/command/medical/patient/consolidated-get.ts
+++ b/packages/api/src/command/medical/patient/consolidated-get.ts
@@ -46,7 +46,6 @@ export type GetConsolidatedFilters = {
   dateFrom?: string;
   dateTo?: string;
   conversionType?: ConsolidationConversionType;
-  getUrl?: boolean;
 };
 
 export type GetConsolidatedParams = {
@@ -69,7 +68,6 @@ export async function startConsolidatedQuery({
   dateTo,
   conversionType,
   cxConsolidatedRequestMetadata,
-  getUrl,
 }: ConsolidatedQueryParams): Promise<QueryProgress> {
   const { log } = Util.out(`startConsolidatedQuery - M patient ${patientId}`);
   const patient = await getPatientOrFail({ id: patientId, cxId });
@@ -107,7 +105,6 @@ export async function startConsolidatedQuery({
     dateTo,
     conversionType,
     requestId,
-    getUrl,
   }).catch(emptyFunction);
 
   return progress;
@@ -147,7 +144,6 @@ export async function getConsolidated({
   dateFrom,
   dateTo,
   conversionType,
-  getUrl,
 }: GetConsolidatedParams): Promise<{
   bundle: Bundle<Resource>;
   filters: Record<string, string | undefined>;
@@ -164,7 +160,7 @@ export async function getConsolidated({
     });
     const hasResources = bundle.entry && bundle.entry.length > 0;
 
-    if (getUrl && !conversionType) {
+    if (conversionType === "json") {
       return uploadConsolidatedJsonAndReturnUrl({
         patient,
         bundle,

--- a/packages/api/src/command/medical/patient/convert-fhir-bundle.ts
+++ b/packages/api/src/command/medical/patient/convert-fhir-bundle.ts
@@ -3,6 +3,7 @@ import {
   ConsolidationConversionType,
   Input as ConversionInput,
   Output as ConversionOutput,
+  MedicalRecordDocType,
 } from "@metriport/core/domain/conversion/fhir-to-medical-record";
 import { createMRSummaryFileName } from "@metriport/core/domain/medical-record-summary";
 import { Patient } from "@metriport/core/domain/patient";
@@ -43,7 +44,7 @@ export async function handleBundleToMedicalRecord({
   resources?: ResourceTypeForConsolidation[];
   dateFrom?: string;
   dateTo?: string;
-  conversionType: ConsolidationConversionType;
+  conversionType: MedicalRecordDocType;
 }): Promise<Bundle<Resource>> {
   const bucketName = Config.getSandboxSeedBucketName();
   if (Config.isSandbox() && bucketName) {
@@ -119,7 +120,7 @@ async function convertFHIRBundleToMedicalRecord({
   resources?: ResourceTypeForConsolidation[];
   dateFrom?: string;
   dateTo?: string;
-  conversionType: ConsolidationConversionType;
+  conversionType: MedicalRecordDocType;
 }): Promise<ConversionOutput> {
   const lambdaName = Config.getFHIRToMedicalRecordLambdaName();
 

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -295,7 +295,8 @@ const medicalRecordDocTypeSchema = z.enum(mrDocType);
  * @param req.query.dateFrom Optional start date that resources will be filtered by (inclusive).
  * @param req.query.dateTo Optional end date that resources will be filtered by (inclusive).
  * @param req.query.docType Optional to indicate the file format you get the document back in.
- *        Accepts "pdf", "html", and "json". If not provided, will send json payload in the webhook.
+ *        Accepts "pdf", "html", and "json". If provided, the Webhook payload will contain a signed URL to download
+ *        the file, which is active for 3 minutes. If not provided, will send json payload in the webhook.
  * @param req.body Optional metadata to be sent through Webhook.
  * @return status of querying for the Patient's consolidated data.
  */

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -2,7 +2,7 @@ import { patientCreateSchema } from "@metriport/api-sdk";
 import { QueryProgress as QueryProgressFromSDK } from "@metriport/api-sdk/medical/models/patient";
 import {
   consolidationConversionType,
-  mrDocType,
+  mrFormat,
 } from "@metriport/core/domain/conversion/fhir-to-medical-record";
 import { toFHIR } from "@metriport/core/external/fhir/patient/index";
 import { stringToBoolean } from "@metriport/shared";
@@ -281,7 +281,7 @@ router.get(
 );
 
 const consolidationConversionTypeSchema = z.enum(consolidationConversionType);
-const medicalRecordDocTypeSchema = z.enum(mrDocType);
+const medicalRecordFormatSchema = z.enum(mrFormat);
 
 /** ---------------------------------------------------------------------------
  * POST /patient/:id/consolidated/query
@@ -347,7 +347,7 @@ router.get(
     const cxId = getCxIdOrFail(req);
     const patientId = getFrom("params").orFail("id", req);
     const type = getFrom("query").orFail("conversionType", req);
-    const conversionType = medicalRecordDocTypeSchema.parse(type);
+    const conversionType = medicalRecordFormatSchema.parse(type);
 
     const url = await getMedicalRecordSummary({ patientId, cxId, conversionType });
     if (!url) throw new NotFoundError("Medical record summary not found");

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -292,6 +292,8 @@ const consolidationConversionTypeSchema = z.enum(consolidationConversionType);
  * @param req.query.dateTo Optional end date that resources will be filtered by (inclusive).
  * @param req.query.conversionType Optional to indicate how the medical record should be rendered.
  *        Accepts "pdf" or "html". Defaults to no conversion.
+ * @param req.query.getUrl Optional to indicate if the URL to download the consolidated json file should be returned in the Webhook.
+ *        Defaults to false, and sends the data through Webhook.
  * @param req.body Optional metadata to be sent through Webhook.
  * @return status of querying for the Patient's consolidated data.
  */
@@ -305,6 +307,7 @@ router.post(
     const dateFrom = parseISODate(getFrom("query").optional("dateFrom", req));
     const dateTo = parseISODate(getFrom("query").optional("dateTo", req));
     const type = getFrom("query").optional("conversionType", req);
+    const getUrl = stringToBoolean(getFrom("query").optional("getUrl", req));
     const conversionType = type ? consolidationConversionTypeSchema.parse(type) : undefined;
     const cxConsolidatedRequestMetadata = cxRequestMetadataSchema.parse(req.body);
 
@@ -316,6 +319,7 @@ router.post(
       dateTo,
       conversionType,
       cxConsolidatedRequestMetadata: cxConsolidatedRequestMetadata?.metadata,
+      getUrl,
     });
     const respPayload: QueryProgressFromSDK = {
       status: queryResponse.status ?? null,

--- a/packages/core/src/domain/conversion/fhir-to-medical-record.ts
+++ b/packages/core/src/domain/conversion/fhir-to-medical-record.ts
@@ -1,8 +1,8 @@
 export const consolidationConversionType = ["html", "pdf", "json"] as const;
 export type ConsolidationConversionType = (typeof consolidationConversionType)[number];
 
-export const mrDocType = ["html", "pdf"] as const;
-export type MedicalRecordDocType = (typeof mrDocType)[number];
+export const mrFormat = ["html", "pdf"] as const;
+export type MedicalRecordFormat = (typeof mrFormat)[number];
 
 export type Input = {
   fileName: string;
@@ -11,7 +11,7 @@ export type Input = {
   cxId: string;
   dateFrom?: string;
   dateTo?: string;
-  conversionType: MedicalRecordDocType;
+  conversionType: MedicalRecordFormat;
 };
 
 export type Output = {

--- a/packages/core/src/domain/conversion/fhir-to-medical-record.ts
+++ b/packages/core/src/domain/conversion/fhir-to-medical-record.ts
@@ -1,6 +1,8 @@
-export const consolidationConversionType = ["html", "pdf"] as const;
-
+export const consolidationConversionType = ["html", "pdf", "json"] as const;
 export type ConsolidationConversionType = (typeof consolidationConversionType)[number];
+
+export const mrDocType = ["html", "pdf"] as const;
+export type MedicalRecordDocType = (typeof mrDocType)[number];
 
 export type Input = {
   fileName: string;
@@ -9,7 +11,7 @@ export type Input = {
   cxId: string;
   dateFrom?: string;
   dateTo?: string;
-  conversionType: ConsolidationConversionType;
+  conversionType: MedicalRecordDocType;
 };
 
 export type Output = {

--- a/packages/core/src/domain/medical-record-summary.ts
+++ b/packages/core/src/domain/medical-record-summary.ts
@@ -1,3 +1,4 @@
+import { ConsolidationConversionType } from "./conversion/fhir-to-medical-record";
 import { createFilePath } from "./filename";
 
 export const MEDICAL_RECORD_KEY = "MR";
@@ -5,7 +6,7 @@ export const MEDICAL_RECORD_KEY = "MR";
 export const createMRSummaryFileName = (
   cxId: string,
   patientId: string,
-  extension: "pdf" | "html" | "json"
+  extension: ConsolidationConversionType
 ): string => {
   if (extension === "pdf") {
     return createFilePath(cxId, patientId, `${MEDICAL_RECORD_KEY}.html.pdf`);


### PR DESCRIPTION
refs. metriport/metriport#1746

### Description

- Added `json` to the `conversionType` on the `consolidated query`

### Testing

- Local
  - [x] Tested locally with the following scenarios: 
    - `conversionType: undefined` - unchanged behavior
    - `conversionType: json` - sends signed URL to the JSON file
    - `conversionType: html` - unchanged behavior
    - `conversionType: json` - unchanged behavior
- Staging
  - [ ] Test the same in staging
- Production
  - [ ] Test a couple scenarios in prod
  

### Screenshot 

Main description:

![image](https://github.com/metriport/metriport/assets/2132564/fc1a0dfc-673d-47ce-893b-e6f1b56350c2)

`conversionType` param:

![image](https://github.com/metriport/metriport/assets/2132564/a8cfb05a-ed71-4b48-a50d-baa620d58b79)


### Release Plan

- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (introduce a feature that would be useful customers)
- [ ] Merge this
