### PR TITLE
PATCH  add correct docref count to analytics

### DIFF
--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -44,8 +44,7 @@ export async function processOutboundDocumentQueryResps({
     const docQueryStartedAt = patient.data.documentQueryProgress?.startedAt;
     const duration = elapsedTimeFromNow(docQueryStartedAt);
 
-    const docRefsPromises = results.map(toDocumentReference);
-    const docRefs = (await Promise.all(docRefsPromises)).flat();
+    const docRefs = results.map(toDocumentReference).flat();
 
     analytics({
       distinctId: cxId,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1669

Ticket: metriport/metriport-internal#1669

### Dependencies

- Upstream: none
- Downstream: none

### Description

Add correct doc ref count to analytics

### Testing

- Local
  - Cant test in integration
- Production
  - [ ] Monitor

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
