### PR TITLE
fix(api): fixed uploading empty json when no fhir resources

### DIFF
--- a/packages/api/src/command/medical/patient/consolidated-get.ts
+++ b/packages/api/src/command/medical/patient/consolidated-get.ts
@@ -159,7 +159,6 @@ export async function getConsolidated({
       dateTo,
     });
     const hasResources = bundle.entry && bundle.entry.length > 0;
-
     const shouldCreateMedicalRecord = conversionType && conversionType != "json" && hasResources;
     const startedAt = patient.data.consolidatedQuery?.startedAt;
 
@@ -198,7 +197,7 @@ export async function getConsolidated({
       });
     }
 
-    if (conversionType === "json") {
+    if (conversionType === "json" && hasResources) {
       return uploadConsolidatedJsonAndReturnUrl({
         patient,
         bundle,


### PR DESCRIPTION
refs. metriport/metriport#1746

### Description

- No more empty json files for patients with no FHIR resources

### Testing

_[Regular PRs:]_

- Local
  - [x] Ran the test with a patient with no FHIR data - works good
- Staging 
  - [ ] Run the test with a patient with no FHIR data

### Release Plan
- [ ] Merge this
