### PR TITLE
1940 Fix webhooks documentation

### DIFF
--- a/docs/home/api-info/webhooks.mdx
+++ b/docs/home/api-info/webhooks.mdx
@@ -226,4 +226,3 @@ To retry failed requests, simply click the `Retry` button, and those requests wi
   Currently, the Metriport API doesn't implement automatic retries - let us know if this is
   something you need.
 </Warning>
-```


### PR DESCRIPTION
Ticket: [#_1940_](https://github.com/metriport/metriport/issues/1940)

### Dependencies

- None

### Description

- Remove extra ```

### Testing

- Local
  - [x] Mintlify
- Staging
  - [ ] N/A?
- Sandbox
  - [ ] N/A?
- Production
  - [ ] Check live docs

### Release Plan

- [ ] Merge this
