### PR TITLE
fix(api): await json file creation

### DIFF
--- a/packages/api/src/command/medical/patient/consolidated-get.ts
+++ b/packages/api/src/command/medical/patient/consolidated-get.ts
@@ -198,7 +198,7 @@ export async function getConsolidated({
     }
 
     if (conversionType === "json" && hasResources) {
-      return uploadConsolidatedJsonAndReturnUrl({
+      return await uploadConsolidatedJsonAndReturnUrl({
         patient,
         bundle,
         filters,


### PR DESCRIPTION
refs. metriport/metriport#1746

### Description

- Added a missing `await` 🤦‍♂️ 

### Testing

- Local
  - [x] Create a `json` consolidated for a patient and check the webhook
- Staging
  - [ ] Create a `json` consolidated for a patient and check the webhook

### Release Plan
- [ ] Merge this
