### PR TITLE
fix(api): part 1/2 add duration to outbound responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29017,11 +29017,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.4.6-alpha.0",
+      "version": "1.4.6-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@metriport/core": "^1.9.11",
-        "@metriport/ihe-gateway-sdk": "^0.5.6-alpha.0"
+        "@metriport/ihe-gateway-sdk": "^0.5.6-alpha.1"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -29238,7 +29238,7 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.5.6-alpha.0",
+      "version": "0.5.6-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@metriport/shared": "^0.4.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29017,11 +29017,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.4.5",
+      "version": "1.4.6-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@metriport/core": "^1.9.11",
-        "@metriport/ihe-gateway-sdk": "^0.5.5"
+        "@metriport/ihe-gateway-sdk": "^0.5.6-alpha.0"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -29238,7 +29238,7 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.5.5",
+      "version": "0.5.6-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@metriport/shared": "^0.4.11",

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -209,6 +209,8 @@ router.post(
 
     const status = getPDResultStatus({ patientMatch: response.patientMatch });
 
+    response.duration = dayjs(response.responseTimestamp).diff(response.requestTimestamp);
+
     await createOutboundPatientDiscoveryResp({
       id: uuidv7(),
       requestId: response.id,
@@ -269,6 +271,8 @@ router.post(
       });
     }
 
+    response.duration = dayjs(response.responseTimestamp).diff(response.requestTimestamp);
+
     await createOutboundDocumentQueryResp({
       id: uuidv7(),
       requestId: response.id,
@@ -320,6 +324,8 @@ router.post(
         docRefLength: response.documentReference?.length,
       });
     }
+
+    response.duration = dayjs(response.responseTimestamp).diff(response.requestTimestamp);
 
     await createOutboundDocumentRetrievalResp({
       id: uuidv7(),

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.4.6-alpha.0",
+  "version": "1.4.6-alpha.1",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,6 +42,6 @@
   },
   "dependencies": {
     "@metriport/core": "^1.9.11",
-    "@metriport/ihe-gateway-sdk": "^0.5.6-alpha.0"
+    "@metriport/ihe-gateway-sdk": "^0.5.6-alpha.1"
   }
 }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.4.5",
+  "version": "1.4.6-alpha.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,6 +42,6 @@
   },
   "dependencies": {
     "@metriport/core": "^1.9.11",
-    "@metriport/ihe-gateway-sdk": "^0.5.5"
+    "@metriport/ihe-gateway-sdk": "^0.5.6-alpha.0"
   }
 }

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.5.5",
+  "version": "0.5.6-alpha.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.5.6-alpha.0",
+  "version": "0.5.6-alpha.1",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/ihe-gateway-sdk/src/models/shared.ts
+++ b/packages/ihe-gateway-sdk/src/models/shared.ts
@@ -76,7 +76,9 @@ export type XCPDPatientId = z.infer<typeof externalGatewayPatientSchema>;
 export const baseResponseSchema = z.object({
   id: z.string(),
   timestamp: z.string(),
+  requestTimestamp: z.string(),
   responseTimestamp: z.string(),
+  duration: z.number().optional(),
   cxId: z.string().optional(),
   externalGatewayPatient: externalGatewayPatientSchema.optional(),
   patientId: z.string().optional(),

--- a/packages/ihe-gateway-sdk/src/models/shared.ts
+++ b/packages/ihe-gateway-sdk/src/models/shared.ts
@@ -76,8 +76,11 @@ export type XCPDPatientId = z.infer<typeof externalGatewayPatientSchema>;
 export const baseResponseSchema = z.object({
   id: z.string(),
   timestamp: z.string(),
-  responseTimestamp: z.string(), // timestamp right after external gateway response
-  requestTimestamp: z.string().optional(), // timestamp right before external gateway request
+  /** timestamp right after external gateway response */
+  responseTimestamp: z.string(),
+  /** timestamp right before external gateway request */
+  requestTimestamp: z.string().optional(),
+  /** duration of the request to the external gateway */
   duration: z.number().optional(),
   cxId: z.string().optional(),
   externalGatewayPatient: externalGatewayPatientSchema.optional(),

--- a/packages/ihe-gateway-sdk/src/models/shared.ts
+++ b/packages/ihe-gateway-sdk/src/models/shared.ts
@@ -76,8 +76,8 @@ export type XCPDPatientId = z.infer<typeof externalGatewayPatientSchema>;
 export const baseResponseSchema = z.object({
   id: z.string(),
   timestamp: z.string(),
-  responseTimestamp: z.string(),
-  requestTimestamp: z.string().optional(),
+  responseTimestamp: z.string(), // timestamp right after external gateway response
+  requestTimestamp: z.string().optional(), // timestamp right before external gateway request
   duration: z.number().optional(),
   cxId: z.string().optional(),
   externalGatewayPatient: externalGatewayPatientSchema.optional(),

--- a/packages/ihe-gateway-sdk/src/models/shared.ts
+++ b/packages/ihe-gateway-sdk/src/models/shared.ts
@@ -76,8 +76,8 @@ export type XCPDPatientId = z.infer<typeof externalGatewayPatientSchema>;
 export const baseResponseSchema = z.object({
   id: z.string(),
   timestamp: z.string(),
-  requestTimestamp: z.string(),
   responseTimestamp: z.string(),
+  requestTimestamp: z.string().optional(),
   duration: z.number().optional(),
   cxId: z.string().optional(),
   externalGatewayPatient: externalGatewayPatientSchema.optional(),

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-0-Process response.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-0-Process response.js
@@ -1,5 +1,6 @@
 // Decode and parse XCA ITI-38 (Cross Gateway Query Response) message
 var xml = null;
+channelMap.put('RESPONSE_TIME', getCurrentDate());
 
 var 	queryResponseCode = '',
 	homeCommunityId = null,

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor/sourceConnector-transformer-step-0-Set stats.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor/sourceConnector-transformer-step-0-Set stats.js
@@ -1,7 +1,7 @@
 // Store internal message id
 channelMap.put('MSG_ID', msg.id.toString());
 channelMap.put('CUSTOMER_ID', msg.cxId.toString());
-channelMap.put('REQUEST_TIME', DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ"));
+channelMap.put('REQUEST_TIME', getCurrentDate());
 
 // Store for further processing
 channelMap.put('REQUEST', msg);

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor/sourceConnector-transformer-step-0-Set stats.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-38 Processor/sourceConnector-transformer-step-0-Set stats.js
@@ -1,6 +1,7 @@
 // Store internal message id
 channelMap.put('MSG_ID', msg.id.toString());
 channelMap.put('CUSTOMER_ID', msg.cxId.toString());
+channelMap.put('REQUEST_TIME', DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ"));
 
 // Store for further processing
 channelMap.put('REQUEST', msg);

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-0-Process response.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/destinationConnector-XCA Endpoint-responseTransformer-step-0-Process response.js
@@ -2,6 +2,7 @@
 var http = $('responseStatusLine');
 http = String(http).replace('HTTP/1.1 ', '').replace(/\D/g, '');
 channelMap.put('HTTP', http.toString());
+channelMap.put('RESPONSE_TIME', getCurrentDate());
 
 // Decode and parse XCA ITI-38 (Cross Gateway Query Response) message
 var xml = null;

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/sourceConnector-transformer-step-0-Set stats.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/sourceConnector-transformer-step-0-Set stats.js
@@ -1,6 +1,6 @@
 // Store internal message id
 channelMap.put('MSG_ID', msg.id.toString());
 channelMap.put('CUSTOMER_ID', msg.cxId.toString());
-
+channelMap.put('REQUEST_TIME', DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ"));
 // Store for further processing
 channelMap.put('REQUEST', msg);

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/sourceConnector-transformer-step-0-Set stats.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCA ITI-39 Processor/sourceConnector-transformer-step-0-Set stats.js
@@ -1,6 +1,6 @@
 // Store internal message id
 channelMap.put('MSG_ID', msg.id.toString());
 channelMap.put('CUSTOMER_ID', msg.cxId.toString());
-channelMap.put('REQUEST_TIME', DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ"));
+channelMap.put('REQUEST_TIME', getCurrentDate());
 // Store for further processing
 channelMap.put('REQUEST', msg);

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor/destinationConnector-XCPD Endpoint-responseTransformer-step-0-Process response.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor/destinationConnector-XCPD Endpoint-responseTransformer-step-0-Process response.js
@@ -2,6 +2,7 @@
 var http = $('responseStatusLine');
 http = String(http).replace('HTTP/1.1 ', '').replace(/\D/g, '');
 channelMap.put('HTTP', http.toString());
+channelMap.put('RESPONSE_TIME', getCurrentDate());
 
 // https://docs.nextgen.com/bundle/Mirth_User_Guide_4_4_2/page/connect/connect/topics/c_Common_Scenarios_connect_ug.html
 //if (responseStatus == QUEUED && connectorMessage.getSendAttempts() >= 2) {

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor/sourceConnector-transformer-step-0-Set Stats.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor/sourceConnector-transformer-step-0-Set Stats.js
@@ -2,6 +2,7 @@
 channelMap.put('MSG_ID', msg.id.toString());
 channelMap.put('CUSTOMER_ID', msg.cxId.toString());
 channelMap.put('PATIENT_ID', msg.patientResource.id.toString());
+channelMap.put('REQUEST_TIME', DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ"));
 channelMap.put('GATEWAY_ID', msg.gateway.id.toString());
 
 // Store for further processing

--- a/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor/sourceConnector-transformer-step-0-Set Stats.js
+++ b/packages/ihe-gateway/server/Channels/CareQuality Document Exchange - Outbound/XCPD ITI-55 Processor/sourceConnector-transformer-step-0-Set Stats.js
@@ -2,7 +2,7 @@
 channelMap.put('MSG_ID', msg.id.toString());
 channelMap.put('CUSTOMER_ID', msg.cxId.toString());
 channelMap.put('PATIENT_ID', msg.patientResource.id.toString());
-channelMap.put('REQUEST_TIME', DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ"));
+channelMap.put('REQUEST_TIME', getCurrentDate());
 channelMap.put('GATEWAY_ID', msg.gateway.id.toString());
 
 // Store for further processing

--- a/packages/ihe-gateway/server/CodeTemplates/Common Library/Get current date/Get current date.js
+++ b/packages/ihe-gateway/server/CodeTemplates/Common Library/Get current date/Get current date.js
@@ -1,0 +1,9 @@
+/**
+	Function that returns the current date
+
+	
+	@return {Date} return current date
+*/
+function getCurrentDate() {
+	return DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ");
+}

--- a/packages/ihe-gateway/server/CodeTemplates/Common Library/index.xml
+++ b/packages/ihe-gateway/server/CodeTemplates/Common Library/index.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?><codeTemplateLibrary version="4.4.2">
   <id>c209459e-8282-4ac7-88cb-42cdeec33805</id>
   <name>Common Library</name>
-  <revision>32</revision>
+  <revision>820</revision>
   <lastModified>
-    <time>1710182494932</time>
+    <time>1713889923054</time>
     <timezone>GMT</timezone>
   </lastModified>
   <description>Common library for all channels
@@ -46,6 +46,9 @@ Last updated: Dec 27 2023</description>
     </codeTemplate>
     <codeTemplate version="4.4.2">
       <id>476ce6dd-1ae0-43c8-b6fa-a3d887c9edd5</id>
+    </codeTemplate>
+    <codeTemplate version="4.4.2">
+      <id>a12fba56-00c8-413b-8510-098d8c6b6caa</id>
     </codeTemplate>
     <codeTemplate version="4.4.2">
       <id>d455b692-51d1-45bb-ab95-ccec79c3290c</id>

--- a/packages/ihe-gateway/server/CodeTemplates/XCA Library - Outbound/Get XCA ITI-38 response template/Get XCA ITI-38 response template.js
+++ b/packages/ihe-gateway/server/CodeTemplates/XCA Library - Outbound/Get XCA ITI-38 response template/Get XCA ITI-38 response template.js
@@ -9,7 +9,7 @@ function getXCA38ResponseTemplate(request, operationOutcome) {
 	
 	var result = request;
   var requestTime = channelMap.get("REQUEST_TIME");
-  var responseTime = DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ");
+  var responseTime = getCurrentDate();
   result.requestTimestamp = requestTime;
 	result.responseTimestamp = responseTime;
 	if (operationOutcome) result.operationOutcome = operationOutcome;

--- a/packages/ihe-gateway/server/CodeTemplates/XCA Library - Outbound/Get XCA ITI-38 response template/Get XCA ITI-38 response template.js
+++ b/packages/ihe-gateway/server/CodeTemplates/XCA Library - Outbound/Get XCA ITI-38 response template/Get XCA ITI-38 response template.js
@@ -8,7 +8,10 @@
 function getXCA38ResponseTemplate(request, operationOutcome) {
 	
 	var result = request;
-	result.responseTimestamp = DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.sssZ");
+  var requestTime = channelMap.get("REQUEST_TIME");
+  var responseTime = DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ");
+  result.requestTimestamp = requestTime;
+	result.responseTimestamp = responseTime;
 	if (operationOutcome) result.operationOutcome = operationOutcome;
 
 	delete result.samlAttributes;

--- a/packages/ihe-gateway/server/CodeTemplates/XCA Library - Outbound/Get XCA ITI-38 response template/Get XCA ITI-38 response template.js
+++ b/packages/ihe-gateway/server/CodeTemplates/XCA Library - Outbound/Get XCA ITI-38 response template/Get XCA ITI-38 response template.js
@@ -9,7 +9,7 @@ function getXCA38ResponseTemplate(request, operationOutcome) {
 	
 	var result = request;
   var requestTime = channelMap.get("REQUEST_TIME");
-  var responseTime = getCurrentDate();
+  var responseTime = channelMap.get("RESPONSE_TIME");
   result.requestTimestamp = requestTime;
 	result.responseTimestamp = responseTime;
 	if (operationOutcome) result.operationOutcome = operationOutcome;

--- a/packages/ihe-gateway/server/CodeTemplates/XCA Library - Outbound/Get XCA ITI-39 response template/Get XCA ITI-39 response template.js
+++ b/packages/ihe-gateway/server/CodeTemplates/XCA Library - Outbound/Get XCA ITI-39 response template/Get XCA ITI-39 response template.js
@@ -8,7 +8,10 @@
 function getXCA39ResponseTemplate(request, operationOutcome) {
 	
 	var result = request;
-	result.responseTimestamp = DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.sssZ");
+  var requestTime = channelMap.get("REQUEST_TIME");
+  var responseTime = DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ");
+  result.requestTimestamp = requestTime;
+	result.responseTimestamp = responseTime;
 	if (operationOutcome) result.operationOutcome = operationOutcome;
 
 	delete result.samlAttributes;

--- a/packages/ihe-gateway/server/CodeTemplates/XCA Library - Outbound/Get XCA ITI-39 response template/Get XCA ITI-39 response template.js
+++ b/packages/ihe-gateway/server/CodeTemplates/XCA Library - Outbound/Get XCA ITI-39 response template/Get XCA ITI-39 response template.js
@@ -9,7 +9,7 @@ function getXCA39ResponseTemplate(request, operationOutcome) {
 	
 	var result = request;
   var requestTime = channelMap.get("REQUEST_TIME");
-  var responseTime = DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ");
+  var responseTime = getCurrentDate()
   result.requestTimestamp = requestTime;
 	result.responseTimestamp = responseTime;
 	if (operationOutcome) result.operationOutcome = operationOutcome;

--- a/packages/ihe-gateway/server/CodeTemplates/XCA Library - Outbound/Get XCA ITI-39 response template/Get XCA ITI-39 response template.js
+++ b/packages/ihe-gateway/server/CodeTemplates/XCA Library - Outbound/Get XCA ITI-39 response template/Get XCA ITI-39 response template.js
@@ -9,7 +9,7 @@ function getXCA39ResponseTemplate(request, operationOutcome) {
 	
 	var result = request;
   var requestTime = channelMap.get("REQUEST_TIME");
-  var responseTime = getCurrentDate()
+  var responseTime = channelMap.get("RESPONSE_TIME");
   result.requestTimestamp = requestTime;
 	result.responseTimestamp = responseTime;
 	if (operationOutcome) result.operationOutcome = operationOutcome;

--- a/packages/ihe-gateway/server/CodeTemplates/XCPD Library - Outbound/Get XCPD ITI-55 response template/Get XCPD ITI-55 response template.js
+++ b/packages/ihe-gateway/server/CodeTemplates/XCPD Library - Outbound/Get XCPD ITI-55 response template/Get XCPD ITI-55 response template.js
@@ -9,7 +9,7 @@ function getXCPD55ResponseTemplate(request, operationOutcome) {
 	
 	var result = request;
   var requestTime = channelMap.get("REQUEST_TIME");
-  var responseTime = getCurrentDate();
+  var responseTime = channelMap.get("RESPONSE_TIME");
 	// Dec 20: patientResourceId to patientId
 	result.patientId = channelMap.get('PATIENT_ID');
 	result.patientMatch = false;

--- a/packages/ihe-gateway/server/CodeTemplates/XCPD Library - Outbound/Get XCPD ITI-55 response template/Get XCPD ITI-55 response template.js
+++ b/packages/ihe-gateway/server/CodeTemplates/XCPD Library - Outbound/Get XCPD ITI-55 response template/Get XCPD ITI-55 response template.js
@@ -9,7 +9,7 @@ function getXCPD55ResponseTemplate(request, operationOutcome) {
 	
 	var result = request;
   var requestTime = channelMap.get("REQUEST_TIME");
-  var responseTime = DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ");
+  var responseTime = getCurrentDate();
 	// Dec 20: patientResourceId to patientId
 	result.patientId = channelMap.get('PATIENT_ID');
 	result.patientMatch = false;

--- a/packages/ihe-gateway/server/CodeTemplates/XCPD Library - Outbound/Get XCPD ITI-55 response template/Get XCPD ITI-55 response template.js
+++ b/packages/ihe-gateway/server/CodeTemplates/XCPD Library - Outbound/Get XCPD ITI-55 response template/Get XCPD ITI-55 response template.js
@@ -8,10 +8,13 @@
 function getXCPD55ResponseTemplate(request, operationOutcome) {
 	
 	var result = request;
+  var requestTime = channelMap.get("REQUEST_TIME");
+  var responseTime = DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.SSSZ");
 	// Dec 20: patientResourceId to patientId
 	result.patientId = channelMap.get('PATIENT_ID');
 	result.patientMatch = false;
-	result.responseTimestamp = DateUtil.getCurrentDate("yyyy-MM-dd'T'hh:mm:ss.sssZ");
+  result.requestTimestamp = requestTime;
+	result.responseTimestamp = responseTime;
 	if (operationOutcome) result.operationOutcome = operationOutcome;
 	
 	delete result.principalCareProviderIds;


### PR DESCRIPTION
Ref. metriport/metriport-internal#1712

Ticket: metriport/metriport-internal#1712

### Dependencies

- Upstream: none
- Downstream: none

### Description

First of 2 PRs this one is going to introduce duration to the outbound responses. Next PR will have the script to get the median times per CQ GW + success attempts. 

### Testing

- Local
  - [x] Duration was successfully stored in the response
- Staging
  - [ ] Duration was successfully stored in the response
- Production
  - [ ] Monitor

### Release Plan

- [ ] Update packages
- [ ] Merge this
