### PR TITLE
1706 Do not allow create/update facility when OBO

### DIFF
--- a/packages/api/src/command/medical/facility/__tests__/verify-access.test.ts
+++ b/packages/api/src/command/medical/facility/__tests__/verify-access.test.ts
@@ -1,0 +1,56 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { faker } from "@faker-js/faker";
+import { OrganizationType } from "@metriport/core/domain/organization";
+import NotFoundError from "@metriport/core/util/error/not-found";
+import { makeOrganization } from "../../../../domain/medical/__tests__/organization";
+import * as getOrganizationOrFail from "../../organization/get-organization";
+import { verifyCxAccess } from "../verify-access";
+
+let getOrganizationOrFailMock: jest.SpyInstance;
+
+beforeAll(() => {
+  jest.restoreAllMocks();
+  getOrganizationOrFailMock = jest.spyOn(getOrganizationOrFail, "getOrganizationOrFail");
+});
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("verifyCxAccess", () => {
+  it("returns true when org is provider", async () => {
+    const org = makeOrganization({ type: OrganizationType.healthcareProvider });
+    getOrganizationOrFailMock.mockImplementation(async () => org);
+    const res = await verifyCxAccess(faker.string.uuid());
+    expect(res).toBeTruthy();
+  });
+
+  it("returns false when org is provider and throwOnNoAccess is false", async () => {
+    const org = makeOrganization({ type: OrganizationType.healthcareITVendor });
+    getOrganizationOrFailMock.mockImplementation(async () => org);
+    const res = await verifyCxAccess(faker.string.uuid(), false);
+    expect(res).toBeFalsy();
+  });
+
+  it("throws when org is provider and throwOnNoAccess is true", async () => {
+    const org = makeOrganization({ type: OrganizationType.healthcareITVendor });
+    getOrganizationOrFailMock.mockImplementation(async () => org);
+    expect(async () => await verifyCxAccess(faker.string.uuid(), true)).rejects.toThrow(
+      "Facilities cannot be created or updated, contact support."
+    );
+  });
+
+  it("throws when org is provider and throwOnNoAccess is not set", async () => {
+    const org = makeOrganization({ type: OrganizationType.healthcareITVendor });
+    getOrganizationOrFailMock.mockImplementation(async () => org);
+    expect(async () => await verifyCxAccess(faker.string.uuid())).rejects.toThrow(
+      "Facilities cannot be created or updated, contact support."
+    );
+  });
+
+  it("throws when org is not found", async () => {
+    getOrganizationOrFailMock.mockImplementation(async () => {
+      throw new NotFoundError("Organization not found");
+    });
+    expect(async () => await verifyCxAccess(faker.string.uuid())).rejects.toThrow();
+  });
+});

--- a/packages/api/src/command/medical/facility/verify-access.ts
+++ b/packages/api/src/command/medical/facility/verify-access.ts
@@ -1,0 +1,14 @@
+import { OrganizationType } from "@metriport/core/domain/organization";
+import ForbiddenError from "../../../errors/forbidden";
+import { getOrganizationOrFail } from "../organization/get-organization";
+
+export async function verifyCxAccess(cxId: string, throwOnNoAccess = true): Promise<boolean> {
+  const org = await getOrganizationOrFail({ cxId });
+  if (org.type === OrganizationType.healthcareITVendor) {
+    if (throwOnNoAccess) {
+      throw new ForbiddenError("Facilities cannot be created or updated, contact support.");
+    }
+    return false;
+  }
+  return true;
+}

--- a/packages/api/src/routes/medical/facility.ts
+++ b/packages/api/src/routes/medical/facility.ts
@@ -4,6 +4,7 @@ import status from "http-status";
 import { createFacility } from "../../command/medical/facility/create-facility";
 import { getFacilities } from "../../command/medical/facility/get-facility";
 import { updateFacility } from "../../command/medical/facility/update-facility";
+import { verifyCxAccess } from "../../command/medical/facility/verify-access";
 import NotFoundError from "../../errors/not-found";
 import { getETag } from "../../shared/http";
 import { requestLogger } from "../helpers/request-logger";
@@ -25,6 +26,8 @@ router.post(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
+    await verifyCxAccess(cxId);
+
     const facilityData = facilityCreateSchema.parse(req.body);
 
     const facility = await createFacility({
@@ -52,6 +55,8 @@ router.put(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
+    await verifyCxAccess(cxId);
+
     const facilityId = getFromParamsOrFail("id", req);
     const facilityData = facilityUpdateSchema.parse(req.body);
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1706

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/1718

### Description

Do not allow create/update facility when OBO

### Testing

- Local
  - [x] Don't allow create/update of facilities when OBO
  - [x] Allows create/update of facilities when OBO
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
- [ ] Merge downstream
