### PR TITLE
fix(api): adjusting response URLs from FHIR server on /fhir/R4

### DIFF
--- a/packages/api/src/routes/medical/fhir-r4-proxy.ts
+++ b/packages/api/src/routes/medical/fhir-r4-proxy.ts
@@ -5,24 +5,6 @@ import { Config } from "../../shared/config";
 import { Util } from "../../shared/util";
 import { asyncHandler, getCxIdOrFail } from "../util";
 
-export type fhirLink = {
-  relation: "self" | "next" | "previous";
-  url: string;
-};
-
-export type fhirEntry = {
-  fullUrl: string;
-  resource: {
-    // TODO: Incomplete type
-    resourceType: string;
-    id: string;
-  };
-  search: {
-    // TODO: Incomplete type
-    mode: string;
-  };
-};
-
 const { log } = Util.out(`FHIR-R4-PROXY`);
 
 const fhirRouter = (fhirServerUrl: string) =>
@@ -37,50 +19,9 @@ const fhirRouter = (fhirServerUrl: string) =>
     },
     //eslint-disable-next-line @typescript-eslint/no-unused-vars
     userResDecorator: function (proxyRes, proxyResData, userReq, userRes) {
-      const data = JSON.parse(proxyResData.toString("utf8"));
-      // v1 handle only known use case `/fhir/R4/{resource}`
-      if (data["resourceType"] === "Bundle" && "type" in data && data["type"] === "searchset") {
-        if ("link" in data) {
-          data["link"].forEach((link: fhirLink) => {
-            const defaultPaginationQueryParams = {
-              _getpages: data["id"],
-              _getpagesoffset: "0",
-              _count: "20",
-              _pretty: "true",
-              _bundletype: "searchset",
-            };
-            let queryParams = link.url.includes("?")
-              ? link.url
-                  .split("?")[1]
-                  .split("&")
-                  .reduce((a, v) => ({ ...a, [v.split("=")[0]]: v.split("=")[1] }), {})
-              : {};
-            queryParams = {
-              ...defaultPaginationQueryParams,
-              ...queryParams,
-            };
-            link.url =
-              Config.getApiUrl() +
-              userReq.baseUrl +
-              "?" +
-              Object.entries(queryParams)
-                .map(entry => `${entry[0]}=${entry[1]}`)
-                .join("&");
-          });
-        }
-        if ("entry" in data) {
-          data["entry"].forEach((entry: fhirEntry) => {
-            entry.fullUrl =
-              Config.getApiUrl() +
-              userReq.baseUrl +
-              "/" +
-              entry.resource.resourceType +
-              "/" +
-              entry.resource.id;
-          });
-        }
-      }
-      return JSON.stringify(data);
+      const data: string = proxyResData.toString("utf8");
+      const apiUrl = Config.getApiUrl();
+      return data.replaceAll(`${apiUrl}/oauth/fhir/${userReq.cxId}`, `${apiUrl}${userReq.baseUrl}`);
     },
   });
 

--- a/packages/api/src/routes/medical/fhir-r4-proxy.ts
+++ b/packages/api/src/routes/medical/fhir-r4-proxy.ts
@@ -5,6 +5,24 @@ import { Config } from "../../shared/config";
 import { Util } from "../../shared/util";
 import { asyncHandler, getCxIdOrFail } from "../util";
 
+export type fhirLink = {
+  relation: "self" | "next" | "previous";
+  url: string;
+};
+
+export type fhirEntry = {
+  fullUrl: string;
+  resource: {
+    // TODO: Incomplete type
+    resourceType: string;
+    id: string;
+  };
+  search: {
+    // TODO: Incomplete type
+    mode: string;
+  };
+};
+
 const { log } = Util.out(`FHIR-R4-PROXY`);
 
 const fhirRouter = (fhirServerUrl: string) =>
@@ -16,6 +34,53 @@ const fhirRouter = (fhirServerUrl: string) =>
       const updatedURL = `/fhir/${cxId}` + req.url;
       log(`Proxying to FHIR server: ${updatedURL}`);
       return updatedURL;
+    },
+    //eslint-disable-next-line @typescript-eslint/no-unused-vars
+    userResDecorator: function (proxyRes, proxyResData, userReq, userRes) {
+      const data = JSON.parse(proxyResData.toString("utf8"));
+      // v1 handle only known use case `/fhir/R4/{resource}`
+      if (data["resourceType"] === "Bundle" && "type" in data && data["type"] === "searchset") {
+        if ("link" in data) {
+          data["link"].forEach((link: fhirLink) => {
+            const defaultPaginationQueryParams = {
+              _getpages: data["id"],
+              _getpagesoffset: "0",
+              _count: "20",
+              _pretty: "true",
+              _bundletype: "searchset",
+            };
+            let queryParams = link.url.includes("?")
+              ? link.url
+                  .split("?")[1]
+                  .split("&")
+                  .reduce((a, v) => ({ ...a, [v.split("=")[0]]: v.split("=")[1] }), {})
+              : {};
+            queryParams = {
+              ...defaultPaginationQueryParams,
+              ...queryParams,
+            };
+            link.url =
+              Config.getApiUrl() +
+              userReq.baseUrl +
+              "?" +
+              Object.entries(queryParams)
+                .map(entry => `${entry[0]}=${entry[1]}`)
+                .join("&");
+          });
+        }
+        if ("entry" in data) {
+          data["entry"].forEach((entry: fhirEntry) => {
+            entry.fullUrl =
+              Config.getApiUrl() +
+              userReq.baseUrl +
+              "/" +
+              entry.resource.resourceType +
+              "/" +
+              entry.resource.id;
+          });
+        }
+      }
+      return JSON.stringify(data);
     },
   });
 

--- a/packages/api/src/routes/medical/fhir-r4-proxy.ts
+++ b/packages/api/src/routes/medical/fhir-r4-proxy.ts
@@ -17,8 +17,7 @@ const fhirRouter = (fhirServerUrl: string) =>
       log(`Proxying to FHIR server: ${updatedURL}`);
       return updatedURL;
     },
-    //eslint-disable-next-line @typescript-eslint/no-unused-vars
-    userResDecorator: function (proxyRes, proxyResData, userReq, userRes) {
+    userResDecorator: function (proxyRes, proxyResData, userReq) {
       const data: string = proxyResData.toString("utf8");
       const apiUrl = Config.getApiUrl();
       return data.replaceAll(`${apiUrl}/oauth/fhir/${userReq.cxId}`, `${apiUrl}${userReq.baseUrl}`);


### PR DESCRIPTION
Ref: #1943

### Description
<p>
<del>
- For the particular case of a Bundle resourceType return object w/ type searchset (i.e. a resource type query against the FHIR server), I adjusted the `link` urls and the individual `entry` object urls (`fullUrl`) to properly reference the API server.
- Note: in the case of the initial request `/fhir/R4/{resourceType}` the `self` parameter in link will spit this back exactly, but reissuing this command *will not* produce the same result. This has been accounted for and the `self` parameter is transformed into a usable pagination link.
- Note: I removed the dependency on `server_address` on the FHIR server and rebuild the URLs with the explicit API server url.
</del>
</p>
After discussion, the more generic approach of string replace was decided.

Important notes:
1. This method *relies* on knowing the `server_address` value on the FHIR server (separate PR here https://github.com/metriport/fhir-server/pull/50 for noting the dependency on the FHIR server side)
2. This does *not* guarantee all links work as intended.

A larger proposed fix on the FHIR side (i.e. updating legacy `server_address` purpose on FHIR side) is documented here https://github.com/metriport/metriport-internal/issues/1721 -- currently labeled `wontfix` for now

### Testing

- Local
  - [x] Request `/fhir/R4/Patient` and validated `links.url` value is usable for `links.relation in ['next', 'previous']`, as expected and that individual entry `fullUrl` value is usable.
- Staging
  - [ ] Request `/fhir/R4/Patient` and validated `links.url` value is usable for `links.relation in ['next', 'previous']`, as expected and that individual entry `fullUrl` value is usable.
- Production
  - [ ] Request `/fhir/R4/Patient` and validated `links.url` value is usable for `links.relation in ['next', 'previous']`, as expected and that individual entry `fullUrl` value is usable.

### Release Plan

- [ ] Merge this
