### PR TITLE
1734 Define DB maintenance window

### DIFF
--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -24,8 +24,52 @@ type EnvConfigBase = {
   domain: string; // Base domain
   subdomain: string; // API subdomain
   authSubdomain: string; // Authentication subdomain
-  dbName: string;
-  dbUsername: string;
+  apiDatabase: {
+    /**
+     * The name of the database.
+     */
+    name: string;
+    /**
+     * The API username to connect to the database.
+     */
+    username: string;
+    /**
+     * From CDK: A preferred maintenance window day/time range. Should be specified as a range ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC).
+     *
+     * Example: 'Sun:23:45-Mon:00:15'.
+     *
+     * Must be at least 30 minutes long.
+     *
+     * @see: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_UpgradeDBInstance.Maintenance.html#Concepts.DBMaintenance
+     */
+    maintenanceWindow: string;
+    /**
+     * From CDK: The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster.
+     *
+     * You can specify ACU values in half-step increments, such as 8, 8.5, 9, and so on. The smallest value that you can use is 0.5.
+     *
+     * @see — http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbcluster-serverlessv2scalingconfiguration.html#cfn-rds-dbcluster-serverlessv2scalingconfiguration-mincapacity
+     */
+    minCapacity: number;
+    /**
+     * From CDK: The maximum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster.
+     *
+     * You can specify ACU values in half-step increments, such as 40, 40.5, 41, and so on. The largest value that you can use is 128.
+     *
+     * The maximum capacity must be higher than 0.5 ACUs. For more information, see Choosing the maximum Aurora Serverless v2 capacity setting for a cluster in the Amazon Aurora User Guide.
+     *
+     * @see — http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbcluster-serverlessv2scalingconfiguration.html#cfn-rds-dbcluster-serverlessv2scalingconfiguration-maxcapacity
+     */
+    maxCapacity: number;
+    /**
+     * The minimum duration in milliseconds for a slow log to be recorded.
+     *
+     * If not present, slow logs will not be recorded.
+     *
+     * @see: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.ParameterGroups.html#AuroraPostgreSQL.Reference.Parameters.Cluster
+     */
+    minSlowLogDurationInMs?: number;
+  };
   loadBalancerDnsName: string;
   apiGatewayUsagePlanId?: string; // optional since we need to create the stack first, then update this and redeploy
   usageReportUrl?: string;

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -10,8 +10,13 @@ export const config: EnvConfigNonSandbox = {
   domain: "myhealthapp.com",
   subdomain: "api",
   authSubdomain: "auth",
-  dbName: "my_db",
-  dbUsername: "my_db_user",
+  apiDatabase: {
+    name: "my_db",
+    username: "my_db_user",
+    maintenanceWindow: "Sun:02:00-Sun:02:30",
+    minCapacity: 0.5,
+    maxCapacity: 1,
+  },
   loadBalancerDnsName: "<your-load-balancer-dns-name>",
   fhirToMedicalLambda: {
     nodeRuntimeArn: "arn:aws:lambda:<region>::runtime:<id>",

--- a/packages/infra/config/ihe-gateway-config.ts
+++ b/packages/infra/config/ihe-gateway-config.ts
@@ -84,19 +84,36 @@ export type IHEGatewayProps = {
     dbNameInbound: string;
     userName: string;
     /**
+     * From CDK: A preferred maintenance window day/time range. Should be specified as a range ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC).
+     *
+     * Example: 'Sun:23:45-Mon:00:15'.
+     *
+     * Must be at least 30 minutes long.
+     *
+     * @see: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_UpgradeDBInstance.Maintenance.html#Concepts.DBMaintenance
+     */
+    maintenanceWindow: string;
+    /**
      * The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster.
      * You can specify ACU values in half-step increments, such as 8, 8.5, 9, and so on. The smallest value that you can use is 0.5.
      * @see — http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbcluster-serverlessv2scalingconfiguration.html#cfn-rds-dbcluster-serverlessv2scalingconfiguration-mincapacity
      */
-    minDBCap: number;
+    minCapacity: number;
     /**
      * The maximum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster.
      * You can specify ACU values in half-step increments, such as 40, 40.5, 41, and so on. The largest value that you can use is 128.
      * The maximum capacity must be higher than 0.5 ACUs.
      * @see — http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbcluster-serverlessv2scalingconfiguration.html#cfn-rds-dbcluster-serverlessv2scalingconfiguration-maxcapacity
      */
-    maxDBCap: number;
-    minSlowLogDurationInMs: number;
+    maxCapacity: number;
+    /**
+     * The minimum duration in milliseconds for a slow log to be recorded.
+     *
+     * If not present, slow logs will not be recorded.
+     *
+     * @see: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.ParameterGroups.html#AuroraPostgreSQL.Reference.Parameters.Cluster
+     */
+    minSlowLogDurationInMs?: number;
     alarmThresholds?: RDSAlarmThresholds;
   };
   inboundPorts: {

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -44,6 +44,7 @@ import { createFHIRConverterService } from "./api-stack/fhir-converter-service";
 import * as fhirServerConnector from "./api-stack/fhir-server-connector";
 import { createAppConfigStack } from "./app-config-stack";
 import { EnvType } from "./env-type";
+import { IHEGatewayV2LambdasNestedStack } from "./iheGatewayV2-stack";
 import { DailyBackup } from "./shared/backup";
 import { addErrorAlarmToLambdaFunc, createLambda, MAXIMUM_LAMBDA_TIMEOUT } from "./shared/lambda";
 import { LambdaLayers, setupLambdasLayers } from "./shared/lambda-layers";
@@ -51,7 +52,6 @@ import { getSecrets, Secrets } from "./shared/secrets";
 import { provideAccessToQueue } from "./shared/sqs";
 import { isProd, isSandbox, mbToBytes } from "./shared/util";
 import { wafRules } from "./shared/waf-rules";
-import { IHEGatewayV2LambdasNestedStack } from "./iheGatewayV2-stack";
 
 const FITBIT_LAMBDA_TIMEOUT = Duration.seconds(60);
 const CDA_TO_VIS_TIMEOUT = Duration.minutes(15);
@@ -144,15 +144,14 @@ export class APIStack extends Stack {
     // Aurora Database for backend data
     //-------------------------------------------
 
-    // create database credentials
-    const dbUsername = props.config.dbUsername;
-    const dbName = props.config.dbName;
+    const dbConfig = props.config.apiDatabase;
     const dbClusterName = "api-cluster";
+    // create database credentials
     const dbCredsSecret = new secret.Secret(this, "DBCreds", {
       secretName: `DBCreds`,
       generateSecretString: {
         secretStringTemplate: JSON.stringify({
-          username: dbUsername,
+          username: dbConfig.username,
         }),
         excludePunctuation: true,
         includeSpace: false,
@@ -166,8 +165,11 @@ export class APIStack extends Stack {
     const parameterGroup = new rds.ParameterGroup(this, "APIDB_Params", {
       engine: dbEngine,
       parameters: {
-        // https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.ParameterGroups.html#AuroraPostgreSQL.Reference.Parameters.Cluster
-        log_min_duration_statement: "3000", // TODO move this and other parameters to env config
+        ...(dbConfig.minSlowLogDurationInMs
+          ? {
+              log_min_duration_statement: dbConfig.minSlowLogDurationInMs.toString(),
+            }
+          : undefined),
       },
     });
 
@@ -179,20 +181,20 @@ export class APIStack extends Stack {
         enablePerformanceInsights: true,
         parameterGroup,
       },
+      preferredMaintenanceWindow: dbConfig.maintenanceWindow,
       credentials: dbCreds,
-      defaultDatabaseName: dbName,
+      defaultDatabaseName: dbConfig.name,
       clusterIdentifier: dbClusterName,
       storageEncrypted: true,
       parameterGroup,
+      cloudwatchLogsExports: ["postgresql"],
     });
-    const minDBCap = this.isProd(props) ? 2 : 0.5;
-    const maxDBCap = this.isProd(props) ? 16 : 2;
     Aspects.of(dbCluster).add({
       visit(node) {
         if (node instanceof rds.CfnDBCluster) {
           node.serverlessV2ScalingConfiguration = {
-            minCapacity: minDBCap,
-            maxCapacity: maxDBCap,
+            minCapacity: dbConfig.minCapacity,
+            maxCapacity: dbConfig.maxCapacity,
           };
         }
       },

--- a/packages/infra/lib/ihe-stack/ihe-db-construct.ts
+++ b/packages/infra/lib/ihe-stack/ihe-db-construct.ts
@@ -51,8 +51,11 @@ export default class IHEDBConstruct extends Construct {
     const parameterGroup = new rds.ParameterGroup(this, "IHE_GW_DB_Params", {
       engine: dbEngine,
       parameters: {
-        // https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.ParameterGroups.html#AuroraPostgreSQL.Reference.Parameters.Cluster
-        log_min_duration_statement: config.rds.minSlowLogDurationInMs.toString(),
+        ...(config.rds.minSlowLogDurationInMs
+          ? {
+              log_min_duration_statement: config.rds.minSlowLogDurationInMs.toString(),
+            }
+          : undefined),
       },
     });
     const dbCluster = new rds.DatabaseCluster(this, `${id}DB`, {
@@ -76,8 +79,8 @@ export default class IHEDBConstruct extends Construct {
       visit(node) {
         if (node instanceof rds.CfnDBCluster) {
           node.serverlessV2ScalingConfiguration = {
-            minCapacity: config.rds.minDBCap,
-            maxCapacity: config.rds.maxDBCap,
+            minCapacity: config.rds.minCapacity,
+            maxCapacity: config.rds.maxCapacity,
           };
         }
       },


### PR DESCRIPTION
Ref. https://github.com/metriport/metriport-internal/issues/1734

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1726
- Downstream: none

### Description

- define db maintenance window
- enable db logs on API DB
- concentrate api db configs in one prop
- make slow logs optional on IHE GW

### Testing

- Local
  - none
- Staging
  - [ ] deployments successful
  - [ ] maintenance window defined for API's DB
  - [ ] maintenance window defined for IHE GW's DB
  - [ ] logs enabled for API's DB
- Sandbox
  - none
- Production
  - [ ] deployments successful
  - [ ] maintenance window defined for API's DB
  - [ ] maintenance window defined for IHE GW's DB
  - [ ] logs enabled for API's DB

### Release Plan

- ⚠️ Contains infra updates
- [ ] Merge upstream
- [ ] Merge this
