### PR TITLE
PATCH RELEASE Disable FHIR test search org

### DIFF
--- a/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/organization.test.e2e.ts
+++ b/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/organization.test.e2e.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from "axios";
-import { makeOrganization } from "./organization";
 import { api } from "../../../../__tests__/shared";
+import { makeOrganization } from "./organization";
 
 jest.setTimeout(15000);
 
@@ -21,20 +21,21 @@ describe("Integration FHIR Org", () => {
     validateOrg(res.data);
   });
 
-  test("search org by name", async () => {
-    const res = await api.get(`/fhir/R4/Organization/?name=${org.name}`);
-    expect(res.status).toBe(200);
-    const body = res.data;
-    expect(body.resourceType).toBeTruthy();
-    expect(body.resourceType).toBe("Bundle");
-    expect(body.entry).toBeTruthy();
-    expect(body.entry.length).toEqual(1);
-    const foundOrg = body.entry[0];
-    expect(foundOrg).toBeTruthy();
-    expect(foundOrg.resource).toBeTruthy();
-    expect(foundOrg.resource.id).toEqual(org.id);
-    expect(foundOrg.resource.name).toEqual(org.name);
-  });
+  // TODO 1634 Disabling b/c it fails in prod, fix as part of 1634
+  // test("search org by name", async () => {
+  //   const res = await api.get(`/fhir/R4/Organization/?name=${org.name}`);
+  //   expect(res.status).toBe(200);
+  //   const body = res.data;
+  //   expect(body.resourceType).toBeTruthy();
+  //   expect(body.resourceType).toBe("Bundle");
+  //   expect(body.entry).toBeTruthy();
+  //   expect(body.entry.length).toEqual(1);
+  //   const foundOrg = body.entry[0];
+  //   expect(foundOrg).toBeTruthy();
+  //   expect(foundOrg.resource).toBeTruthy();
+  //   expect(foundOrg.resource.id).toEqual(org.id);
+  //   expect(foundOrg.resource.name).toEqual(org.name);
+  // });
 
   // This test always fails on the second run, couldn't figure out why. Left for a couple of commits
   // in case someone wants to debug it.


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Description

Disable FHIR test search org - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1714150003631489?thread_ts=1713820888.482169&cid=C04DMKE9DME)

### Testing

none

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
