### PR TITLE
Patch release 2024 04 29

### DIFF
--- a/packages/api/src/command/medical/facility/get-facility.ts
+++ b/packages/api/src/command/medical/facility/get-facility.ts
@@ -29,3 +29,23 @@ export const getFacilityOrFail = async ({ cxId, id }: GetFacilityQuery): Promise
   if (!facility) throw new NotFoundError(`Could not find facility`, undefined, { facilityId: id });
   return facility;
 };
+
+type GetFacilityStrictQuery = GetFacilityQuery & { npi: string };
+export const getFacilityStrictOrFail = async ({
+  cxId,
+  id,
+  npi,
+}: GetFacilityStrictQuery): Promise<FacilityModel> => {
+  const facility = await FacilityModel.findOne({
+    where: {
+      id,
+      cxId,
+      data: {
+        npi,
+      },
+    },
+  });
+  if (!facility)
+    throw new NotFoundError(`Could not find facility`, undefined, { facilityId: id, npi });
+  return facility;
+};

--- a/packages/api/src/command/medical/facility/update-facility.ts
+++ b/packages/api/src/command/medical/facility/update-facility.ts
@@ -1,13 +1,14 @@
-import { FacilityData } from "../../../domain/medical/facility";
-import { FacilityModel } from "../../../models/medical/facility";
+import { FacilityUpdate } from "../../../domain/medical/facility";
 import { validateVersionForUpdate } from "../../../models/_default";
+import { FacilityModel } from "../../../models/medical/facility";
 import { BaseUpdateCmdWithCustomer } from "../base-update-command";
 import { getFacilityOrFail } from "./get-facility";
 
-export type FacilityUpdateCmd = BaseUpdateCmdWithCustomer & FacilityData;
+export type FacilityUpdateCmd = BaseUpdateCmdWithCustomer & FacilityUpdate;
 
 export const updateFacility = async (facilityUpdate: FacilityUpdateCmd): Promise<FacilityModel> => {
-  const { id, cxId, eTag, name, npi, tin, active, address } = facilityUpdate;
+  const { id, cxId, eTag, data, cqOboActive, cwOboActive, cqOboOid, cwOboOid } = facilityUpdate;
+  const { name, npi, tin, active, address } = data;
 
   const facility = await getFacilityOrFail({ id, cxId });
   validateVersionForUpdate(facility, eTag);
@@ -20,5 +21,9 @@ export const updateFacility = async (facilityUpdate: FacilityUpdateCmd): Promise
       active,
       address,
     },
+    cqOboActive: cqOboActive ?? false,
+    cwOboActive: cwOboActive ?? false,
+    cqOboOid,
+    cwOboOid,
   });
 };

--- a/packages/api/src/domain/medical/facility.ts
+++ b/packages/api/src/domain/medical/facility.ts
@@ -29,6 +29,15 @@ export interface FacilityCreate extends BaseDomainCreate {
   type: FacilityType;
   data: FacilityData;
 }
+
+export interface FacilityUpdate {
+  data: FacilityData;
+  cqOboActive?: boolean;
+  cwOboActive?: boolean;
+  cqOboOid?: string;
+  cwOboOid?: string;
+}
+
 export interface Facility extends BaseDomain, FacilityCreate {}
 
 export function makeFacilityOid(orgNumber: number, facilityNumber: number) {

--- a/packages/api/src/routes/medical/facility.ts
+++ b/packages/api/src/routes/medical/facility.ts
@@ -6,10 +6,10 @@ import { getFacilities } from "../../command/medical/facility/get-facility";
 import { updateFacility } from "../../command/medical/facility/update-facility";
 import NotFoundError from "../../errors/not-found";
 import { getETag } from "../../shared/http";
+import { requestLogger } from "../helpers/request-logger";
 import { asyncHandler, getCxIdOrFail, getFromParamsOrFail } from "../util";
 import { dtoFromModel } from "./dtos/facilityDTO";
 import { facilityCreateSchema, facilityUpdateSchema } from "./schemas/facility";
-import { requestLogger } from "../helpers/request-logger";
 
 const router = Router();
 
@@ -56,12 +56,14 @@ router.put(
     const facilityData = facilityUpdateSchema.parse(req.body);
 
     const facility = await updateFacility({
-      ...facilityData,
+      data: {
+        ...facilityData,
+        tin: facilityData.tin ?? undefined,
+        active: facilityData.active ?? undefined,
+      },
       ...getETag(req),
       id: facilityId,
       cxId,
-      tin: facilityData.tin ?? undefined,
-      active: facilityData.active ?? undefined,
     });
 
     return res.status(status.OK).json(dtoFromModel(facility));


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1706

### Description

- Internal facility route now makes updates to existing facilities instead of always creating new ones
- Added support for a different facility name in CW
- Updated FacilityUpdate schemas and made the corresponding changes in relevant functions
- Added a stricter getFacility method, which depends on having both the `id` and the `npi` to avoid mistakes in manual updates

### Testing

- Local
  - [x] Update with random facility ID -> throws error ✅ 
  - [x] Update with existing ID, but incorrect NPI -> throws error ✅ 
  - [x] CQ create/update payload -> looks good ✅ 
  - [x] CW create/update payload -> looks good + works with CW-specific facility name ✅ 
- Production
  - [ ] Use with a CX facility and monitor 

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
