### PR TITLE
1706 Add type to facility update

### DIFF
--- a/packages/api/src/command/medical/facility/__tests__/create-facility.test.ts
+++ b/packages/api/src/command/medical/facility/__tests__/create-facility.test.ts
@@ -1,0 +1,126 @@
+import { FacilityType } from "../../../../domain/medical/facility";
+import { makeFacility } from "../../../../domain/medical/__tests__/facility";
+import { FacilityModel } from "../../../../models/medical/facility";
+import { mockStartTransaction } from "../../../../models/__tests__/transaction";
+import { createFacility, validateCreate } from "../create-facility";
+import { makeFacilityCreate, makeFacilityCreateCmd } from "./create-facility";
+
+describe("createFacility", () => {
+  describe("createFacility", () => {
+    let facilityModel_create: jest.SpyInstance;
+    beforeEach(() => {
+      jest.restoreAllMocks();
+      mockStartTransaction();
+      facilityModel_create = jest.spyOn(FacilityModel, "create").mockImplementation(async f => f);
+    });
+
+    it("creates facility when no OBO data is provided", async () => {
+      const facilityCreate = makeFacilityCreateCmd({
+        type: null,
+        cqOboActive: null,
+        cwOboActive: null,
+        cqOboOid: null,
+        cwOboOid: null,
+      });
+      await createFacility(facilityCreate);
+      expect(facilityModel_create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...facilityCreate,
+          type: FacilityType.initiatorAndResponder,
+          cqOboActive: false,
+          cwOboActive: false,
+          cqOboOid: null,
+          cwOboOid: null,
+        })
+      );
+    });
+
+    it("creates facility with provided data", async () => {
+      const facilityCreate = makeFacilityCreateCmd();
+      await createFacility(facilityCreate);
+      expect(facilityModel_create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...facilityCreate,
+          cqOboOid: facilityCreate.cqOboOid ?? null,
+          cwOboOid: facilityCreate.cwOboOid ?? null,
+        })
+      );
+    });
+
+    it("makeFacilityCreateCmd and OBO", async () => {
+      const facilityCreate = makeFacilityCreateCmd({
+        type: FacilityType.initiatorOnly,
+      });
+      expect(facilityCreate).toEqual(
+        expect.objectContaining({
+          cqOboActive: true,
+          cwOboActive: true,
+        })
+      );
+      expect(facilityCreate.cqOboOid).toBeDefined();
+      expect(facilityCreate.cwOboOid).toBeDefined();
+    });
+  });
+
+  describe("validateCreate", () => {
+    it("throws when OBO and neither CW or CQ OBO are active", async () => {
+      const facility = makeFacility({
+        type: FacilityType.initiatorOnly,
+        cqOboActive: false,
+        cwOboActive: false,
+      });
+      expect(() => validateCreate(facility)).toThrow(
+        "OBO facility must have at least one OBO active"
+      );
+    });
+
+    it("throws when non-OBO and CW OBO is active", async () => {
+      const facility = makeFacilityCreate({
+        type: FacilityType.initiatorAndResponder,
+        cqOboActive: false,
+        cwOboActive: true,
+      });
+      expect(() => validateCreate(facility)).toThrow("Non-OBO facility cannot have OBO active");
+    });
+
+    it("throws when non-OBO and CQ OBO is active", async () => {
+      const facility = makeFacilityCreate({
+        type: FacilityType.initiatorAndResponder,
+        cqOboActive: true,
+        cwOboActive: false,
+      });
+      expect(() => validateCreate(facility)).toThrow("Non-OBO facility cannot have OBO active");
+    });
+
+    it("throws when non-OBO and both CW and CQ OBO are active", async () => {
+      const facility = makeFacilityCreate({
+        type: FacilityType.initiatorAndResponder,
+        cqOboActive: true,
+        cwOboActive: true,
+      });
+      expect(() => validateCreate(facility)).toThrow("Non-OBO facility cannot have OBO active");
+    });
+
+    it("throws when CQ OBO is active but no CQ OID", async () => {
+      const facility = makeFacilityCreate({
+        type: FacilityType.initiatorOnly,
+        cqOboActive: true,
+        cqOboOid: null,
+      });
+      expect(() => validateCreate(facility)).toThrow(
+        "Facility must have CQ OBO OID when CQ OBO active"
+      );
+    });
+
+    it("throws when CW OBO is active but no CW OID", async () => {
+      const facility = makeFacilityCreate({
+        type: FacilityType.initiatorOnly,
+        cwOboActive: true,
+        cwOboOid: null,
+      });
+      expect(() => validateCreate(facility)).toThrow(
+        "Facility must have CW OBO OID when CW OBO active"
+      );
+    });
+  });
+});

--- a/packages/api/src/command/medical/facility/__tests__/create-facility.ts
+++ b/packages/api/src/command/medical/facility/__tests__/create-facility.ts
@@ -1,0 +1,83 @@
+import { faker } from "@faker-js/faker";
+import { DeepNullable } from "ts-essentials";
+import { FacilityCreate, FacilityType, isOboFacility } from "../../../../domain/medical/facility";
+import { makeFacilityData } from "../../../../domain/medical/__tests__/facility";
+import { makeBaseDomain } from "../../../../domain/__tests__/base-domain";
+import { FacilityCreateCmd } from "../create-facility";
+
+export function makeFacilityCreateCmd(
+  params: Partial<DeepNullable<FacilityCreateCmd>> & Partial<Pick<FacilityCreateCmd, "data">> = {}
+): FacilityCreateCmd {
+  const type =
+    params.type !== undefined
+      ? params.type
+      : faker.helpers.arrayElement(Object.values(FacilityType));
+  const cqOboActive =
+    params.cqOboActive !== undefined
+      ? params.cqOboActive
+      : type && isOboFacility(type)
+      ? true
+      : false;
+  const cwOboActive =
+    params.cwOboActive !== undefined
+      ? params.cwOboActive
+      : type && isOboFacility(type)
+      ? true
+      : false;
+
+  const preResponse = {
+    ...makeBaseDomain(),
+    cxId: params.cxId ?? faker.string.uuid(),
+    cqOboActive: cqOboActive ?? undefined,
+    cwOboActive: cwOboActive ?? undefined,
+    cqOboOid:
+      params.cqOboOid != undefined
+        ? params.cqOboOid
+        : cqOboActive
+        ? faker.string.uuid()
+        : undefined,
+    cwOboOid:
+      params.cwOboOid != undefined
+        ? params.cwOboOid
+        : cwOboActive
+        ? faker.string.uuid()
+        : undefined,
+    type: type ?? undefined,
+    data: makeFacilityData(params.data),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id, eTag, createdAt, updatedAt, ...resp } = preResponse;
+  return resp;
+}
+
+export function makeFacilityCreate(
+  params: Partial<DeepNullable<FacilityCreate>> & Partial<Pick<FacilityCreate, "data">> = {}
+): FacilityCreate {
+  const type = params.type ?? faker.helpers.arrayElement(Object.values(FacilityType));
+  const cqOboActive =
+    params.cqOboActive != undefined
+      ? params.cqOboActive
+      : type && isOboFacility(type)
+      ? faker.datatype.boolean()
+      : false;
+  const cwOboActive =
+    params.cwOboActive != undefined
+      ? params.cwOboActive
+      : type && isOboFacility(type)
+      ? faker.datatype.boolean()
+      : false;
+  return {
+    ...makeBaseDomain(),
+    oid: params.oid ?? faker.string.uuid(),
+    facilityNumber: params.facilityNumber ?? faker.number.int(),
+    cxId: params.cxId ?? faker.string.uuid(),
+    cqOboActive: cqOboActive,
+    cwOboActive: cwOboActive,
+    cqOboOid:
+      params.cqOboOid !== undefined ? params.cqOboOid : cqOboActive ? faker.string.uuid() : null,
+    cwOboOid:
+      params.cwOboOid !== undefined ? params.cwOboOid : cwOboActive ? faker.string.uuid() : null,
+    type,
+    data: makeFacilityData(params.data),
+  };
+}

--- a/packages/api/src/command/medical/facility/__tests__/create-facility.ts
+++ b/packages/api/src/command/medical/facility/__tests__/create-facility.ts
@@ -3,11 +3,10 @@ import { DeepNullable } from "ts-essentials";
 import { FacilityCreate, FacilityType, isOboFacility } from "../../../../domain/medical/facility";
 import { makeFacilityData } from "../../../../domain/medical/__tests__/facility";
 import { makeBaseDomain } from "../../../../domain/__tests__/base-domain";
-import { FacilityCreateCmd } from "../create-facility";
 
 export function makeFacilityCreateCmd(
-  params: Partial<DeepNullable<FacilityCreateCmd>> & Partial<Pick<FacilityCreateCmd, "data">> = {}
-): FacilityCreateCmd {
+  params: Partial<DeepNullable<FacilityCreate>> & Partial<Pick<FacilityCreate, "data">> = {}
+): FacilityCreate {
   const type =
     params.type !== undefined
       ? params.type
@@ -68,8 +67,6 @@ export function makeFacilityCreate(
       : false;
   return {
     ...makeBaseDomain(),
-    oid: params.oid ?? faker.string.uuid(),
-    facilityNumber: params.facilityNumber ?? faker.number.int(),
     cxId: params.cxId ?? faker.string.uuid(),
     cqOboActive: cqOboActive,
     cwOboActive: cwOboActive,

--- a/packages/api/src/command/medical/facility/__tests__/update-facility.test.ts
+++ b/packages/api/src/command/medical/facility/__tests__/update-facility.test.ts
@@ -1,0 +1,118 @@
+import { faker } from "@faker-js/faker";
+import { Facility, FacilityType } from "../../../../domain/medical/facility";
+import { makeFacility } from "../../../../domain/medical/__tests__/facility";
+import * as createFacility from "../create-facility";
+import { validateUpdate } from "../update-facility";
+import { makeFacilityUpdateCmd } from "./update-facility";
+
+function makeValidUpdateCmd(params: Partial<Facility> = {}) {
+  return makeFacilityUpdateCmd({
+    type: FacilityType.initiatorOnly,
+    cwOboActive: true,
+    cqOboActive: true,
+    ...params,
+  });
+}
+
+describe("updateFacility", () => {
+  describe("validate", () => {
+    let validateCreate_mock: jest.SpyInstance;
+    beforeAll(() => {
+      jest.restoreAllMocks();
+      validateCreate_mock = jest.spyOn(createFacility, "validateCreate").mockReturnValue(true);
+    });
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it("calls validateCreate", async () => {
+      const existing = makeFacility();
+      const updateFac = makeValidUpdateCmd();
+      updateFac.type = undefined;
+      updateFac.cqOboActive = undefined;
+      updateFac.cwOboActive = undefined;
+      updateFac.cqOboOid = undefined;
+      updateFac.cwOboOid = undefined;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { type, cqOboActive, cwOboActive, cqOboOid, cwOboOid, ...updateWithoutObo } = updateFac;
+      validateUpdate(existing, updateFac);
+      expect(validateCreate_mock).toHaveBeenCalledWith({
+        ...existing,
+        ...updateWithoutObo,
+      });
+    });
+
+    it("uses existing type when update is not present", async () => {
+      const existing = makeFacility({ type: FacilityType.initiatorOnly });
+      const updateFac = makeValidUpdateCmd();
+      updateFac.type = undefined;
+      const res = validateUpdate(existing, updateFac);
+      expect(res).toBeTruthy();
+      expect(res).toEqual(expect.objectContaining({ type: existing.type }));
+    });
+
+    it("uses existing CQ data when update is not present", async () => {
+      const existing = makeFacility({ cqOboActive: true, cqOboOid: faker.string.uuid() });
+      const updateFac = makeValidUpdateCmd();
+      updateFac.cqOboActive = undefined;
+      updateFac.cqOboOid = undefined;
+      const res = validateUpdate(existing, updateFac);
+      expect(res).toBeTruthy();
+      expect(res).toEqual(
+        expect.objectContaining({
+          cqOboActive: existing.cqOboActive,
+          cqOboOid: existing.cqOboOid,
+        })
+      );
+    });
+
+    it("uses existing CW data when update is not present", async () => {
+      const existing = makeFacility({ cwOboActive: true, cwOboOid: faker.string.uuid() });
+      const updateFac = makeValidUpdateCmd();
+      updateFac.cwOboActive = undefined;
+      updateFac.cwOboOid = undefined;
+      const res = validateUpdate(existing, updateFac);
+      expect(res).toBeTruthy();
+      expect(res).toEqual(
+        expect.objectContaining({
+          cwOboActive: existing.cwOboActive,
+          cwOboOid: existing.cwOboOid,
+        })
+      );
+    });
+
+    it("uses update type when provided", async () => {
+      const existing = makeFacility({ type: FacilityType.initiatorOnly });
+      const updateFac = makeFacility({ type: FacilityType.initiatorAndResponder });
+      const res = validateUpdate(existing, updateFac);
+      expect(res).toBeTruthy();
+      expect(res).toEqual(expect.objectContaining({ type: updateFac.type }));
+    });
+
+    it("uses update CQ data when provided", async () => {
+      const existing = makeFacility({ cqOboActive: false, cqOboOid: faker.string.uuid() });
+      const updateFac = makeValidUpdateCmd({ cqOboActive: true, cqOboOid: faker.string.uuid() });
+      const res = validateUpdate(existing, updateFac);
+      expect(res).toBeTruthy();
+      expect(res).toEqual(
+        expect.objectContaining({
+          cqOboActive: updateFac.cqOboActive,
+          cqOboOid: updateFac.cqOboOid,
+        })
+      );
+    });
+
+    it("uses update CW data when provided", async () => {
+      const existing = makeFacility({ cwOboActive: false, cwOboOid: faker.string.uuid() });
+      const updateFac = makeValidUpdateCmd({ cwOboActive: true, cwOboOid: faker.string.uuid() });
+      const res = validateUpdate(existing, updateFac);
+      expect(res).toBeTruthy();
+      expect(res).toEqual(
+        expect.objectContaining({
+          cwOboActive: updateFac.cwOboActive,
+          cwOboOid: updateFac.cwOboOid,
+        })
+      );
+    });
+  });
+});

--- a/packages/api/src/command/medical/facility/__tests__/update-facility.ts
+++ b/packages/api/src/command/medical/facility/__tests__/update-facility.ts
@@ -1,0 +1,8 @@
+import { makeFacility } from "../../../../domain/medical/__tests__/facility";
+import { FacilityUpdateCmd } from "../update-facility";
+
+export function makeFacilityUpdateCmd(params: Partial<FacilityUpdateCmd> = {}): FacilityUpdateCmd {
+  return {
+    ...makeFacility(params),
+  };
+}

--- a/packages/api/src/command/medical/facility/create-facility.ts
+++ b/packages/api/src/command/medical/facility/create-facility.ts
@@ -1,6 +1,23 @@
+import BadRequestError from "@metriport/core/util/error/bad-request";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
-import { FacilityData, FacilityType } from "../../../domain/medical/facility";
+import {
+  FacilityCreate,
+  FacilityData,
+  FacilityType,
+  isOboFacility,
+  Facility,
+} from "../../../domain/medical/facility";
 import { FacilityModel } from "../../../models/medical/facility";
+
+export type FacilityCreateCmd = {
+  cxId: string;
+  data: FacilityData;
+  type?: FacilityType;
+  cqOboActive?: boolean;
+  cwOboActive?: boolean;
+  cqOboOid?: string;
+  cwOboOid?: string;
+};
 
 export const createFacility = async ({
   cxId,
@@ -10,25 +27,43 @@ export const createFacility = async ({
   cwOboActive = false,
   cqOboOid,
   cwOboOid,
-}: {
-  cxId: string;
-  data: FacilityData;
-  type?: FacilityType;
-  cqOboActive?: boolean;
-  cwOboActive?: boolean;
-  cqOboOid?: string;
-  cwOboOid?: string;
-}): Promise<FacilityModel> => {
-  return FacilityModel.create({
+}: FacilityCreateCmd): Promise<Facility> => {
+  const input: FacilityCreate = {
     id: uuidv7(),
-    cxId,
-    type,
     oid: "", // will be set when facility is created in hook
     facilityNumber: 0, // will be set when facility is created in hook
+    cxId,
+    type,
     cqOboActive,
     cwOboActive,
-    cqOboOid,
-    cwOboOid,
+    cqOboOid: cqOboOid ?? null,
+    cwOboOid: cwOboOid ?? null,
     data,
-  });
+  };
+  validateCreate(input);
+  return FacilityModel.create(input);
 };
+
+export function validateCreate(facility: FacilityCreate, throwOnError = true): boolean {
+  const { type, cqOboActive, cwOboActive, cqOboOid, cwOboOid } = facility;
+
+  if (isOboFacility(type) && !cqOboActive && !cwOboActive) {
+    if (!throwOnError) return false;
+    throw new BadRequestError("OBO facility must have at least one OBO active");
+  }
+  if (!isOboFacility(type) && (cqOboActive || cwOboActive)) {
+    if (!throwOnError) return false;
+    throw new BadRequestError("Non-OBO facility cannot have OBO active");
+  }
+
+  if (cqOboActive && !cqOboOid) {
+    if (!throwOnError) return false;
+    throw new BadRequestError("Facility must have CQ OBO OID when CQ OBO active");
+  }
+  if (cwOboActive && !cwOboOid) {
+    if (!throwOnError) return false;
+    throw new BadRequestError("Facility must have CW OBO OID when CW OBO active");
+  }
+
+  return true;
+}

--- a/packages/api/src/command/medical/facility/create-facility.ts
+++ b/packages/api/src/command/medical/facility/create-facility.ts
@@ -1,23 +1,12 @@
 import BadRequestError from "@metriport/core/util/error/bad-request";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import {
+  Facility,
   FacilityCreate,
-  FacilityData,
   FacilityType,
   isOboFacility,
-  Facility,
 } from "../../../domain/medical/facility";
 import { FacilityModel } from "../../../models/medical/facility";
-
-export type FacilityCreateCmd = {
-  cxId: string;
-  data: FacilityData;
-  type?: FacilityType;
-  cqOboActive?: boolean;
-  cwOboActive?: boolean;
-  cqOboOid?: string;
-  cwOboOid?: string;
-};
 
 export const createFacility = async ({
   cxId,
@@ -27,8 +16,8 @@ export const createFacility = async ({
   cwOboActive = false,
   cqOboOid,
   cwOboOid,
-}: FacilityCreateCmd): Promise<Facility> => {
-  const input: FacilityCreate = {
+}: FacilityCreate): Promise<Facility> => {
+  const input = {
     id: uuidv7(),
     oid: "", // will be set when facility is created in hook
     facilityNumber: 0, // will be set when facility is created in hook

--- a/packages/api/src/command/medical/facility/update-facility.ts
+++ b/packages/api/src/command/medical/facility/update-facility.ts
@@ -1,17 +1,27 @@
-import { FacilityUpdate } from "../../../domain/medical/facility";
-import { validateVersionForUpdate } from "../../../models/_default";
+import { Facility } from "../../../domain/medical/facility";
 import { FacilityModel } from "../../../models/medical/facility";
+import { validateVersionForUpdate } from "../../../models/_default";
 import { BaseUpdateCmdWithCustomer } from "../base-update-command";
+import { validateCreate } from "./create-facility";
 import { getFacilityOrFail } from "./get-facility";
 
-export type FacilityUpdateCmd = BaseUpdateCmdWithCustomer & FacilityUpdate;
+type PartialProps = "eTag" | "type" | "cqOboActive" | "cwOboActive" | "cqOboOid" | "cwOboOid";
+
+export type FacilityUpdateCmd = BaseUpdateCmdWithCustomer &
+  Omit<Facility, "oid" | "facilityNumber" | "createdAt" | "updatedAt" | PartialProps> &
+  Partial<Pick<Facility, PartialProps>>;
 
 export const updateFacility = async (facilityUpdate: FacilityUpdateCmd): Promise<FacilityModel> => {
-  const { id, cxId, eTag, data, cqOboActive, cwOboActive, cqOboOid, cwOboOid } = facilityUpdate;
-  const { name, npi, tin, active, address } = data;
+  const { id, cxId, eTag } = facilityUpdate;
 
   const facility = await getFacilityOrFail({ id, cxId });
   validateVersionForUpdate(facility, eTag);
+
+  const { data, cqOboActive, cwOboActive, cqOboOid, cwOboOid } = validateUpdate(
+    facility,
+    facilityUpdate
+  );
+  const { name, npi, tin, active, address } = data;
 
   return facility.update({
     data: {
@@ -21,9 +31,29 @@ export const updateFacility = async (facilityUpdate: FacilityUpdateCmd): Promise
       active,
       address,
     },
-    cqOboActive: cqOboActive ?? false,
-    cwOboActive: cwOboActive ?? false,
+    cqOboActive,
+    cwOboActive,
     cqOboOid,
     cwOboOid,
   });
 };
+
+export function validateUpdate(existing: Facility, updateFac: FacilityUpdateCmd): Facility {
+  const type = updateFac.type ?? existing.type;
+  const cqOboActive = updateFac.cqOboActive ?? existing.cqOboActive;
+  const cwOboActive = updateFac.cwOboActive ?? existing.cwOboActive;
+  const cqOboOid = updateFac.cqOboOid === undefined ? existing.cqOboOid : updateFac.cqOboOid;
+  const cwOboOid = updateFac.cwOboOid === undefined ? existing.cwOboOid : updateFac.cwOboOid;
+
+  const result = {
+    ...existing,
+    ...updateFac,
+    type,
+    cqOboActive,
+    cwOboActive,
+    cqOboOid,
+    cwOboOid,
+  };
+  validateCreate(result);
+  return result;
+}

--- a/packages/api/src/domain/medical/__tests__/facility.ts
+++ b/packages/api/src/domain/medical/__tests__/facility.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { makeBaseDomain } from "../../__tests__/base-domain";
-import { Facility, FacilityData, FacilityType, makeFacilityOid } from "../facility";
+import { Facility, FacilityData, FacilityType, isOboFacility, makeFacilityOid } from "../facility";
 import { makeAddressStrict } from "./location-address";
 import { makeOrgNumber } from "./organization";
 
@@ -26,8 +26,19 @@ export function makeFacility(params: Partial<Facility> = {}): Facility {
   const facilityNumber =
     params.facilityNumber ?? getNumberFromOid(params.oid) ?? makeFacilityNumber();
   const oid = params.oid ?? makeFacilityOid(makeOrgNumber(), facilityNumber);
-  const cqOboActive = params.cqOboActive ?? faker.datatype.boolean();
-  const cwOboActive = params.cwOboActive ?? faker.datatype.boolean();
+  const type = params.type ?? faker.helpers.arrayElement(Object.values(FacilityType));
+  const cqOboActive =
+    params.cqOboActive !== undefined
+      ? params.cqOboActive
+      : isOboFacility(type)
+      ? faker.datatype.boolean()
+      : false;
+  const cwOboActive =
+    params.cwOboActive !== undefined
+      ? params.cwOboActive
+      : isOboFacility(type)
+      ? faker.datatype.boolean()
+      : false;
   return {
     ...makeBaseDomain(),
     ...(params.id ? { id: params.id } : {}),
@@ -40,7 +51,7 @@ export function makeFacility(params: Partial<Facility> = {}): Facility {
       params.cqOboOid !== undefined ? params.cqOboOid : cqOboActive ? faker.string.uuid() : null,
     cwOboOid:
       params.cwOboOid !== undefined ? params.cwOboOid : cwOboActive ? faker.string.uuid() : null,
-    type: params.type ?? faker.helpers.arrayElement(Object.values(FacilityType)),
+    type,
     data: makeFacilityData(params.data),
   };
 }

--- a/packages/api/src/domain/medical/facility.ts
+++ b/packages/api/src/domain/medical/facility.ts
@@ -30,14 +30,6 @@ export interface FacilityCreate extends BaseDomainCreate {
   data: FacilityData;
 }
 
-export interface FacilityUpdate {
-  data: FacilityData;
-  cqOboActive?: boolean;
-  cwOboActive?: boolean;
-  cqOboOid?: string;
-  cwOboOid?: string;
-}
-
 export interface Facility extends BaseDomain, FacilityCreate {}
 
 export function makeFacilityOid(orgNumber: number, facilityNumber: number) {

--- a/packages/api/src/domain/medical/facility.ts
+++ b/packages/api/src/domain/medical/facility.ts
@@ -18,19 +18,20 @@ export type FacilityData = {
   address: AddressStrict;
 };
 
-export interface FacilityCreate extends BaseDomainCreate {
+export interface FacilityCreate extends Omit<BaseDomainCreate, "id"> {
   cxId: string;
-  oid: string;
-  facilityNumber: number;
-  cqOboActive: boolean;
-  cwOboActive: boolean;
-  cqOboOid: string | null;
-  cwOboOid: string | null;
-  type: FacilityType;
+  cqOboActive?: boolean;
+  cwOboActive?: boolean;
+  cqOboOid?: string | null;
+  cwOboOid?: string | null;
+  type?: FacilityType;
   data: FacilityData;
 }
 
-export interface Facility extends BaseDomain, FacilityCreate {}
+export interface Facility extends BaseDomain, Required<FacilityCreate> {
+  oid: string;
+  facilityNumber: number;
+}
 
 export function makeFacilityOid(orgNumber: number, facilityNumber: number) {
   return `${Config.getSystemRootOID()}.${OIDNode.organizations}.${orgNumber}.${
@@ -38,7 +39,7 @@ export function makeFacilityOid(orgNumber: number, facilityNumber: number) {
   }.${facilityNumber}`;
 }
 
-export function isOboFacility(facilityType: FacilityType): boolean {
+export function isOboFacility(facilityType?: FacilityType): boolean {
   return facilityType === FacilityType.initiatorOnly;
 }
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1706

### Dependencies

- downstream: https://github.com/metriport/metriport/pull/2078

### Description

- add `type` to facility update
- adjust type of facility create
- add validation to facility create and update
- add unit tests

### Testing

- Local
  - none (done w/ downstream PR)
- Staging
  - [ ] create facility using dash
  - [ ] update facility using dash
  - [ ] create OBO facility for CQ
  - [ ] create OBO facility for CW
  - [ ] disable OBO facility both CQ and CW - requires change on type to non-OBO
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
