### PR TITLE
PATCH update pd start time

### DIFF
--- a/packages/api/src/command/medical/patient/update-patient.ts
+++ b/packages/api/src/command/medical/patient/update-patient.ts
@@ -97,6 +97,7 @@ export async function updatePatientWithoutHIEs(
           personalIdentifiers: sanitized.personalIdentifiers,
           address: patientUpdate.address,
           contact: sanitized.contact,
+          patientDiscovery: sanitized.patientDiscovery,
         },
         externalId: sanitized.externalId,
       },


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Dependencies

- Upstream: none
- Downstream: none

### Description

Start time is not updated when doing a patient update for pd

### Testing

- Local
  - [x] updates the start time
- Production
  - [ ] monitor

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
