### PR TITLE
1734 Set db maintenance window on IHE GW

### DIFF
--- a/packages/infra/lib/ihe-stack/ihe-db-construct.ts
+++ b/packages/infra/lib/ihe-stack/ihe-db-construct.ts
@@ -66,6 +66,7 @@ export default class IHEDBConstruct extends Construct {
         enablePerformanceInsights: true,
         parameterGroup,
       },
+      preferredMaintenanceWindow: config.rds.maintenanceWindow,
       credentials: dbCreds,
       defaultDatabaseName: dbName,
       clusterIdentifier: dbClusterName,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1734

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1968
- Downstream: none

### Description

Set db maintenance window on IHE GW - it was added to config but not to the CDK construct.

### Testing

See upstream PR

### Release Plan

- [ ] Merge this
