### PR TITLE
1743 Additional SOC2 alarms

### DIFF
--- a/packages/infra/config/aws/rds.ts
+++ b/packages/infra/config/aws/rds.ts
@@ -1,7 +1,11 @@
 export type RDSAlarmThresholds = {
   acuUtilizationPct: number;
   cpuUtilizationPct: number;
-  freeableMemoryMB: number;
-  volumeReadIOPs: number;
-  volumeWriteIOPs: number;
+  freeableMemoryMb: number;
+  volumeReadIops: number;
+  volumeWriteIops: number;
+  /**
+   * The amount of available storage in MB. Defaults to 10GB.
+   */
+  freeLocalStorageMb?: number;
 };

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -1,4 +1,5 @@
 import { EnvType } from "../lib/env-type";
+import { RDSAlarmThresholds } from "./aws/rds";
 import { IHEGatewayProps } from "./ihe-gateway-config";
 
 export type ConnectWidgetConfig = {
@@ -69,6 +70,10 @@ type EnvConfigBase = {
      * @see: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.ParameterGroups.html#AuroraPostgreSQL.Reference.Parameters.Cluster
      */
     minSlowLogDurationInMs?: number;
+    /**
+     * The thresholds for the RDS alarms.
+     */
+    alarmThresholds: RDSAlarmThresholds;
   };
   loadBalancerDnsName: string;
   apiGatewayUsagePlanId?: string; // optional since we need to create the stack first, then update this and redeploy

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -16,6 +16,13 @@ export const config: EnvConfigNonSandbox = {
     maintenanceWindow: "Sun:02:00-Sun:02:30",
     minCapacity: 0.5,
     maxCapacity: 1,
+    alarmThresholds: {
+      acuUtilizationPct: 80,
+      cpuUtilizationPct: 80,
+      freeableMemoryMb: 1_000,
+      volumeReadIops: 2_000,
+      volumeWriteIops: 2_000,
+    },
   },
   loadBalancerDnsName: "<your-load-balancer-dns-name>",
   fhirToMedicalLambda: {

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -183,6 +183,9 @@ export class APIStack extends Stack {
       clusterIdentifier: dbClusterName,
       storageEncrypted: true,
       parameterGroup,
+      cloudwatchLogsExports: ["postgresql"],
+      deletionProtection: true,
+      removalPolicy: RemovalPolicy.RETAIN,
     });
     const minDBCap = this.isProd(props) ? 2 : 0.5;
     const maxDBCap = this.isProd(props) ? 16 : 2;

--- a/packages/infra/lib/api-stack/alarm-slack-chatbot.ts
+++ b/packages/infra/lib/api-stack/alarm-slack-chatbot.ts
@@ -49,7 +49,7 @@ export class AlarmSlackBot {
       notificationTopics: [...topics],
       role,
       loggingLevel: LoggingLevel.INFO,
-      logRetention: RetentionDays.ONE_MONTH,
+      logRetention: RetentionDays.ONE_YEAR,
     });
   }
 }

--- a/packages/infra/lib/api-stack/ccda-search-connector.ts
+++ b/packages/infra/lib/api-stack/ccda-search-connector.ts
@@ -9,7 +9,7 @@ import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
 import { IQueue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
 import { EnvType } from "../env-type";
-import { METRICS_NAMESPACE, getConfig } from "../shared/config";
+import { getConfig, METRICS_NAMESPACE } from "../shared/config";
 import { createLambda as defaultCreateLambda } from "../shared/lambda";
 import { LambdaLayers } from "../shared/lambda-layers";
 import OpenSearchConstruct, { OpenSearchConstructProps } from "../shared/open-search-construct";
@@ -129,6 +129,8 @@ export function setup({
     lambdaLayers: [lambdaLayers.shared],
     envType,
     alarmSnsAction,
+    alarmMaxAgeOfOldestMessage: Duration.minutes(1),
+    alarmMaxAgeOfOldestMessageDlq: Duration.minutes(5),
   });
 
   const dlq = queue.deadLetterQueue;

--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -73,6 +73,7 @@ export function createQueueAndBucket({
     lambdaLayers: [lambdaLayers.shared],
     envType,
     alarmSnsAction,
+    alarmMaxAgeOfOldestMessage: Duration.minutes(2),
   });
 
   const dlq = queue.deadLetterQueue;

--- a/packages/infra/lib/api-stack/fhir-server-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-server-connector.ts
@@ -86,6 +86,8 @@ export function createConnector({
     lambdaLayers: [lambdaLayers.shared],
     envType,
     alarmSnsAction,
+    alarmMaxAgeOfOldestMessage: Duration.minutes(2),
+    alarmMaxAgeOfOldestMessageDlq: Duration.minutes(5),
   });
 
   const dlq = queue.deadLetterQueue;

--- a/packages/infra/lib/ihe-stack/ihe-db-construct.ts
+++ b/packages/infra/lib/ihe-stack/ihe-db-construct.ts
@@ -1,4 +1,4 @@
-import { Aspects, CfnOutput } from "aws-cdk-lib";
+import { Aspects, CfnOutput, RemovalPolicy } from "aws-cdk-lib";
 import { BackupResource } from "aws-cdk-lib/aws-backup";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
@@ -73,6 +73,8 @@ export default class IHEDBConstruct extends Construct {
       storageEncrypted: true,
       parameterGroup,
       cloudwatchLogsExports: ["postgresql"],
+      deletionProtection: true,
+      removalPolicy: RemovalPolicy.RETAIN,
     });
     this.server = dbCluster;
 

--- a/packages/infra/lib/shared/cloudwatch-metric.ts
+++ b/packages/infra/lib/shared/cloudwatch-metric.ts
@@ -1,0 +1,35 @@
+import { Alarm, ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Construct } from "constructs";
+
+export function addAlarmToMetric({
+  scope,
+  metric,
+  alarmName,
+  threshold,
+  evaluationPeriods,
+  comparisonOperator,
+  treatMissingData,
+  alarmAction,
+  includeOkAction = true,
+}: {
+  scope: Construct;
+  metric: Metric;
+  alarmName: string;
+  threshold: number;
+  evaluationPeriods: number;
+  comparisonOperator?: ComparisonOperator;
+  treatMissingData?: TreatMissingData;
+  alarmAction?: SnsAction;
+  includeOkAction?: boolean;
+}): Alarm {
+  const alarm = metric.createAlarm(scope, alarmName, {
+    threshold,
+    evaluationPeriods,
+    comparisonOperator,
+    treatMissingData,
+  });
+  alarmAction && alarm.addAlarmAction(alarmAction);
+  alarmAction && includeOkAction && alarm.addOkAction(alarmAction);
+  return alarm;
+}


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1743

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1744
- Downstream: none

### Description

- add deletion protection to DBs
- add alarm on SQS' maxAgeOfOldestMessage 
- add alarm on RDS' freeLocalStorage 
- add alarm IHE GW's LB/TG metrics
- increase log retention of SlackConfig

### Testing

- Local
  - [x] cdk diff works
- Staging
  - [ ] successful deployment
  - [ ] deletion protection to DBs (API, IHE GW)
     - [x] no restart needed
  - [ ] SOC2 controls passing
- Sandbox
  - [ ] successful deployment
  - [ ] deletion protection to DBs (API, IHE GW)
  - [ ] SOC2 controls passing
- Production
  - [ ] successful deployment
  - [ ] deletion protection to DBs (API, IHE GW)
  - [ ] SOC2 controls passing

### Release Plan

- [ ] Merge upstream
- [ ] Merge this
