### PR TITLE
fix(api): make cq directory rebuild async

### DIFF
--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -63,7 +63,7 @@ router.post(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     if (Config.isSandbox()) return res.sendStatus(httpStatus.NOT_IMPLEMENTED);
-    await rebuildCQDirectory();
+    rebuildCQDirectory();
     return res.sendStatus(httpStatus.OK);
   })
 );


### PR DESCRIPTION
refs. metriport/metriport-internal#1350

### Description

 - Making the CQ directory rebuild route async, so the scheduled lambda quickly receives a return

### Testing
- Staging
  - [ ] Rebuild it on develop
- Production
  - [ ] Monitor rebuilding on prod

### Release Plan
- [ ] Merge this
