### PR TITLE
Fix: IHE Gateway V2 s3 files with wrong urls

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
@@ -18,7 +18,7 @@ import { DRSamlClientResponse } from "../send/dr-requests";
 import { successStatus, partialSuccessStatus } from "./constants";
 import { S3Utils } from "../../../../../aws/s3";
 import { Config } from "../../../../../../util/config";
-import { createFileName, createFilePath } from "../../../../../../domain/filename";
+import { createFileName, createFolderName } from "../../../../../../domain/filename";
 import { MetriportError } from "../../../../../../util/error/metriport-error";
 
 const bucket = Config.getMedicalDocumentsBucketName();
@@ -61,7 +61,10 @@ async function parseDocumentReference({
     outboundRequest.patientId,
     metriportId
   )}${fileExtension}`;
-  const filePath = createFilePath(outboundRequest.cxId, outboundRequest.patientId, fileName);
+  const filePath = `${createFolderName(
+    outboundRequest.cxId,
+    outboundRequest.patientId
+  )}/${fileName}`;
   const fileInfo = await s3Utils.getFileInfoFromS3(filePath, bucket);
 
   if (!fileInfo.exists) {

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
@@ -18,7 +18,11 @@ import { DRSamlClientResponse } from "../send/dr-requests";
 import { successStatus, partialSuccessStatus } from "./constants";
 import { S3Utils } from "../../../../../aws/s3";
 import { Config } from "../../../../../../util/config";
-import { createFileName, createFolderName } from "../../../../../../domain/filename";
+import { createFileName } from "../../../../../../domain/filename";
+import {
+  createDocumentFilePath,
+  createDocumentFileName,
+} from "../../../../../../domain/document/filename";
 import { MetriportError } from "../../../../../../util/error/metriport-error";
 
 const bucket = Config.getMedicalDocumentsBucketName();
@@ -49,22 +53,21 @@ async function parseDocumentReference({
   s3Utils: S3Utils;
   idMapping: Record<string, string>;
 }): Promise<DocumentReference> {
-  const { mimeType, fileExtension, decodedBytes } = parseFileFromString(documentResponse.Document);
+  const { mimeType, decodedBytes } = parseFileFromString(documentResponse.Document);
   const strippedDocUniqueId = stripUrnPrefix(documentResponse.DocumentUniqueId);
   const metriportId = idMapping[strippedDocUniqueId];
   if (!metriportId) {
     throw new MetriportError("MetriportId not found for document");
   }
 
-  const fileName = `${createFileName(
+  const fileName = createFileName(outboundRequest.cxId, outboundRequest.patientId, metriportId);
+  const documentFileName = createDocumentFileName(fileName, mimeType);
+  const filePath = createDocumentFilePath(
     outboundRequest.cxId,
     outboundRequest.patientId,
-    metriportId
-  )}${fileExtension}`;
-  const filePath = `${createFolderName(
-    outboundRequest.cxId,
-    outboundRequest.patientId
-  )}/${fileName}`;
+    metriportId,
+    mimeType
+  );
   const fileInfo = await s3Utils.getFileInfoFromS3(filePath, bucket);
 
   if (!fileInfo.exists) {
@@ -80,7 +83,7 @@ async function parseDocumentReference({
     url: s3Utils.buildFileUrl(bucket, filePath),
     size: documentResponse.size ? parseInt(documentResponse.size) : undefined,
     title: documentResponse?.title,
-    fileName: fileName,
+    fileName: documentFileName,
     creation: documentResponse.creation,
     language: documentResponse.language,
     contentType: mimeType,


### PR DESCRIPTION
Ticket: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- patching urls stored on s3. 

### Testing

- Local
  - [x] unit tests [here](https://github.com/metriport/metriport/blob/1f2a6dc59aa252a30350b31921ece029c7a7e306/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dr.test.ts#L110) are actually failing. Now they pass 

### Release Plan

- [x] Merge this
