### PR TITLE
1040 1/3 Create new lambdas nested stack 

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -31,12 +31,12 @@ import { ITopic } from "aws-cdk-lib/aws-sns";
 import { Construct } from "constructs";
 import { EnvConfig, EnvConfigSandbox } from "../config/env-config";
 import { AlarmSlackBot } from "./api-stack/alarm-slack-chatbot";
-import { createScheduledAPIQuotaChecker } from "./api-stack/api-quota-checker";
+// import { createScheduledAPIQuotaChecker } from "./api-stack/api-quota-checker";
 import { createAPIService } from "./api-stack/api-service";
 import * as ccdaSearch from "./api-stack/ccda-search-connector";
 import { createCqDirectoryRebuilder } from "./api-stack/cq-directory-rebuilder";
 import * as cwEnhancedCoverageConnector from "./api-stack/cw-enhanced-coverage-connector";
-import { createScheduledDBMaintenance } from "./api-stack/db-maintenance";
+// import { createScheduledDBMaintenance } from "./api-stack/db-maintenance";
 import { createDocQueryChecker } from "./api-stack/doc-query-checker";
 import * as documentUploader from "./api-stack/document-upload";
 import * as fhirConverterConnector from "./api-stack/fhir-converter-connector";
@@ -841,18 +841,19 @@ export class APIStack extends Stack {
       },
     });
 
-    createScheduledAPIQuotaChecker({
-      stack: this,
-      lambdaLayers,
-      vpc: this.vpc,
-      apiAddress: apiLoadBalancerAddress,
-    });
-    createScheduledDBMaintenance({
-      stack: this,
-      lambdaLayers,
-      vpc: this.vpc,
-      apiAddress: apiLoadBalancerAddress,
-    });
+    // TODO 1040 temporarily remove these
+    // createScheduledAPIQuotaChecker({
+    //   stack: this,
+    //   lambdaLayers,
+    //   vpc: this.vpc,
+    //   apiAddress: apiLoadBalancerAddress,
+    // });
+    // createScheduledDBMaintenance({
+    //   stack: this,
+    //   lambdaLayers,
+    //   vpc: this.vpc,
+    //   apiAddress: apiLoadBalancerAddress,
+    // });
 
     //-------------------------------------------
     // Backups

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -1,0 +1,348 @@
+import { Duration, NestedStack, NestedStackProps } from "aws-cdk-lib";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Function as Lambda } from "aws-cdk-lib/aws-lambda";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as secret from "aws-cdk-lib/aws-secretsmanager";
+import { Construct } from "constructs";
+import { EnvConfig } from "../config/env-config";
+import { EnvType } from "./env-type";
+import { createLambda } from "./shared/lambda";
+import { LambdaLayers, setupLambdasLayers } from "./shared/lambda-layers";
+import { Secrets } from "./shared/secrets";
+
+export const CDA_TO_VIS_TIMEOUT = Duration.minutes(15);
+
+interface LambdasNestedStackProps extends NestedStackProps {
+  config: EnvConfig;
+  vpc: ec2.IVpc;
+  secrets: Secrets;
+  dbCluster: rds.IDatabaseCluster;
+  dbCredsSecret: secret.ISecret;
+  medicalDocumentsBucket: s3.Bucket;
+  sandboxSeedDataBucket: s3.IBucket | undefined;
+  alarmAction?: SnsAction;
+}
+
+export class LambdasNestedStack extends NestedStack {
+  readonly lambdaLayers: LambdaLayers;
+  readonly cdaToVisualizationLambda: Lambda;
+  readonly documentDownloaderLambda: lambda.Function;
+  readonly outboundPatientDiscoveryLambda: lambda.Function;
+  readonly outboundDocumentQueryLambda: lambda.Function;
+  readonly outboundDocumentRetrievalLambda: lambda.Function;
+
+  constructor(scope: Construct, id: string, props: LambdasNestedStackProps) {
+    super(scope, id, props);
+
+    this.lambdaLayers = setupLambdasLayers(this);
+
+    this.cdaToVisualizationLambda = this.setupCdaToVisualization({
+      lambdaLayers: this.lambdaLayers,
+      vpc: props.vpc,
+      envType: props.config.environmentType,
+      medicalDocumentsBucket: props.medicalDocumentsBucket,
+      sandboxSeedDataBucket: props.sandboxSeedDataBucket,
+      sentryDsn: props.config.lambdasSentryDSN,
+      alarmAction: props.alarmAction,
+    });
+
+    this.documentDownloaderLambda = this.setupDocumentDownloader({
+      lambdaLayers: this.lambdaLayers,
+      vpc: props.vpc,
+      secrets: props.secrets,
+      cwOrgCertificate: props.config.cwSecretNames.CW_ORG_CERTIFICATE,
+      cwOrgPrivateKey: props.config.cwSecretNames.CW_ORG_PRIVATE_KEY,
+      bucketName: props.medicalDocumentsBucket.bucketName,
+      envType: props.config.environmentType,
+      sentryDsn: props.config.lambdasSentryDSN,
+    });
+
+    this.outboundPatientDiscoveryLambda = this.setupOutboundPatientDiscovery({
+      lambdaLayers: this.lambdaLayers,
+      vpc: props.vpc,
+      envType: props.config.environmentType,
+      sentryDsn: props.config.lambdasSentryDSN,
+      alarmAction: props.alarmAction,
+      dbCluster: props.dbCluster,
+      dbCredsSecret: props.dbCredsSecret,
+      // TODO move this to a config
+      maxPollingDuration: Duration.minutes(11),
+    });
+
+    this.outboundDocumentQueryLambda = this.setupOutboundDocumentQuery({
+      lambdaLayers: this.lambdaLayers,
+      vpc: props.vpc,
+      envType: props.config.environmentType,
+      sentryDsn: props.config.lambdasSentryDSN,
+      alarmAction: props.alarmAction,
+      dbCluster: props.dbCluster,
+      dbCredsSecret: props.dbCredsSecret,
+      // TODO move this to a config
+      maxPollingDuration: Duration.minutes(15),
+    });
+
+    this.outboundDocumentRetrievalLambda = this.setupOutboundDocumentRetrieval({
+      lambdaLayers: this.lambdaLayers,
+      vpc: props.vpc,
+      envType: props.config.environmentType,
+      sentryDsn: props.config.lambdasSentryDSN,
+      alarmAction: props.alarmAction,
+      dbCluster: props.dbCluster,
+      dbCredsSecret: props.dbCredsSecret,
+      // TODO move this to a config
+      maxPollingDuration: Duration.minutes(15),
+    });
+  }
+
+  private setupCdaToVisualization(ownProps: {
+    lambdaLayers: LambdaLayers;
+    vpc: ec2.IVpc;
+    envType: EnvType;
+    medicalDocumentsBucket: s3.Bucket;
+    sandboxSeedDataBucket: s3.IBucket | undefined;
+    sentryDsn: string | undefined;
+    alarmAction: SnsAction | undefined;
+  }): Lambda {
+    const {
+      lambdaLayers,
+      vpc,
+      sentryDsn,
+      envType,
+      alarmAction,
+      medicalDocumentsBucket,
+      sandboxSeedDataBucket,
+    } = ownProps;
+
+    const cdaToVisualizationLambda = createLambda({
+      stack: this,
+      name: "CdaToVisualization",
+      runtime: lambda.Runtime.NODEJS_16_X,
+      entry: "cda-to-visualization",
+      envType,
+      envVars: {
+        CDA_TO_VIS_TIMEOUT_MS: CDA_TO_VIS_TIMEOUT.toMilliseconds().toString(),
+        ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
+      },
+      layers: [lambdaLayers.shared, lambdaLayers.chromium],
+      memory: 1024,
+      timeout: CDA_TO_VIS_TIMEOUT,
+      vpc,
+      alarmSnsAction: alarmAction,
+    });
+
+    medicalDocumentsBucket.grantReadWrite(cdaToVisualizationLambda);
+
+    if (sandboxSeedDataBucket) {
+      sandboxSeedDataBucket.grantReadWrite(cdaToVisualizationLambda);
+    }
+
+    return cdaToVisualizationLambda;
+  }
+
+  /**
+   * We are intentionally not setting an alarm action for this lambda, as many issues
+   * may be caused outside of our system. To eliminate noise, we will not alarm on this
+   * lambda.
+   */
+  private setupDocumentDownloader(ownProps: {
+    lambdaLayers: LambdaLayers;
+    vpc: ec2.IVpc;
+    secrets: Secrets;
+    cwOrgCertificate: string;
+    cwOrgPrivateKey: string;
+    bucketName: string | undefined;
+    envType: EnvType;
+    sentryDsn: string | undefined;
+  }): Lambda {
+    const {
+      lambdaLayers,
+      vpc,
+      secrets,
+      cwOrgCertificate,
+      cwOrgPrivateKey,
+      bucketName,
+      envType,
+      sentryDsn,
+    } = ownProps;
+
+    const documentDownloaderLambda = createLambda({
+      stack: this,
+      name: "DocumentDownloader",
+      runtime: lambda.Runtime.NODEJS_18_X,
+      entry: "document-downloader",
+      envType,
+      envVars: {
+        TEST_ENV: "TEST",
+        CW_ORG_CERTIFICATE: cwOrgCertificate,
+        CW_ORG_PRIVATE_KEY: cwOrgPrivateKey,
+        ...(bucketName && {
+          MEDICAL_DOCUMENTS_BUCKET_NAME: bucketName,
+        }),
+        ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
+      },
+      layers: [lambdaLayers.shared],
+      memory: 512,
+      timeout: Duration.minutes(5),
+      vpc,
+    });
+
+    // granting secrets read access to lambda
+    const cwOrgCertificateKey = "CW_ORG_CERTIFICATE";
+    if (!secrets[cwOrgCertificateKey]) {
+      throw new Error(`${cwOrgCertificateKey} is not defined in config`);
+    }
+    secrets[cwOrgCertificateKey].grantRead(documentDownloaderLambda);
+
+    const cwOrgPrivateKeyKey = "CW_ORG_PRIVATE_KEY";
+    if (!secrets[cwOrgPrivateKeyKey]) {
+      throw new Error(`${cwOrgPrivateKeyKey} is not defined in config`);
+    }
+    secrets[cwOrgPrivateKeyKey].grantRead(documentDownloaderLambda);
+
+    return documentDownloaderLambda;
+  }
+
+  private setupOutboundPatientDiscovery(ownProps: {
+    lambdaLayers: LambdaLayers;
+    vpc: ec2.IVpc;
+    envType: EnvType;
+    dbCredsSecret: secret.ISecret;
+    dbCluster: rds.IDatabaseCluster;
+    maxPollingDuration: Duration;
+    sentryDsn: string | undefined;
+    alarmAction: SnsAction | undefined;
+  }): Lambda {
+    const {
+      lambdaLayers,
+      dbCredsSecret,
+      vpc,
+      sentryDsn,
+      envType,
+      alarmAction,
+      dbCluster,
+      maxPollingDuration,
+    } = ownProps;
+
+    const outboundPatientDiscoveryLambda = createLambda({
+      stack: this,
+      name: "OutboundPatientDiscovery",
+      entry: "ihe-outbound-patient-discovery",
+      envType,
+      envVars: {
+        ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
+        DB_CREDS: dbCredsSecret.secretArn,
+        MAX_POLLING_DURATION: maxPollingDuration
+          .minus(Duration.minutes(1))
+          .toMilliseconds()
+          .toString(),
+      },
+      layers: [lambdaLayers.shared],
+      memory: 512,
+      timeout: maxPollingDuration,
+      vpc,
+      alarmSnsAction: alarmAction,
+    });
+
+    dbCluster.connections.allowDefaultPortFrom(outboundPatientDiscoveryLambda);
+    dbCredsSecret.grantRead(outboundPatientDiscoveryLambda);
+
+    return outboundPatientDiscoveryLambda;
+  }
+
+  private setupOutboundDocumentQuery(ownProps: {
+    lambdaLayers: LambdaLayers;
+    vpc: ec2.IVpc;
+    envType: EnvType;
+    dbCredsSecret: secret.ISecret;
+    dbCluster: rds.IDatabaseCluster;
+    maxPollingDuration: Duration;
+    sentryDsn: string | undefined;
+    alarmAction: SnsAction | undefined;
+  }): Lambda {
+    const {
+      lambdaLayers,
+      dbCredsSecret,
+      vpc,
+      sentryDsn,
+      envType,
+      alarmAction,
+      dbCluster,
+      maxPollingDuration,
+    } = ownProps;
+
+    const outboundDocumentQueryLambda = createLambda({
+      stack: this,
+      name: "OutboundDocumentQuery",
+      entry: "ihe-outbound-document-query",
+      envType,
+      envVars: {
+        ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
+        DB_CREDS: dbCredsSecret.secretArn,
+        MAX_POLLING_DURATION: maxPollingDuration
+          .minus(Duration.minutes(1))
+          .toMilliseconds()
+          .toString(),
+      },
+      layers: [lambdaLayers.shared],
+      memory: 512,
+      timeout: maxPollingDuration,
+      vpc,
+      alarmSnsAction: alarmAction,
+    });
+
+    dbCluster.connections.allowDefaultPortFrom(outboundDocumentQueryLambda);
+    dbCredsSecret.grantRead(outboundDocumentQueryLambda);
+
+    return outboundDocumentQueryLambda;
+  }
+
+  private setupOutboundDocumentRetrieval(ownProps: {
+    lambdaLayers: LambdaLayers;
+    vpc: ec2.IVpc;
+    envType: EnvType;
+    dbCredsSecret: secret.ISecret;
+    dbCluster: rds.IDatabaseCluster;
+    maxPollingDuration: Duration;
+    sentryDsn: string | undefined;
+    alarmAction: SnsAction | undefined;
+  }): Lambda {
+    const {
+      lambdaLayers,
+      dbCredsSecret,
+      vpc,
+      sentryDsn,
+      envType,
+      alarmAction,
+      dbCluster,
+      maxPollingDuration,
+    } = ownProps;
+
+    const outboundDocumentRetrievalLambda = createLambda({
+      stack: this,
+      name: "OutboundDocumentRetrieval",
+      entry: "ihe-outbound-document-retrieval",
+      envType,
+      envVars: {
+        ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
+        DB_CREDS: dbCredsSecret.secretArn,
+        MAX_POLLING_DURATION: maxPollingDuration
+          .minus(Duration.minutes(1))
+          .toMilliseconds()
+          .toString(),
+      },
+      layers: [lambdaLayers.shared],
+      memory: 512,
+      timeout: maxPollingDuration,
+      vpc,
+      alarmSnsAction: alarmAction,
+    });
+
+    dbCluster.connections.allowDefaultPortFrom(outboundDocumentRetrievalLambda);
+    dbCredsSecret.grantRead(outboundDocumentRetrievalLambda);
+
+    return outboundDocumentRetrievalLambda;
+  }
+}

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -119,6 +119,7 @@ export class LambdasNestedStack extends NestedStack {
     const cdaToVisualizationLambda = createLambda({
       stack: this,
       name: "CdaToVisualization",
+      nameSuffix: "v2",
       runtime: lambda.Runtime.NODEJS_16_X,
       entry: "cda-to-visualization",
       envType,
@@ -171,6 +172,7 @@ export class LambdasNestedStack extends NestedStack {
     const documentDownloaderLambda = createLambda({
       stack: this,
       name: "DocumentDownloader",
+      nameSuffix: "v2",
       runtime: lambda.Runtime.NODEJS_18_X,
       entry: "document-downloader",
       envType,
@@ -229,6 +231,7 @@ export class LambdasNestedStack extends NestedStack {
     const outboundPatientDiscoveryLambda = createLambda({
       stack: this,
       name: "OutboundPatientDiscovery",
+      nameSuffix: "v2",
       entry: "ihe-outbound-patient-discovery",
       envType,
       envVars: {
@@ -276,6 +279,7 @@ export class LambdasNestedStack extends NestedStack {
     const outboundDocumentQueryLambda = createLambda({
       stack: this,
       name: "OutboundDocumentQuery",
+      nameSuffix: "v2",
       entry: "ihe-outbound-document-query",
       envType,
       envVars: {
@@ -323,6 +327,7 @@ export class LambdasNestedStack extends NestedStack {
     const outboundDocumentRetrievalLambda = createLambda({
       stack: this,
       name: "OutboundDocumentRetrieval",
+      nameSuffix: "v2",
       entry: "ihe-outbound-document-retrieval",
       envType,
       envVars: {

--- a/packages/infra/lib/shared/lambda-layers.ts
+++ b/packages/infra/lib/shared/lambda-layers.ts
@@ -9,20 +9,20 @@ export type LambdaLayers = Record<LambdaLayer, ILayerVersion>;
 export function setupLambdasLayers(stack: Stack, prefixStackName = false): LambdaLayers {
   const prefix = prefixStackName ? `${stack.stackName}-` : "";
   return {
-    shared: new LayerVersion(stack, `${prefix}lambdaNodeModules`, {
+    shared: new LayerVersion(stack, `${prefix}LambdaNodeModules`, {
       code: Code.fromAsset("../lambdas/layers/shared/shared-layer.zip"),
     }),
-    chromium: new LayerVersion(stack, `${prefix}chromium-layer`, {
+    chromium: new LayerVersion(stack, `${prefix}Chromium-layer`, {
       compatibleRuntimes: [Runtime.NODEJS_16_X],
       code: Code.fromAsset("../lambdas/layers/chromium"),
       description: "Adds chromium to the lambda",
     }),
-    dig: new LayerVersion(stack, `${prefix}dig-layer`, {
+    dig: new LayerVersion(stack, `${prefix}Dig-layer`, {
       compatibleRuntimes: [Runtime.NODEJS_16_X],
       code: Code.fromAsset("../lambdas/layers/dig-layer"),
       description: "Adds dig to the lambdas",
     }),
-    playwright: new LayerVersion(stack, `${prefix}playwrightLayer`, {
+    playwright: new LayerVersion(stack, `${prefix}PlaywrightLayer`, {
       code: Code.fromAsset("../lambdas/layers/playwright/dist/playwright-layer.zip"),
     }),
   };

--- a/packages/infra/lib/shared/lambda.ts
+++ b/packages/infra/lib/shared/lambda.ts
@@ -38,6 +38,7 @@ export const buildPolicy = (
 export interface LambdaProps extends StackProps {
   readonly stack: Construct;
   readonly name: string;
+  readonly nameSuffix?: string;
   /**
    * Name of the lambda file without the extension. The file must be a TS file and in the `lambdas/src` folder.
    */
@@ -61,8 +62,10 @@ export interface LambdaProps extends StackProps {
 }
 
 export function createLambda(props: LambdaProps): Lambda {
+  const functionNameSuffix = props.nameSuffix ? `_${props.nameSuffix}` : "";
+  const functionName = props.name + "Lambda" + functionNameSuffix;
   const lambda = new Lambda(props.stack, props.name, {
-    functionName: props.name + "Lambda",
+    functionName,
     runtime: props.runtime ?? Runtime.NODEJS_18_X,
     runtimeManagementMode: props.runtimeManagementMode,
     // TODO move our lambdas to use layers, quicker to deploy and execute them


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

- Upstream:
  - https://github.com/metriport/metriport/pull/2015
  - https://github.com/metriport/metriport/pull/2017
- Downstream:
   - https://github.com/metriport/metriport/pull/2022

### Description

- Part 1 of 3 to reintroduce moving lambdas to a nested stack - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1715010778920459).
   - Original PR: https://github.com/metriport/metriport/pull/2015
   - This time renaming the lambdas to avoid conflicts
- This PR only adds the new lambda nested stack, the next one will make the API use it
- Temporarily remove these to make up space for resources
   - `ScheduledAPIQuotaChecker`
   - `ScheduledDBMaintenance`

Context: https://metriport.slack.com/archives/C04DMKE9DME/p1715015443211939?thread_ts=1715010778.920459&cid=C04DMKE9DME

### Testing

- Local
  - [x] `cdk diff -c env=production APIInfrastructureStack ` within limits
     `Number of resources: 481 is approaching allowed maximum of 500`
- Staging
  - [ ] deploys successfully
  - [ ] api doesn't get restarted
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge AND DEPLOY this
- [ ] Merge downstream
