### PR TITLE
1743 Reintroduce additional SOC2 controls

### DIFF
--- a/packages/infra/lib/api-stack/fhir-converter-service.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-service.ts
@@ -11,6 +11,7 @@ import { EnvConfig } from "../../config/env-config";
 import { getConfig } from "../shared/config";
 import { vCPU } from "../shared/fargate";
 import { MAXIMUM_LAMBDA_TIMEOUT } from "../shared/lambda";
+import { addDefaultMetricsToTargetGroup } from "../shared/target-group";
 import { isProd } from "../shared/util";
 
 export function settings() {
@@ -134,6 +135,14 @@ export function createFHIRConverterService(
     targetUtilizationPercent: 80,
     scaleInCooldown: Duration.minutes(2),
     scaleOutCooldown: Duration.seconds(30),
+  });
+
+  const targetGroup = fargateService.targetGroup;
+  addDefaultMetricsToTargetGroup({
+    targetGroup,
+    scope: stack,
+    id: "FhirConverter",
+    alarmAction,
   });
 
   return { service: fargateService.service, address: serverAddress };

--- a/packages/infra/lib/ihe-stack/ihe-gw-construct.ts
+++ b/packages/infra/lib/ihe-stack/ihe-gw-construct.ts
@@ -196,7 +196,6 @@ export default class IHEGatewayConstruct extends Construct {
     const addPortToLB = (
       port: number,
       theLB: ApplicationLoadBalancer,
-      idx: number,
       healthcheckInterval?: Duration
     ) => {
       const existingListener = portToListener[port];
@@ -241,13 +240,12 @@ export default class IHEGatewayConstruct extends Construct {
         targetGroup,
         scope,
         id,
-        idx,
+        idx: port,
         alarmAction: props.alarmAction,
       });
     };
-    let albIdx = 0;
-    defaultPorts.forEach(port => addPortToLB(port, alb, albIdx++));
-    httpPorts.forEach(port => addPortToLB(port, alb, albIdx++, healthcheckIntervalAdditionalPorts));
+    defaultPorts.forEach(port => addPortToLB(port, alb));
+    httpPorts.forEach(port => addPortToLB(port, alb, healthcheckIntervalAdditionalPorts));
 
     this.server = fargateService.service;
     if (!patientDiscoveryListener || !documentQueryListener || !documentRetrievalListener) {

--- a/packages/infra/lib/shared/target-group.ts
+++ b/packages/infra/lib/shared/target-group.ts
@@ -1,0 +1,52 @@
+import { Duration } from "aws-cdk-lib";
+import { ComparisonOperator, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { ApplicationTargetGroup, HttpCodeTarget } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { Construct } from "constructs";
+import { addAlarmToMetric } from "../shared/cloudwatch-metric";
+
+export function addDefaultMetricsToTargetGroup({
+  targetGroup,
+  scope,
+  id,
+  idx = 0,
+  alarmAction,
+}: {
+  targetGroup: ApplicationTargetGroup;
+  scope: Construct;
+  id: string;
+  idx?: number;
+  alarmAction?: SnsAction;
+}) {
+  const name = `${id}_TargetGroup${idx}`;
+  addAlarmToMetric({
+    scope,
+    metric: targetGroup.metrics.unhealthyHostCount(),
+    alarmName: `${name}_UnhealthyRequestCount`,
+    threshold: 1,
+    evaluationPeriods: 1,
+    comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+    alarmAction,
+  });
+  addAlarmToMetric({
+    scope,
+    metric: targetGroup.metrics.targetResponseTime(),
+    alarmName: `${name}_TargetResponseTime`,
+    threshold: Duration.seconds(29).toSeconds(),
+    evaluationPeriods: 1,
+    comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+    alarmAction,
+  });
+  addAlarmToMetric({
+    scope,
+    metric: targetGroup.metrics.httpCodeTarget(HttpCodeTarget.TARGET_5XX_COUNT),
+    alarmName: `${name}_Target5xxCount`,
+    threshold: 5,
+    evaluationPeriods: 1,
+    comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+    alarmAction,
+  });
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1743

### Dependencies

- Upstream:
   - https://github.com/metriport/metriport/pull/2023
   - https://github.com/metriport/metriport/pull/2006
- Downstream: none

### Description

- This reintroduces "ALB/TG metrics/alarm to FHIR converter" originally created w/ this PR: https://github.com/metriport/metriport/pull/2006
   - It was reverted on this PR https://github.com/metriport/metriport/pull/2021

Context: https://metriport.slack.com/archives/C04DMKE9DME/p1715010778920459

### Testing

- Local
  - [x] `cdk diff -c env=production APIInfrastructureStack ` within limits
     `Number of resources: 454 is approaching allowed maximum of 500`
- Staging
  - [ ] deploys successfully
- Sandbox
  - [ ] deploys successfully
- Production
  - [ ] deploys successfully

### Release Plan

- [ ] Merge AND DEPLOY upstream
- [ ] Merge this
