### PR TITLE
fix(api): send filepath in dr resp

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dr.test.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dr.test.ts
@@ -107,7 +107,7 @@ describe("processDRResponse", () => {
   });
 });
 
-describe.skip("processDRResponse for various file types and verify successful upload without corruption", () => {
+describe("processDRResponse for various file types and verify successful upload without corruption", () => {
   const s3Utils = new S3Utils(Config.getAWSRegion());
 
   testFiles.forEach(({ name, mimeType, fileExtension }) => {
@@ -153,7 +153,7 @@ describe.skip("processDRResponse for various file types and verify successful up
             },
           });
 
-          this.key = `${outboundDRRequest.cxId}/${outboundDRRequest.patientId}/${this.response.documentReference?.[0]?.fileName}`;
+          this.key = this.response.documentReference?.[0]?.fileName || "";
           this.bucket = this.response.documentReference?.[0]?.fileLocation;
         }
 

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dr.test.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dr.test.ts
@@ -107,7 +107,7 @@ describe("processDRResponse", () => {
   });
 });
 
-describe("processDRResponse for various file types and verify successful upload without corruption", () => {
+describe.skip("processDRResponse for various file types and verify successful upload without corruption", () => {
   const s3Utils = new S3Utils(Config.getAWSRegion());
 
   testFiles.forEach(({ name, mimeType, fileExtension }) => {

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
@@ -18,11 +18,7 @@ import { DRSamlClientResponse } from "../send/dr-requests";
 import { successStatus, partialSuccessStatus } from "./constants";
 import { S3Utils } from "../../../../../aws/s3";
 import { Config } from "../../../../../../util/config";
-import { createFileName } from "../../../../../../domain/filename";
-import {
-  createDocumentFilePath,
-  createDocumentFileName,
-} from "../../../../../../domain/document/filename";
+import { createDocumentFilePath } from "../../../../../../domain/document/filename";
 import { MetriportError } from "../../../../../../util/error/metriport-error";
 
 const bucket = Config.getMedicalDocumentsBucketName();
@@ -60,8 +56,6 @@ async function parseDocumentReference({
     throw new MetriportError("MetriportId not found for document");
   }
 
-  const fileName = createFileName(outboundRequest.cxId, outboundRequest.patientId, metriportId);
-  const documentFileName = createDocumentFileName(fileName, mimeType);
   const filePath = createDocumentFilePath(
     outboundRequest.cxId,
     outboundRequest.patientId,
@@ -83,7 +77,7 @@ async function parseDocumentReference({
     url: s3Utils.buildFileUrl(bucket, filePath),
     size: documentResponse.size ? parseInt(documentResponse.size) : undefined,
     title: documentResponse?.title,
-    fileName: documentFileName,
+    fileName: filePath,
     creation: documentResponse.creation,
     language: documentResponse.language,
     contentType: mimeType,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1667

Ticket: #1667
### Dependencies

- Upstream: none
- Downstream: none

### Description

Send filepath 

### Testing

- Local
  - [x] Uses filepath in dr resp
- Staging
  - [ ] Uses filepath in dr resp
- Production
  - [ ] Uses filepath in dr resp

### Release Plan

- [ ] Merge this
