### PR TITLE
fix(api): send webhook when reset progress

### DIFF
--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -33,7 +33,13 @@ export async function getDocumentsFromCQ({
   const { log } = out(`CQ DQ - requestId ${requestId}, patient ${patient.id}`);
   const { cxId, id: patientId } = patient;
 
-  const interrupt = buildInterrupt({ patientId, cxId, source: MedicalDataSource.CAREQUALITY, log });
+  const interrupt = buildInterrupt({
+    patientId,
+    requestId,
+    cxId,
+    source: MedicalDataSource.CAREQUALITY,
+    log,
+  });
   if (!iheGateway) return interrupt(`IHE GW not available`);
   if (!resultPoller.isDQEnabled()) return interrupt(`IHE DQ result poller not available`);
   if (!(await isCQDirectEnabledForCx(cxId))) return interrupt(`CQ disabled for cx ${cxId}`);

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -115,7 +115,13 @@ export async function queryAndProcessDocuments({
     return;
   }
 
-  const interrupt = buildInterrupt({ patientId, cxId, source: MedicalDataSource.COMMONWELL, log });
+  const interrupt = buildInterrupt({
+    patientId,
+    cxId,
+    requestId,
+    source: MedicalDataSource.COMMONWELL,
+    log,
+  });
   if (!(await isCWEnabledForCx(cxId))) {
     return interrupt(`CW disabled for cx ${cxId}`);
   }


### PR DESCRIPTION
Ref. metriport/metriport-internal#1669

Ticket: #1669

### Dependencies

- Upstream: none
- Downstream: none

### Description

If we reset the doc query progress we want to see if its complete and should send a webhook -[context](https://metriport.slack.com/archives/C04DMKE9DME/p1715122157358159)

### Testing

- Local
  - [x] Manually update logic to send webhook
- Staging
  - [ ] Cant replicate because CW integration doesnt work
- Production
  - [ ] Monitor

### Release Plan

- [ ] Merge this
