### PR TITLE
fix(api): add doc content types to analytics

### DIFF
--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -21,6 +21,7 @@ import { getCqInitiator } from "../shared";
 import { createOutboundDocumentRetrievalReqs } from "./create-outbound-document-retrieval-req";
 import { getNonExistentDocRefs } from "./get-non-existent-doc-refs";
 import { cqToFHIR, DocumentReferenceWithMetriportId, toDocumentReference } from "./shared";
+import { getDocumentReferenceContentTypeCounts } from "../../hie/get-docr-content-type-counts";
 import { makeIHEGatewayV2 } from "../../ihe-gateway-v2/ihe-gateway-v2-factory";
 import { getOidsWithIHEGatewayV2Enabled } from "../../aws/appConfig";
 import { Config } from "../../../shared/config";
@@ -48,6 +49,12 @@ export async function processOutboundDocumentQueryResps({
     const duration = elapsedTimeFromNow(docQueryStartedAt);
 
     const docRefs = results.map(toDocumentReference).flat();
+    const contentTypes = docRefs.map(docRef => {
+      if (!docRef.contentType) return "unknown";
+
+      return docRef.contentType;
+    });
+    const contentTypeCounts = getDocumentReferenceContentTypeCounts(contentTypes);
 
     analytics({
       distinctId: cxId,
@@ -58,6 +65,7 @@ export async function processOutboundDocumentQueryResps({
         hie: MedicalDataSource.CAREQUALITY,
         duration,
         documentCount: docRefs.length,
+        ...contentTypeCounts,
       },
     });
 

--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -20,7 +20,12 @@ import { getCQDirectoryEntry } from "../command/cq-directory/get-cq-directory-en
 import { getCqInitiator } from "../shared";
 import { createOutboundDocumentRetrievalReqs } from "./create-outbound-document-retrieval-req";
 import { getNonExistentDocRefs } from "./get-non-existent-doc-refs";
-import { cqToFHIR, DocumentReferenceWithMetriportId, toDocumentReference } from "./shared";
+import {
+  cqToFHIR,
+  DocumentReferenceWithMetriportId,
+  toDocumentReference,
+  getContentTypeOrUnknown,
+} from "./shared";
 import { getDocumentReferenceContentTypeCounts } from "../../hie/get-docr-content-type-counts";
 import { makeIHEGatewayV2 } from "../../ihe-gateway-v2/ihe-gateway-v2-factory";
 import { getOidsWithIHEGatewayV2Enabled } from "../../aws/appConfig";
@@ -49,11 +54,7 @@ export async function processOutboundDocumentQueryResps({
     const duration = elapsedTimeFromNow(docQueryStartedAt);
 
     const docRefs = results.map(toDocumentReference).flat();
-    const contentTypes = docRefs.map(docRef => {
-      if (!docRef.contentType) return "unknown";
-
-      return docRef.contentType;
-    });
+    const contentTypes = docRefs.map(getContentTypeOrUnknown);
     const contentTypeCounts = getDocumentReferenceContentTypeCounts(contentTypes);
 
     analytics({

--- a/packages/api/src/external/carequality/document/shared.ts
+++ b/packages/api/src/external/carequality/document/shared.ts
@@ -155,3 +155,7 @@ export function dedupeContainedResources(combined: Resource[]): Resource[] | und
 
   return deduped;
 }
+
+export function getContentTypeOrUnknown(docRef: DocumentReference) {
+  return docRef.contentType ?? "unknown";
+}

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -60,6 +60,7 @@ import {
   DocumentWithLocation,
   DocumentWithMetriportId,
   getFileName,
+  getContentTypeOrUnknown,
 } from "./shared";
 import { getDocumentReferenceContentTypeCounts } from "../../hie/get-docr-content-type-counts";
 
@@ -184,11 +185,7 @@ export async function queryAndProcessDocuments({
 
     const docQueryStartedAt = patient.data.documentQueryProgress?.startedAt;
     const duration = elapsedTimeFromNow(docQueryStartedAt);
-    const contentTypes = cwDocuments.map(docRef => {
-      if (!docRef.content.mimeType) return "unknown";
-
-      return docRef.content.mimeType;
-    });
+    const contentTypes = cwDocuments.map(getContentTypeOrUnknown);
     const contentTypeCounts = getDocumentReferenceContentTypeCounts(contentTypes);
 
     analytics({

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -61,6 +61,7 @@ import {
   DocumentWithMetriportId,
   getFileName,
 } from "./shared";
+import { getDocumentReferenceContentTypeCounts } from "../../hie/get-docr-content-type-counts";
 
 const DOC_DOWNLOAD_CHUNK_SIZE = 10;
 
@@ -183,6 +184,12 @@ export async function queryAndProcessDocuments({
 
     const docQueryStartedAt = patient.data.documentQueryProgress?.startedAt;
     const duration = elapsedTimeFromNow(docQueryStartedAt);
+    const contentTypes = cwDocuments.map(docRef => {
+      if (!docRef.content.mimeType) return "unknown";
+
+      return docRef.content.mimeType;
+    });
+    const contentTypeCounts = getDocumentReferenceContentTypeCounts(contentTypes);
 
     analytics({
       distinctId: cxId,
@@ -193,6 +200,7 @@ export async function queryAndProcessDocuments({
         hie: MedicalDataSource.COMMONWELL,
         duration,
         documentCount: cwDocuments.length,
+        ...contentTypeCounts,
       },
     });
 

--- a/packages/api/src/external/commonwell/document/shared.ts
+++ b/packages/api/src/external/commonwell/document/shared.ts
@@ -34,3 +34,7 @@ function getSuffix(id: string | undefined): string {
   if (!id) return "";
   return id.replace("urn:uuid:", "");
 }
+
+export function getContentTypeOrUnknown(doc: Document): string {
+  return doc.content?.mimeType || "unknown";
+}

--- a/packages/api/src/external/hie/get-docr-content-type-counts.ts
+++ b/packages/api/src/external/hie/get-docr-content-type-counts.ts
@@ -1,0 +1,11 @@
+export function getDocumentReferenceContentTypeCounts(
+  docRefsContentTypes: string[]
+): Record<string, number> {
+  const contentTypeCounts = docRefsContentTypes.reduce((acc, curr) => {
+    acc[curr] = (acc[curr] || 0) + 1;
+
+    return acc;
+  }, {} as Record<string, number>);
+
+  return contentTypeCounts;
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1669

Ticket: #1669

### Dependencies

- Upstream: none
- Downstream: none

### Description

Add content types to analytics 

### Testing

- Local
  - [x] Manually updated to see results in posthog
- Staging
  - [ ] Trigger DQ and see the types
- Production
  - [ ]Monitor

### Release Plan

- [ ] Merge this
