### PR TITLE
1634 Add manual run of E2E tests against staging

### DIFF
--- a/.github/workflows/run-e2e-test-staging.yml
+++ b/.github/workflows/run-e2e-test-staging.yml
@@ -1,0 +1,26 @@
+# Runs E2E tests using the chosen branch's E2E test code, against the running instance on staging.
+name: Run E2E tests against Staging
+
+on:
+  workflow_dispatch: # manually executed by a user
+
+jobs:
+  e2e-tests:
+    uses: ./.github/workflows/_e2e-tests.yml
+    with:
+      deploy_env: "staging"
+      api_url: ${{ vars.API_URL_STAGING }}
+      fhir_url: ${{ vars.FHIR_SERVER_URL_STAGING }}
+      test_patient_id: ${{ vars.TEST_PATIENT_ID }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      TEST_API_KEY: ${{ secrets.TEST_API_KEY_STAGING }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      CW_CERTIFICATE: ${{ secrets.CW_CERTIFICATE_STAGING }}
+      CW_PRIVATE_KEY: ${{ secrets.CW_PRIVATE_KEY_STAGING }}
+      CW_MEMBER_CERTIFICATE: ${{ secrets.CW_MEMBER_CERTIFICATE_STAGING }}
+      CW_MEMBER_PRIVATE_KEY: ${{ secrets.CW_MEMBER_PRIVATE_KEY_STAGING }}
+      CW_MEMBER_NAME: ${{ secrets.CW_MEMBER_NAME_STAGING }}
+      CW_MEMBER_OID: ${{ secrets.CW_MEMBER_OID_STAGING }}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1634

### Dependencies

none

### Description

Add manual run of E2E tests against the `staging` instance.

### Testing

- Local
  - none
- Staging
  - [ ] manually run e2e test works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
