### PR TITLE
PATCH: bulk signer use seed bucket in sandbox

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -683,6 +683,7 @@ export class APIStack extends Stack {
       lambdaLayers,
       vpc: this.vpc,
       medicalDocumentsBucket: medicalDocumentsBucket,
+      medicalSeedDocumentsBucket: sandboxSeedDataBucket,
       fhirServerUrl: props.config.fhirServerUrl,
       envType: props.config.environmentType,
       sentryDsn: props.config.lambdasSentryDSN,
@@ -1089,6 +1090,7 @@ export class APIStack extends Stack {
     lambdaLayers: LambdaLayers;
     vpc: ec2.IVpc;
     medicalDocumentsBucket: s3.Bucket;
+    medicalSeedDocumentsBucket: s3.IBucket | undefined;
     fhirServerUrl: string;
     envType: EnvType;
     sentryDsn: string | undefined;
@@ -1103,6 +1105,7 @@ export class APIStack extends Stack {
       lambdaLayers,
       vpc,
       medicalDocumentsBucket,
+      medicalSeedDocumentsBucket,
       fhirServerUrl,
       sentryDsn,
       alarmAction,
@@ -1114,6 +1117,8 @@ export class APIStack extends Stack {
       apiService,
     } = ownProps;
 
+    const isSandboxSeed = envType === "sandbox" && medicalSeedDocumentsBucket;
+
     const bulkUrlSigningLambda = createLambda({
       stack: this,
       name: "BulkUrlSigning",
@@ -1121,7 +1126,9 @@ export class APIStack extends Stack {
       entry: "document-bulk-signer",
       envType,
       envVars: {
-        MEDICAL_DOCUMENTS_BUCKET_NAME: medicalDocumentsBucket.bucketName,
+        MEDICAL_DOCUMENTS_BUCKET_NAME: isSandboxSeed
+          ? medicalSeedDocumentsBucket.bucketName
+          : medicalDocumentsBucket.bucketName,
         FHIR_SERVER_URL: fhirServerUrl,
         SEARCH_ENDPOINT: searchEndpoint,
         SEARCH_INDEX: searchIndex,
@@ -1137,6 +1144,7 @@ export class APIStack extends Stack {
       alarmSnsAction: alarmAction,
     });
 
+    isSandboxSeed && medicalSeedDocumentsBucket.grantRead(bulkUrlSigningLambda);
     medicalDocumentsBucket.grantRead(bulkUrlSigningLambda);
     bulkUrlSigningLambda.grantInvoke(apiService.taskDefinition.taskRole);
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ticket: #799

### Dependencies

- Upstream: none
- Downstream: none

### Description

Using the wrong bucket name for bulk download url in sandbox - [context](https://metriport.slack.com/archives/C05UXMPAVS8/p1715233353044289)
### Testing

- Sandbox
  - [ ] Has correct base URL

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
