### PR TITLE
fix(api): send address field if string

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/process/xcpd-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/process/xcpd-response.ts
@@ -56,13 +56,19 @@ function handlePatientMatchResponse({
   const subject1 =
     getPatientRegistryProfile(jsonObj)?.controlActProcess?.subject?.registrationEvent?.subject1;
   const addr = subject1?.patient?.patientPerson?.addr;
+  const addressLine1 = addr?.streetAddressLine?._text ?? addr?.streetAddressLine;
+  const city = addr?.city?._text ?? addr?.city;
+  const state = addr?.state?._text ?? addr?.state;
+  const postalCode = addr?.postalCode?._text ?? addr?.postalCode;
+  const country = addr?.country?._text ?? addr?.country;
+
   const addresses = [
     {
-      line: [addr?.streetAddressLine?._text ?? addr?.streetAddressLine],
-      city: addr?.city?._text ?? addr?.city,
-      state: addr?.state?._text ?? addr?.state,
-      postalCode: String(addr?.postalCode?._text ?? addr?.postalCode),
-      country: addr?.country?._text ?? addr?.country,
+      ...(addressLine1 && { line: [addressLine1] }),
+      ...(city && { city }),
+      ...(state && { state }),
+      ...(postalCode && { postalCode: String(postalCode) }),
+      ...(country && { country: country }),
     },
   ];
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ticket: #_[ticket-number]_

### Dependencies

- Upstream: none
- Downstream: none

### Description

Send address field only if string

### Testing

- Local
  - [x] Test locally with expected output
  - [x] ...
- Staging
  - [ ] Would need to find endpoint that returns no address
- Production
  - [ ] Monitor


### Release Plan

- [ ] Merge this
