### PR TITLE
1040 Mark `check-pr` successful if no changes to packages

### DIFF
--- a/.github/workflows/fern-check.yml
+++ b/.github/workflows/fern-check.yml
@@ -2,6 +2,7 @@ name: "Fern Check"
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [master, develop]
 

--- a/.github/workflows/pull-request_other.yml
+++ b/.github/workflows/pull-request_other.yml
@@ -1,0 +1,67 @@
+# Just marks the required checks as successful so PRs can be merged
+# It should only run if there are no changes on the regular packages
+name: PR Check - Others
+
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  files-changed:
+    name: Detect changes on packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    # Map a step output to a job output
+    outputs:
+      packages: ${{ steps.changes.outputs.packages }}
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Detect Changes
+        uses: dorny/paths-filter@4067d885736b84de7c414f582ac45897079b0a78 # v2
+        id: changes
+        with:
+          filters: |
+            packages:
+              - "packages/api/**"
+              - "packages/api-sdk/**"
+              - "packages/carequality-cert-runner/**"
+              - "packages/carequality-sdk/**"
+              - "packages/commonwell-cert-runner/**"
+              - "packages/commonwell-jwt-maker/**"
+              - "packages/commonwell-sdk/**"
+              - "packages/connect-widget/**"
+              - "packages/core/**"
+              - "packages/ihe-gateway/**"
+              - "packages/ihe-gateway-sdk/**"
+              - "packages/infra/**"
+              - "packages/lambdas/**"
+              - "packages/react-native-sdk/**"
+              - "packages/shared/**"
+              - "packages/utils/**"
+
+  check-pr:
+    needs: files-changed
+    if: needs.files-changed.outputs.packages != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark check-pr as successful
+        run: |
+          echo "Not running any checks, just marking 'check-pr' as successful"
+
+  not-running:
+    needs: files-changed
+    if: needs.files-changed.outputs.packages == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Not running
+        run: |
+          echo "NOT making changes to 'check-pr'"


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

- Downstream: https://github.com/metriport/metriport/pull/2056

### Description

- Mark `check-pr` successful if no changes to packages
- Trigger `fern-check` on merge queue

Context: https://metriport.slack.com/archives/C04DMKE9DME/p1715279718404439

### Testing

- Local
  - none
- Staging
  - [ ] [This PR](https://github.com/metriport/metriport/pull/2056) can be merged after it gets "rebased"
  - [ ] `fern-check` runs on merge queue when [this PR](https://github.com/metriport/metriport/pull/2056) gets merged
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
- [ ] Update required checks for `develop`
   - [ ] Remove existing ones
   - [ ] Add `check-pr`
   - [ ] Add `fern-check`
- [ ] Merge the downstream PR
