### PR TITLE
fix(api): setting content type on ccd upload

### DIFF
--- a/packages/api/src/external/cda/generate-ccd.ts
+++ b/packages/api/src/external/cda/generate-ccd.ts
@@ -30,8 +30,7 @@ export async function generateCcd({
   const structuredBody = buildStructuredBody();
   const currentTime = getCurrentDate();
 
-  return `<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<realmCode code="US"/>
+  return `<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" moodCode="EVN">
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
 	<templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>

--- a/packages/api/src/external/cda/generate-ccd.ts
+++ b/packages/api/src/external/cda/generate-ccd.ts
@@ -31,7 +31,8 @@ export async function generateCcd({
   const currentTime = getCurrentDate();
 
   return `<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" moodCode="EVN">
-	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+	<realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
 	<templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
 	<id root="${metriportOid}" assigningAuthorityName="${metriportOrganization.name}"/>

--- a/packages/api/src/external/cda/generate-ccd.ts
+++ b/packages/api/src/external/cda/generate-ccd.ts
@@ -30,7 +30,7 @@ export async function generateCcd({
   const structuredBody = buildStructuredBody();
   const currentTime = getCurrentDate();
 
-  return `<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" moodCode="EVN">
+  return `<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>

--- a/packages/api/src/external/cda/generate-ccd.ts
+++ b/packages/api/src/external/cda/generate-ccd.ts
@@ -32,11 +32,11 @@ export async function generateCcd({
 
   return `<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" moodCode="EVN">
 	<realmCode code="US"/>
-  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+        <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 	<templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
 	<templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
 	<id root="${metriportOid}" assigningAuthorityName="${metriportOrganization.name}"/>
-  <code code="34133-9" codeSystem="2.16.840.1.113883.6.1" displayName="Summarization of episode note" codeSystemName="LOINC"/>
+        <code code="34133-9" codeSystem="2.16.840.1.113883.6.1" displayName="Summarization of episode note" codeSystemName="LOINC"/>
 	<title>Continuity of Care Document</title>
 	<effectiveTime value="${currentTime}"/>
 	<confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="Normal"/>

--- a/packages/api/src/external/cda/generate-ccd.ts
+++ b/packages/api/src/external/cda/generate-ccd.ts
@@ -31,17 +31,17 @@ export async function generateCcd({
   const currentTime = getCurrentDate();
 
   return `<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" moodCode="EVN">
-  <realmCode code="US"/>
+	<realmCode code="US"/>
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
-  <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
-  <templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
-  <id root="${metriportOid}" assigningAuthorityName="${metriportOrganization.name}"/>
+	<templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
+	<templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
+	<id root="${metriportOid}" assigningAuthorityName="${metriportOrganization.name}"/>
   <code code="34133-9" codeSystem="2.16.840.1.113883.6.1" displayName="Summarization of episode note" codeSystemName="LOINC"/>
-  <title>Continuity of Care Document</title>
-  <effectiveTime value="${currentTime}"/>
-  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="Normal"/>
-  <languageCode code="en-US"/>
-  <recordTarget>
+	<title>Continuity of Care Document</title>
+	<effectiveTime value="${currentTime}"/>
+	<confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="Normal"/>
+	<languageCode code="en-US"/>
+	<recordTarget>
 		<patientRole>
 			<id root="${patientId}"/>
 			${addresses}

--- a/packages/api/src/external/cda/generate-ccd.ts
+++ b/packages/api/src/external/cda/generate-ccd.ts
@@ -31,17 +31,17 @@ export async function generateCcd({
   const currentTime = getCurrentDate();
 
   return `<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" moodCode="EVN">
-	<realmCode code="US"/>
-        <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
-	<templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
-	<templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
-	<id root="${metriportOid}" assigningAuthorityName="${metriportOrganization.name}"/>
-        <code code="34133-9" codeSystem="2.16.840.1.113883.6.1" displayName="Summarization of episode note" codeSystemName="LOINC"/>
-	<title>Continuity of Care Document</title>
-	<effectiveTime value="${currentTime}"/>
-	<confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="Normal"/>
-	<languageCode code="en-US"/>
-	<recordTarget>
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
+  <templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
+  <id root="${metriportOid}" assigningAuthorityName="${metriportOrganization.name}"/>
+  <code code="34133-9" codeSystem="2.16.840.1.113883.6.1" displayName="Summarization of episode note" codeSystemName="LOINC"/>
+  <title>Continuity of Care Document</title>
+  <effectiveTime value="${currentTime}"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="Normal"/>
+  <languageCode code="en-US"/>
+  <recordTarget>
 		<patientRole>
 			<id root="${patientId}"/>
 			${addresses}

--- a/packages/core/src/external/carequality/dq/process-inbound-dq.ts
+++ b/packages/core/src/external/carequality/dq/process-inbound-dq.ts
@@ -90,7 +90,12 @@ async function createAndUploadCcdAndMetadata(cxId: string, patientId: string, ap
     const resp = await api.get(url);
     const ccd = resp.data as string;
     const ccdSize = sizeInBytes(ccd);
-    await s3Utils.uploadFile({ bucket, key: fileName, file: Buffer.from(ccd) });
+    await s3Utils.uploadFile({
+      bucket,
+      key: fileName,
+      file: Buffer.from(ccd),
+      contentType: "application/xml",
+    });
     log(`CCD uploaded into ${bucket} under this name: ${fileName}`);
 
     const docRef: DocumentReference = {


### PR DESCRIPTION
refs. metriport/metriport-internal#1730

### Description

- Setting the content type to `application/xml` on CCD file upload

### Testing

- Local
  - [x] Generated one from local env and got file info using s3 utils

### Release Plan
- [ ] Merge this
