### PR TITLE
1040 Update CW exclude list

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
@@ -1,13 +1,23 @@
 import { Op, Sequelize } from "sequelize";
 import { CQDirectoryEntryModel } from "../../models/cq-directory";
 
-export async function getOrganizationIds(excludeManagingOrgs: string[]): Promise<string[]> {
+/**
+ * Returns the ID of CQ directory entries that are not managed by the organizations provided as
+ * parameter.
+ *
+ * @param managingOrgNames - An array of managing organization names
+ * @returns IDs of the CQ directory entries not managed by the provided orgs
+ */
+export async function getOrganizationIdsNotManagedBy(
+  managingOrgNames: string[]
+): Promise<string[]> {
   const entries = await CQDirectoryEntryModel.findAll({
     attributes: ["id"],
     where: {
-      managingOrganization: {
-        [Op.notIn]: excludeManagingOrgs,
-      },
+      [Op.or]: [
+        { managingOrganization: { [Op.is]: undefined } },
+        { managingOrganization: { [Op.notIn]: managingOrgNames } },
+      ],
     },
   });
   const ids = entries.map(entry => entry.id);

--- a/packages/api/src/external/hie/cross-hie-ids.ts
+++ b/packages/api/src/external/hie/cross-hie-ids.ts
@@ -1,5 +1,8 @@
-import { getOrganizationIds } from "../carequality/command/cq-directory/cq-gateways";
+import { getOrganizationIdsNotManagedBy } from "../carequality/command/cq-directory/cq-gateways";
 
+/**
+ * Returns the list of Org OIDs that are not allowed to be used on CW.
+ */
 export async function getCqOrgIdsToDenyOnCw() {
-  return getOrganizationIds(["CommonWell"]);
+  return getOrganizationIdsNotManagedBy(["CommonWell"]);
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Updates the code that excludes CQ orgs from CW links so its clearer what it does - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1715711377475049?thread_ts=1715704101.580579&cid=C04DMKE9DME).

### Testing

- Local
  - [x] lists CQ OIDs not managed by CW
- Staging
  - none (CW integration env is down)
- Sandbox
  - none
- Production
  - [ ] monitor a patient create

### Release Plan

- [ ] Merge this
