### PR TITLE
PATCH RELEASE 2024_05_13 FHIR Converter (2)

### DIFF
--- a/packages/fhir-converter/src/lib/inputProcessor/dateProcessor.js
+++ b/packages/fhir-converter/src/lib/inputProcessor/dateProcessor.js
@@ -1,4 +1,12 @@
 const { XMLParser } = require("fast-xml-parser");
+var { v4: uuidv4 } = require("uuid");
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "",
+  parseAttributeValue: false,
+  removeNSPrefix: true,
+});
 
 /**
  * Extracts the effective time period (low and high) from the given XML data.
@@ -6,12 +14,6 @@ const { XMLParser } = require("fast-xml-parser");
  * @returns {Object} An object containing the low and high values of the effective time period.
  */
 function extractEncounterTimePeriod(srcData) {
-  const parser = new XMLParser({
-    ignoreAttributes: false,
-    attributeNamePrefix: "",
-    parseAttributeValue: false,
-    removeNSPrefix: true,
-  });
   const jsonObj = parser.parse(srcData);
   const effectiveTime = jsonObj.ClinicalDocument?.documentationOf?.serviceEvent?.effectiveTime;
   const low = effectiveTime?.low;
@@ -19,4 +21,20 @@ function extractEncounterTimePeriod(srcData) {
   return { low, high };
 }
 
+/**
+ * Checks whether the given XML data contains an encompassing encounter, and returns a UUID for it.
+ * Otherwise, returns undefined.
+ * @param {string} srcData - The XML data as a string.
+ * @returns {string} A UUID for the encompassing encounter or undefined.
+ */
+function getEncompassingEncounterId(srcData) {
+  const jsonObj = parser.parse(srcData);
+  const encompassingEncounter = jsonObj.ClinicalDocument?.componentOf?.encompassingEncounter;
+  if (encompassingEncounter) {
+    return uuidv4();
+  }
+  return undefined;
+}
+
 module.exports.extractEncounterTimePeriod = extractEncounterTimePeriod;
+module.exports.getEncompassingEncounterId = getEncompassingEncounterId;

--- a/packages/fhir-converter/src/lib/workers/worker.js
+++ b/packages/fhir-converter/src/lib/workers/worker.js
@@ -13,7 +13,10 @@ var errorMessage = require("../error/error").errorMessage;
 var HandlebarsConverter = require("../handlebars-converter/handlebars-converter");
 var WorkerUtils = require("./workerUtils");
 var dataHandlerFactory = require("../dataHandler/dataHandlerFactory");
-var { extractEncounterTimePeriod } = require("../inputProcessor/dateProcessor");
+var {
+  extractEncounterTimePeriod,
+  getEncompassingEncounterId,
+} = require("../inputProcessor/dateProcessor");
 var { v4: uuidv4 } = require("uuid");
 
 const { createNamespace } = require("cls-hooked");
@@ -190,7 +193,7 @@ WorkerUtils.workerTaskProcessor(msg => {
             let encounterTimePeriod = extractEncounterTimePeriod(srcData);
             let dataTypeHandler = dataHandlerFactory.createDataHandler(srcDataType);
             let handlebarInstance = GetHandlebarsInstance(dataTypeHandler);
-            let encompassingEncounterId = uuidv4();
+            let encompassingEncounterId = getEncompassingEncounterId(srcData);
             session.set(constants.CLS_KEY_HANDLEBAR_INSTANCE, handlebarInstance);
             session.set(
               constants.CLS_KEY_TEMPLATE_LOCATION,

--- a/packages/fhir-converter/src/templates/cda/Sections/History_of_Present_Illness.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/History_of_Present_Illness.hbs
@@ -7,7 +7,7 @@
                 {{/with}}
 
                 {{!-- TODO need to add references, author, etc --}}
-                {{#if ../../msg.ClinicalDocument.componentOf.encompassingEncounter}} 
+                {{#if @encompassingEncounterId}} 
                     {{>References/DiagnosticReport/encounter.hbs ID=(generateUUID (toJsonString note.act)) REF=(concat 'Encounter/' @encompassingEncounterId)}}
                 {{/if}}
 

--- a/packages/fhir-converter/src/templates/cda/Sections/Notes.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Notes.hbs
@@ -7,13 +7,13 @@
                         {{>Resources/DiagnosticReport.hbs diagReport=note.act ID=(generateUUID (toJsonString note.act))}},
                         {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
                             {{>References/DiagnosticReport/subject.hbs ID=(generateUUID (toJsonString note.act)) REF=(concat 'Patient/' patientId.Id)}},
+                            {{#if @encompassingEncounterId}} 
+                                {{>References/DiagnosticReport/encounter.hbs ID=(generateUUID (toJsonString note.act)) REF=(concat 'Encounter/' @encompassingEncounterId)}}
+                            {{/if}}
                         {{/with}}
                     {{/if}}
 
                     {{!-- TODO need to add references, author, etc --}}
-                    {{#if @encompassingEncounterId}} 
-                        {{>References/DiagnosticReport/encounter.hbs ID=(generateUUID (toJsonString note.act)) REF=(concat 'Encounter/' @encompassingEncounterId)}}
-                    {{/if}}
 
                     {{#if note.act.author.assignedAuthor}}
                         {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=note.act.author.assignedAuthor) as |practitionerId|}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Notes.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Notes.hbs
@@ -11,6 +11,10 @@
                     {{/if}}
 
                     {{!-- TODO need to add references, author, etc --}}
+                    {{#if @encompassingEncounterId}} 
+                        {{>References/DiagnosticReport/encounter.hbs ID=(generateUUID (toJsonString note.act)) REF=(concat 'Encounter/' @encompassingEncounterId)}}
+                    {{/if}}
+
                     {{#if note.act.author.assignedAuthor}}
                         {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=note.act.author.assignedAuthor) as |practitionerId|}}
                             {{>Resources/Practitioner.hbs practitioner=note.act.author.assignedAuthor ID=practitionerId.Id}},

--- a/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
@@ -6,11 +6,10 @@
                     {{>Resources/DiagnosticReport.hbs diagReport=drEntry.organizer categoryCode=categoryCode ID=(generateUUID (toJsonString drEntry.organizer))}},
                     {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
                         {{>References/DiagnosticReport/subject.hbs ID=(generateUUID (toJsonString drEntry.organizer)) REF=(concat 'Patient/' patientId.Id)}},
+                        {{#if @encompassingEncounterId}} 
+                            {{>References/DiagnosticReport/encounter.hbs ID=(generateUUID (toJsonString drEntry.organizer)) REF=(concat 'Encounter/' @encompassingEncounterId)}}
+                        {{/if}}
                     {{/with}}
-                {{/if}}
-
-                {{#if @encompassingEncounterId}} 
-                    {{>References/DiagnosticReport/encounter.hbs ID=(generateUUID (toJsonString drEntry.organizer)) REF=(concat 'Encounter/' @encompassingEncounterId)}}
                 {{/if}}
 
                 {{#if drEntry.organizer.performer}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
@@ -8,6 +8,11 @@
                         {{>References/DiagnosticReport/subject.hbs ID=(generateUUID (toJsonString drEntry.organizer)) REF=(concat 'Patient/' patientId.Id)}},
                     {{/with}}
                 {{/if}}
+
+                {{#if @encompassingEncounterId}} 
+                    {{>References/DiagnosticReport/encounter.hbs ID=(generateUUID (toJsonString drEntry.organizer)) REF=(concat 'Encounter/' @encompassingEncounterId)}}
+                {{/if}}
+
                 {{#if drEntry.organizer.performer}}
                      {{#if drEntry.organizer.performer.assignedEntity}}
                         {{!-- should we use author.assignedAuthor or performer.assignedEntity? Not sure which one is generally fuller  --}}


### PR DESCRIPTION
Ticket: #[1978](https://github.com/metriport/metriport/issues/1978) 

### Description

- CDA sections `Notes` and `Results` will also reference the `encompassingEncounter` for the `DiagnosticReports`. 

### Testing

- Local
  - [x] Verified the reference exists when running on a handful of files
  - [x] Verified that no unexpected behaviour is caused by the absence of `encompassingEncounter`
  - [x] Ran the test suite and found an increase in the number of `DiagnosticReports`

### Release Plan

- :warning: Points to `master`
- [x] Merge this
