### PR TITLE
1603 fhir to cda restore CDA validity

### DIFF
--- a/packages/core/src/fhir-to-cda/cda-templates/clinical-document/author.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/clinical-document/author.ts
@@ -1,11 +1,11 @@
 import { Organization } from "@medplum/fhirtypes";
+import { CdaAuthor } from "../../cda-types/shared-types";
 import {
-  withNullFlavor,
   buildAddress,
   buildRepresentedOrganization,
   buildTelecom,
+  withNullFlavor,
 } from "../commons";
-import { CdaAuthor } from "../../cda-types/shared-types";
 import { _rootAttribute, _valueAttribute } from "../constants";
 
 export function buildAuthor(organization: Organization): CdaAuthor {

--- a/packages/core/src/fhir-to-cda/cda-templates/clinical-document/clinical-document.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/clinical-document/clinical-document.ts
@@ -11,7 +11,7 @@ import {
   withNullFlavor,
   withoutNullFlavorObject,
 } from "../commons";
-import { _valueAttribute, clinicalDocumentConstants } from "../constants";
+import { clinicalDocumentConstants, _namespaceAttribute, _valueAttribute } from "../constants";
 
 //eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function removeEmptyFields(obj: any): unknown {
@@ -41,7 +41,7 @@ export function buildClinicalDocumentXml(
 ): string {
   const jsonObj: ClinicalDocument = {
     ClinicalDocument: {
-      _namespaceAttribute: "urn:hl7-org:v3",
+      [_namespaceAttribute]: "urn:hl7-org:v3",
       realmCode: buildCodeCe({ code: clinicalDocumentConstants.realmCode }),
       typeId: buildInstanceIdentifier({
         extension: clinicalDocumentConstants.typeIdExtension,

--- a/packages/core/src/fhir-to-cda/cda-templates/commons.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/commons.ts
@@ -19,9 +19,19 @@ import {
   EntryObject,
 } from "../cda-types/shared-types";
 import {
+  _assigningAuthorityNameAttribute,
+  _codeAttribute,
+  _codeSystemAttribute,
+  _codeSystemNameAttribute,
+  _displayNameAttribute,
+  _extensionAttribute,
+  _inlineTextAttribute,
+  _nullFlavorAttribute,
   _rootAttribute,
   _useAttribute,
   _valueAttribute,
+  _xmlnsXsiAttribute,
+  _xsiTypeAttribute,
   amaAssnSystemCode,
   fdasisSystemCode,
   loincSystemCode,
@@ -48,7 +58,7 @@ export function withoutNullFlavorString(value: string | undefined): Entry {
 }
 
 export function withNullFlavor(value: string | undefined, key: string): Entry {
-  if (value == undefined) return { _nullFlavorAttribute: "UNK" };
+  if (value == undefined) return { [_nullFlavorAttribute]: "UNK" };
   return { [key]: value };
 }
 
@@ -65,10 +75,10 @@ export function buildCodeCe({
   displayName?: string | undefined;
 }): CdaCodeCe {
   const codeObject: CdaCodeCe = {};
-  if (code) codeObject._codeAttribute = code;
-  if (codeSystem) codeObject._codeSystemAttribute = codeSystem;
-  if (codeSystemName) codeObject._codeSystemNameAttribute = codeSystemName;
-  if (displayName) codeObject._displayNameAttribute = displayName;
+  if (code) codeObject[_codeAttribute] = code;
+  if (codeSystem) codeObject[_codeSystemAttribute] = codeSystem;
+  if (codeSystemName) codeObject[_codeSystemNameAttribute] = codeSystemName;
+  if (displayName) codeObject[_displayNameAttribute] = displayName;
 
   return codeObject;
 }
@@ -120,9 +130,9 @@ export function buildInstanceIdentifier({
   assigningAuthorityName?: string | undefined;
 }): CdaInstanceIdentifier {
   const identifier: CdaInstanceIdentifier = {};
-  if (root) identifier._rootAttribute = root;
-  if (extension) identifier._extensionAttribute = extension;
-  if (assigningAuthorityName) identifier._assigningAuthorityNameAttribute = assigningAuthorityName;
+  if (root) identifier[_rootAttribute] = root;
+  if (extension) identifier[_extensionAttribute] = extension;
+  if (assigningAuthorityName) identifier[_assigningAuthorityNameAttribute] = assigningAuthorityName;
 
   return identifier;
 }
@@ -203,9 +213,9 @@ export function buildValueST(value: string | undefined): CdaValueSt | undefined 
   if (!value) return undefined;
 
   const valueObject: CdaValueSt = {};
-  valueObject._xsiTypeAttribute = "ST";
-  valueObject._xmlnsXsiAttribute = "http://www.w3.org/2001/XMLSchema-instance";
-  valueObject._inlineTextAttribute = value;
+  valueObject[_xsiTypeAttribute] = "ST";
+  valueObject[_xmlnsXsiAttribute] = "http://www.w3.org/2001/XMLSchema-instance";
+  valueObject[_inlineTextAttribute] = value;
   return valueObject;
 }
 

--- a/packages/core/src/fhir-to-cda/cda-templates/components/observations.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/components/observations.ts
@@ -8,7 +8,12 @@ import {
   buildValueST,
   withoutNullFlavorObject,
 } from "../commons";
-import { _codeAttribute, _valueAttribute } from "../constants";
+import {
+  _classCodeAttribute,
+  _codeAttribute,
+  _moodCodeAttribute,
+  _valueAttribute,
+} from "../constants";
 
 export function buildObservations(observations: Observation[]): CDAObservation[] {
   return observations.map(observation => {
@@ -16,8 +21,8 @@ export function buildObservations(observations: Observation[]): CDAObservation[]
     return {
       component: {
         observation: {
-          _classCodeAttribute: "OBS",
-          _moodCodeAttribute: "EVN",
+          [_classCodeAttribute]: "OBS",
+          [_moodCodeAttribute]: "EVN",
           templateId: buildInstanceIdentifier({
             root: "2.16.840.1.113883.10.20.22.4.2",
             extension: "2015-08-01",

--- a/packages/core/src/fhir-to-cda/cda-templates/components/results.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/components/results.ts
@@ -8,7 +8,13 @@ import {
   buildInstanceIdentifier,
   withoutNullFlavorObject,
 } from "../commons";
-import { _valueAttribute } from "../constants";
+import {
+  _classCodeAttribute,
+  _idAttribute,
+  _moodCodeAttribute,
+  _typeCodeAttribute,
+  _valueAttribute,
+} from "../constants";
 import { buildObservations } from "./observations";
 
 function buildEntriesFromDiagnosticReports(
@@ -29,8 +35,8 @@ function buildEntriesFromDiagnosticReports(
     });
 
     const organizer = {
-      _classCodeAttribute: "BATTERY",
-      _moodCodeAttribute: "EVN",
+      [_classCodeAttribute]: "BATTERY",
+      [_moodCodeAttribute]: "EVN",
       templateId: buildInstanceIdentifier({
         root: "2.16.840.1.113883.10.20.22.4.1",
         extension: "2015-08-01",
@@ -51,7 +57,7 @@ function buildEntriesFromDiagnosticReports(
 
     return {
       entry: {
-        _typeCodeAttribute: "DRIV",
+        [_typeCodeAttribute]: "DRIV",
         organizer,
       },
     };
@@ -102,7 +108,7 @@ function getTextItemsFromDiagnosticReports(diagnosticReports: DiagnosticReport[]
         return {
           item: {
             content: {
-              _idAttribute: `_${report.id}`,
+              [_idAttribute]: `_${report.id}`,
               br: contentObjects.map(o => o.br),
             },
           },

--- a/packages/core/src/fhir-to-cda/cda-types/observation.ts
+++ b/packages/core/src/fhir-to-cda/cda-types/observation.ts
@@ -1,10 +1,11 @@
+import { _classCodeAttribute, _moodCodeAttribute } from "../cda-templates/constants";
 import { CdaCodeCv, CdaInstanceIdentifier, CdaValueSt, Entry, EntryObject } from "./shared-types";
 
 export interface CDAObservation {
   component: {
     observation: {
-      _classCodeAttribute: Entry;
-      _moodCodeAttribute: Entry;
+      [_classCodeAttribute]: Entry;
+      [_moodCodeAttribute]: Entry;
       id?: CdaInstanceIdentifier[] | Entry;
       code: CdaCodeCv | Entry;
       text?: Entry;

--- a/packages/core/src/fhir-to-cda/cda-types/shared-types.ts
+++ b/packages/core/src/fhir-to-cda/cda-types/shared-types.ts
@@ -1,6 +1,20 @@
+import {
+  _assigningAuthorityNameAttribute,
+  _codeAttribute,
+  _codeSystemAttribute,
+  _codeSystemNameAttribute,
+  _displayNameAttribute,
+  _extensionAttribute,
+  _inlineTextAttribute,
+  _namespaceAttribute,
+  _rootAttribute,
+  _xmlnsXsiAttribute,
+  _xsiTypeAttribute,
+} from "../cda-templates/constants";
+
 export type ClinicalDocument = {
   ClinicalDocument: {
-    _namespaceAttribute: string;
+    [_namespaceAttribute]: string;
     realmCode?: CdaCodeCe;
     typeId?: CdaInstanceIdentifier;
     templateId?: CdaInstanceIdentifier[];
@@ -75,17 +89,17 @@ export type CdaName = {
 
 // Ce (CE) stands for Coded with Equivalents
 export type CdaCodeCe = {
-  _codeAttribute?: string;
-  _codeSystemAttribute?: string;
-  _codeSystemNameAttribute?: string;
-  _displayNameAttribute?: string;
+  [_codeAttribute]?: string;
+  [_codeSystemAttribute]?: string;
+  [_codeSystemNameAttribute]?: string;
+  [_displayNameAttribute]?: string;
 };
 
 // St (ST) stands for Simple Text
 export type CdaValueSt = {
-  _xsiTypeAttribute?: string;
-  _xmlnsXsiAttribute?: string;
-  _inlineTextAttribute?: string;
+  [_xsiTypeAttribute]?: string;
+  [_xmlnsXsiAttribute]?: string;
+  [_inlineTextAttribute]?: string;
 };
 
 // Cv (CV) stands for Coded Value
@@ -101,9 +115,9 @@ export interface CdaCodeCv extends CdaCodeCe {
 
 // see https://build.fhir.org/ig/HL7/CDA-core-sd/StructureDefinition-II.html
 export type CdaInstanceIdentifier = {
-  _rootAttribute?: string;
-  _extensionAttribute?: string;
-  _assigningAuthorityNameAttribute?: string;
+  [_rootAttribute]?: string;
+  [_extensionAttribute]?: string;
+  [_assigningAuthorityNameAttribute]?: string;
 };
 
 // TOP Level CDA Section Types


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1603

### Dependencies 
- Upstream: https://github.com/metriport/metriport/pull/1757
- Downstream: https://github.com/metriport/metriport/pull/1894

### Description

 - Reverted a change for the removal of brackets around attribute constants

### Testing

- Local
  - [x] The CDAs are now valid again

### Release Plan
- [ ] Merge this
