### PR TITLE
1790 address fields cq dir

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/__tests__/get-address-fields.test.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/__tests__/get-address-fields.test.ts
@@ -1,0 +1,113 @@
+import { getAddressFields, LenientAddress } from "../parse-cq-directory-entry";
+
+const fullAddress = {
+  line: [{ value: "1111 Example St" }],
+  city: { value: "Austin" },
+  state: { value: "TX" },
+  postalCode: { value: "12345" },
+};
+
+const resultAddress: LenientAddress = {
+  addressLine: "1111 Example St",
+  city: "Austin",
+  state: "TX",
+  zip: "12345",
+};
+
+describe("getAddressFields", () => {
+  test("should return an empty object when addresses array is undefined", () => {
+    const result = getAddressFields(undefined);
+    expect(result).toEqual({});
+  });
+
+  test("should return the address with all attributes if found", () => {
+    const addresses = [
+      fullAddress,
+      {
+        line: [{ value: "456 Elm St" }],
+        city: { value: "Austin" },
+        state: { value: "TX" },
+        postalCode: { value: "67890" },
+      },
+    ];
+
+    const result = getAddressFields(addresses);
+    expect(result).toEqual(resultAddress);
+  });
+
+  test("should return the first address if all attributes are present", () => {
+    const addresses = [
+      fullAddress,
+      {
+        line: [{ value: "456 Elm St" }],
+        city: { value: "Austin" },
+        state: { value: "TX" },
+        postalCode: { value: "67890" },
+      },
+    ];
+
+    const result = getAddressFields(addresses);
+    expect(result).toEqual(resultAddress);
+  });
+
+  test("should return the address with the most attributes", () => {
+    const addresses = [
+      { line: [{ value: "123 Main St" }], city: { value: "Austin" }, state: { value: "TX" } },
+      {
+        line: [{ value: "456 Elm St" }],
+        city: { value: "Austin" },
+        postalCode: { value: "12345" },
+      },
+      fullAddress,
+    ];
+
+    const result = getAddressFields(addresses);
+    expect(result).toEqual(resultAddress);
+  });
+
+  test("should return the address with the most attributes if none have all attributes", () => {
+    const addresses = [
+      { line: [{ value: "123 Main St" }] },
+      {
+        line: [{ value: "456 Elm St" }],
+        city: { value: "Austin" },
+        postalCode: { value: "12345" },
+      },
+      {
+        line: [{ value: "111 Sample St" }],
+        city: { value: "Austin" },
+      },
+    ];
+
+    const result = getAddressFields(addresses);
+    expect(result).toEqual({
+      addressLine: "456 Elm St",
+      city: "Austin",
+      zip: "12345",
+    });
+  });
+
+  test("should handle empty address attributes", () => {
+    const addresses = [
+      {
+        line: [{ value: "123 Main St" }],
+        city: { value: "Austin" },
+        state: { value: "TX" },
+        postalCode: { value: "" },
+      },
+      {
+        line: [],
+        city: { value: "Austin" },
+        state: { value: "TX" },
+        postalCode: { value: "12345" },
+      },
+    ];
+
+    const result = getAddressFields(addresses);
+    expect(result).toEqual({
+      addressLine: "123 Main St",
+      city: "Austin",
+      state: "TX",
+    });
+  });
+});

--- a/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/cq-gateways.ts
@@ -1,18 +1,5 @@
-import { out } from "@metriport/core/util/log";
 import { Op, Sequelize } from "sequelize";
 import { CQDirectoryEntryModel } from "../../models/cq-directory";
-
-export async function setEntriesAsGateway(oids: string[]): Promise<void> {
-  out(`setEntriesAsGateway`).log(`Found ${oids.length} gateways in the CQ directory. Updating...`);
-  await CQDirectoryEntryModel.update(
-    {
-      gateway: true,
-    },
-    {
-      where: { id: { [Op.in]: oids } },
-    }
-  );
-}
 
 export async function getOrganizationIds(excludeManagingOrgs: string[]): Promise<string[]> {
   const entries = await CQDirectoryEntryModel.findAll({

--- a/packages/api/src/external/carequality/command/cq-directory/create-cq-directory-entry.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/create-cq-directory-entry.ts
@@ -24,7 +24,6 @@ function createKeys(): string {
     "managingOrganization";
   const managingOrganizationId: keyof Pick<CQDirectoryEntryModel, "managingOrganizationId"> =
     "managingOrganizationId";
-  const gateway: keyof Pick<CQDirectoryEntryModel, "gateway"> = "gateway";
   const active: keyof Pick<CQDirectoryEntryModel, "active"> = "active";
   const lastUpdatedAtCQ: keyof Pick<CQDirectoryEntryModel, "lastUpdatedAtCQ"> = "lastUpdatedAtCQ";
 
@@ -45,7 +44,6 @@ function createKeys(): string {
     createdAt ? "created_at" : undefined,
     managingOrganization ? "managing_organization" : undefined,
     managingOrganizationId ? "managing_organization_id" : undefined,
-    gateway ? "gateway" : undefined,
     active ? "active" : undefined,
     lastUpdatedAtCQ ? "last_updated_at_cq" : undefined,
   ];
@@ -81,7 +79,6 @@ export async function bulkInsertCQDirectoryEntries(
     date,
     entry.managingOrganization ?? null,
     entry.managingOrganizationId ?? null,
-    entry.gateway ?? false,
     entry.active ?? false,
     entry.lastUpdatedAtCQ ?? null,
   ]);

--- a/packages/api/src/external/carequality/command/cq-directory/create-cq-directory-entry.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/create-cq-directory-entry.ts
@@ -14,7 +14,10 @@ function createKeys(): string {
   const lat: keyof Pick<CQDirectoryEntryModel, "lat"> = "lat";
   const lon: keyof Pick<CQDirectoryEntryModel, "lon"> = "lon";
   const point: keyof Pick<CQDirectoryEntryModel, "point"> = "point";
+  const addressLine: keyof Pick<CQDirectoryEntryModel, "addressLine"> = "addressLine";
+  const city: keyof Pick<CQDirectoryEntryModel, "city"> = "city";
   const state: keyof Pick<CQDirectoryEntryModel, "state"> = "state";
+  const zip: keyof Pick<CQDirectoryEntryModel, "zip"> = "zip";
   const data: keyof Pick<CQDirectoryEntryModel, "data"> = "data";
   const createdAt: keyof Pick<CQDirectoryEntryModel, "createdAt"> = "createdAt";
   const managingOrganization: keyof Pick<CQDirectoryEntryModel, "managingOrganization"> =
@@ -34,7 +37,10 @@ function createKeys(): string {
     lat,
     lon,
     point,
+    addressLine ? "address_line" : undefined,
+    city,
     state,
+    zip,
     data,
     createdAt ? "created_at" : undefined,
     managingOrganization ? "managing_organization" : undefined,
@@ -67,7 +73,10 @@ export async function bulkInsertCQDirectoryEntries(
     entry.lat ?? null,
     entry.lon ?? null,
     entry.point ?? null,
+    entry.addressLine ?? null,
+    entry.city ?? null,
     entry.state ?? null,
+    entry.zip ?? null,
     entry.data ? JSON.stringify(entry.data) : null,
     date,
     entry.managingOrganization ?? null,

--- a/packages/api/src/external/carequality/command/cq-directory/parse-cq-directory-entry.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/parse-cq-directory-entry.ts
@@ -4,9 +4,12 @@ import { Contained } from "@metriport/carequality-sdk/models/contained";
 import { ManagingOrganization, Organization } from "@metriport/carequality-sdk/models/organization";
 import { Coordinates } from "@metriport/core/external/aws/location";
 import { capture } from "@metriport/core/util/notifications";
-import { normalizeOid, normalizeZipCode } from "@metriport/shared";
+import { errorToString, normalizeOid, normalizeZipCode } from "@metriport/shared";
 import { CQDirectoryEntryData } from "../../cq-directory";
 import { CQOrgUrls } from "../../shared";
+import { out } from "@metriport/core/util/log";
+
+const { log } = out(`parseCQDirectoryEntries`);
 
 export type LenientAddress = {
   addressLine?: string | undefined;
@@ -154,7 +157,7 @@ export function getAddressFields(addresses: Address[] | undefined): LenientAddre
       try {
         parsedAddress.zip = normalizeZipCode(postalCode);
       } catch (err) {
-        console.log(`normalizeZipCode error for zip ${postalCode} - error: ${err}`);
+        log(`normalizeZipCode error for zip ${postalCode} - error: ${errorToString(err)}`);
       }
     }
 
@@ -208,7 +211,7 @@ function getNormalizedOid(
   try {
     return normalizeOid(oid);
   } catch (err) {
-    console.log(`${entityDescription} has invalid OID: ${oid}`);
+    log(`${entityDescription} has invalid OID: ${oid}`);
   }
 }
 
@@ -220,7 +223,7 @@ function getUrlType(value: string | undefined): ChannelUrl | undefined {
 
   if (value.includes("Direct Messaging")) return;
   const msg = `Unknown CQ Endpoint type`;
-  console.log(msg);
+  log(msg);
   capture.message(msg, {
     extra: { value, context: "parseCQDirectoryEntries" },
     level: "warning",

--- a/packages/api/src/external/carequality/command/cq-directory/parse-cq-directory-entry.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/parse-cq-directory-entry.ts
@@ -3,9 +3,8 @@ import { Address } from "@metriport/carequality-sdk/models/address";
 import { Contained } from "@metriport/carequality-sdk/models/contained";
 import { ManagingOrganization, Organization } from "@metriport/carequality-sdk/models/organization";
 import { Coordinates } from "@metriport/core/external/aws/location";
-import { normalizeZipCode } from "@metriport/core/mpi/normalize-patient";
 import { capture } from "@metriport/core/util/notifications";
-import { normalizeOid } from "@metriport/shared";
+import { normalizeOid, normalizeZipCode } from "@metriport/shared";
 import { CQDirectoryEntryData } from "../../cq-directory";
 import { CQOrgUrls } from "../../shared";
 

--- a/packages/api/src/external/carequality/command/cq-directory/parse-cq-directory-entry.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/parse-cq-directory-entry.ts
@@ -147,8 +147,13 @@ function getAddressFields(addresses: Address[] | undefined): LenientAddress {
     }
     if (firstAddress?.city?.value) address.city = firstAddress?.city?.value;
     if (firstAddress?.state?.value) address.state = firstAddress?.state?.value;
-    if (firstAddress?.postalCode?.value) {
-      address.zip = normalizeZipCode(firstAddress?.postalCode?.value);
+    const postalCode = firstAddress?.postalCode?.value;
+    if (postalCode && postalCode.length > 0) {
+      try {
+        address.zip = normalizeZipCode(postalCode);
+      } catch (err) {
+        console.log(`normalizeZipCode error for zip ${postalCode} - error: ${err}`);
+      }
     }
   }
   return address;

--- a/packages/api/src/external/carequality/command/cq-directory/parse-cq-directory-entry.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/parse-cq-directory-entry.ts
@@ -55,7 +55,6 @@ export function parseCQDirectoryEntries(orgsInput: Organization[]): CQDirectoryE
       data: org,
       managingOrganization,
       managingOrganizationId,
-      gateway: false,
       active,
       lastUpdatedAtCQ: org.meta.lastUpdated.value,
     };

--- a/packages/api/src/external/carequality/cq-directory.ts
+++ b/packages/api/src/external/carequality/cq-directory.ts
@@ -9,7 +9,10 @@ export type CQDirectoryEntryData = {
   urlDR?: string;
   lat?: number;
   lon?: number;
+  addressLine?: string;
+  city?: string;
   state?: string;
+  zip?: string;
   data?: Organization;
   point?: string;
   managingOrganization?: string;

--- a/packages/api/src/external/carequality/cq-directory.ts
+++ b/packages/api/src/external/carequality/cq-directory.ts
@@ -17,7 +17,6 @@ export type CQDirectoryEntryData = {
   point?: string;
   managingOrganization?: string;
   managingOrganizationId?: string;
-  gateway: boolean;
   active: boolean;
   lastUpdatedAtCQ: string;
 };

--- a/packages/api/src/external/carequality/models/cq-directory.ts
+++ b/packages/api/src/external/carequality/models/cq-directory.ts
@@ -16,7 +16,10 @@ export class CQDirectoryEntryModel
   declare lat?: number;
   declare lon?: number;
   declare point?: string;
+  declare addressLine?: string;
+  declare city?: string;
   declare state?: string;
+  declare zip?: string;
   declare data?: Organization;
   declare managingOrganization?: string;
   declare managingOrganizationId?: string;
@@ -50,7 +53,17 @@ export class CQDirectoryEntryModel
         lon: {
           type: DataTypes.FLOAT,
         },
+        addressLine: {
+          type: DataTypes.STRING,
+          field: "address_line",
+        },
+        city: {
+          type: DataTypes.STRING,
+        },
         state: {
+          type: DataTypes.STRING,
+        },
+        zip: {
           type: DataTypes.STRING,
         },
         data: {

--- a/packages/api/src/external/carequality/models/cq-directory.ts
+++ b/packages/api/src/external/carequality/models/cq-directory.ts
@@ -23,7 +23,6 @@ export class CQDirectoryEntryModel
   declare data?: Organization;
   declare managingOrganization?: string;
   declare managingOrganizationId?: string;
-  declare gateway: boolean;
   declare active: boolean;
   declare lastUpdatedAtCQ: string;
 
@@ -79,10 +78,6 @@ export class CQDirectoryEntryModel
         managingOrganizationId: {
           type: DataTypes.STRING,
           field: "managing_organization_id",
-        },
-        gateway: {
-          type: DataTypes.BOOLEAN,
-          defaultValue: false,
         },
         active: {
           type: DataTypes.BOOLEAN,

--- a/packages/api/src/sequelize/migrations/2024-05-15_00_alter-cq-directory-add-address-fields.ts
+++ b/packages/api/src/sequelize/migrations/2024-05-15_00_alter-cq-directory-add-address-fields.ts
@@ -5,6 +5,7 @@ const tableName = "cq_directory_entry";
 const addressLineColumn = "address_line";
 const cityColumn = "city";
 const zipColumn = "zip";
+const gatewayColumn = "gateway";
 
 export const up: Migration = async ({ context: queryInterface }) => {
   await queryInterface.sequelize.transaction(async transaction => {
@@ -26,6 +27,7 @@ export const up: Migration = async ({ context: queryInterface }) => {
       { type: DataTypes.STRING, allowNull: true },
       { transaction }
     );
+    await queryInterface.removeColumn(tableName, gatewayColumn, { transaction });
   });
 };
 
@@ -34,5 +36,11 @@ export const down: Migration = ({ context: queryInterface }) => {
     await queryInterface.removeColumn(tableName, addressLineColumn, { transaction });
     await queryInterface.removeColumn(tableName, cityColumn, { transaction });
     await queryInterface.removeColumn(tableName, zipColumn, { transaction });
+    await queryInterface.addColumn(
+      tableName,
+      gatewayColumn,
+      { type: DataTypes.BOOLEAN, defaultValue: false, allowNull: true },
+      { transaction }
+    );
   });
 };

--- a/packages/api/src/sequelize/migrations/2024-05-15_00_alter-cq-directory-add-address-fields.ts
+++ b/packages/api/src/sequelize/migrations/2024-05-15_00_alter-cq-directory-add-address-fields.ts
@@ -1,0 +1,38 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "cq_directory_entry";
+const addressLineColumn = "address_line";
+const cityColumn = "city";
+const zipColumn = "zip";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.addColumn(
+      tableName,
+      addressLineColumn,
+      { type: DataTypes.STRING, allowNull: true },
+      { transaction }
+    );
+    await queryInterface.addColumn(
+      tableName,
+      cityColumn,
+      { type: DataTypes.STRING, allowNull: true },
+      { transaction }
+    );
+    await queryInterface.addColumn(
+      tableName,
+      zipColumn,
+      { type: DataTypes.STRING, allowNull: true },
+      { transaction }
+    );
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.removeColumn(tableName, addressLineColumn, { transaction });
+    await queryInterface.removeColumn(tableName, cityColumn, { transaction });
+    await queryInterface.removeColumn(tableName, zipColumn, { transaction });
+  });
+};

--- a/packages/core/src/mpi/normalize-patient.ts
+++ b/packages/core/src/mpi/normalize-patient.ts
@@ -46,7 +46,7 @@ export function normalizePatient<T extends PatientData>(patient: T): T {
  * @param zipCode - The zip code to be normalized.
  * @returns The normalized zip code as a string.
  */
-function normalizeZipCode(zipCode: string): string {
+export function normalizeZipCode(zipCode: string): string {
   return zipCode.slice(0, 5);
 }
 

--- a/packages/core/src/mpi/normalize-patient.ts
+++ b/packages/core/src/mpi/normalize-patient.ts
@@ -1,5 +1,6 @@
 import { Address } from "../domain/address";
 import { PatientData } from "../domain/patient";
+import { normalizeZipCode } from "@metriport/shared";
 
 /**
  * Takes in patient data and normalizes it by splitting the first and last names,
@@ -39,15 +40,6 @@ export function normalizePatient<T extends PatientData>(patient: T): T {
     }),
   };
   return normalizedPatient;
-}
-
-/**
- * Normalizes a zip code by taking the first 5 characters.
- * @param zipCode - The zip code to be normalized.
- * @returns The normalized zip code as a string.
- */
-export function normalizeZipCode(zipCode: string): string {
-  return zipCode.slice(0, 5);
 }
 
 /**

--- a/packages/shared/src/common/__tests__/normalize-zip.test.ts
+++ b/packages/shared/src/common/__tests__/normalize-zip.test.ts
@@ -1,0 +1,27 @@
+import { normalizeZipCode } from "../normalize-zip";
+
+describe("normalizeZipCode", () => {
+  test("should handle short zip codes", () => {
+    const input = "1234";
+    const expectedOutput = "1234";
+    expect(normalizeZipCode(input)).toBe(expectedOutput);
+  });
+
+  test("should return first 4 characters when zip code length is 9", () => {
+    const input = "1234-6677";
+    const expectedOutput = "1234";
+    expect(normalizeZipCode(input)).toBe(expectedOutput);
+  });
+
+  test("should return first 5 characters when zip code length is 10", () => {
+    const input = "12345-6677";
+    const expectedOutput = "12345";
+    expect(normalizeZipCode(input)).toBe(expectedOutput);
+  });
+
+  test("should return first 5 characters when zip code length is 5", () => {
+    const input = "54321";
+    const expectedOutput = "54321";
+    expect(normalizeZipCode(input)).toBe(expectedOutput);
+  });
+});

--- a/packages/shared/src/common/__tests__/normalize-zip.test.ts
+++ b/packages/shared/src/common/__tests__/normalize-zip.test.ts
@@ -24,4 +24,19 @@ describe("normalizeZipCode", () => {
     const expectedOutput = "54321";
     expect(normalizeZipCode(input)).toBe(expectedOutput);
   });
+
+  test("should throw an error if zip contains non-digit and non-dash characters (length 9)", () => {
+    const input = "12345-667a";
+    expect(() => normalizeZipCode(input)).toThrow();
+  });
+
+  test("should throw an error if zip contains non-digit and non-dash characters (length 5)", () => {
+    const input = "1234a";
+    expect(() => normalizeZipCode(input)).toThrow();
+  });
+
+  test("should throw an error if zip is an empty string", () => {
+    const input = "";
+    expect(() => normalizeZipCode(input)).toThrow();
+  });
 });

--- a/packages/shared/src/common/normalize-zip.ts
+++ b/packages/shared/src/common/normalize-zip.ts
@@ -1,0 +1,11 @@
+/**
+ * Normalizes a zip code by taking the first 5 characters.
+ * @param zipCode - The zip code to be normalized.
+ * @returns The normalized zip code as a string.
+ */
+export function normalizeZipCode(zipCode: string): string {
+  if (zipCode.includes("-") && zipCode.length === 9) {
+    return zipCode.slice(0, 4);
+  }
+  return zipCode.slice(0, 5);
+}

--- a/packages/shared/src/common/normalize-zip.ts
+++ b/packages/shared/src/common/normalize-zip.ts
@@ -2,19 +2,22 @@
  * Normalizes a zip code by taking the first 4-5 characters.
  * @param zipCode - The zip code to be normalized.
  * @returns The normalized zip code as a string.
+ *
+ * TODO: Refactor, so `normalize` simply returns a zip of a certain format and returns undefined if it cannot,
+ * while `validate` would throw an error.
  */
 export function normalizeZipCode(zipCode: string): string {
-  if (!isValidZipCode(zipCode)) {
+  const trimmedZip = zipCode.trim();
+  if (!isValidZipCode(trimmedZip)) {
     throw new Error("Zip codes may only contain numbers (0-9) and a dash (-)");
   }
-  if (zipCode.includes("-") && zipCode.length === 9) return zipCode.slice(0, 4);
-  if (zipCode.length === 8) return zipCode.slice(0, 4);
-  return zipCode.slice(0, 5);
+  if (trimmedZip.includes("-") && trimmedZip.trim().length === 9) return trimmedZip.slice(0, 4);
+  if (trimmedZip.trim().length === 8) return trimmedZip.slice(0, 4);
+  return trimmedZip.slice(0, 5);
 }
 
 function isValidZipCode(zipCode: string): boolean {
   if (zipCode.length === 0) return false;
-  const regex = /[^0-9-]/;
-  const res = regex.test(zipCode);
-  return !res;
+  const regex = /^[0-9-]+$/;
+  return regex.test(zipCode);
 }

--- a/packages/shared/src/common/normalize-zip.ts
+++ b/packages/shared/src/common/normalize-zip.ts
@@ -4,8 +4,17 @@
  * @returns The normalized zip code as a string.
  */
 export function normalizeZipCode(zipCode: string): string {
-  if (zipCode.includes("-") && zipCode.length === 9) {
-    return zipCode.slice(0, 4);
+  if (!isValidZipCode(zipCode)) {
+    throw new Error("Zip codes may only contain numbers (0-9) and a dash (-)");
   }
+  if (zipCode.includes("-") && zipCode.length === 9) return zipCode.slice(0, 4);
+  if (zipCode.length === 8) return zipCode.slice(0, 4);
   return zipCode.slice(0, 5);
+}
+
+function isValidZipCode(zipCode: string): boolean {
+  if (zipCode.length === 0) return false;
+  const regex = /[^0-9-]/;
+  const res = regex.test(zipCode);
+  return !res;
 }

--- a/packages/shared/src/common/normalize-zip.ts
+++ b/packages/shared/src/common/normalize-zip.ts
@@ -1,5 +1,5 @@
 /**
- * Normalizes a zip code by taking the first 5 characters.
+ * Normalizes a zip code by taking the first 4-5 characters.
  * @param zipCode - The zip code to be normalized.
  * @returns The normalized zip code as a string.
  */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export { getDomainFromEmailWithoutTld } from "./common/email";
 export { errorToString } from "./common/error";
 export { emptyFunction } from "./common/general";
 export { normalizeOid } from "./common/normalize-oid";
+export { normalizeZipCode } from "./common/normalize-zip";
 export { PurposeOfUse } from "./common/purpose-of-use";
 export { executeWithRetries, executeWithRetriesOrFail } from "./common/retry";
 export { sleep } from "./common/sleep";


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1790

### Description

- Added the following columns to `cq_directory_entry` table: 
  - `address_line`
  - `city`
  - `zip`
- Removed the unused `gateway` column, and functions that used to set it. Note, there were no functions that currently use it for anything. 
- Moved and improved the `normalizeZipCode` function

### Testing
- Local
  - [x] Rebuilt the directory with staging (cap at 1000 orgs). 
  - [x] Rebuild the staging directory locally
  - [x] Rebuilt the production directory locally 

- Staging
  - [ ] Rebuild the staging directory
- Production
  - [ ] Rebuild the production directory

### Release Plan

- :warning: This contains a DB migration
- [ ] Actions:
  - [ ] For staging, after the test with rebuilding the directory, run the following commands on the Staging OSS DB:
    - [ ] `delete from cq_directory_entry;`
    - [ ] (insert the testing partners) - code can be found on Slack
- [ ] Merge this
