### PR TITLE
feat(mr): updating mrs to check if related person has a name

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
@@ -1993,7 +1993,10 @@ function createRelatedPersonSection(relatedPersons: RelatedPerson[]) {
     );
   }
 
-  const removeDuplicate = uniqWith(relatedPersons, (a, b) => {
+  const filteredRelatedPersons = relatedPersons.filter(
+    person => getName(person) && getRelationship(person)
+  );
+  const removeDuplicate = uniqWith(filteredRelatedPersons, (a, b) => {
     return getName(a) === getName(b) && getRelationship(a) === getRelationship(b);
   });
 

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -1898,7 +1898,10 @@ function createRelatedPersonSection(relatedPersons: RelatedPerson[]) {
     );
   }
 
-  const removeDuplicate = uniqWith(relatedPersons, (a, b) => {
+  const filteredRelatedPersons = relatedPersons.filter(
+    person => getName(person) && getRelationship(person)
+  );
+  const removeDuplicate = uniqWith(filteredRelatedPersons, (a, b) => {
     return getName(a) === getName(b) && getRelationship(a) === getRelationship(b);
   });
 


### PR DESCRIPTION
Refs: #[1792](https://github.com/metriport/metriport-internal/issues/1792)

### Description

- dont include relatedPerson in MR if the person doesn't have a name. Then the MR will also be considered empty and not get sent. 

### Testing

- Local
  - [x] building MRs and then testing if they get recognized as emoty 
- Staging
  - [ ] _testing step 1_
  - [ ] _testing step 2_

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
