### PR TITLE
fix(api): specified xml content type for cda uploads

### DIFF
--- a/packages/core/src/shareback/cda-uploader.ts
+++ b/packages/core/src/shareback/cda-uploader.ts
@@ -28,7 +28,6 @@ export async function cdaDocumentUploaderHandler({
   const { log } = out(`CDA Upload - cxId: ${cxId} - patientId: ${patientId}`);
   const fileSize = sizeInBytes(cdaBundle);
   const s3Utils = new S3Utils(region);
-  const metadataFileName = createUploadMetadataFilePath(cxId, patientId, docId);
   const destinationKey = createUploadFilePath(cxId, patientId, `${docId}.xml`);
 
   try {
@@ -36,6 +35,7 @@ export async function cdaDocumentUploaderHandler({
       bucket: medicalDocumentsBucket,
       key: destinationKey,
       file: Buffer.from(cdaBundle),
+      contentType: XML_APP_MIME_TYPE,
     });
     log(`Successfully uploaded the file to ${medicalDocumentsBucket} with key ${destinationKey}`);
   } catch (error) {
@@ -47,6 +47,7 @@ export async function cdaDocumentUploaderHandler({
     });
   }
 
+  const metadataFileName = createUploadMetadataFilePath(cxId, patientId, docId);
   try {
     await createAndUploadDocumentMetadataFile({
       s3Utils,

--- a/packages/core/src/shareback/create-and-upload-extrinsic-object.ts
+++ b/packages/core/src/shareback/create-and-upload-extrinsic-object.ts
@@ -4,6 +4,7 @@ import { createExtrinsicObjectXml } from "../external/carequality/dq/create-meta
 import { createPatientUniqueId } from "../external/carequality/shared";
 import { isOrganization } from "../external/fhir/shared";
 import { out } from "../util/log";
+import { XML_APP_MIME_TYPE } from "../util/mime";
 
 const { log } = out("Core Create and Upload Extrinsic Object");
 
@@ -56,5 +57,6 @@ export async function createAndUploadDocumentMetadataFile({
     bucket: destinationBucket,
     key: metadataFileName,
     file: Buffer.from(extrinsicObjectXml),
+    contentType: XML_APP_MIME_TYPE,
   });
 }


### PR DESCRIPTION
refs. metriport/metriport-internal#1603

### Description

- Specifying `application/xml` content type for the CDA documents resulting from data contributions

### Release Plan
- [ ] Merge this
