### PR TITLE
1667 pd v2 lambda mem bump

### DIFF
--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -105,7 +105,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
       layers: [lambdaLayers.shared],
-      memory: 1024,
+      memory: 4096,
       timeout: Duration.minutes(5),
       vpc,
     });


### PR DESCRIPTION
Ticket: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- bump up pd v2 lambda memory as a safety measure for upping number of gateways 

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
