### PR TITLE
PATCH: create in hie if not active

### DIFF
--- a/packages/api/src/external/carequality/get-obo-data.ts
+++ b/packages/api/src/external/carequality/get-obo-data.ts
@@ -12,11 +12,8 @@ export type CqOboDetails =
       enabled: false;
     };
 
-export async function getCqOboData(
-  cqActive?: boolean | null,
-  cqOboOid?: string | null
-): Promise<CqOboDetails> {
-  if (cqActive && cqOboOid) {
+export async function getCqOboData(cqOboOid?: string | null): Promise<CqOboDetails> {
+  if (cqOboOid) {
     const cqFacilityName = await getCqFacilityName(cqOboOid);
     return {
       enabled: true,

--- a/packages/api/src/external/hie/__tests__/register-facility.test.ts
+++ b/packages/api/src/external/hie/__tests__/register-facility.test.ts
@@ -331,21 +331,12 @@ describe("registerFacility", () => {
   });
 
   it("calls createOrUpdateInCq with obo when cqType is initiatorOnly, and cqActive is false", async () => {
-    const cxId = uuidv7_file.uuidv4();
-
     mockedFacility = {
       ...mockedFacility,
       cqType: FacilityType.initiatorOnly,
       cqActive: false,
       cqOboOid: faker.string.uuid(),
     };
-
-    await shared.createOrUpdateInCw(
-      mockedFacility,
-      mockedRegisterFacility.cwFacilityName,
-      getCxOrganizationNameAndOidResult,
-      cxId
-    );
 
     await shared.createOrUpdateInCq(
       mockedFacility,
@@ -376,13 +367,6 @@ describe("registerFacility", () => {
       mockedRegisterFacility.cwFacilityName,
       getCxOrganizationNameAndOidResult,
       cxId
-    );
-
-    await shared.createOrUpdateInCq(
-      mockedFacility,
-      getCxOrganizationNameAndOidResult,
-      { enabled: true, cqFacilityName: faker.company.name(), cqOboOid: faker.string.uuid() },
-      coordinates
     );
 
     expect(createOrUpdateCwOrganizationMock).toHaveBeenCalledWith(

--- a/packages/api/src/external/hie/__tests__/register-facility.test.ts
+++ b/packages/api/src/external/hie/__tests__/register-facility.test.ts
@@ -329,4 +329,47 @@ describe("registerFacility", () => {
       })
     );
   });
+
+  it("calls createOrUpdateInCq with obo and createOrUpdateInCw with obo when cqType is initiatorOnly, cwType is initiatorOnly and both are not active", async () => {
+    const cxId = uuidv7_file.uuidv4();
+
+    mockedFacility = {
+      ...mockedFacility,
+      cqType: FacilityType.initiatorOnly,
+      cqActive: false,
+      cqOboOid: faker.string.uuid(),
+      cwType: FacilityType.initiatorOnly,
+      cwActive: false,
+      cwOboOid: faker.string.uuid(),
+    };
+
+    await shared.createOrUpdateInCw(
+      mockedFacility,
+      mockedRegisterFacility.cwFacilityName,
+      getCxOrganizationNameAndOidResult,
+      cxId
+    );
+
+    await shared.createOrUpdateInCq(
+      mockedFacility,
+      getCxOrganizationNameAndOidResult,
+      { enabled: true, cqFacilityName: faker.company.name(), cqOboOid: faker.string.uuid() },
+      coordinates
+    );
+
+    expect(createOrUpdateCwOrganizationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: expect.stringContaining("OBO"),
+        }),
+      }),
+      true
+    );
+
+    expect(createOrUpdateCqOrganizationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: expect.stringContaining("OBO"),
+      })
+    );
+  });
 });

--- a/packages/api/src/external/hie/__tests__/register-facility.test.ts
+++ b/packages/api/src/external/hie/__tests__/register-facility.test.ts
@@ -330,7 +330,7 @@ describe("registerFacility", () => {
     );
   });
 
-  it("calls createOrUpdateInCq with obo and createOrUpdateInCw with obo when cqType is initiatorOnly, cwType is initiatorOnly and both are not active", async () => {
+  it("calls createOrUpdateInCq with obo when cqType is initiatorOnly, and cqActive is false", async () => {
     const cxId = uuidv7_file.uuidv4();
 
     mockedFacility = {
@@ -338,6 +338,34 @@ describe("registerFacility", () => {
       cqType: FacilityType.initiatorOnly,
       cqActive: false,
       cqOboOid: faker.string.uuid(),
+    };
+
+    await shared.createOrUpdateInCw(
+      mockedFacility,
+      mockedRegisterFacility.cwFacilityName,
+      getCxOrganizationNameAndOidResult,
+      cxId
+    );
+
+    await shared.createOrUpdateInCq(
+      mockedFacility,
+      getCxOrganizationNameAndOidResult,
+      { enabled: true, cqFacilityName: faker.company.name(), cqOboOid: faker.string.uuid() },
+      coordinates
+    );
+
+    expect(createOrUpdateCqOrganizationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: expect.stringContaining("OBO"),
+      })
+    );
+  });
+
+  it("calls createOrUpdateInCw with obo when cwType is initiatorOnly, and cwActive is false", async () => {
+    const cxId = uuidv7_file.uuidv4();
+
+    mockedFacility = {
+      ...mockedFacility,
       cwType: FacilityType.initiatorOnly,
       cwActive: false,
       cwOboOid: faker.string.uuid(),
@@ -364,12 +392,6 @@ describe("registerFacility", () => {
         }),
       }),
       true
-    );
-
-    expect(createOrUpdateCqOrganizationMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: expect.stringContaining("OBO"),
-      })
     );
   });
 });

--- a/packages/api/src/external/hie/register-facility.ts.ts
+++ b/packages/api/src/external/hie/register-facility.ts.ts
@@ -30,7 +30,7 @@ export async function registerFacilityWithinHIEs(
   const [cxOrg, address, cqOboData] = await Promise.all([
     getCxOrganizationNameOidAndType(cxId),
     getAddressWithCoordinates(getAddressFromInput(facility), cxId),
-    getCqOboData(facility.cqActive, facility.cqOboOid),
+    getCqOboData(facility.cqOboOid),
   ]);
 
   const { facilityDetails, coordinates } = createFacilityDetails(cxId, facility, address);

--- a/packages/api/src/external/hie/shared.ts
+++ b/packages/api/src/external/hie/shared.ts
@@ -70,7 +70,7 @@ export async function createOrUpdateInCw(
 
   const isProvider = isNonOboFacility(facility.cwType);
   const isObo = isOboFacility(facility.cwType);
-  const cwOboDisabled = !isObo || !facility.cwActive || !facility.cwOboOid;
+  const cwOboDisabled = !isObo || !facility.cwOboOid;
 
   if (cwOboDisabled && !isProvider) {
     log(`CW OBO is not enabled for this facility`);


### PR DESCRIPTION
Ref. metriport/metriport-internal#1785

Ticket: #2101 

### Dependencies

- Upstream: none
- Downstream: none

### Description

Create in hie if not active - [context](https://metriport.slack.com/archives/C04DBBJSKGB/p1716334842494709?thread_ts=1716328345.871839&cid=C04DBBJSKGB)

### Testing

_[Regular PRs:]_

- Local
  - [x] Create in hie when not active
- Production
  - [ ] Monitor

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
