### PR TITLE
1667 patch ntst oid

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
@@ -1,0 +1,45 @@
+import { XCAGateway, XCPDGateway } from "@metriport/ihe-gateway-sdk";
+
+/*
+ * Gateways with this url require the Metriport OID instead of the Initiator OID in the SOAP body.
+ */
+const requiresMetriportOidUrl =
+  "https://carequality.ntstplatform.com:443/Inbound/XCPDRespondingGateway";
+
+/*
+ * Gateways with this url require the URN namespace to NOT be in the SOAP body.
+ */
+const specialNamespaceRequiredUrl =
+  "https://www.medentcq.com:14430/MedentRespondingGateway-1.0-SNAPSHOT/RespondingGateway/xcpd-iti55";
+
+const pointClickCareOid = "2.16.840.1.113883.3.6448";
+const redoxOid = "2.16.840.1.113883.3.6147.458";
+const redoxGatewayOid = "2.16.840.1.113883.3.6147.458.2";
+
+/*
+ * These gateways only accept a single document reference per request.
+ */
+const gatewaysThatAcceptOneDocRefPerRequest = [pointClickCareOid, redoxOid, redoxGatewayOid];
+
+/*
+ * These gateways require that the home community ID in the DR request is the same as the one
+ * in the gateway. But these gateways also return different home community IDs in the DQ response
+ * than in the gateway. So we need to handle this and use the request home community ID instead of the response.
+ */
+const enforceSameHomeCommunityIdList = [pointClickCareOid, redoxOid, redoxGatewayOid];
+
+export function requiresMetriportOidInsteadOfInitiatorOid(gateway: XCPDGateway): boolean {
+  return gateway.url == requiresMetriportOidUrl;
+}
+
+export function requiresUrnInSoapBody(gateway: XCPDGateway): boolean {
+  return gateway.url != specialNamespaceRequiredUrl;
+}
+
+export function requiresOnlyOneDocRefPerRequest(gateway: XCAGateway): boolean {
+  return gatewaysThatAcceptOneDocRefPerRequest.includes(gateway.homeCommunityId);
+}
+
+export function requiresRequestHomeCommunityId(gateway: XCAGateway): boolean {
+  return enforceSameHomeCommunityIdList.includes(gateway.homeCommunityId);
+}

--- a/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
@@ -1,5 +1,5 @@
-import { XCAGateway, XCPDGateway } from "@metriport/ihe-gateway-sdk";
-
+import { XCAGateway, XCPDGateway, SamlAttributes } from "@metriport/ihe-gateway-sdk";
+import { METRIPORT_HOME_COMMUNITY_ID_NO_PREFIX } from "../shared";
 /*
  * Gateways with this url require the Metriport OID instead of the Initiator OID in the SOAP body.
  */
@@ -28,8 +28,14 @@ const gatewaysThatAcceptOneDocRefPerRequest = [pointClickCareOid, redoxOid, redo
  */
 const enforceSameHomeCommunityIdList = [pointClickCareOid, redoxOid, redoxGatewayOid];
 
-export function requiresMetriportOidInsteadOfInitiatorOid(gateway: XCPDGateway): boolean {
+function requiresMetriportOidInsteadOfInitiatorOid(gateway: XCPDGateway): boolean {
   return gateway.url == requiresMetriportOidUrl;
+}
+
+export function getHomeCommunityId(gateway: XCPDGateway, samlAttributes: SamlAttributes): string {
+  return requiresMetriportOidInsteadOfInitiatorOid(gateway)
+    ? METRIPORT_HOME_COMMUNITY_ID_NO_PREFIX
+    : samlAttributes.homeCommunityId;
 }
 
 export function requiresUrnInSoapBody(gateway: XCPDGateway): boolean {

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
@@ -16,12 +16,7 @@ import {
 } from "../../../../shared";
 import { successStatus, partialSuccessStatus } from "./constants";
 import { capture } from "../../../../../../util/notifications";
-
-const enforceSameHomeCommunityIdList = [
-  "2.16.840.1.113883.3.6448",
-  "2.16.840.1.113883.3.6147.458",
-  "2.16.840.1.113883.3.6147.458.2",
-];
+import { requiresRequestHomeCommunityId } from "../../../gateways";
 
 type Identifier = {
   _identificationScheme: string;
@@ -61,7 +56,7 @@ function getHomeCommunityIdForDr(
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
   extrinsicObject: any
 ): string {
-  if (enforceSameHomeCommunityIdList.includes(request.gateway.homeCommunityId)) {
+  if (requiresRequestHomeCommunityId(request.gateway)) {
     return getRequestHomeCommunityId(request);
   }
   return getResponseHomeCommunityId(extrinsicObject);

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/create/iti55-envelope.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/create/iti55-envelope.ts
@@ -13,10 +13,7 @@ import {
 import { OutboundPatientDiscoveryReq, XCPDGateway } from "@metriport/ihe-gateway-sdk";
 import { timestampToSoapBody } from "../../../utils";
 import { wrapIdInUrnUuid } from "../../../../../../util/urn";
-import {
-  requiresUrnInSoapBody,
-  requiresMetriportOidInsteadOfInitiatorOid,
-} from "../../../gateways";
+import { requiresUrnInSoapBody, getHomeCommunityId } from "../../../gateways";
 
 const DATE_DASHES_REGEX = /-/g;
 const action = "urn:hl7-org:v3:PRPA_IN201305UV02:CrossGatewayPatientDiscovery";
@@ -222,9 +219,7 @@ function createSoapBody({
   const receiverDeviceId = gateway.oid;
   const toUrl = gateway.url;
   const providerId = bodyData.principalCareProviderIds[0];
-  const homeCommunityId = requiresMetriportOidInsteadOfInitiatorOid(gateway)
-    ? METRIPORT_HOME_COMMUNITY_ID_NO_PREFIX
-    : bodyData.samlAttributes.homeCommunityId;
+  const homeCommunityId = getHomeCommunityId(gateway, bodyData.samlAttributes);
   const patientGender = bodyData.patientResource.gender === "female" ? "F" : "M";
   const patientBirthtime = bodyData.patientResource.birthDate.replace(DATE_DASHES_REGEX, "");
   const patientFamilyName = bodyData.patientResource.name?.[0]?.family;
@@ -268,9 +263,7 @@ export function createITI5SoapEnvelope({
   const toUrl = gateway.url;
   const gatewayOid = gateway.oid;
   const subjectRole = bodyData.samlAttributes.subjectRole.display;
-  const homeCommunityId = requiresMetriportOidInsteadOfInitiatorOid(gateway)
-    ? METRIPORT_HOME_COMMUNITY_ID_NO_PREFIX
-    : bodyData.samlAttributes.homeCommunityId;
+  const homeCommunityId = getHomeCommunityId(gateway, bodyData.samlAttributes);
   const purposeOfUse = bodyData.samlAttributes.purposeOfUse;
 
   const createdTimestamp = dayjs().toISOString();

--- a/packages/utils/src/saml/bulk-saml.ts
+++ b/packages/utils/src/saml/bulk-saml.ts
@@ -9,6 +9,7 @@ import { XCPDGateway } from "@metriport/ihe-gateway-sdk";
 import { createAndSignBulkXCPDRequests } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xcpd/create/iti55-envelope";
 import { sendSignedXCPDRequests } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests";
 import { processXCPDResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xcpd/process/xcpd-response";
+import { setRejectUnauthorized } from "@metriport/core/external/carequality/ihe-gateway-v2/saml/saml-client";
 
 /** This is a helper script to test constructing your own SOAP+SAML requests. It creates the SOAP 
 Envelope and sends it to the gateway specified in the request body. It logs the output into the 
@@ -18,13 +19,15 @@ Metriport-IHE GW / XML + SAML Constructor - Postman collection.
 */
 
 const timestamp = dayjs().toISOString();
+const env = "STAGING";
+setRejectUnauthorized(false);
 
 // Set these to staging if you want to actually test the endpoints in a pre-prod env
 const samlCertsAndKeys = {
-  publicCert: getEnvVarOrFail("CQ_ORG_CERTIFICATE_STAGING"),
-  privateKey: getEnvVarOrFail("CQ_ORG_PRIVATE_KEY_STAGING"),
-  privateKeyPassword: getEnvVarOrFail("CQ_ORG_PRIVATE_KEY_PASSWORD_STAGING"),
-  certChain: getEnvVarOrFail("CQ_ORG_CERTIFICATE_INTERMEDIATE_STAGING"),
+  publicCert: getEnvVarOrFail(`CQ_ORG_CERTIFICATE_${env}`),
+  privateKey: getEnvVarOrFail(`CQ_ORG_PRIVATE_KEY_${env}`),
+  privateKeyPassword: getEnvVarOrFail(`CQ_ORG_PRIVATE_KEY_PASSWORD_${env}`),
+  certChain: getEnvVarOrFail(`CQ_ORG_CERTIFICATE_INTERMEDIATE_${env}`),
 };
 
 const patientId = uuidv4();

--- a/packages/utils/src/saml/pre-prod-tester.ts
+++ b/packages/utils/src/saml/pre-prod-tester.ts
@@ -21,12 +21,16 @@ import {
   setS3UtilsInstance,
 } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response";
 import { Config } from "@metriport/core/util/config";
+import { setRejectUnauthorized } from "@metriport/core/external/carequality/ihe-gateway-v2/saml/saml-client";
 import { MockS3Utils } from "./mock-s3";
+
 /** 
 This script is a test script that queries the database for DQs and DRs, sends them to the Carequality gateway, and processes the responses.
 It is being used to test that DQs and DRs do not have runtime errors, and to test that the responses are returning similar responses to those in 
 the db.
 */
+
+setRejectUnauthorized(false);
 
 const samlAttributes = {
   subjectId: "System User",


### PR DESCRIPTION
Ticket: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- toggle to use Metriport OID instead of Cxs for Netsmart Endpoints
- tiny refactor to put all the special logic for different gateways in a single file so we can keep track of all of it. 

### Testing

- Local
  - [x] repro-ed the error and local queries to all existing endpoints + NTST and Medent still work

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
