### PR TITLE
PATCH: remove unnecessary checks

### DIFF
--- a/packages/api/src/external/hie/__tests__/register-facility.test.ts
+++ b/packages/api/src/external/hie/__tests__/register-facility.test.ts
@@ -7,7 +7,7 @@ import * as getAddress from "../../../domain/medical/address";
 import * as getOrg from "../../../command/medical/organization/get-organization";
 import * as getCqOboData from "../../../external/carequality/get-obo-data";
 import * as createOrUpdateFacility from "../../../command/medical/facility/create-or-update-facility";
-import { registerFacilityWithinHIEs } from "../register-facility.ts";
+import { registerFacilityWithinHIEs, createFacilityDetails } from "../register-facility.ts";
 import * as shared from "../shared";
 import {
   getCxOrganizationNameAndOidResult,
@@ -377,5 +377,38 @@ describe("registerFacility", () => {
       }),
       true
     );
+  });
+});
+
+describe("createFacilityDetails", () => {
+  it("returns facilityDetails and coordinates with facilityDetails containing addressStrict", async () => {
+    const cxId = uuidv7_file.uuidv4();
+
+    const result = createFacilityDetails(cxId, mockedRegisterFacility, addressWithCoordinates);
+
+    expect(result).toEqual({
+      facilityDetails: {
+        cqActive: mockedRegisterFacility.cqActive,
+        cqOboOid: mockedRegisterFacility.cqOboOid,
+        cqType: mockedRegisterFacility.cqType,
+        cwActive: mockedRegisterFacility.cwActive,
+        cwOboOid: mockedRegisterFacility.cwOboOid,
+        cwType: mockedRegisterFacility.cwType,
+        cxId,
+        data: {
+          address: {
+            addressLine1: addressWithCoordinates.addressLine1,
+            addressLine2: addressWithCoordinates.addressLine2,
+            city: addressWithCoordinates.city,
+            country: "USA",
+            state: addressWithCoordinates.state,
+            zip: addressWithCoordinates.zip,
+          },
+          name: mockedRegisterFacility.data.name,
+          npi: mockedRegisterFacility.data.npi,
+        },
+      },
+      coordinates,
+    });
   });
 });

--- a/packages/api/src/external/hie/register-facility.ts.ts
+++ b/packages/api/src/external/hie/register-facility.ts.ts
@@ -4,12 +4,7 @@ import {
   removeCoordinates,
 } from "@metriport/core/domain/location-address";
 import { Coordinates } from "@metriport/core/domain/address";
-import {
-  FacilityRegister,
-  Facility,
-  FacilityCreate,
-  isOboFacility,
-} from "../../domain/medical/facility";
+import { FacilityRegister, Facility, FacilityCreate } from "../../domain/medical/facility";
 import { getCxOrganizationNameOidAndType } from "../../command/medical/organization/get-organization";
 import { getAddressWithCoordinates } from "../../domain/medical/address";
 import { getCqOboData } from "../../external/carequality/get-obo-data";
@@ -51,16 +46,14 @@ export async function registerFacilityWithinHIEs(
   return cmdFacility;
 }
 
-function createFacilityDetails(
+export function createFacilityDetails(
   cxId: string,
   facility: FacilityRegister,
   address: AddressWithCoordinates
 ): { facilityDetails: FacilityCreate; coordinates: Coordinates } {
-  const isCqObo = isOboFacility(facility.cqType);
-  const isCwObo = isOboFacility(facility.cwType);
   const { address: addressStrict, coordinates } = removeCoordinates(address);
 
-  let facilityDetails: FacilityCreate = {
+  const facilityDetails: FacilityCreate = {
     cxId,
     data: {
       name: facility.data.name,
@@ -69,23 +62,11 @@ function createFacilityDetails(
     },
     cqType: facility.cqType,
     cwType: facility.cwType,
+    cqActive: facility.cqActive,
+    cwActive: facility.cwActive,
+    cqOboOid: facility.cqOboOid,
+    cwOboOid: facility.cwOboOid,
   };
-
-  if (isCqObo) {
-    facilityDetails = {
-      ...facilityDetails,
-      cqActive: facility.cqActive,
-      cqOboOid: facility.cqOboOid,
-    };
-  }
-
-  if (isCwObo) {
-    facilityDetails = {
-      ...facilityDetails,
-      cwActive: facility.cwActive,
-      cwOboOid: facility.cwOboOid,
-    };
-  }
 
   return {
     facilityDetails,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1785

Ticket: #2101 

### Dependencies

- Upstream: none
- Downstream: none

### Description

Remove checks in `createFacilityDetails` so we can set active or not active regarless if obo. 

### Testing

_[Regular PRs:]_

- Local
  - [x] Validate active is inputted correctly
- Production
  - [ ] Monitor

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
