### PR TITLE
1813 FHIR converter retries + FIFO on FHIR converter and server queues

### DIFF
--- a/packages/api/src/external/fhir-converter/connector-sqs.ts
+++ b/packages/api/src/external/fhir-converter/connector-sqs.ts
@@ -42,6 +42,9 @@ export class FHIRConverterConnectorSQS implements FHIRConverterConnector {
         startedAt: dayjs.utc().toISOString(),
         ...(source && { source }),
       },
+      fifo: true,
+      messageGroupId: documentId,
+      messageDeduplicationId: documentId,
     });
   }
 }

--- a/packages/api/src/external/fhir/connector/connector-sqs.ts
+++ b/packages/api/src/external/fhir/connector/connector-sqs.ts
@@ -23,6 +23,9 @@ export class FHIRServerConnectorSQS implements FHIRServerConnector {
         jobId: createJobId(requestId, documentId),
         startedAt: dayjs.utc().toISOString(),
       },
+      fifo: true,
+      messageGroupId: documentId,
+      messageDeduplicationId: documentId,
     });
   }
 }

--- a/packages/infra/lib/shared/sqs.ts
+++ b/packages/infra/lib/shared/sqs.ts
@@ -22,7 +22,7 @@ import { createRetryLambda, DEFAULT_LAMBDA_TIMEOUT } from "./lambda";
  */
 const DEFAULT_VISIBILITY_TIMEOUT_MULTIPLIER = 6;
 
-const DEFAULT_MAX_RECEIVE_COUNT = 5;
+const DEFAULT_MAX_RECEIVE_COUNT = 1;
 const DEFAULT_MAX_AGE_OF_OLDEST_MESSAGE = Duration.minutes(10);
 
 export type QueueProps = (StandardQueueProps | FifoQueueProps) & {
@@ -49,7 +49,7 @@ export type QueueProps = (StandardQueueProps | FifoQueueProps) & {
  * Creates a SQS queue.
  *
  * @param props.createDLQ - create a dead letter queue, default true
- * @param props.createRetryLambda - create a lambda to retry messages on DLQ, default true
+ * @param props.createRetryLambda - create a lambda to retry messages on DLQ (default true)
  * @param props.fifo - whether to create a FIFO queue or not, default false
  * @returns
  */
@@ -57,6 +57,8 @@ export function createQueue(props: QueueProps): Queue {
   const alarmMaxAgeOfOldestMessage =
     props.alarmMaxAgeOfOldestMessage ?? DEFAULT_MAX_AGE_OF_OLDEST_MESSAGE;
   const createDLQ = props.createDLQ !== false;
+  const isParamCreateRetryLambda =
+    props.createRetryLambda === undefined ? true : props.createRetryLambda;
 
   const dlq = createDLQ
     ? defaultDLQ(props.stack, props.name, props.fifo, {
@@ -85,7 +87,7 @@ export function createQueue(props: QueueProps): Queue {
     alarmAction: props?.alarmSnsAction,
   });
 
-  if (createDLQ && dlq) {
+  if (createDLQ && dlq && isParamCreateRetryLambda) {
     createRetryLambda({
       ...props,
       sourceQueue: dlq,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1813

### Dependencies

none

### Description

- fix fhir converter retries
- fhir converter queue to FIFO
- fhir server don't retry
- fhir server queue to FIFO
- default lambda max receive to 0 (no retries)

### Testing

- Local
  - [ ] branch to staging
- Staging
  - [ ] cross download 5 docs using IHE GW v1
  - [ ] conversion works
  - [ ] resources stored on FHIR
- Sandbox
  - none
- Production
  - none

### Release Plan

WIP

_[This is the release plan for production]_

_[You should execute the exact same steps when releasing to staging to validate it works]_

_[Add and remove items below accordingly]_

- :warning: Points to `master`
- :warning: This contains a DB migration
- [ ] Maintenance window scheduled/created at Checkly
- [ ] Execute this on <env1>, <env2>
  - [ ] _step1_
  - [ ] _step2_
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (deprecates a feature that needs to be communicated with customers)
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (introduce a feature that would be useful customers)
- [ ] Upstream dependencies are met/released
- [ ] Release NPM packages
- [ ] Fern Definition Updated
- [ ] Release Fern SDKs
- [ ] FFs have been set in Staging, Production, and Sandbox
- [ ] No dependencies between API and Infra that will cause errors during deployment
- [ ] _[action n-1]_
- [ ] _[action n]_
- [ ] Merge this
