### PR TITLE
1040 Add git signoff husky hook

### DIFF
--- a/.husky/check-signoff.sh
+++ b/.husky/check-signoff.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+SOB=$(git var GIT_AUTHOR_IDENT | sed -n -E 's/^(.+>).*$/Signed-off-by: \1/p')
+grep -qs "${SOB}" $1
+RES=$?
+
+if [ $RES -ne 0 ]; then
+  echo ""
+  echo "🚨 Missing commit sign-off!"
+  echo " "
+  echo "If you're using the terminal, add the -s option to the commit command."
+  echo "If you're using VSCode, you can set the 'Always Sign Off' option in the settings."
+  echo ""
+  exit 1
+fi
+
+exit 0

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -2,3 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx --no -- commitlint --edit ${1}
+
+./.husky/check-signoff.sh ${1}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Add git signoff husky hook - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1716483398391339)

### Testing

- Local
  - [x] fails when no signoff
  - [x] works with signoff
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
