### PR TITLE
feat(api): add urls if registering ci

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/create-or-update-cq-organization.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/create-or-update-cq-organization.ts
@@ -10,17 +10,15 @@ const cq = makeCarequalityManagementAPI();
 export async function createOrUpdateCQOrganization(orgDetails: CQOrgDetails): Promise<string> {
   if (!cq) throw new Error("Carequality API not initialized");
   const org = CQOrganization.fromDetails(orgDetails);
-  const orgExists = await doesOrganizationExistInCQ(cq, org.oid);
+  const orgExists = await doesOrganizationExistInCQ(org.oid);
   if (orgExists) {
     return updateCQOrganization(cq, org);
   }
   return registerOrganization(cq, org);
 }
 
-async function doesOrganizationExistInCQ(
-  cq: CarequalityManagementAPI,
-  oid: string
-): Promise<boolean> {
+export async function doesOrganizationExistInCQ(oid: string): Promise<boolean> {
+  if (!cq) throw new Error("Carequality API not initialized");
   const org = await cq.listOrganizations({ count: 1, oid });
   if (org.length > 0) {
     return true;

--- a/packages/api/src/external/carequality/organization-template.ts
+++ b/packages/api/src/external/carequality/organization-template.ts
@@ -28,12 +28,16 @@ export function buildXmlStringFromTemplate(orgDetails: CQOrgDetailsWithUrls) {
     email,
     role,
     parentOrgOid,
+    organizationBizType,
   } = orgDetails;
 
   const urnOid = "urn:oid:" + oid;
 
+  const isImplementer = role === "Implementer";
+  const isHealthItVendor = organizationBizType === "healthcare_it_vendor";
+
   const endpoints =
-    role === "Implementer"
+    isImplementer || isHealthItVendor
       ? getEndpoint(urnOid, XCPD_STRING, urlXCPD) +
         getEndpoint(urnOid, XCA_DQ_STRING, urlDQ) +
         getEndpoint(urnOid, XCA_DR_STRING, urlDR)

--- a/packages/api/src/external/carequality/organization.ts
+++ b/packages/api/src/external/carequality/organization.ts
@@ -1,3 +1,4 @@
+import { OrganizationBizType } from "@metriport/core/domain/organization";
 import { Config } from "../../shared/config";
 import { buildXmlStringFromTemplate } from "./organization-template";
 import { CQOrgDetails, CQOrgUrls, cqOrgUrlsSchema } from "./shared";
@@ -25,6 +26,7 @@ export class CQOrganization {
     public email: string,
     public role: "Implementer" | "Connection",
     public parentOrgOid?: string,
+    public organizationBizType?: OrganizationBizType,
     public urlXCPD?: string,
     public urlDQ?: string,
     public urlDR?: string
@@ -44,7 +46,8 @@ export class CQOrganization {
       orgDetails.phone,
       orgDetails.email,
       orgDetails.role,
-      orgDetails.parentOrgOid
+      orgDetails.parentOrgOid,
+      orgDetails.organizationBizType
     );
 
     this.addUrls(organization);
@@ -72,6 +75,7 @@ export class CQOrganization {
       email: this.email,
       role: this.role,
       parentOrgOid: this.parentOrgOid,
+      organizationBizType: this.organizationBizType,
     };
   }
 

--- a/packages/api/src/external/carequality/shared.ts
+++ b/packages/api/src/external/carequality/shared.ts
@@ -3,6 +3,7 @@ import { capture } from "@metriport/core/util/notifications";
 import { IHEGateway } from "@metriport/ihe-gateway-sdk";
 import { PurposeOfUse } from "@metriport/shared";
 import { MedicalDataSource } from "@metriport/core/external/index";
+import { OrganizationBizType } from "@metriport/core/domain/organization";
 import { errorToString } from "@metriport/shared/common/error";
 import z from "zod";
 import { isCarequalityEnabled, isCQDirectEnabledForCx } from "../aws/appConfig";
@@ -85,7 +86,12 @@ export const cqOrgDetailsSchema = z.object({
   phone: z.string(),
   email: z.string(),
   role: z.enum(["Implementer", "Connection"]),
+  organizationBizType: z.nativeEnum(OrganizationBizType).optional(),
   parentOrgOid: z.string().optional(),
+});
+
+export const cqOrgDetailsOrgBizRequiredSchema = cqOrgDetailsSchema.required({
+  organizationBizType: true,
 });
 
 export type CQOrgDetails = z.infer<typeof cqOrgDetailsSchema>;

--- a/packages/api/src/external/hie/__tests__/register-facility.test.ts
+++ b/packages/api/src/external/hie/__tests__/register-facility.test.ts
@@ -21,6 +21,7 @@ import { CqOboDetails } from "../../../external/carequality/get-obo-data";
 let mockedFacility: Facility;
 let mockedRegisterFacility: FacilityRegister;
 let getCqOboDataMock: jest.SpyInstance;
+let doesOrganizationExistInCQMock: jest.SpyInstance;
 let createOrUpdateCqOrganizationMock: jest.SpyInstance;
 let createOrUpdateCwOrganizationMock: jest.SpyInstance;
 
@@ -49,6 +50,9 @@ beforeEach(() => {
   jest
     .spyOn(createOrUpdateFacility, "createOrUpdateFacility")
     .mockImplementation(async () => mockedFacility);
+  doesOrganizationExistInCQMock = jest
+    .spyOn(createOrUpdateCqOrg, "doesOrganizationExistInCQ")
+    .mockImplementation(async () => true);
   createOrUpdateCqOrganizationMock = jest
     .spyOn(createOrUpdateCqOrg, "createOrUpdateCQOrganization")
     .mockImplementation(async () => "");
@@ -148,6 +152,19 @@ describe("registerFacility", () => {
         name: expect.not.stringContaining("OBO"),
       })
     );
+  });
+
+  it("returns createOrUpdateInCq early when cxOrg doesnt exist in directory", async () => {
+    doesOrganizationExistInCQMock.mockResolvedValue(false);
+
+    await shared.createOrUpdateInCq(
+      mockedFacility,
+      getCxOrganizationNameAndOidResult,
+      { enabled: true, cqFacilityName: faker.company.name(), cqOboOid: faker.string.uuid() },
+      coordinates
+    );
+
+    expect(createOrUpdateCqOrganizationMock).not.toHaveBeenCalled();
   });
 
   it("returns createOrUpdateInCq early when its an obo but cqObo not enabled", async () => {

--- a/packages/api/src/external/hie/shared.ts
+++ b/packages/api/src/external/hie/shared.ts
@@ -4,7 +4,10 @@ import { OrgType } from "@metriport/core/domain/organization";
 import { metriportEmail as metriportEmailForCq } from "../../external/carequality/constants";
 import { metriportCompanyDetails } from "@metriport/shared";
 import { Facility } from "../../domain/medical/facility";
-import { createOrUpdateCQOrganization } from "../../external/carequality/command/cq-directory/create-or-update-cq-organization";
+import {
+  createOrUpdateCQOrganization,
+  doesOrganizationExistInCQ,
+} from "../../external/carequality/command/cq-directory/create-or-update-cq-organization";
 import { createOrUpdateCWOrganization } from "../../external/commonwell/create-or-update-cw-organization";
 import { CqOboDetails } from "../../external/carequality/get-obo-data";
 import { buildCqOrgName } from "../../external/carequality/shared";
@@ -18,6 +21,13 @@ export async function createOrUpdateInCq(
   coordinates: Coordinates
 ): Promise<void> {
   const { log } = out("createOrUpdateInCq");
+  const orgExistsInDirectory = await doesOrganizationExistInCQ(cxOrg.oid);
+
+  if (!orgExistsInDirectory) {
+    log(`Organization ${cxOrg.name} with OID ${cxOrg.oid} does not exist in the CQ directory`);
+    return;
+  }
+
   const isObo = isOboFacility(facility.cqType);
   const isProvider = isNonOboFacility(facility.cqType);
   const cqOboDisabled = !isObo || !cqOboData.enabled;

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -42,7 +42,7 @@ import {
 } from "../../external/carequality/ihe-result";
 import { processOutboundPatientDiscoveryResps } from "../../external/carequality/process-outbound-patient-discovery-resps";
 import { processPostRespOutboundPatientDiscoveryResps } from "../../external/carequality/process-subsequent-outbound-patient-discovery-resps";
-import { cqOrgDetailsSchema } from "../../external/carequality/shared";
+import { cqOrgDetailsOrgBizRequiredSchema } from "../../external/carequality/shared";
 import { Config } from "../../shared/config";
 import { requestLogger } from "../helpers/request-logger";
 import { asyncHandler, getFrom, getFromQueryAsBoolean } from "../util";
@@ -143,7 +143,7 @@ router.post(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const body = req.body;
-    const orgDetails = cqOrgDetailsSchema.parse(body);
+    const orgDetails = cqOrgDetailsOrgBizRequiredSchema.parse(body);
     await createOrUpdateCQOrganization(orgDetails);
 
     return res.sendStatus(httpStatus.OK);


### PR DESCRIPTION
Ref. metriport/metriport-internal#1785

Ticket: #2101 

### Dependencies

- Upstream: none
- Downstream: none

### Description

Add urls to Candidate implementers in CQ. Also do not create facilities if org has not been created in directory yet. 

### Testing

- Local
  - [x] Appends the Urls
- Staging
  - [ ] Appends the Urls
- Production
  - [ ] Appends the Urls

### Release Plan

- [ ] Merge this
