### PR TITLE
1634 AppConfig FF as zod schema

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,8 @@
       "request": "launch",
       "cwd": "${workspaceFolder}/packages/api",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run-script", "dev"]
+      "runtimeArgs": ["run-script", "dev"],
+      "console": "integratedTerminal"
     },
     {
       "name": "Debug API - Attach to Node",

--- a/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
@@ -134,7 +134,7 @@ export function filterCQOrgsToSearch(orgs: CQOrgBasicDetails[]): CQOrgBasicDetai
 function constructGatewayExcludeList(): string[] {
   let excludeList: string[] = [];
   const urlsToExclude = Config.getCQUrlsToExclude();
-  if (urlsToExclude) excludeList = urlsToExclude.split(",");
+  if (urlsToExclude) excludeList = JSON.parse(urlsToExclude);
   return excludeList.map(url => url.toLowerCase());
 }
 

--- a/packages/core/src/external/aws/app-config.ts
+++ b/packages/core/src/external/aws/app-config.ts
@@ -1,34 +1,69 @@
-import { AppConfig } from "aws-sdk";
+import AWS, { AppConfig } from "aws-sdk";
+import { z } from "zod";
 import { MetriportError } from "../../util/error/metriport-error";
 import { out } from "../../util/log";
+import { uuidv4 } from "../../util/uuid-v7";
 
 const { log } = out(`Core appConfig - FF`);
+
+const clientId = uuidv4();
 
 function makeAppConfigClient(region: string): AWS.AppConfig {
   return new AppConfig({ region });
 }
 
-export type StringValuesFF = {
-  enabled: boolean;
-  values: string[];
-};
+export const ffStringValuesSchema = z.object({
+  enabled: z.boolean(),
+  values: z.string().array(),
+});
+export type StringValuesFF = z.infer<typeof ffStringValuesSchema>;
 
-export type BooleanFF = {
-  enabled: boolean;
-  values: never;
-};
+export const ffBooleanSchema = z.object({
+  enabled: z.boolean(),
+  values: z.never().or(z.literal(undefined)),
+});
+export type BooleanFF = z.infer<typeof ffBooleanSchema>;
 
-export type FeatureFlagDatastore = {
-  cxsWithEnhancedCoverageFeatureFlag: StringValuesFF;
-  cxsWithCQDirectFeatureFlag: StringValuesFF;
-  cxsWithCWFeatureFlag: StringValuesFF;
-  cxsWithADHDMRFeatureFlag: StringValuesFF;
-  cxsWithNoWebhookPongFeatureFlag: StringValuesFF;
-  cxsWithIncreasedSandboxLimitFeatureFlag: StringValuesFF;
-  oidsWithIHEGatewayV2Enabled: StringValuesFF;
-  commonwellFeatureFlag: BooleanFF;
-  carequalityFeatureFlag: BooleanFF;
-};
+export const ffDatastoreSchema = z.object({
+  cxsWithEnhancedCoverageFeatureFlag: ffStringValuesSchema,
+  cxsWithCQDirectFeatureFlag: ffStringValuesSchema,
+  cxsWithCWFeatureFlag: ffStringValuesSchema,
+  cxsWithADHDMRFeatureFlag: ffStringValuesSchema,
+  cxsWithNoWebhookPongFeatureFlag: ffStringValuesSchema,
+  cxsWithIncreasedSandboxLimitFeatureFlag: ffStringValuesSchema,
+  oidsWithIHEGatewayV2Enabled: ffStringValuesSchema,
+  commonwellFeatureFlag: ffBooleanSchema,
+  carequalityFeatureFlag: ffBooleanSchema,
+});
+export type FeatureFlagDatastore = z.infer<typeof ffDatastoreSchema>;
+
+export async function getFeatureFlags(
+  region: string,
+  appId: string,
+  configId: string,
+  envName: string
+): Promise<FeatureFlagDatastore> {
+  const appConfig = makeAppConfigClient(region);
+  const config = await appConfig
+    .getConfiguration({
+      Application: appId,
+      Configuration: configId,
+      Environment: envName,
+      ClientId: clientId,
+    })
+    .promise();
+  // TODO we should store this on each call, so the SDK will only retrieve the config again if the deployed version changes
+  // let version = config.ConfigurationVersion;
+  const configContent = config.Content;
+  log(
+    `From config with appId=${appId} configId=${configId} envName=${envName} ` +
+      ` - got config version: ${config.ConfigurationVersion}`
+  );
+  if (configContent && config.ContentType && config.ContentType === "application/json") {
+    return ffDatastoreSchema.parse(JSON.parse(configContent.toString()));
+  }
+  throw new MetriportError(`Failed to get Feature Flags`);
+}
 
 export async function getFeatureFlagValue<T extends keyof FeatureFlagDatastore>(
   region: string,
@@ -37,27 +72,10 @@ export async function getFeatureFlagValue<T extends keyof FeatureFlagDatastore>(
   envName: string,
   featureFlagName: T
 ): Promise<FeatureFlagDatastore[T]> {
-  const appConfig = makeAppConfigClient(region);
-  const config = await appConfig
-    .getConfiguration({
-      Application: appId,
-      Configuration: configId,
-      Environment: envName,
-      ClientId: featureFlagName,
-    })
-    .promise();
-  const configContent = config.Content;
-  log(
-    `From config with appId=${appId} configId=${configId} envName=${envName} ` +
-      `featureFlagName=${featureFlagName} - got config version: ${config.ConfigurationVersion}`
-  );
-  if (configContent && config.ContentType && config.ContentType === "application/json") {
-    const configContentValue = JSON.parse(configContent.toString());
-    if (configContentValue && configContentValue[featureFlagName]) {
-      return configContentValue[featureFlagName];
-    } else {
-      throw new MetriportError(`Feature Flag not found in config`, undefined, { featureFlagName });
-    }
+  const configContentValue = await getFeatureFlags(region, appId, configId, envName);
+  if (configContentValue && configContentValue[featureFlagName]) {
+    return configContentValue[featureFlagName];
+  } else {
+    throw new MetriportError(`Feature Flag not found in config`, undefined, { featureFlagName });
   }
-  throw new MetriportError(`Failed to get Feature Flag Value`, undefined, { featureFlagName });
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#1634

### Dependencies

- Upstream:
   - https://github.com/metriport/metriport/pull/2158
   - https://github.com/metriport/metriport-internal/pull/1820
- Downstream: https://github.com/metriport/metriport/pull/2164

### Description

- appConfig FF as zod schema
- `CQ_URLS_TO_EXCLUDE` stored as JSON

### Testing

- Local
  - [x] loads FFs successfully
- Staging
  - [ ] app runs
  - [ ] PD works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [x] Merge upstream
- [x] Merge this
- [ ] Update shared `.env`
