### PR TITLE
1040 Disable DCO for team members and npm publishing

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,3 @@
+# https://github.com/dcoapp/app?tab=readme-ov-file#skipping-sign-off-for-organization-members
+require:
+  members: false

--- a/.husky/check-signoff.sh
+++ b/.husky/check-signoff.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 
-SOB=$(git var GIT_AUTHOR_IDENT | sed -n -E 's/^(.+>).*$/Signed-off-by: \1/p')
-grep -qs "${SOB}" $1
-RES=$?
+NPM_PUBLISH_MSG="chore(release): publish"
+grep -qs "${NPM_PUBLISH_MSG}" $1 # returns 0 if found, 1 if not found
+containsNpmPublishMessage=$?
 
-if [ $RES -ne 0 ]; then
+SOB=$(git var GIT_AUTHOR_IDENT | sed -n -E 's/^(.+>).*$/Signed-off-by: \1/p')
+grep -qs "${SOB}" $1 # returns 0 if found, 1 if not found
+containsSignOffBy=$?
+
+if [ $containsNpmPublishMessage -ne 0 ] && [ $containsSignOffBy -ne 0 ]; then
+  commitMessage="$(cat $1)"
   echo ""
   echo "🚨 Missing commit sign-off!"
   echo " "
   echo "If you're using the terminal, add the -s option to the commit command."
   echo "If you're using VSCode, you can set the 'Always Sign Off' option in the settings."
   echo ""
+  echo "Original commit message:"
+  echo " "
+  echo $commitMessage
   exit 1
 fi
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Disable DCO for team members and npm publishing

### Testing

- Local
  - [x] requires DCO if not publishing NPM
  - [x] doesn't require DCO if publishing NPM
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
