### PR TITLE
1634 FF to set the XCPD GW for E2E tests

### DIFF
--- a/packages/api/src/__tests__/e2e/mapi/shared.ts
+++ b/packages/api/src/__tests__/e2e/mapi/shared.ts
@@ -1,13 +1,11 @@
 import { MedplumClient } from "@medplum/core";
 import { MetriportMedicalApi } from "@metriport/api-sdk";
-import { getEnvVarOrFail } from "@metriport/core/util/env-var";
-import { baseURL } from "../shared";
+import { baseURL, testApiKey } from "../shared";
 
 export const ACCOUNT_PATH = "/internal/admin/cx-account";
 export const CUSTOMER_PATH = "/internal/customer";
 export const MAPI_ACCESS = "/internal/mapi-access";
 
-export const testApiKey = getEnvVarOrFail("TEST_API_KEY");
 export const fhirHeaders = { headers: { "x-api-key": testApiKey } };
 
 export const fhirApi = new MedplumClient({ baseUrl: baseURL });

--- a/packages/api/src/__tests__/e2e/shared.ts
+++ b/packages/api/src/__tests__/e2e/shared.ts
@@ -1,9 +1,9 @@
 import * as dotenv from "dotenv";
 dotenv.config();
 // Keep dotenv import and config before everything else
+import { getEnvVarOrFail } from "@metriport/shared";
 import Axios from "axios";
 import { customAlphabet } from "nanoid";
-import { getEnvVarOrFail } from "../../shared/config";
 
 export const nanoid = customAlphabet("1234567890abcdef", 10);
 

--- a/packages/api/src/external/carequality/gateway/index.ts
+++ b/packages/api/src/external/carequality/gateway/index.ts
@@ -1,0 +1,70 @@
+import { Patient } from "@metriport/core/domain/patient";
+import { out } from "@metriport/core/util/log";
+import { XCPDGateway } from "@metriport/ihe-gateway-sdk";
+import { MetriportError } from "@metriport/shared";
+import { Config } from "../../../shared/config";
+import { getE2eCxIds as getE2eCxIds } from "../../aws/app-config";
+import { getCQDirectoryEntryOrFail } from "../command/cq-directory/get-cq-directory-entry";
+import { getOrganizationsForXCPD } from "../command/cq-directory/get-organizations-for-xcpd";
+import {
+  filterCQOrgsToSearch,
+  searchCQDirectoriesAroundPatientAddresses,
+  toBasicOrgAttributes,
+} from "../command/cq-directory/search-cq-directory";
+import { buildXcpdGateway, cqOrgsToXCPDGateways } from "../organization-conversion";
+
+type Gateways = {
+  v1Gateways: XCPDGateway[];
+  v2Gateways: XCPDGateway[];
+};
+
+export async function gatherXCPDGateways(patient: Patient): Promise<Gateways> {
+  const { log } = out(`gatherXCPDGateways, cx ${patient.cxId}, patient ${patient.id}`);
+
+  /**
+   * This is dedicated to E2E testing: limits the XCPD to the System Root's E2E Gateway.
+   * Avoid this approach as much as possible.
+   */
+  const e2eCxId = await getE2eCxIds();
+  if (e2eCxId === patient.cxId) {
+    log("Limiting to E2E Gateways");
+    return getE2eGateways();
+  }
+
+  const nearbyOrgsWithUrls = await searchCQDirectoriesAroundPatientAddresses({
+    patient,
+    mustHaveXcpdLink: true,
+  });
+  const orgOrderMap = new Map<string, number>();
+
+  nearbyOrgsWithUrls.forEach((org, index) => {
+    orgOrderMap.set(org.id, index);
+  });
+
+  const allOrgs = await getOrganizationsForXCPD(orgOrderMap);
+  const allOrgsWithBasics = allOrgs.map(toBasicOrgAttributes);
+  const orgsToSearch = filterCQOrgsToSearch(allOrgsWithBasics);
+  const { v1Gateways, v2Gateways } = await cqOrgsToXCPDGateways(orgsToSearch);
+
+  return {
+    v1Gateways,
+    v2Gateways,
+  };
+}
+
+async function getE2eGateways(): Promise<Gateways> {
+  const e2eCqDirectoryEntry = await getCQDirectoryEntryOrFail(Config.getSystemRootOID());
+  if (!e2eCqDirectoryEntry.urlXCPD) {
+    throw new MetriportError("E2E CQ Directory entry missing XCPD URL", undefined, {
+      id: e2eCqDirectoryEntry.id,
+    });
+  }
+  const e2eXcpdGateway = buildXcpdGateway({
+    urlXCPD: e2eCqDirectoryEntry.urlXCPD,
+    id: e2eCqDirectoryEntry.id,
+  });
+  return {
+    v1Gateways: [],
+    v2Gateways: [e2eXcpdGateway],
+  };
+}

--- a/packages/api/src/external/carequality/organization-conversion.ts
+++ b/packages/api/src/external/carequality/organization-conversion.ts
@@ -1,8 +1,8 @@
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { XCPDGateway } from "@metriport/ihe-gateway-sdk";
-import { CQOrgBasicDetails } from "./command/cq-directory/search-cq-directory";
-import { getOidsWithIHEGatewayV2Enabled } from "../aws/app-config";
 import { Config } from "../../shared/config";
+import { getOidsWithIHEGatewayV2Enabled } from "../aws/app-config";
+import { CQOrgBasicDetails } from "./command/cq-directory/search-cq-directory";
 
 export async function cqOrgsToXCPDGateways(cqOrgs: CQOrgBasicDetails[]): Promise<{
   v1Gateways: XCPDGateway[];
@@ -16,12 +16,10 @@ export async function cqOrgsToXCPDGateways(cqOrgs: CQOrgBasicDetails[]): Promise
 
   for (const org of cqOrgs) {
     if (org.urlXCPD) {
-      const gateway = {
-        url: org.urlXCPD,
-        oid: org.id,
-        id: uuidv7(),
-      };
-
+      const gateway = buildXcpdGateway({
+        urlXCPD: org.urlXCPD,
+        id: org.id,
+      });
       if (iheGatewayV2OIDs.includes(org.id)) {
         v2Gateways.push(gateway);
       } else {
@@ -33,5 +31,13 @@ export async function cqOrgsToXCPDGateways(cqOrgs: CQOrgBasicDetails[]): Promise
   return {
     v1Gateways,
     v2Gateways,
+  };
+}
+
+export function buildXcpdGateway(org: { id: string; urlXCPD: string }): XCPDGateway {
+  return {
+    url: org.urlXCPD,
+    oid: org.id,
+    id: uuidv7(),
   };
 }

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -4,23 +4,18 @@ import { MedicalDataSource } from "@metriport/core/external/index";
 import { processAsyncError } from "@metriport/core/util/error/shared";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
-import { IHEGateway, OutboundPatientDiscoveryReq, XCPDGateway } from "@metriport/ihe-gateway-sdk";
+import { IHEGateway, OutboundPatientDiscoveryReq } from "@metriport/ihe-gateway-sdk";
+import { errorToString } from "@metriport/shared";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
+import { makeIHEGatewayV2 } from "../ihe-gateway-v2/ihe-gateway-v2-factory";
 import { makeOutboundResultPoller } from "../ihe-gateway/outbound-result-poller-factory";
-import { getOrganizationsForXCPD } from "./command/cq-directory/get-organizations-for-xcpd";
-import {
-  filterCQOrgsToSearch,
-  searchCQDirectoriesAroundPatientAddresses,
-  toBasicOrgAttributes,
-} from "./command/cq-directory/search-cq-directory";
 import { deleteCQPatientData } from "./command/cq-patient-data/delete-cq-data";
 import { createOutboundPatientDiscoveryReq } from "./create-outbound-patient-discovery-req";
-import { cqOrgsToXCPDGateways } from "./organization-conversion";
+import { gatherXCPDGateways } from "./gateway";
 import { PatientDataCarequality } from "./patient-shared";
-import { getCqInitiator, validateCQEnabledAndInitGW } from "./shared";
-import { makeIHEGatewayV2 } from "../ihe-gateway-v2/ihe-gateway-v2-factory";
 import { processPatientDiscoveryProgress } from "./process-patient-discovery-progress";
+import { getCqInitiator, validateCQEnabledAndInitGW } from "./shared";
 
 dayjs.extend(duration);
 
@@ -93,6 +88,7 @@ async function prepareAndTriggerPD(
     });
   } catch (error) {
     const msg = `Error on Patient Discovery`;
+    out(baseLogMessage).log(`${msg} - ${errorToString(error)}`);
     await processPatientDiscoveryProgress({ patient, status: "failed" });
     capture.error(msg, {
       extra: {
@@ -144,31 +140,6 @@ async function prepareForPatientDiscovery(
   };
 }
 
-export async function gatherXCPDGateways(patient: Patient): Promise<{
-  v1Gateways: XCPDGateway[];
-  v2Gateways: XCPDGateway[];
-}> {
-  const nearbyOrgsWithUrls = await searchCQDirectoriesAroundPatientAddresses({
-    patient,
-    mustHaveXcpdLink: true,
-  });
-  const orgOrderMap = new Map<string, number>();
-
-  nearbyOrgsWithUrls.forEach((org, index) => {
-    orgOrderMap.set(org.id, index);
-  });
-
-  const allOrgs = await getOrganizationsForXCPD(orgOrderMap);
-  const allOrgsWithBasics = allOrgs.map(toBasicOrgAttributes);
-  const orgsToSearch = filterCQOrgsToSearch(allOrgsWithBasics);
-  const { v1Gateways, v2Gateways } = await cqOrgsToXCPDGateways(orgsToSearch);
-
-  return {
-    v1Gateways,
-    v2Gateways,
-  };
-}
-
 export function getCQData(
   data: PatientExternalData | undefined
 ): PatientDataCarequality | undefined {
@@ -177,6 +148,7 @@ export function getCQData(
 }
 
 export async function remove(patient: Patient): Promise<void> {
-  console.log(`Deleting CQ data - M patientId ${patient.id}`);
+  const { log } = out(`cq.patient.remove - M patientId ${patient.id}`);
+  log(`Deleting CQ data`);
   await deleteCQPatientData({ id: patient.id, cxId: patient.cxId });
 }

--- a/packages/api/src/routes/middlewares/__tests__/auth.test.ts
+++ b/packages/api/src/routes/middlewares/__tests__/auth.test.ts
@@ -1,0 +1,39 @@
+import { faker } from "@faker-js/faker";
+import { nanoid } from "nanoid";
+import { getCxIdFromApiKey } from "../auth";
+
+describe("getCxIdFromApiKey", () => {
+  const makeEncodedKey = (cxId?: string | undefined) => {
+    const input = cxId !== undefined ? `${nanoid()}:${cxId}` : nanoid();
+    return Buffer.from(input).toString("base64");
+  };
+
+  it("throws when no encoded API key is provided", async () => {
+    expect(() => getCxIdFromApiKey(undefined)).toThrow();
+  });
+
+  it(`throws when it gets empty encoded string`, async () => {
+    expect(() => getCxIdFromApiKey("")).toThrow();
+  });
+
+  it(`throws when it gets invalid encoded string`, async () => {
+    expect(() => getCxIdFromApiKey("N1Hqevi6FA")).toThrow();
+  });
+
+  it("throws when API key doesnt include separator and cxId", async () => {
+    const encodedKey = makeEncodedKey();
+    expect(() => getCxIdFromApiKey(encodedKey)).toThrow();
+  });
+
+  it("throws when API key doesnt include cxId", async () => {
+    const encodedKey = makeEncodedKey("");
+    expect(() => getCxIdFromApiKey(encodedKey)).toThrow();
+  });
+
+  it("cxId when its encoded correctly", async () => {
+    const expectedCxId = faker.string.uuid();
+    const encodedKey = makeEncodedKey(expectedCxId);
+    const cxId = getCxIdFromApiKey(encodedKey);
+    expect(cxId).toEqual(expectedCxId);
+  });
+});

--- a/packages/core/src/external/aws/app-config.ts
+++ b/packages/core/src/external/aws/app-config.ts
@@ -34,6 +34,7 @@ export const ffDatastoreSchema = z.object({
   oidsWithIHEGatewayV2Enabled: ffStringValuesSchema,
   commonwellFeatureFlag: ffBooleanSchema,
   carequalityFeatureFlag: ffBooleanSchema,
+  e2eCxIds: ffStringValuesSchema,
 });
 export type FeatureFlagDatastore = z.infer<typeof ffDatastoreSchema>;
 


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1634

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2159
- Downstream: none

### Description

- Limit XCPD on E2E to System Root's GW
- On local env, uses the same `TEST_API_KEY` env var to define the account for E2E test to run and the one on the server to check whether to use the System Root's GW
- On the cloud env, uses a newly created FF, `e2eCxIds`
- Add unit test to part of auth.ts

### Testing

- Local
  - [x] Load FF from staging
  - [x] Use env var from local env vars
  - [x] unit tests
- Staging
  - [ ] Update patient on Dash - XCPD to CQ test partners successful
  - [ ] E2E test works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
- [ ] Create a `GH Actions - TEST_API_KEY_PRODUCTION` entry on pwd manager to store the one used for E2E in production
- [ ] Create FF `e2eCxIds` in production pointing to the prod E2E account
- [ ] Update shared `.env`
