### PR TITLE
1634 Don't alarm when e2eCxIds FF has 1 item or fewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24754,7 +24754,7 @@
       }
     },
     "packages/api": {
-      "version": "1.16.6-alpha.0",
+      "version": "1.16.6",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -24835,11 +24835,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "7.18.0-alpha.0",
+      "version": "7.18.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.15.6-alpha.0",
-        "@metriport/shared": "^0.7.7-alpha.0",
+        "@metriport/commonwell-sdk": "^4.15.6",
+        "@metriport/shared": "^0.7.7",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -24895,24 +24895,19 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.7.7-alpha.0",
+      "version": "1.7.7",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.8.7-alpha.0",
+        "@metriport/ihe-gateway-sdk": "^0.8.7",
         "@metriport/shared": "^0.7.4"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
       }
     },
-    "packages/carequality-cert-runner/node_modules/@metriport/shared": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@metriport/shared/-/shared-0.7.6.tgz",
-      "integrity": "sha512-6uwPIVGZpF28AnYYpFlGZDCAkHVqIJsH/8UZOZ/VBgpQ/NdeUIvn42CWJmC9TZ9+SmYB/Nt9dYwrvnYAaYJkFw=="
-    },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.9.6-alpha.0",
+      "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -24922,10 +24917,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.16.6-alpha.0",
+      "version": "1.16.6",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.15.6-alpha.0",
+        "@metriport/commonwell-sdk": "^4.15.6",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -24964,10 +24959,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.13.6-alpha.0",
+      "version": "1.13.6",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.15.6-alpha.0",
+        "@metriport/commonwell-sdk": "^4.15.6",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -24999,7 +24994,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.15.6-alpha.0",
+      "version": "4.15.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",
@@ -25049,7 +25044,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.12.6-alpha.0",
+      "version": "1.12.6",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -25121,17 +25116,17 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.8.7-alpha.0",
+      "version": "0.8.7",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.7.7-alpha.0",
+        "@metriport/shared": "^0.7.7",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.11.6-alpha.0",
+      "version": "1.11.6",
       "dependencies": {
         "aws-cdk-lib": "^2.122.0",
         "constructs": "^10.2.69",
@@ -25179,7 +25174,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.11.6-alpha.0",
+      "version": "1.11.6",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -26206,14 +26201,14 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.7.7-alpha.0",
+      "version": "0.7.7",
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^8.0.2"
       }
     },
     "packages/utils": {
-      "version": "1.13.6-alpha.0",
+      "version": "1.13.6",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "7.18.0-alpha.0",
+  "version": "7.18.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -56,8 +56,8 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.15.6-alpha.0",
-    "@metriport/shared": "^0.7.7-alpha.0",
+    "@metriport/commonwell-sdk": "^4.15.6",
+    "@metriport/shared": "^0.7.7",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.16.6-alpha.0",
+  "version": "1.16.6",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/src/external/aws/app-config.ts
+++ b/packages/api/src/external/aws/app-config.ts
@@ -114,8 +114,8 @@ export async function getE2eCxIds(): Promise<string | undefined> {
     return apiKey ? getCxIdFromApiKey(apiKey) : undefined;
   }
   const cxIds = await getCxsWithFeatureFlagEnabled("e2eCxIds");
-  if (cxIds.length > 0) {
-    const msg = `FF e2eCxIds should only have 1 cxId`;
+  if (cxIds.length > 1) {
+    const msg = `FF e2eCxIds should have 1 cxId`;
     log(`${msg} but it has ${cxIds.length}, using the first one.`);
     capture.message(msg, { extra: { cxIds }, level: "warning" });
   }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.7.7-alpha.0",
+  "version": "1.7.7",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.8.7-alpha.0",
+    "@metriport/ihe-gateway-sdk": "^0.8.7",
     "@metriport/shared": "^0.7.4"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.9.6-alpha.0",
+  "version": "0.9.6",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.16.6-alpha.0",
+  "version": "1.16.6",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.15.6-alpha.0",
+    "@metriport/commonwell-sdk": "^4.15.6",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.13.6-alpha.0",
+  "version": "1.13.6",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.15.6-alpha.0",
+    "@metriport/commonwell-sdk": "^4.15.6",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.15.6-alpha.0",
+  "version": "4.15.6",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.12.6-alpha.0",
+  "version": "1.12.6",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.8.7-alpha.0",
+  "version": "0.8.7",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -55,7 +55,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.7.7-alpha.0",
+    "@metriport/shared": "^0.7.7",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.11.6-alpha.0",
+  "version": "1.11.6",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.11.6-alpha.0",
+  "version": "1.11.6",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.7.7-alpha.0",
+  "version": "0.7.7",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.13.6-alpha.0",
+  "version": "1.13.6",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1634

### Dependencies

none

### Description

Don't alarm when e2eCxIds FF has 1 item or fewer.

Release non-alpha NPM packages.

### Testing

- Local
  - none
- Staging
  - [ ] don't get alarm when using E2E test account
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
