### PR TITLE
PATCH RELEASE 1634

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
@@ -134,7 +134,13 @@ export function filterCQOrgsToSearch(orgs: CQOrgBasicDetails[]): CQOrgBasicDetai
 function constructGatewayExcludeList(): string[] {
   let excludeList: string[] = [];
   const urlsToExclude = Config.getCQUrlsToExclude();
-  if (urlsToExclude) excludeList = JSON.parse(urlsToExclude);
+  if (urlsToExclude) {
+    try {
+      excludeList = JSON.parse(urlsToExclude);
+    } catch (error) {
+      excludeList = urlsToExclude.split(",");
+    }
+  }
   return excludeList.map(url => url.toLowerCase());
 }
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1634

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2163
- Downstream: none

### Description

Accept JSON and string for `CQ_URLS_TO_EXCLUDE` - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1716942141099129)

### Testing

- Local
   - [ ] Runs with comma-separated string
   - [ ] Runs with JSON-based array

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
