### PR TITLE
1634 Make getFeatureFlagValue return strong type

### DIFF
--- a/packages/lambdas/src/fhir-to-medical-record.ts
+++ b/packages/lambdas/src/fhir-to-medical-record.ts
@@ -1,6 +1,6 @@
 import { Input, Output } from "@metriport/core/domain/conversion/fhir-to-medical-record";
 import { createMRSummaryFileName } from "@metriport/core/domain/medical-record-summary";
-import { getFeatureFlagValue } from "@metriport/core/external/aws/app-config";
+import { getFeatureFlagValueStringArray } from "@metriport/core/external/aws/app-config";
 import { bundleToHtml } from "@metriport/core/external/aws/lambda-logic/bundle-to-html";
 import { bundleToHtmlADHD } from "@metriport/core/external/aws/lambda-logic/bundle-to-html-adhd";
 import { getSignedUrl as coreGetSignedUrl, makeS3Client } from "@metriport/core/external/aws/s3";
@@ -201,7 +201,7 @@ const convertStoreAndReturnPdfUrl = async ({
 
 async function getCxsWithADHDFeatureFlagValue(): Promise<string[]> {
   try {
-    const featureFlag = await getFeatureFlagValue(
+    const featureFlag = await getFeatureFlagValueStringArray(
       region,
       appConfigAppID,
       appConfigConfigID,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1634

### Dependencies

none

### Description

Make `getFeatureFlagValue` return strong type.

Previously

<img width="542" alt="image" src="https://github.com/metriport/metriport/assets/2132564/2f8a75a9-2d27-4bf2-aa90-e961b1d39952">

<img width="749" alt="image" src="https://github.com/metriport/metriport/assets/2132564/cc663fb8-6f62-4406-b96c-ea03f7f2c3e4">

With this PR

![image](https://github.com/metriport/metriport/assets/2132564/1e977765-16cd-4e1a-9b3a-48ad5c4b4618)

![image](https://github.com/metriport/metriport/assets/2132564/482ca940-d528-4629-9b20-050dfa1321ea)

### Testing

- Local
  - [x] Retrieves string FF
  - [x] Retrieves boolean FF
- Staging
  - [ ] Update a patient and it runs w/o error
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
