### PR TITLE
1828 Dont fail XCPD when no address coordinates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15729,6 +15729,27 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-extended": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-4.0.2.tgz",
+      "integrity": "sha512-FH7aaPgtGYHc9mRjriS0ZEHYM5/W69tLrFTIdzm+yJgeoCmmrSB/luSfMSqWP9O29QWHPEmJ4qmU6EwsZideog==",
+      "dev": true,
+      "dependencies": {
+        "jest-diff": "^29.0.0",
+        "jest-get-type": "^29.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "jest": ">=27.2.5"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "29.4.3",
       "dev": true,
@@ -24826,6 +24847,7 @@
         "eslint": "^8.32.0",
         "eslint-config-prettier": "^8.6.0",
         "jest": "^29.5.0",
+        "jest-extended": "^4.0.2",
         "prettier": "^2.8.3",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -95,6 +95,7 @@
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "jest": "^29.5.0",
+    "jest-extended": "^4.0.2",
     "prettier": "^2.8.3",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",

--- a/packages/api/src/__tests__/env-setup.ts
+++ b/packages/api/src/__tests__/env-setup.ts
@@ -5,3 +5,6 @@ const paths = [cwd, ...(cwd.includes("packages") ? [] : ["packages", "api"])];
 dotenv.config({ path: path.resolve(...paths, ".env") });
 dotenv.config({ path: path.resolve(...paths, ".env.test") });
 // Keep dotenv import and config before everything else
+import * as matchers from "jest-extended";
+
+expect.extend(matchers);

--- a/packages/api/src/domain/medical/__tests__/location-address.ts
+++ b/packages/api/src/domain/medical/__tests__/location-address.ts
@@ -1,14 +1,26 @@
 import { fakerEN_US as faker } from "@faker-js/faker";
-import { AddressStrict } from "@metriport/core/domain/location-address";
 import { USState } from "@metriport/core/domain/geographic-locations";
+import { AddressStrict, AddressWithCoordinates } from "@metriport/core/domain/location-address";
 
-export const makeAddressStrict = (): AddressStrict => {
+export function makeAddressStrict(params: Partial<AddressStrict> = {}): AddressStrict {
   const randomIndex = Math.floor(Math.random() * Object.keys(USState).length);
   return {
-    addressLine1: faker.location.streetAddress(),
-    zip: faker.location.zipCode(),
-    city: faker.location.city(),
-    state: Object.values(USState)[randomIndex],
-    country: "US",
+    addressLine1: params.addressLine1 ?? faker.location.streetAddress(),
+    zip: params.zip ?? faker.location.zipCode(),
+    city: params.city ?? faker.location.city(),
+    state: params.state ?? Object.values(USState)[randomIndex],
+    country: params.country ?? "US",
   };
-};
+}
+
+export function makeAddressWithCoordinates(
+  params: Partial<AddressWithCoordinates> = {}
+): AddressWithCoordinates {
+  return {
+    ...makeAddressStrict(params),
+    coordinates: {
+      lat: params.coordinates?.lat ?? faker.location.latitude(),
+      lon: params.coordinates?.lon ?? faker.location.longitude(),
+    },
+  };
+}

--- a/packages/api/src/domain/medical/__tests__/patient.ts
+++ b/packages/api/src/domain/medical/__tests__/patient.ts
@@ -32,7 +32,9 @@ export function makePatientData(data: Partial<PatientData> = {}): PatientData {
   };
 }
 
-export function makePatient(params: Partial<Patient> = {}): Patient {
+export function makePatient(
+  params: Partial<Omit<Patient, "data"> & { data: Partial<PatientData> }> = {}
+): Patient {
   return {
     ...makeBaseDomain(),
     ...(params.id ? { id: params.id } : {}),

--- a/packages/api/src/external/carequality/__tests__/cq-directory.ts
+++ b/packages/api/src/external/carequality/__tests__/cq-directory.ts
@@ -1,0 +1,33 @@
+import { CQDirectoryEntry } from "../cq-directory";
+import { makeBaseDomain } from "../../../domain/__tests__/base-domain";
+import { faker } from "@faker-js/faker";
+import { Organization } from "@metriport/carequality-sdk/models/organization";
+
+// TODO implement this
+export function makeOrganization(): Organization | undefined {
+  return undefined;
+}
+
+export function makeCQDirectoryEntry(params: Partial<CQDirectoryEntry> = {}): CQDirectoryEntry {
+  const org = params.data ?? makeOrganization();
+  return {
+    ...makeBaseDomain(),
+    ...(params.id ? { id: params.id } : {}),
+    name: params.name ?? faker.company.name(),
+    urlXCPD: params.urlXCPD ?? faker.internet.url(),
+    urlDQ: params.urlDQ ?? faker.internet.url(),
+    urlDR: params.urlDR ?? faker.internet.url(),
+    lat: params.lat ?? faker.location.latitude(),
+    lon: params.lon ?? faker.location.longitude(),
+    addressLine: params.addressLine ?? faker.location.streetAddress(),
+    city: params.city ?? faker.location.city(),
+    state: params.state ?? faker.location.state(),
+    zip: params.zip ?? faker.location.zipCode(),
+    data: org,
+    point: params.point ?? undefined,
+    managingOrganization: params.managingOrganization ?? undefined,
+    managingOrganizationId: params.managingOrganizationId ?? undefined,
+    active: params.active ?? true,
+    lastUpdatedAtCQ: params.lastUpdatedAtCQ ?? faker.date.recent().toISOString(),
+  };
+}

--- a/packages/api/src/external/carequality/command/cq-directory/__tests__/search-cq-directory.test.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/__tests__/search-cq-directory.test.ts
@@ -28,6 +28,9 @@ describe("searchCQDirectoriesAroundPatientAddresses", () => {
 
   it("returns empty array if no coordinates", async () => {
     const patient = makePatient();
+    const expectedResult: CQDirectoryEntry[] = [makeCQDirectoryEntry()];
+    searchCQDirectoriesByRadius_mock = jest.fn(() => expectedResult);
+
     const result = await searchCQDirectoriesAroundPatientAddresses({ patient });
     expect(result).toBeTruthy();
     expect(result.length).toEqual(0);
@@ -37,7 +40,7 @@ describe("searchCQDirectoriesAroundPatientAddresses", () => {
   it("returns search result when there are coordinates", async () => {
     const address = makeAddressWithCoordinates();
     const patient = makePatient({ data: { address: [address] } });
-    const expectedResult: CQDirectoryEntry[] = [makeCQDirectoryEntry()];
+    const expectedResult: CQDirectoryEntry[] = [makeCQDirectoryEntry(), makeCQDirectoryEntry()];
     searchCQDirectoriesByRadius_mock = jest.fn(() => expectedResult);
 
     const result = await searchCQDirectoriesAroundPatientAddresses({

--- a/packages/api/src/external/carequality/command/cq-directory/__tests__/search-cq-directory.test.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/__tests__/search-cq-directory.test.ts
@@ -1,0 +1,73 @@
+import { faker } from "@faker-js/faker";
+import convert from "convert-units";
+import { makeAddressWithCoordinates } from "../../../../../domain/medical/__tests__/location-address";
+import { makePatient } from "../../../../../domain/medical/__tests__/patient";
+import { CQDirectoryEntry } from "../../../cq-directory";
+import { makeCQDirectoryEntry } from "../../../__tests__/cq-directory";
+import {
+  searchCQDirectoriesAroundPatientAddresses,
+  searchCQDirectoriesByRadius,
+} from "../search-cq-directory";
+
+describe("searchCQDirectoriesAroundPatientAddresses", () => {
+  let searchCQDirectoriesByRadius_mock: jest.Func;
+  beforeAll(() => {
+    jest.restoreAllMocks();
+  });
+  beforeEach(() => {
+    searchCQDirectoriesByRadius_mock = jest.fn(
+      async () => []
+    ) as typeof searchCQDirectoriesByRadius;
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns empty array if no coordinates", async () => {
+    const patient = makePatient();
+    const result = await searchCQDirectoriesAroundPatientAddresses({ patient });
+    expect(result).toBeTruthy();
+    expect(result.length).toEqual(0);
+    expect(searchCQDirectoriesByRadius_mock).not.toHaveBeenCalled();
+  });
+
+  it("returns search result when there are coordinates", async () => {
+    const address = makeAddressWithCoordinates();
+    const patient = makePatient({ data: { address: [address] } });
+    const expectedResult: CQDirectoryEntry[] = [makeCQDirectoryEntry()];
+    searchCQDirectoriesByRadius_mock = jest.fn(() => expectedResult);
+
+    const result = await searchCQDirectoriesAroundPatientAddresses({
+      patient,
+      _searchCQDirectoriesByRadius: searchCQDirectoriesByRadius_mock,
+    });
+    expect(result).toBeTruthy();
+    expect(result.length).toEqual(expectedResult.length);
+    expect(searchCQDirectoriesByRadius_mock).toHaveBeenCalled();
+  });
+
+  it("passes correct params to searchCQDirectoriesByRadius", async () => {
+    const address1 = makeAddressWithCoordinates();
+    const address2 = makeAddressWithCoordinates();
+    const patient = makePatient({ data: { address: [address1, address2] } });
+    const radiusInMiles = faker.number.int({ min: 5, max: 100 });
+    const radiusInMeters = convert(radiusInMiles).from("mi").to("m");
+    const mustHaveXcpdLink = faker.datatype.boolean();
+    searchCQDirectoriesByRadius_mock = jest.fn(() => []);
+
+    await searchCQDirectoriesAroundPatientAddresses({
+      patient,
+      radiusInMiles,
+      mustHaveXcpdLink,
+      _searchCQDirectoriesByRadius: searchCQDirectoriesByRadius_mock,
+    });
+    expect(searchCQDirectoriesByRadius_mock).toHaveBeenCalledWith({
+      coordinates: expect.arrayContaining([address1.coordinates, address2.coordinates]),
+      radiusInMeters,
+      mustHaveXcpdLink,
+    });
+  });
+});


### PR DESCRIPTION
Ref. metriport/metriport-internal#1828

### Dependencies

none

### Description

Don't fail XCPD when no address coordinates

### Testing

- Local
  - [x] unit tests
- Staging
  - [ ] XCPD works with regular address
  - [ ] XCPD works with "John Doe One", city "Somewhere" (no coords)
     - [ ] We get a notification
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
