### PR TITLE
858 Store additional info on WH table

### DIFF
--- a/packages/api/src/command/medical/patient/consolidated-webhook.ts
+++ b/packages/api/src/command/medical/patient/consolidated-webhook.ts
@@ -75,6 +75,7 @@ export const processConsolidatedDataWebhook = async ({
         cxId,
         type: "medical.consolidated-data",
         payload,
+        requestId,
       });
 
       const additionalWHRequestMeta: Record<string, string> = {};
@@ -98,6 +99,7 @@ export const processConsolidatedDataWebhook = async ({
         type: "medical.consolidated-data",
         payload,
         status: "success",
+        requestId,
       });
     }
     await updateConsolidatedQueryProgress({

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -1,6 +1,8 @@
 import { webhookDisableFlagName } from "@metriport/core/domain/webhook/index";
-import { errorToString } from "@metriport/shared/common/error";
 import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
+import { out } from "@metriport/core/util/log";
+import { capture } from "@metriport/core/util/notifications";
+import { errorToString, isTrue } from "@metriport/shared";
 import Axios from "axios";
 import crypto from "crypto";
 import dayjs from "dayjs";
@@ -8,20 +10,28 @@ import { nanoid } from "nanoid";
 import { v4 as uuidv4 } from "uuid";
 import { z, ZodError } from "zod";
 import { Product } from "../../domain/product";
+import { WebhookRequestStatus } from "../../domain/webhook";
 import WebhookError from "../../errors/webhook";
 import { isWebhookPongDisabledForCx } from "../../external/aws/app-config";
 import { Settings, WEBHOOK_STATUS_OK } from "../../models/settings";
 import { WebhookRequest } from "../../models/webhook-request";
-import { capture } from "../../shared/notifications";
-import { Util } from "../../shared/util";
+import { getHttpStatusFromAxiosError } from "../../shared/http";
 import { updateWebhookStatus } from "../settings/updateSettings";
 import { isDAPIWebhookRequest } from "./devices-util";
-import { updateWebhookRequestStatus, WebhookRequestData } from "./webhook-request";
+import { updateWebhookRequest, WebhookRequestData } from "./webhook-request";
 
 const DEFAULT_TIMEOUT_SEND_PAYLOAD_MS = 5_000;
 const DEFAULT_TIMEOUT_SEND_TEST_MS = 2_000;
-const axios = Axios.create();
-const log = Util.log(`Webhook`);
+
+const successfulStatusDetail = "OK";
+
+const axios = Axios.create({
+  transitional: {
+    // enables ETIMEDOUT instead of ECONNABORTED for timeouts - https://betterstack.com/community/guides/scaling-nodejs/nodejs-errors/
+    clarifyTimeoutError: true,
+  },
+});
+const { log } = out(`Webhook`);
 
 // General
 type WebhookPingPayload = {
@@ -52,7 +62,7 @@ async function missingWHSettings(
   const loggableKey = webhookKey ? "<defined>" : "<not-defined>";
   log(msg + ` (url: ${webhookUrl}, key: ${loggableKey}`);
   // mark this WH request as failed
-  await updateWebhookRequestStatus({
+  await updateWebhookRequest({
     id: webhookRequest.id,
     status: "failure",
   });
@@ -69,12 +79,12 @@ function getProductFromWebhookRequest(
   }
 }
 
-export const processRequest = async (
+export async function processRequest(
   webhookRequest: WebhookRequest | WebhookRequestData,
   settings: Settings,
   additionalWHRequestMeta?: Record<string, string>,
   cxWHRequestMeta?: unknown
-): Promise<boolean> => {
+): Promise<boolean> {
   const sendAnalytics = (status: string, properties?: Record<string, string>) => {
     analytics({
       distinctId: webhookRequest.cxId,
@@ -104,7 +114,7 @@ export const processRequest = async (
       data: cxWHRequestMeta,
     };
 
-    await sendPayload(
+    const sendResponse = await sendPayload(
       {
         meta,
         ...payload,
@@ -117,9 +127,13 @@ export const processRequest = async (
     if (productType === Product.medical) {
       // mark this request as successful on the DB
       const status = "success";
-      await updateWebhookRequestStatus({
+      await updateWebhookRequest({
         id: webhookRequest.id,
         status,
+        statusDetail: successfulStatusDetail,
+        durationMillis: sendResponse.durationMillis,
+        httpStatus: sendResponse.status,
+        requestUrl: sendResponse.url,
       });
 
       // if the webhook was not working before, update the status to successful since we were able to send the payload
@@ -133,61 +147,89 @@ export const processRequest = async (
       sendAnalytics(status);
     }
     return true;
-
-    //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    // TODO: 1411 - remove when DAPI is fully discontinued
+  } catch (error) {
+    // TODO: 1411 - remove the conditional and keep the code inside it when DAPI is fully discontinued
     if (productType === Product.medical) {
       log(`Failed to process WH request: ${errorToString(error)}`);
       const status = "failure";
-      try {
-        // mark this individual WH request as failed
-        await updateWebhookRequestStatus({
-          id: webhookRequest.id,
-          status,
-        });
-      } catch (err2) {
-        log(`Failed to store failure state on WH log: ${errorToString(err2)}`);
-        capture.error(err2, {
-          extra: {
-            webhookRequestId: webhookRequest.id,
-            webhookUrl,
-            context: `webhook.processRequest.updateStatus.failed`,
-            error: err2,
-          },
-        });
-      }
+      await Promise.all([
+        updateWhRequestWithError(error, webhookRequest.id, webhookUrl, status),
+        updateWhStatusWithError(error, webhookRequest.id, webhookUrl, settings.id),
+      ]);
       sendAnalytics(status);
-
-      let webhookStatusDetail;
-      if (error instanceof WebhookError) {
-        webhookStatusDetail = errorToWhStatusDetails(error);
-      } else {
-        log(`Unexpected error testing webhook`, error);
-        webhookStatusDetail = `Internal error: ${error.message}`;
-      }
-      try {
-        // update the status of the webhook endpoint on the cx's settings table
-        await updateWebhookStatus({
-          cxId: settings.id,
-          webhookEnabled: false,
-          webhookStatusDetail,
-        });
-      } catch (err2) {
-        log(`Failed to store failure state on WH settings: ${errorToString(err2)}`);
-        capture.error(err2, {
-          extra: {
-            webhookRequestId: webhookRequest.id,
-            webhookUrl,
-            context: `webhook.processRequest.updateStatus.details`,
-            error: err2,
-          },
-        });
-      }
     }
   }
   return false;
-};
+}
+
+/**
+ * Updates the individual Webhook (WH) request status.
+ */
+async function updateWhRequestWithError(
+  error: unknown,
+  webhookRequestId: string,
+  webhookUrl: string,
+  status: WebhookRequestStatus
+) {
+  try {
+    const detail =
+      error instanceof WebhookError ? errorToWhStatusDetails(error) : errorToString(error);
+    const httpStatus = error instanceof WebhookError ? error.additionalInfo.httpStatus : 500;
+    await updateWebhookRequest({
+      id: webhookRequestId,
+      status,
+      statusDetail: detail,
+      requestUrl: webhookUrl,
+      httpStatus,
+    });
+  } catch (err2) {
+    log(`Failed to store failure state on WH log: ${errorToString(err2)}`);
+    capture.error(err2, {
+      extra: {
+        webhookRequestId: webhookRequestId,
+        webhookUrl,
+        context: `webhook.processRequest.updateStatus.failed`,
+        error: err2,
+      },
+    });
+  }
+}
+
+/**
+ * Updates the Customer's Webhook status on settings.
+ */
+async function updateWhStatusWithError(
+  error: unknown,
+  webhookRequestId: string,
+  webhookUrl: string,
+  settingsId: string
+) {
+  let webhookStatusDetail;
+  if (error instanceof WebhookError) {
+    webhookStatusDetail = errorToWhStatusDetails(error);
+  } else {
+    log(`Unexpected error testing webhook: ${errorToString(error)}`);
+    webhookStatusDetail = `Internal error`;
+  }
+  try {
+    // update the status of the webhook endpoint on the cx's settings table
+    await updateWebhookStatus({
+      cxId: settingsId,
+      webhookEnabled: false,
+      webhookStatusDetail,
+    });
+  } catch (err2) {
+    log(`Failed to store failure state on WH settings: ${errorToString(err2)}`);
+    capture.error(err2, {
+      extra: {
+        webhookRequestId: webhookRequestId,
+        webhookUrl,
+        context: `webhook.processRequest.updateStatus.details`,
+        error: err2,
+      },
+    });
+  }
+}
 
 const webhookResponseSchema = z
   .object({
@@ -195,16 +237,22 @@ const webhookResponseSchema = z
   })
   .or(z.string());
 
-type WebhookResponseSchema = z.infer<typeof webhookResponseSchema>;
+type WebhookResponse = z.infer<typeof webhookResponseSchema>;
 
 export const sendPayload = async (
   payload: unknown,
   url: string,
   apiKey: string,
   timeout = DEFAULT_TIMEOUT_SEND_PAYLOAD_MS
-): Promise<WebhookResponseSchema> => {
+): Promise<{
+  status: number;
+  webhookResponse: WebhookResponse;
+  url: string;
+  durationMillis: number;
+}> => {
   try {
     const hmac = crypto.createHmac("sha256", apiKey).update(JSON.stringify(payload)).digest("hex");
+    const before = Date.now();
     const res = await axios.post(url, payload, {
       headers: {
         "x-webhook-key": apiKey,
@@ -214,11 +262,23 @@ export const sendPayload = async (
       timeout,
       maxRedirects: 0, // disable redirects to prevent SSRF
     });
+    const duration = Date.now() - before;
     const webhookResponse = webhookResponseSchema.parse(res.data);
-    return webhookResponse;
+    return {
+      status: res.status,
+      webhookResponse,
+      url,
+      durationMillis: duration,
+    };
   } catch (err) {
     // Don't change this error message, it's used to detect if the webhook is working or not
-    throw new WebhookError(`Failed to send payload`, err);
+    const msg = "Failed to send payload";
+    const httpStatus = getHttpStatusFromAxiosError(err);
+    throw new WebhookError(msg, err, {
+      url,
+      httpStatus,
+      httpMessage: errorToString(err),
+    });
   }
 };
 
@@ -233,20 +293,35 @@ export const sendTestPayload = async (url: string, key: string, cxId: string): P
       type: "ping",
     },
   };
-
-  const res = await sendPayload(payload, url, key, DEFAULT_TIMEOUT_SEND_TEST_MS);
-  if (!res) return false;
-
-  const isWebhookPongDisabled = await isWebhookPongDisabledForCx(cxId);
+  const [sendResponse, isWebhookPongDisabled] = await Promise.all([
+    sendPayload(payload, url, key, DEFAULT_TIMEOUT_SEND_TEST_MS),
+    isWebhookPongDisabledForCxSafe(cxId),
+  ]);
   if (isWebhookPongDisabled) return true;
   // check for a matching pong response, unless FF is enabled to skip that check
-  return typeof res !== "string" && res.pong && res.pong === ping ? true : false;
+  const whResponse = sendResponse.webhookResponse;
+  return typeof whResponse !== "string" && whResponse.pong && whResponse.pong === ping
+    ? true
+    : false;
 };
+
+async function isWebhookPongDisabledForCxSafe(cxId: string): Promise<boolean> {
+  try {
+    return await isWebhookPongDisabledForCx(cxId);
+  } catch (error) {
+    const msg = "Error checking if WH Pong is disabled for cx";
+    log(`${msg}: ${errorToString(error)}`);
+    capture.error(msg, { extra: { cxId, error } });
+    // Fail gracefully since there was no error from Ping and we don't know if the cx supports Pong
+  }
+  return true;
+}
 
 export function isWebhookDisabled(meta?: unknown): boolean {
   if (!meta) return false;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return Boolean((meta as any)[webhookDisableFlagName]);
+  const value = (meta as any)[webhookDisableFlagName];
+  return isTrue(value);
 }
 
 export function errorToWhStatusDetails(error: WebhookError): string {

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -182,14 +182,14 @@ async function updateWhRequestWithError(
       requestUrl: webhookUrl,
       httpStatus,
     });
-  } catch (err2) {
-    log(`Failed to store failure state on WH log: ${errorToString(err2)}`);
-    capture.error(err2, {
+  } catch (error) {
+    log(`Failed to store failure state on WH log: ${errorToString(error)}`);
+    capture.error(error, {
       extra: {
         webhookRequestId: webhookRequestId,
         webhookUrl,
         context: `webhook.processRequest.updateStatus.failed`,
-        error: err2,
+        error,
       },
     });
   }
@@ -218,14 +218,14 @@ async function updateWhStatusWithError(
       webhookEnabled: false,
       webhookStatusDetail,
     });
-  } catch (err2) {
-    log(`Failed to store failure state on WH settings: ${errorToString(err2)}`);
-    capture.error(err2, {
+  } catch (error) {
+    log(`Failed to store failure state on WH settings: ${errorToString(error)}`);
+    capture.error(error, {
       extra: {
         webhookRequestId: webhookRequestId,
         webhookUrl,
         context: `webhook.processRequest.updateStatus.details`,
-        error: err2,
+        error,
       },
     });
   }

--- a/packages/api/src/domain/__tests__/webhook.ts
+++ b/packages/api/src/domain/__tests__/webhook.ts
@@ -1,8 +1,7 @@
 import { faker } from "@faker-js/faker";
-import { WebhookRequestStatus } from "../../models/webhook-request";
 import { WebhookRequest } from "../webhook";
 import { makeBaseDomain } from "./base-domain";
-import { WebhookType } from "../webhook";
+import { WebhookType, WebhookRequestStatus } from "../webhook";
 
 export const makeWebhook = ({
   id,

--- a/packages/api/src/domain/webhook.ts
+++ b/packages/api/src/domain/webhook.ts
@@ -1,6 +1,5 @@
-import { Product } from "./product";
 import { BaseDomain, BaseDomainCreate } from "@metriport/core/domain/base-domain";
-import { WebhookRequestStatus } from "../models/webhook-request";
+import { Product } from "./product";
 
 // TODO: 1411 - remove this section when DAPI is fully discontinued
 export const dapiWHPrefix = Product.devices;
@@ -22,12 +21,18 @@ export type MAPIWebhookType = (typeof mapiWebhookType)[number];
 export type PingWebhookType = "ping";
 export type WebhookType = DAPIWebhookType | MAPIWebhookType | PingWebhookType;
 
+export type WebhookRequestStatus = "processing" | "success" | "failure";
+
 export interface WebhookRequestCreate extends Omit<BaseDomainCreate, "id"> {
   cxId: string;
   requestId?: string;
   type: WebhookType;
   payload: object;
   status?: WebhookRequestStatus;
+  statusDetail?: string;
+  requestUrl?: string;
+  httpStatus?: number;
+  durationMillis?: number;
 }
 
 export interface WebhookRequest extends BaseDomain, WebhookRequestCreate {}

--- a/packages/api/src/errors/webhook.ts
+++ b/packages/api/src/errors/webhook.ts
@@ -1,12 +1,16 @@
-import MetriportError from "./metriport-error";
+import { MetriportError } from "@metriport/shared";
 
-export type ErrorCause = Error & { message: string; status?: number };
+export type WebhookErrorAddititionalInfo = {
+  url: string;
+  httpStatus: number;
+  httpMessage?: string;
+} & Record<string, string | number | undefined | null>;
 
 export default class WebhookError extends MetriportError {
   constructor(
     message = "Unexpected error with webhook",
-    cause?: unknown,
-    additionalInfo?: Record<string, string | undefined | null>
+    override readonly cause: unknown,
+    override readonly additionalInfo: WebhookErrorAddititionalInfo
   ) {
     super(message, cause, additionalInfo);
     this.name = this.constructor.name;

--- a/packages/api/src/models/__tests__/webhook.ts
+++ b/packages/api/src/models/__tests__/webhook.ts
@@ -1,7 +1,6 @@
+import { WebhookRequestStatus, WebhookType } from "../../domain/webhook";
 import { makeWebhook } from "../../domain/__tests__/webhook";
 import { WebhookRequest } from "../webhook-request";
-import { WebhookType } from "../../domain/webhook";
-import { WebhookRequestStatus } from "../webhook-request";
 
 export const makeWebhookModel = (params: {
   id: string;

--- a/packages/api/src/models/webhook-request.ts
+++ b/packages/api/src/models/webhook-request.ts
@@ -1,7 +1,6 @@
 import { DataTypes, Sequelize } from "sequelize";
+import { WebhookRequestStatus } from "../domain/webhook";
 import { BaseModel, ModelSetup } from "./_default";
-
-export type WebhookRequestStatus = "processing" | "success" | "failure";
 
 export class WebhookRequest extends BaseModel<WebhookRequest> {
   static NAME = "webhook_request";
@@ -11,6 +10,10 @@ export class WebhookRequest extends BaseModel<WebhookRequest> {
   declare type: string; // intentionally 'string' to avoid circular dependency and coupling
   declare payload: object;
   declare status: WebhookRequestStatus;
+  declare statusDetail?: string;
+  declare requestUrl?: string;
+  declare httpStatus?: number;
+  declare durationMillis?: number;
 
   static setup: ModelSetup = (sequelize: Sequelize) => {
     WebhookRequest.init(
@@ -21,7 +24,6 @@ export class WebhookRequest extends BaseModel<WebhookRequest> {
         },
         requestId: {
           type: DataTypes.STRING,
-          allowNull: true,
         },
         type: {
           type: DataTypes.STRING,
@@ -31,6 +33,18 @@ export class WebhookRequest extends BaseModel<WebhookRequest> {
         },
         status: {
           type: DataTypes.STRING,
+        },
+        statusDetail: {
+          type: DataTypes.STRING,
+        },
+        requestUrl: {
+          type: DataTypes.STRING,
+        },
+        httpStatus: {
+          type: DataTypes.INTEGER,
+        },
+        durationMillis: {
+          type: DataTypes.INTEGER,
         },
       },
       {

--- a/packages/api/src/sequelize/migrations/2024-05-31_00_alter-webhook-add-statusDetail.ts
+++ b/packages/api/src/sequelize/migrations/2024-05-31_00_alter-webhook-add-statusDetail.ts
@@ -1,0 +1,59 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "webhook_request";
+const typeColumn = "type";
+const statusDetail = "status_detail";
+const requestUrl = "request_url";
+const httpStatus = "http_status";
+const durationMillis = "duration_millis";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.changeColumn(
+      tableName,
+      typeColumn,
+      { type: DataTypes.STRING, allowNull: false },
+      { transaction }
+    );
+    await queryInterface.addColumn(
+      tableName,
+      statusDetail,
+      { type: DataTypes.STRING, allowNull: true },
+      { transaction }
+    );
+    await queryInterface.addColumn(
+      tableName,
+      requestUrl,
+      { type: DataTypes.STRING, allowNull: true },
+      { transaction }
+    );
+    await queryInterface.addColumn(
+      tableName,
+      httpStatus,
+      { type: DataTypes.INTEGER, allowNull: true },
+      { transaction }
+    );
+    await queryInterface.addColumn(
+      tableName,
+      durationMillis,
+      { type: DataTypes.INTEGER, allowNull: true },
+      { transaction }
+    );
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.removeColumn(tableName, durationMillis, { transaction });
+    await queryInterface.removeColumn(tableName, httpStatus, { transaction });
+    await queryInterface.removeColumn(tableName, requestUrl, { transaction });
+    await queryInterface.removeColumn(tableName, statusDetail, { transaction });
+    await queryInterface.changeColumn(
+      tableName,
+      typeColumn,
+      { type: DataTypes.STRING, allowNull: true },
+      { transaction }
+    );
+  });
+};

--- a/packages/api/src/shared/http.ts
+++ b/packages/api/src/shared/http.ts
@@ -27,3 +27,50 @@ export function getETag(req: Request): {
     eTag: eTagHeader ?? eTagPayload,
   };
 }
+
+/**
+ * Returns the HTTP status of an error. This is based on Axios error object.
+ *
+ * @param error error instance
+ * @returns HTTP status of the error, 500 if it can't be determined
+ */
+export function getHttpStatusFromAxiosError(error: unknown): number {
+  const status = getHttpStatusFromAxiosErrorOptional(error);
+  return status ?? (isTimeoutError(error) ? 504 : 500);
+}
+
+/**
+ * Returns the HTTP status of an error. This is based on Axios error object.
+ *
+ * @param error error instance
+ * @returns HTTP status of the error, undefined if it can't be determined
+ */
+export function getHttpStatusFromAxiosErrorOptional(err: unknown): number | undefined {
+  if (err && typeof err === "object" && `response` in err) {
+    const response = err.response;
+    if (response && typeof response === "object" && `status` in response) {
+      const status = response.status;
+
+      if (status && typeof status === "number") {
+        return status;
+      }
+      if (status && typeof status === "string") {
+        return Number.parseInt(status);
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Returns true if the error is a timeout error. This is based on Axios error object.
+ *
+ * @param error error instance
+ * @returns boolean indicating if the error is a timeout error
+ */
+export function isTimeoutError(error: unknown): boolean {
+  if (error && typeof error === "object" && `code` in error) {
+    return error.code === `ETIMEDOUT`;
+  }
+  return false;
+}

--- a/packages/shared/src/common/__tests__/boolean.test.ts
+++ b/packages/shared/src/common/__tests__/boolean.test.ts
@@ -1,0 +1,56 @@
+import { faker } from "@faker-js/faker";
+import { isTrue } from "../boolean";
+
+describe("isTrue", () => {
+  it("returns false when it gets null value", async () => {
+    expect(isTrue(null)).toEqual(false);
+  });
+
+  it("returns false when it gets undefined value", async () => {
+    expect(isTrue(undefined)).toEqual(false);
+  });
+
+  it("returns false when it gets object", async () => {
+    expect(isTrue({})).toEqual(false);
+  });
+
+  it("returns false when it gets empty string", async () => {
+    expect(isTrue("")).toEqual(false);
+  });
+
+  it("returns false when it gets string diff than 'true'", async () => {
+    expect(isTrue(faker.string.alpha())).toEqual(false);
+  });
+
+  it("returns true when it gets string 'true' in fixed caps", async () => {
+    expect(isTrue("true")).toEqual(true);
+  });
+
+  it("returns true when it gets string 'true' in various caps", async () => {
+    expect(isTrue("tRuE")).toEqual(true);
+  });
+
+  it("returns true when it gets string 'true' with prefix", async () => {
+    expect(isTrue(" true")).toEqual(true);
+  });
+
+  it("returns true when it gets string 'true' with suffix", async () => {
+    expect(isTrue("true ")).toEqual(true);
+  });
+
+  it("returns true when it gets boolean 'true'", async () => {
+    expect(isTrue(true)).toEqual(true);
+  });
+
+  it("returns false when it gets boolean 'false'", async () => {
+    expect(isTrue(false)).toEqual(false);
+  });
+
+  it("returns true when it gets object Boolean 'true'", async () => {
+    expect(isTrue(Boolean(true))).toEqual(true);
+  });
+
+  it("returns false when it gets object Boolean 'false'", async () => {
+    expect(isTrue(Boolean(false))).toEqual(false);
+  });
+});

--- a/packages/shared/src/common/boolean.ts
+++ b/packages/shared/src/common/boolean.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns true if the value is true. It doesn't check for "truthyness"!
+ * - if value is a string, it will normalized and compared agains "true";
+ * - if value is a boolean, it will return the value;
+ * - otherwise, it will return false.
+ */
+export function isTrue(value: unknown): boolean {
+  if (!value) return false;
+  if (typeof value === "string") return isTrueString(value);
+  if (typeof value === "boolean") return value;
+  return false;
+}
+
+export function isTrueString(value: string): boolean {
+  if (!value) return false;
+  const parsed = typeof value === "string" ? value.trim().toLowerCase() : value;
+  return parsed === "true";
+}

--- a/packages/shared/src/common/types.ts
+++ b/packages/shared/src/common/types.ts
@@ -8,6 +8,9 @@ export function stringToBoolean(value?: string): boolean | undefined {
   return stringToBooleanRequired(value);
 }
 
+/**
+ * @deprecated Use isTrue() instead
+ */
 export function stringToBooleanRequired(value: string): boolean {
   return value.toLowerCase().trim() === "true";
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export { toArray } from "./common/array";
+export { isTrue } from "./common/boolean";
 export { optionalDateSchema } from "./common/date";
 export { getDomainFromEmailWithoutTld } from "./common/email";
 export * from "./common/env-var";

--- a/packages/utils/src/mock-webhook.ts
+++ b/packages/utils/src/mock-webhook.ts
@@ -1,9 +1,9 @@
 import * as dotenv from "dotenv";
 dotenv.config();
-
+// keep dotenv.config() at the top of the file
 import { MetriportMedicalApi } from "@metriport/api-sdk";
-import express, { Application, Request, Response } from "express";
 import { getEnvVarOrFail } from "@metriport/core/util/env-var";
+import express, { Application, Request, Response } from "express";
 
 const app: Application = express();
 
@@ -23,7 +23,7 @@ const metriportApi = new MetriportMedicalApi(apiKey, {
   baseAddress: apiUrl,
 });
 
-app.post("/", (req: Request, res: Response) => {
+app.post("/", async (req: Request, res: Response) => {
   console.log(`BODY: ${JSON.stringify(req.body, undefined, 2)}`);
 
   const signature = req.headers["x-metriport-signature"];


### PR DESCRIPTION
Ref. metriport/metriport-internal#858

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport/pull/2189

### Description

Store additional info on WH table. Implemented this to support debugging E2E tests.

### Testing

- Local
  - [x] successful WH execution
  - [x] timedout WH execution
  - [x] conn refused WH execution
- Staging
  - [ ] successful WH execution
  - [ ] timedout WH execution
  - [ ] conn refused WH execution
- Sandbox
  - nont
- Production
  - none

### Release Plan

- :warning: This contains a DB migration
- [ ] Merge this
