### PR TITLE
fix(api): add urls only to cq metriport

### DIFF
--- a/packages/api/src/external/carequality/organization-template.ts
+++ b/packages/api/src/external/carequality/organization-template.ts
@@ -28,20 +28,17 @@ export function buildXmlStringFromTemplate(orgDetails: CQOrgDetailsWithUrls) {
     email,
     role,
     parentOrgOid,
-    organizationBizType,
   } = orgDetails;
 
   const urnOid = "urn:oid:" + oid;
 
   const isImplementer = role === "Implementer";
-  const isHealthItVendor = organizationBizType === "healthcare_it_vendor";
 
-  const endpoints =
-    isImplementer || isHealthItVendor
-      ? getEndpoint(urnOid, XCPD_STRING, urlXCPD) +
-        getEndpoint(urnOid, XCA_DQ_STRING, urlDQ) +
-        getEndpoint(urnOid, XCA_DR_STRING, urlDR)
-      : "";
+  const endpoints = isImplementer
+    ? getEndpoint(urnOid, XCPD_STRING, urlXCPD) +
+      getEndpoint(urnOid, XCA_DQ_STRING, urlDQ) +
+      getEndpoint(urnOid, XCA_DR_STRING, urlDR)
+    : "";
 
   return `<Organization>
     <identifier>


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

Ticket: #1040

### Dependencies

- Upstream: none
- Downstream: none

### Description

Only add urls to metriport imploementer 

### Testing

_[Regular PRs:]_

- Local
  - [x] Doest add urls to CI
- Staging
  - [ ] Doest add urls to CI
- Production
  - [ ] Monoitor

### Release Plan

- [ ] Merge this
