### PR TITLE
fix(ihev2): batch requests to lambda

### DIFF
--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -220,19 +220,23 @@ export async function processOutboundDocumentQueryResps({
     // We send the request to IHE Gateway to initiate the doc retrieval with doc references by each respective gateway.
     log(`Starting document retrieval, ${docsToDownload.length} docs to download`);
 
-    log(`Starting document retrieval - Gateway V1`);
-    await iheGateway.startDocumentsRetrieval({
-      outboundDocumentRetrievalReq: documentRetrievalRequestsV1,
-    });
+    if (documentRetrievalRequestsV1.length > 0) {
+      log(`Starting document retrieval - Gateway V1`);
+      await iheGateway.startDocumentsRetrieval({
+        outboundDocumentRetrievalReq: documentRetrievalRequestsV1,
+      });
+    }
 
-    log(`Starting document retrieval - Gateway V2`);
-    const iheGatewayV2 = makeIHEGatewayV2();
-    await iheGatewayV2.startDocumentRetrievalGatewayV2({
-      drRequestsGatewayV2: documentRetrievalRequestsV2,
-      requestId,
-      patientId,
-      cxId,
-    });
+    if (documentRetrievalRequestsV2.length > 0) {
+      log(`Starting document retrieval - Gateway V2`);
+      const iheGatewayV2 = makeIHEGatewayV2();
+      await iheGatewayV2.startDocumentRetrievalGatewayV2({
+        drRequestsGatewayV2: documentRetrievalRequestsV2,
+        requestId,
+        patientId,
+        cxId,
+      });
+    }
 
     await resultPoller.pollOutboundDocRetrievalResults({
       requestId,

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -146,17 +146,20 @@ export async function getDocumentsFromCQ({
     // We send the request to IHE Gateway to initiate the doc query.
     // Then as they are processed by each gateway it will start
     // sending them to the internal route one by one
-    log(`Starting document query - Gateway V1`);
-    await iheGateway.startDocumentsQuery({ outboundDocumentQueryReq: documentQueryRequestsV1 });
-
-    log(`Starting document query - Gateway V2`);
-    const iheGatewayV2 = makeIHEGatewayV2();
-    await iheGatewayV2.startDocumentQueryGatewayV2({
-      dqRequestsGatewayV2: documentQueryRequestsV2,
-      requestId,
-      patientId,
-      cxId,
-    });
+    if (documentQueryRequestsV1.length > 0) {
+      log(`Starting document query - Gateway V1`);
+      await iheGateway.startDocumentsQuery({ outboundDocumentQueryReq: documentQueryRequestsV1 });
+    }
+    if (documentQueryRequestsV2.length > 0) {
+      log(`Starting document query - Gateway V2`);
+      const iheGatewayV2 = makeIHEGatewayV2();
+      await iheGatewayV2.startDocumentQueryGatewayV2({
+        dqRequestsGatewayV2: documentQueryRequestsV2,
+        requestId,
+        patientId,
+        cxId,
+      });
+    }
 
     await resultPoller.pollOutboundDocQueryResults({
       requestId,

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -68,16 +68,20 @@ async function prepareAndTriggerPD(
       `${baseLogMessage}, requestIdV1: ${pdRequestGatewayV1.id}, requestIdV2: ${pdRequestGatewayV2.id}`
     );
 
-    log(`Kicking off patient discovery Gateway V1`);
-    await enabledIHEGW.startPatientDiscovery(pdRequestGatewayV1);
+    if (numGatewaysV1 > 0) {
+      log(`Kicking off patient discovery Gateway V1`);
+      await enabledIHEGW.startPatientDiscovery(pdRequestGatewayV1);
+    }
 
-    log(`Kicking off patient discovery Gateway V2`);
-    const iheGatewayV2 = makeIHEGatewayV2();
-    await iheGatewayV2.startPatientDiscovery({
-      pdRequestGatewayV2,
-      patientId: patient.id,
-      cxId: patient.cxId,
-    });
+    if (numGatewaysV2 > 0) {
+      log(`Kicking off patient discovery Gateway V2`);
+      const iheGatewayV2 = makeIHEGatewayV2();
+      await iheGatewayV2.startPatientDiscovery({
+        pdRequestGatewayV2,
+        patientId: patient.id,
+        cxId: patient.cxId,
+      });
+    }
 
     // only poll for the Gateway V1 request
     await resultPoller.pollOutboundPatientDiscoveryResults({


### PR DESCRIPTION
Refs: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- batch requests to patient discovery lambda so that the request doesnt go over the max payload size for lambdas
- [context](https://metriport.slack.com/archives/C04DBBJSKGB/p1717444037216089)

### Testing

- Local
  - [x] tested batching local

### Release Plan

- [x] Merge this
- [ ] Re-enable FF in Production
