### PR TITLE
fix(lambda): added system root oid env var

### DIFF
--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -66,6 +66,7 @@ export class LambdasNestedStack extends NestedStack {
       vpc: props.vpc,
       medicalDocumentsBucket: props.medicalDocumentsBucket,
       envType: props.config.environmentType,
+      systemRootOid: props.config.systemRootOID,
       sentryDsn: props.config.lambdasSentryDSN,
     });
 
@@ -221,9 +222,11 @@ export class LambdasNestedStack extends NestedStack {
     vpc: ec2.IVpc;
     medicalDocumentsBucket: s3.Bucket;
     envType: EnvType;
+    systemRootOid: string;
     sentryDsn: string | undefined;
   }): Lambda {
-    const { lambdaLayers, vpc, medicalDocumentsBucket, sentryDsn, envType } = ownProps;
+    const { lambdaLayers, vpc, medicalDocumentsBucket, sentryDsn, envType, systemRootOid } =
+      ownProps;
 
     const fhirToCdaConverterLambda = createLambda({
       stack: this,
@@ -233,6 +236,7 @@ export class LambdasNestedStack extends NestedStack {
       envType,
       envVars: {
         MEDICAL_DOCUMENTS_BUCKET_NAME: medicalDocumentsBucket.bucketName,
+        SYSTEM_ROOT_OID: systemRootOid,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
       layers: [lambdaLayers.shared],


### PR DESCRIPTION
refs. metriport/metriport#1603

### Description
- Adding `SYSTEM_ROOT_OID` env var to the FHIR-to-CDA lambda

### Testing
- Staging
  - [x] Addition of this env var on the lambda on AWS resolves the issue

### Release Plan
- [ ] Merge this
