### PR TITLE
PATCH RELEASE fixing date parsing for non iso dates

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/constants.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/constants.ts
@@ -219,7 +219,7 @@ export const expectedDqDocumentReference = [
     language: "en-US",
     size: 141255,
     title: "Continuity of Care Document",
-    creation: "2024-03-27T21:43:04.878Z",
+    creation: "2024-03-27T21:43:04",
     authorInstitution: "Metriport^^^^^^^^^2.16.840.1.113883.3.9621",
   },
   {
@@ -230,7 +230,7 @@ export const expectedDqDocumentReference = [
     language: "en-US",
     size: 163264,
     title: "Continuity of Care Document",
-    creation: "2024-03-29T16:31:46.171Z",
+    creation: "2024-03-29T16:31:46",
     authorInstitution: "Metriport^^^^^^^^^2.16.840.1.113883.3.9621",
   },
 ];

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/constants.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/constants.ts
@@ -230,7 +230,7 @@ export const expectedDqDocumentReference = [
     language: "en-US",
     size: 163264,
     title: "Continuity of Care Document",
-    creation: "2024-03-29T16:31:46",
+    creation: "2024-03-29T20:31:46.000Z",
     authorInstitution: "Metriport^^^^^^^^^2.16.840.1.113883.3.9621",
   },
 ];

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/constants.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/constants.ts
@@ -219,7 +219,7 @@ export const expectedDqDocumentReference = [
     language: "en-US",
     size: 141255,
     title: "Continuity of Care Document",
-    creation: "2024-03-27T21:43:04",
+    creation: "2024-03-27T21:43:04.878Z",
     authorInstitution: "Metriport^^^^^^^^^2.16.840.1.113883.3.9621",
   },
   {

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dq.test.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dq.test.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { processDQResponse } from "../xca/process/dq-response";
+import { processDQResponse, parseCreationTime } from "../xca/process/dq-response";
 import { outboundDqRequest, expectedDqDocumentReference } from "./constants";
 
 describe("processDQResponse", () => {
@@ -58,5 +58,70 @@ describe("processDQResponse", () => {
     });
     expect(response.operationOutcome).toBeTruthy();
     expect(response.operationOutcome?.issue[0]?.severity).toEqual("information");
+  });
+});
+
+describe("parseCreationTime", () => {
+  it("should return the iso date correctly", () => {
+    const input = "2023-10-01T12:34:56";
+    const result = parseCreationTime(input);
+    expect(result).toBe(input);
+  });
+
+  it("should format the string correctly", () => {
+    const input = "20231001123456";
+    const expectedOutput = "2023-10-01T12:34:56";
+    const result = parseCreationTime(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it("should format the date correctly for no dashes in date", () => {
+    const input = "20231001";
+    const expectedOutput = "2023-10-01T00:00:00";
+    const result = parseCreationTime(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it("should format the date correctly for dash date format", () => {
+    const input = "2023-10-01";
+    const expectedOutput = "2023-10-01T00:00:00";
+    const result = parseCreationTime(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it("should return undefined for a random number", () => {
+    const input = "123456";
+    const result = parseCreationTime(input);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined for an invalid date string", () => {
+    const input = "invalid-date-string";
+    const result = parseCreationTime(input);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined for an empty string", () => {
+    const input = "";
+    const result = parseCreationTime(input);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined for a date with a space in it", () => {
+    const input = "2023-10-01 12:34:56";
+    const result = parseCreationTime(input);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined for a string with only time part", () => {
+    const input = "12:34:56";
+    const result = parseCreationTime(input);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined for a string with invalid characters", () => {
+    const input = "2023-10-01T12:34:56@";
+    const result = parseCreationTime(input);
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dq.test.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dq.test.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { processDQResponse, parseCreationTime } from "../xca/process/dq-response";
+import { processDQResponse } from "../xca/process/dq-response";
 import { outboundDqRequest, expectedDqDocumentReference } from "./constants";
 
 describe("processDQResponse", () => {
@@ -58,70 +58,5 @@ describe("processDQResponse", () => {
     });
     expect(response.operationOutcome).toBeTruthy();
     expect(response.operationOutcome?.issue[0]?.severity).toEqual("information");
-  });
-});
-
-describe("parseCreationTime", () => {
-  it("should return the iso date correctly", () => {
-    const input = "2023-10-01T12:34:56";
-    const result = parseCreationTime(input);
-    expect(result).toBe(input);
-  });
-
-  it("should format the string correctly", () => {
-    const input = "20231001123456";
-    const expectedOutput = "2023-10-01T12:34:56";
-    const result = parseCreationTime(input);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it("should format the date correctly for no dashes in date", () => {
-    const input = "20231001";
-    const expectedOutput = "2023-10-01T00:00:00";
-    const result = parseCreationTime(input);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it("should format the date correctly for dash date format", () => {
-    const input = "2023-10-01";
-    const expectedOutput = "2023-10-01T00:00:00";
-    const result = parseCreationTime(input);
-    expect(result).toBe(expectedOutput);
-  });
-
-  it("should return undefined for a random number", () => {
-    const input = "123456";
-    const result = parseCreationTime(input);
-    expect(result).toBeUndefined();
-  });
-
-  it("should return undefined for an invalid date string", () => {
-    const input = "invalid-date-string";
-    const result = parseCreationTime(input);
-    expect(result).toBeUndefined();
-  });
-
-  it("should return undefined for an empty string", () => {
-    const input = "";
-    const result = parseCreationTime(input);
-    expect(result).toBeUndefined();
-  });
-
-  it("should return undefined for a date with a space in it", () => {
-    const input = "2023-10-01 12:34:56";
-    const result = parseCreationTime(input);
-    expect(result).toBeUndefined();
-  });
-
-  it("should return undefined for a string with only time part", () => {
-    const input = "12:34:56";
-    const result = parseCreationTime(input);
-    expect(result).toBeUndefined();
-  });
-
-  it("should return undefined for a string with invalid characters", () => {
-    const input = "2023-10-01T12:34:56@";
-    const result = parseCreationTime(input);
-    expect(result).toBeUndefined();
   });
 });

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/dq_multiple_docs.xml
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/dq_multiple_docs.xml
@@ -18,7 +18,7 @@
                 <ExtrinsicObject home="urn:oid:2.16.840.1.113883.3.9621" id="018e81dd-ddaf-7d7c-b02c-d8a145ebb0c8" isOpaque="false" mimeType="application/pdf" objectType="urn:uuid:34268e47-fdf5-41a6-ba33-82133c465248" status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved">
                     <Slot name="creationTime">
                         <ValueList>
-                            <Value>2024-03-27T21:43:04.878Z</Value>
+                            <Value>2024-03-27T21:43:04</Value>
                         </ValueList>
                     </Slot>
                     <Slot name="languageCode">
@@ -130,7 +130,7 @@
                 <ExtrinsicObject home="urn:oid:2.16.840.1.113883.3.9621" id="018e8b0d-91fb-732b-b9a1-f476a940642c" isOpaque="false" mimeType="application/pdf" objectType="urn:uuid:34268e47-fdf5-41a6-ba33-82133c465248" status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved">
                     <Slot name="creationTime">
                         <ValueList>
-                            <Value>2024-03-29T16:31:46.171Z</Value>
+                            <Value>20240329163146</Value>
                         </ValueList>
                     </Slot>
                     <Slot name="languageCode">

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/dq_multiple_docs.xml
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/dq_multiple_docs.xml
@@ -18,7 +18,7 @@
                 <ExtrinsicObject home="urn:oid:2.16.840.1.113883.3.9621" id="018e81dd-ddaf-7d7c-b02c-d8a145ebb0c8" isOpaque="false" mimeType="application/pdf" objectType="urn:uuid:34268e47-fdf5-41a6-ba33-82133c465248" status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved">
                     <Slot name="creationTime">
                         <ValueList>
-                            <Value>2024-03-27T21:43:04</Value>
+                            <Value>2024-03-27T21:43:04.878Z</Value>
                         </ValueList>
                     </Slot>
                     <Slot name="languageCode">

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
@@ -1,6 +1,5 @@
 import { XMLParser } from "fast-xml-parser";
 import dayjs from "dayjs";
-import customParseFormat from "dayjs/plugin/customParseFormat";
 import {
   OutboundDocumentQueryReq,
   OutboundDocumentQueryResp,
@@ -17,8 +16,6 @@ import {
 } from "../../../../shared";
 import { successStatus, partialSuccessStatus } from "./constants";
 import { capture } from "../../../../../../util/notifications";
-
-dayjs.extend(customParseFormat);
 
 type Identifier = {
   _identificationScheme: string;
@@ -47,28 +44,6 @@ function getResponseHomeCommunityId(
   extrinsicObject: any
 ): string {
   return stripUrnPrefix(extrinsicObject?._home);
-}
-
-export function parseCreationTime(created: string): string | undefined {
-  try {
-    const isValidISO = dayjs(created, "YYYY-MM-DDTHH:mm:ss", true).isValid();
-    const isValid1 = dayjs(created, "YYYY-MM-DD", true).isValid();
-    const isValid2 = dayjs(created, "YYYYMMDDHHmmss", true).isValid();
-    const isValid3 = dayjs(created, "YYYYMMDD", true).isValid();
-
-    if (isValidISO) {
-      return created;
-    } else if (isValid1) {
-      return dayjs(created, "YYYY-MM-DD").format("YYYY-MM-DDTHH:mm:ss");
-    } else if (isValid2) {
-      return dayjs(created, "YYYYMMDDHHmmss").format("YYYY-MM-DDTHH:mm:ss");
-    } else if (isValid3) {
-      return dayjs(created, "YYYYMMDD").format("YYYY-MM-DDTHH:mm:ss");
-    }
-    return undefined;
-  } catch (ex) {
-    return undefined;
-  }
 }
 
 function getHomeCommunityIdForDr(
@@ -157,8 +132,7 @@ function parseDocumentReference(
     return undefined;
   }
 
-  const creationTime = findSlotValue("creationTime");
-
+  const creationTime = String(findSlotValue("creationTime"));
   const documentReference: DocumentReference = {
     homeCommunityId: getHomeCommunityIdForDr(outboundRequest, extrinsicObject),
     repositoryUniqueId,
@@ -167,7 +141,7 @@ function parseDocumentReference(
     language: findSlotValue("languageCode"),
     size: sizeValue ? parseInt(sizeValue) : undefined,
     title: findClassificationName(XDSDocumentEntryClassCode),
-    creation: creationTime ? parseCreationTime(String(creationTime)) : undefined,
+    creation: creationTime ? dayjs(creationTime).toISOString() : undefined,
     authorInstitution: findClassificationSlotValue(XDSDocumentEntryAuthor, "authorInstitution"),
   };
   return documentReference;


### PR DESCRIPTION
Ticket: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- fixing date parsing for non iso dates + unit tests. For dates like 20240329163146 dayJs was messing it up and returning a crazy date like Nov 16 2608
- [Context](https://metriport.slack.com/archives/C0616FCPAKZ/p1717536123628429)

### Testing

- Local
  - [x] unit testing

Check each PR.

- :warning: Points to `master`
- [ ] Merge this
- [ ] backmerge
