### PR TITLE
feat(ihev2): storing all ihe responses on s3

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/monitor/__tests__/store.test.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/monitor/__tests__/store.test.ts
@@ -1,0 +1,18 @@
+import { buildIheResponseKey } from "../store";
+
+it("should construct the correct file path and upload the file", async () => {
+  const cxId = "cxId";
+  const patientId = "patientId";
+  const requestId = "requestId";
+  const oid = "oid";
+  const timestamp = "2024-05-01T00:00:00";
+  const key = buildIheResponseKey({
+    type: "xcpd",
+    cxId,
+    patientId,
+    requestId,
+    oid,
+    timestamp,
+  });
+  expect(key).toEqual(`${cxId}/${patientId}/xcpd/${requestId}_2024-05-01/${oid}.xml`);
+});

--- a/packages/core/src/external/carequality/ihe-gateway-v2/monitor/store.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/monitor/store.ts
@@ -14,7 +14,7 @@ let s3UtilsInstance = new S3Utils(Config.getAWSRegion());
 function getS3UtilsInstance(): S3Utils {
   return s3UtilsInstance;
 }
-export function setS3UtilsInstanceForStoringIheResponse(s3Utils: S3Utils): void {
+export function setS3UtilsInstance(s3Utils: S3Utils): void {
   s3UtilsInstance = s3Utils;
 }
 

--- a/packages/core/src/external/carequality/ihe-gateway-v2/monitor/store.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/monitor/store.ts
@@ -1,0 +1,102 @@
+import {
+  OutboundPatientDiscoveryReq,
+  OutboundDocumentQueryReq,
+  OutboundDocumentRetrievalReq,
+  XCPDGateway,
+  XCAGateway,
+} from "@metriport/ihe-gateway-sdk";
+import { S3Utils } from "../../../aws/s3";
+import { Config } from "../../../../util/config";
+
+const bucket = Config.getIheResponsesBucketName();
+let s3UtilsInstance = new S3Utils(Config.getAWSRegion());
+
+function getS3UtilsInstance(): S3Utils {
+  return s3UtilsInstance;
+}
+export function setS3UtilsInstanceForStoringIheResponse(s3Utils: S3Utils): void {
+  s3UtilsInstance = s3Utils;
+}
+
+export async function storeXcpdResponses({
+  response,
+  outboundRequest,
+  gateway,
+}: {
+  response: string;
+  outboundRequest: OutboundPatientDiscoveryReq;
+  gateway: XCPDGateway;
+}) {
+  const s3Utils = getS3UtilsInstance();
+  const { cxId, patientId, id: requestId } = outboundRequest;
+  const key = buildIheResponseKey({ type: "xcpd", cxId, patientId, requestId, oid: gateway.oid });
+  await s3Utils.uploadFile({
+    bucket,
+    key,
+    file: Buffer.from(response),
+    contentType: "application/xml",
+  });
+}
+
+export async function storeDqResponses({
+  response,
+  outboundRequest,
+  gateway,
+}: {
+  response: string;
+  outboundRequest: OutboundDocumentQueryReq;
+  gateway: XCAGateway;
+}) {
+  const s3Utils = getS3UtilsInstance();
+  const { cxId, patientId, id: requestId } = outboundRequest;
+  const key = buildIheResponseKey({
+    type: "dq",
+    cxId,
+    patientId,
+    requestId,
+    oid: gateway.homeCommunityId,
+  });
+  await s3Utils.uploadFile({
+    bucket,
+    key,
+    file: Buffer.from(response),
+    contentType: "application/xml",
+  });
+}
+
+export async function storeDrResponses({
+  response,
+  outboundRequest,
+  gateway,
+}: {
+  response: Buffer;
+  outboundRequest: OutboundDocumentRetrievalReq;
+  gateway: XCAGateway;
+}) {
+  const s3Utils = getS3UtilsInstance();
+  const { cxId, patientId, id: requestId } = outboundRequest;
+  const key = buildIheResponseKey({
+    type: "dr",
+    cxId,
+    patientId,
+    requestId,
+    oid: gateway.homeCommunityId,
+  });
+  await s3Utils.uploadFile({ bucket, key, file: response, contentType: "application/xml" });
+}
+
+function buildIheResponseKey({
+  type,
+  cxId,
+  patientId,
+  requestId,
+  oid,
+}: {
+  type: "xcpd" | "dq" | "dr";
+  cxId: string;
+  patientId: string;
+  requestId: string;
+  oid: string;
+}) {
+  return `${type}/${cxId}/${patientId}/${requestId}/${oid}.xml`;
+}

--- a/packages/core/src/external/carequality/ihe-gateway-v2/monitor/store.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/monitor/store.ts
@@ -27,6 +27,9 @@ export async function storeXcpdResponses({
   outboundRequest: OutboundPatientDiscoveryReq;
   gateway: XCPDGateway;
 }) {
+  if (!bucket) {
+    return;
+  }
   const s3Utils = getS3UtilsInstance();
   const { cxId, patientId, id: requestId } = outboundRequest;
   const key = buildIheResponseKey({ type: "xcpd", cxId, patientId, requestId, oid: gateway.oid });
@@ -47,6 +50,9 @@ export async function storeDqResponses({
   outboundRequest: OutboundDocumentQueryReq;
   gateway: XCAGateway;
 }) {
+  if (!bucket) {
+    return;
+  }
   const s3Utils = getS3UtilsInstance();
   const { cxId, patientId, id: requestId } = outboundRequest;
   const key = buildIheResponseKey({
@@ -73,6 +79,9 @@ export async function storeDrResponses({
   outboundRequest: OutboundDocumentRetrievalReq;
   gateway: XCAGateway;
 }) {
+  if (!bucket) {
+    return;
+  }
   const s3Utils = getS3UtilsInstance();
   const { cxId, patientId, id: requestId } = outboundRequest;
   const key = buildIheResponseKey({

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
@@ -125,8 +125,7 @@ function parseDocumentReference(
     capture.error(msg, {
       extra: {
         extrinsicObject,
-        repositoryUniqueId,
-        docUniqueId,
+        outboundRequest,
       },
     });
     return undefined;

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
@@ -44,10 +44,10 @@ export type DocumentResponse = {
 };
 
 let s3UtilsInstance = new S3Utils(region);
-export function getS3UtilsInstance(): S3Utils {
+function getS3UtilsInstance(): S3Utils {
   return s3UtilsInstance;
 }
-export function setS3UtilsInstance(s3Utils: S3Utils): void {
+export function setS3UtilsInstanceForStoringDrResponse(s3Utils: S3Utils): void {
   s3UtilsInstance = s3Utils;
 }
 

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
@@ -47,7 +47,7 @@ let s3UtilsInstance = new S3Utils(region);
 function getS3UtilsInstance(): S3Utils {
   return s3UtilsInstance;
 }
-export function setS3UtilsInstanceForStoringDrResponse(s3Utils: S3Utils): void {
+export function setS3UtilsInstance(s3Utils: S3Utils): void {
   s3UtilsInstance = s3Utils;
 }
 

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/send/dq-requests.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/send/dq-requests.ts
@@ -5,6 +5,7 @@ import { SamlCertsAndKeys } from "../../../saml/security/types";
 import { getTrustedKeyStore, SamlClientResponse, sendSignedXml } from "../../../saml/saml-client";
 import { BulkSignedDQ } from "../create/iti38-envelope";
 import { out } from "../../../../../../util/log";
+import { storeDqResponses } from "../../../monitor/store";
 
 const { log } = out("Sending DQ Requests");
 const context = "ihe-gateway-v2-dq-saml-client";
@@ -39,6 +40,11 @@ export async function sendSignedDQRequests({
           request.gateway.homeCommunityId
         }`
       );
+      await storeDqResponses({
+        response,
+        outboundRequest: request.outboundRequest,
+        gateway: request.gateway,
+      });
       return {
         gateway: request.gateway,
         response,

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/send/dr-requests.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/send/dr-requests.ts
@@ -6,6 +6,7 @@ import { getTrustedKeyStore, sendSignedXmlMtom } from "../../../saml/saml-client
 import { MtomAttachments } from "../mtom/parser";
 import { BulkSignedDR } from "../create/iti39-envelope";
 import { out } from "../../../../../../util/log";
+import { storeDrResponses } from "../../../monitor/store";
 
 const { log } = out("Sending DR Requests");
 const context = "ihe-gateway-v2-dr-saml-client";
@@ -31,7 +32,7 @@ export async function sendSignedDRRequests({
   const trustedKeyStore = await getTrustedKeyStore();
   const requestPromises = signedRequests.map(async (request, index) => {
     try {
-      const mtomParts = await sendSignedXmlMtom({
+      const { mtomParts, rawResponse } = await sendSignedXmlMtom({
         signedXml: request.signedRequest,
         url: request.gateway.url,
         samlCertsAndKeys,
@@ -42,6 +43,11 @@ export async function sendSignedDRRequests({
           request.gateway.homeCommunityId
         }`
       );
+      await storeDrResponses({
+        response: rawResponse,
+        outboundRequest: request.outboundRequest,
+        gateway: request.gateway,
+      });
       return {
         gateway: request.gateway,
         mtomResponse: mtomParts,

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests.ts
@@ -4,6 +4,7 @@ import { SamlCertsAndKeys } from "../../../saml/security/types";
 import { getTrustedKeyStore, SamlClientResponse, sendSignedXml } from "../../../saml/saml-client";
 import { BulkSignedXCPD } from "../create/iti55-envelope";
 import { out } from "../../../../../../util/log";
+import { storeXcpdResponses } from "../../../monitor/store";
 
 const { log } = out("Sending XCPD Requests");
 
@@ -37,6 +38,11 @@ export async function sendSignedXCPDRequests({
           request.gateway.oid
         }`
       );
+      await storeXcpdResponses({
+        response,
+        outboundRequest: request.outboundRequest,
+        gateway: request.gateway,
+      });
       return {
         gateway: request.gateway,
         response,

--- a/packages/core/src/external/carequality/ihe-gateway-v2/saml/saml-client.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/saml/saml-client.ts
@@ -99,7 +99,7 @@ export async function sendSignedXmlMtom({
   url: string;
   samlCertsAndKeys: SamlCertsAndKeys;
   trustedKeyStore: string;
-}): Promise<MtomAttachments> {
+}): Promise<{ mtomParts: MtomAttachments; rawResponse: Buffer }> {
   const agent = new https.Agent({
     rejectUnauthorized: getRejectUnauthorized(),
     requestCert: true,
@@ -129,7 +129,7 @@ export async function sendSignedXmlMtom({
 
   const boundary = getBoundaryFromMtomResponse(response.headers["content-type"]);
   if (boundary) {
-    return await parseMtomResponse(binaryData, boundary);
+    return { mtomParts: await parseMtomResponse(binaryData, boundary), rawResponse: binaryData };
   }
-  return convertSoapResponseToMtomResponse(binaryData);
+  return { mtomParts: convertSoapResponseToMtomResponse(binaryData), rawResponse: binaryData };
 }

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -95,7 +95,7 @@ export class Config {
     return getEnvVar("POST_HOG_API_KEY_SECRET");
   }
 
-  static getIheResponsesBucketName(): string {
-    return getEnvVarOrFail("IHE_RESPONSES_BUCKET_NAME");
+  static getIheResponsesBucketName(): string | undefined {
+    return getEnvVar("IHE_RESPONSES_BUCKET_NAME");
   }
 }

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -94,4 +94,8 @@ export class Config {
   static getPostHogApiKey(): string | undefined {
     return getEnvVar("POST_HOG_API_KEY_SECRET");
   }
+
+  static getIheResponsesBucketName(): string {
+    return getEnvVarOrFail("IHE_RESPONSES_BUCKET_NAME");
+  }
 }

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -85,6 +85,7 @@ type EnvConfigBase = {
   generalBucketName: string;
   medicalDocumentsBucketName: string;
   medicalDocumentsUploadBucketName: string;
+  iheResponsesBucketName: string;
   fhirConverterBucketName?: string;
   analyticsSecretNames?: {
     POST_HOG_API_KEY_SECRET: string;

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -101,6 +101,7 @@ export const config: EnvConfigNonSandbox = {
   generalBucketName: "test-bucket",
   medicalDocumentsBucketName: "test-bucket",
   medicalDocumentsUploadBucketName: "test-upload-bucket",
+  iheResponsesBucketName: "test-ihe-responses-bucket",
   engineeringCxId: "12345678-1234-1234-1234-123456789012",
 };
 export default config;

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -448,6 +448,7 @@ export class APIStack extends Stack {
         apiURL: apiService.loadBalancer.loadBalancerDnsName,
         envType: props.config.environmentType,
         sentryDsn: props.config.lambdasSentryDSN,
+        iheResponsesBucketName: props.config.iheResponsesBucketName,
       });
     }
 

--- a/packages/utils/src/saml/bulk-saml.ts
+++ b/packages/utils/src/saml/bulk-saml.ts
@@ -10,6 +10,9 @@ import { createAndSignBulkXCPDRequests } from "@metriport/core/external/carequal
 import { sendSignedXCPDRequests } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests";
 import { processXCPDResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xcpd/process/xcpd-response";
 import { setRejectUnauthorized } from "@metriport/core/external/carequality/ihe-gateway-v2/saml/saml-client";
+import { setS3UtilsInstanceForStoringIheResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/monitor/store";
+import { MockS3Utils } from "./mock-s3";
+import { Config } from "@metriport/core/util/config";
 
 /** This is a helper script to test constructing your own SOAP+SAML requests. It creates the SOAP 
 Envelope and sends it to the gateway specified in the request body. It logs the output into the 
@@ -21,6 +24,8 @@ Metriport-IHE GW / XML + SAML Constructor - Postman collection.
 const timestamp = dayjs().toISOString();
 const env = "STAGING";
 setRejectUnauthorized(false);
+const s3utils = new MockS3Utils(Config.getAWSRegion());
+setS3UtilsInstanceForStoringIheResponse(s3utils);
 
 // Set these to staging if you want to actually test the endpoints in a pre-prod env
 const samlCertsAndKeys = {

--- a/packages/utils/src/saml/bulk-saml.ts
+++ b/packages/utils/src/saml/bulk-saml.ts
@@ -10,7 +10,7 @@ import { createAndSignBulkXCPDRequests } from "@metriport/core/external/carequal
 import { sendSignedXCPDRequests } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests";
 import { processXCPDResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xcpd/process/xcpd-response";
 import { setRejectUnauthorized } from "@metriport/core/external/carequality/ihe-gateway-v2/saml/saml-client";
-import { setS3UtilsInstanceForStoringIheResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/monitor/store";
+import { setS3UtilsInstance as setS3UtilsInstanceForStoringIheResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/monitor/store";
 import { MockS3Utils } from "./mock-s3";
 import { Config } from "@metriport/core/util/config";
 

--- a/packages/utils/src/saml/pre-prod-tester.ts
+++ b/packages/utils/src/saml/pre-prod-tester.ts
@@ -18,8 +18,9 @@ import { createAndSignBulkDRRequests } from "@metriport/core/external/carequalit
 import { sendSignedDRRequests } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xca/send/dr-requests";
 import {
   processDrResponse,
-  setS3UtilsInstance,
+  setS3UtilsInstanceForStoringDrResponse,
 } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response";
+import { setS3UtilsInstanceForStoringIheResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/monitor/store";
 import { Config } from "@metriport/core/util/config";
 import { setRejectUnauthorized } from "@metriport/core/external/carequality/ihe-gateway-v2/saml/saml-client";
 import { MockS3Utils } from "./mock-s3";
@@ -31,6 +32,9 @@ the db.
 */
 
 setRejectUnauthorized(false);
+const s3utils = new MockS3Utils(Config.getAWSRegion());
+setS3UtilsInstanceForStoringDrResponse(s3utils);
+setS3UtilsInstanceForStoringIheResponse(s3utils);
 
 const samlAttributes = {
   subjectId: "System User",
@@ -300,8 +304,6 @@ async function queryDR(
       cxId: drRequest.cxId,
     });
 
-    const s3utils = new MockS3Utils(Config.getAWSRegion());
-    setS3UtilsInstance(s3utils);
     return processDrResponse({
       drResponse: response[0],
     });

--- a/packages/utils/src/saml/pre-prod-tester.ts
+++ b/packages/utils/src/saml/pre-prod-tester.ts
@@ -18,9 +18,9 @@ import { createAndSignBulkDRRequests } from "@metriport/core/external/carequalit
 import { sendSignedDRRequests } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xca/send/dr-requests";
 import {
   processDrResponse,
-  setS3UtilsInstanceForStoringDrResponse,
+  setS3UtilsInstance as setS3UtilsInstanceForStoringDrResponse,
 } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response";
-import { setS3UtilsInstanceForStoringIheResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/monitor/store";
+import { setS3UtilsInstance as setS3UtilsInstanceForStoringIheResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/monitor/store";
 import { Config } from "@metriport/core/util/config";
 import { setRejectUnauthorized } from "@metriport/core/external/carequality/ihe-gateway-v2/saml/saml-client";
 import { MockS3Utils } from "./mock-s3";

--- a/packages/utils/src/saml/saml-server.ts
+++ b/packages/utils/src/saml/saml-server.ts
@@ -16,9 +16,9 @@ import { processXCPDResponse } from "@metriport/core/external/carequality/ihe-ga
 import { processDQResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response";
 import {
   processDrResponse,
-  setS3UtilsInstanceForStoringDrResponse,
+  setS3UtilsInstance as setS3UtilsInstanceForStoringDrResponse,
 } from "@metriport/core/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response";
-import { setS3UtilsInstanceForStoringIheResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/monitor/store";
+import { setS3UtilsInstance as setS3UtilsInstanceForStoringIheResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/monitor/store";
 import { setRejectUnauthorized } from "@metriport/core/external/carequality/ihe-gateway-v2/saml/saml-client";
 import { Config } from "@metriport/core/util/config";
 import { MockS3Utils } from "./mock-s3";


### PR DESCRIPTION
Refs: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Dependencies

- upstream: https://github.com/metriport/metriport-internal/pull/1845

### Description

- store all responses from ihe gateways on s3

### Testing

- Local
  - [x] mocked storing files 
- Staging
  - [x] branch to staging
  - [ ] test on staging 

### Release Plan

- [ ] Merge this after internal is merged
- [ ] This PR adds infra (a bucket) but the only thing that interacts with that infra are the lambdas, so there shouldnt be any issues with downtime that sometimes happens with infra changes where the api has a dependency on the lambdas. 
