### PR TITLE
PATCH remove urn docoid

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
@@ -135,7 +135,7 @@ function parseDocumentReference(
   const documentReference: DocumentReference = {
     homeCommunityId: getHomeCommunityIdForDr(outboundRequest, extrinsicObject),
     repositoryUniqueId,
-    docUniqueId,
+    docUniqueId: stripUrnPrefix(docUniqueId),
     contentType: extrinsicObject?._mimeType,
     language: findSlotValue("languageCode"),
     size: sizeValue ? parseInt(sizeValue) : undefined,

--- a/packages/core/src/util/__tests__/urn.test.ts
+++ b/packages/core/src/util/__tests__/urn.test.ts
@@ -1,0 +1,36 @@
+import { stripUrnPrefix } from "../urn";
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("stripUrnPrefix", () => {
+  it("returns empty string when gets undefined", async () => {
+    const res = stripUrnPrefix(undefined);
+    expect(res).toEqual("");
+  });
+
+  it("returns string when gets number", async () => {
+    const original = 123;
+    const res = stripUrnPrefix(original);
+    expect(res).toEqual("123");
+  });
+
+  it("returns stripped string when gets urn:oid", async () => {
+    const original = "urn:oid:2.16.840.1.113883.3.9621";
+    const res = stripUrnPrefix(original);
+    expect(res).toEqual("2.16.840.1.113883.3.9621");
+  });
+
+  it("returns stripped string when gets urn:uuid", async () => {
+    const original = "urn:uuid:2.16.840.1.113883.3.9621";
+    const res = stripUrnPrefix(original);
+    expect(res).toEqual("2.16.840.1.113883.3.9621");
+  });
+
+  it("returns string when its a normal oid", async () => {
+    const original = "2.16.840.1.113883.3.9621";
+    const res = stripUrnPrefix(original);
+    expect(res).toEqual("2.16.840.1.113883.3.9621");
+  });
+});

--- a/packages/core/src/util/urn.ts
+++ b/packages/core/src/util/urn.ts
@@ -1,4 +1,4 @@
-const urnRegex = /^urn:oid:/;
+const urnRegex = /^urn:(oid|uuid):/;
 
 export function wrapIdInUrnUuid(id: string): string {
   return `urn:uuid:${id}`;


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ticket: #_[ticket-number]_

### Dependencies

- Upstream: none
- Downstream: none

### Description

Dont store doc unique id with urn - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1717621712277569)

### Testing

- Production
  - [ ] Monitor

_[Release PRs:]_

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
