### PR TITLE
fix(ihev2): remove urn:oid prefix from repository unique id

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/create/iti39-envelope.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/create/iti39-envelope.ts
@@ -64,7 +64,7 @@ export function createITI39SoapEnvelope({
       "urn:RetrieveDocumentSetRequest": {
         "urn:DocumentRequest": documentReferences.map(docRef => ({
           "urn:HomeCommunityId": wrapIdInUrnOid(docRef.homeCommunityId),
-          "urn:RepositoryUniqueId": wrapIdInUrnOid(docRef.repositoryUniqueId),
+          "urn:RepositoryUniqueId": docRef.repositoryUniqueId,
           "urn:DocumentUniqueId": docRef.documentUniqueId,
         })),
       },


### PR DESCRIPTION
Refs: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- remove urn:oid prefix from repository unique id

### Testing

- Local
  - [x] ran pre-prod tester and all DRs succeeded still 

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
