### PR TITLE
chore(release): publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24828,7 +24828,7 @@
       }
     },
     "packages/api": {
-      "version": "1.17.2-alpha.0",
+      "version": "1.17.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -24910,11 +24910,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "8.0.0-alpha.0",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.15.8-alpha.0",
-        "@metriport/shared": "^0.8.0-alpha.0",
+        "@metriport/commonwell-sdk": "^4.15.8",
+        "@metriport/shared": "^0.8.0",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -24970,11 +24970,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.8.0-alpha.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.9.0-alpha.0",
-        "@metriport/shared": "^0.8.0-alpha.0"
+        "@metriport/ihe-gateway-sdk": "^0.9.0",
+        "@metriport/shared": "^0.8.0"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -24982,7 +24982,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.9.8-alpha.0",
+      "version": "0.9.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -24992,10 +24992,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.16.8-alpha.0",
+      "version": "1.16.8",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.15.8-alpha.0",
+        "@metriport/commonwell-sdk": "^4.15.8",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -25034,10 +25034,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.13.8-alpha.0",
+      "version": "1.13.8",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.15.8-alpha.0",
+        "@metriport/commonwell-sdk": "^4.15.8",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -25069,7 +25069,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.15.8-alpha.0",
+      "version": "4.15.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",
@@ -25119,7 +25119,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.13.0-alpha.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -25195,17 +25195,17 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.9.0-alpha.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.8.0-alpha.0",
+        "@metriport/shared": "^0.8.0",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.12.0-alpha.0",
+      "version": "1.12.0",
       "dependencies": {
         "aws-cdk-lib": "^2.122.0",
         "constructs": "^10.2.69",
@@ -25253,7 +25253,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.11.8-alpha.0",
+      "version": "1.11.8",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -26280,14 +26280,14 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.8.0-alpha.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^8.0.2"
       }
     },
     "packages/utils": {
-      "version": "1.14.0-alpha.0",
+      "version": "1.14.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "8.0.0-alpha.0",
+  "version": "8.0.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -56,8 +56,8 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.15.8-alpha.0",
-    "@metriport/shared": "^0.8.0-alpha.0",
+    "@metriport/commonwell-sdk": "^4.15.8",
+    "@metriport/shared": "^0.8.0",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.17.2-alpha.0",
+  "version": "1.17.2",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.8.0-alpha.0",
+  "version": "1.8.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.9.0-alpha.0",
-    "@metriport/shared": "^0.8.0-alpha.0"
+    "@metriport/ihe-gateway-sdk": "^0.9.0",
+    "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.9.8-alpha.0",
+  "version": "0.9.8",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.16.8-alpha.0",
+  "version": "1.16.8",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.15.8-alpha.0",
+    "@metriport/commonwell-sdk": "^4.15.8",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.13.8-alpha.0",
+  "version": "1.13.8",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.15.8-alpha.0",
+    "@metriport/commonwell-sdk": "^4.15.8",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.15.8-alpha.0",
+  "version": "4.15.8",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.13.0-alpha.0",
+  "version": "1.13.0",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.9.0-alpha.0",
+  "version": "0.9.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -55,7 +55,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.8.0-alpha.0",
+    "@metriport/shared": "^0.8.0",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.12.0-alpha.0",
+  "version": "1.12.0",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.11.8-alpha.0",
+  "version": "1.11.8",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.8.0-alpha.0",
+  "version": "0.8.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.14.0-alpha.0",
+  "version": "1.14.0",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ref: #000

 - api@1.17.2
 - @metriport/api-sdk@8.0.0
 - @metriport/carequality-cert-runner@1.8.0
 - @metriport/carequality-sdk@0.9.8
 - @metriport/commonwell-cert-runner@1.16.8
 - @metriport/commonwell-jwt-maker@1.13.8
 - @metriport/commonwell-sdk@4.15.8
 - @metriport/core@1.13.0
 - @metriport/ihe-gateway-sdk@0.9.0
 - infrastructure@1.12.0
 - @metriport/react-native-sdk@1.11.8
 - @metriport/shared@0.8.0
 - utils@1.14.0

### Dependencies

- Upstream: _[this PR points to another PR or depends on its release]_
- Downstream: _[PRs that depend on this one, either point to this or can only be released after this one is released]_

### Description

Release packages - https://github.com/metriport/metriport/pull/2219

### Release Plan

- [ ] Merge this
