### PR TITLE
1634 WHs on E2E tests (3/4)

### DIFF
--- a/packages/api/src/__tests__/e2e/mapi/webhook/consolidated.ts
+++ b/packages/api/src/__tests__/e2e/mapi/webhook/consolidated.ts
@@ -14,7 +14,7 @@ export function resetConsolidatedData(
 }
 
 export function handleConsolidated(whRequest: ConsolidatedWebhookRequest, res: Response) {
-  webhookRequest = whRequest;
   console.log(`[WH] ================> Handle Consolidated WH running...`);
+  webhookRequest = whRequest;
   return res.sendStatus(200);
 }

--- a/packages/api/src/__tests__/e2e/mapi/webhook/settings.ts
+++ b/packages/api/src/__tests__/e2e/mapi/webhook/settings.ts
@@ -1,0 +1,18 @@
+import { PingWebhookRequest } from "@metriport/shared/src/medical/webhook/webhook-request";
+import { Response } from "express";
+
+let webhookRequest: PingWebhookRequest | undefined = undefined;
+
+export function getPingWebhookRequest(): PingWebhookRequest | undefined {
+  return webhookRequest;
+}
+
+export function resetPingData(value: PingWebhookRequest | undefined = undefined): void {
+  webhookRequest = value;
+}
+
+export function handlePing(whRequest: PingWebhookRequest, res: Response) {
+  console.log(`[WH] ================> Handle Ping WH running...`);
+  webhookRequest = whRequest;
+  return res.status(200).send({ pong: whRequest.ping });
+}

--- a/packages/shared/src/common/net.ts
+++ b/packages/shared/src/common/net.ts
@@ -1,0 +1,9 @@
+export function isValidUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    new URL(url);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export { getDomainFromEmailWithoutTld } from "./common/email";
 export * from "./common/env-var";
 export { emptyFunction } from "./common/general";
 export { metriportOrganization } from "./common/metriport-organization";
+export { isValidUrl } from "./common/net";
 export { normalizeOid } from "./common/normalize-oid";
 export { normalizeZipCode } from "./common/normalize-zip";
 export { PurposeOfUse } from "./common/purpose-of-use";

--- a/packages/shared/src/medical/index.ts
+++ b/packages/shared/src/medical/index.ts
@@ -1,28 +1,3 @@
-export { SearchSetBundle } from "./fhir/bundle";
-export {
-  ConsolidatedWebhookPatient,
-  consolidatedWebhookPatientSchema,
-  ConsolidatedWebhookRequest,
-  consolidatedWebhookRequestSchema,
-  DocumentBulkDownloadWebhookRequest,
-  DocumentBulkDownloadWebhookType,
-  DocumentConversionWebhookRequest,
-  documentConversionWebhookRequestSchema,
-  DocumentDownloadWebhookRequest,
-  documentDownloadWebhookRequestSchema,
-  filtersSchema,
-  isConsolidatedWebhookRequest,
-  isDocumentBulkDownloadWebhookRequest,
-  isDocumentConversionWebhookRequest,
-  isDocumentDownloadWebhookRequest,
-  MAPIWebhookType,
-  PingWebhookRequest,
-  pingWebhookRequestDataSchema,
-  WebhookMetadata,
-  WebhookRequest,
-  WebhookRequestParsingError,
-  webhookRequestSchema,
-  WebhookRequestStatus,
-  WebhookType,
-} from "./webhook/webhook-request";
-export { WebhookStatusResponse } from "./webhook/webhook-status-response";
+export * from "./fhir/bundle";
+export * from "./webhook/webhook-request";
+export * from "./webhook/webhook-status-response";

--- a/packages/shared/src/medical/webhook/webhook-request.ts
+++ b/packages/shared/src/medical/webhook/webhook-request.ts
@@ -113,6 +113,11 @@ export class WebhookRequestParsingError {
   ) {}
 }
 
+export function isPingWebhookRequest(whRequest: WebhookRequest): whRequest is PingWebhookRequest {
+  if (whRequest.meta.type === "ping") return true;
+  return false;
+}
+
 export function isConsolidatedWebhookRequest(
   whRequest: WebhookRequest
 ): whRequest is ConsolidatedWebhookRequest {


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1634

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2227
- Downstream:https://github.com/metriport/metriport/pull/2240

### Description

- [x] test ping WH
- [x] test custom meta on WH
- [x] test WH can be disabled

### Testing

- Local
  - [x] Unit test successful
  - [x] E2E successful
  - [ ] App successful
- Staging
  - [ ] E2E successful
  - [ ] App successful
- Sandbox
  - [ ] E2E successful
- Production
  - [ ] E2E successful

### Release Plan

- [ ] Merge upstream
- [ ] Merge this
