### PR TITLE
fix(ihev2): wrap dayjs in try catch

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
@@ -16,6 +16,9 @@ import {
 } from "../../../../shared";
 import { successStatus, partialSuccessStatus } from "./constants";
 import { capture } from "../../../../../../util/notifications";
+import { out } from "../../../../../../util/log";
+
+const { log } = out("DQ Processing");
 
 type Identifier = {
   _identificationScheme: string;
@@ -52,6 +55,15 @@ function getHomeCommunityIdForDr(
   extrinsicObject: any
 ): string {
   return getResponseHomeCommunityId(extrinsicObject);
+}
+
+function getCreationTime(time: string | undefined): string | undefined {
+  try {
+    return time ? dayjs(time).toISOString() : undefined;
+  } catch (error) {
+    log(`Error parsing creation time: ${time}, error: ${error}`);
+    return undefined;
+  }
 }
 
 function parseDocumentReference(
@@ -133,6 +145,7 @@ function parseDocumentReference(
   }
 
   const creationTime = String(findSlotValue("creationTime"));
+
   const documentReference: DocumentReference = {
     homeCommunityId: getHomeCommunityIdForDr(outboundRequest, extrinsicObject),
     repositoryUniqueId,
@@ -141,7 +154,7 @@ function parseDocumentReference(
     language: findSlotValue("languageCode"),
     size: sizeValue ? parseInt(sizeValue) : undefined,
     title: findClassificationName(XDSDocumentEntryClassCode),
-    creation: creationTime ? dayjs(creationTime).toISOString() : undefined,
+    creation: getCreationTime(creationTime),
     authorInstitution: findClassificationSlotValue(XDSDocumentEntryAuthor, "authorInstitution"),
   };
   return documentReference;


### PR DESCRIPTION
Refs: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- wrap calls to dayjs in a try catch 

### Testing

- Local
  - [x] _[Indicate how you tested this, on local or staging]_
  - [x] ...
- Staging
  - [ ] _testing step 1_
  - [ ] _testing step 2_

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
