### PR TITLE
fix(test): make times in dq always utc so tests pass local

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
@@ -1,5 +1,6 @@
 import { XMLParser } from "fast-xml-parser";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import {
   OutboundDocumentQueryReq,
   OutboundDocumentQueryResp,
@@ -17,6 +18,8 @@ import {
 import { successStatus, partialSuccessStatus } from "./constants";
 import { capture } from "../../../../../../util/notifications";
 import { out } from "../../../../../../util/log";
+
+dayjs.extend(utc);
 
 const { log } = out("DQ Processing");
 
@@ -59,7 +62,7 @@ function getHomeCommunityIdForDr(
 
 function getCreationTime(time: string | undefined): string | undefined {
   try {
-    return time ? dayjs(time).toISOString() : undefined;
+    return time ? dayjs.utc(time).toISOString() : undefined;
   } catch (error) {
     log(`Error parsing creation time: ${time}, error: ${error}`);
     return undefined;


### PR DESCRIPTION
Refs: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- fix timestamp on dqs to always be in utc so that unit tests pass local

### Testing

- Local
  - [x] unit tests pass local 

### Release Plan

- [ ] Merge this
