### PR TITLE
1040 Remove alarms on TargetGroups

### DIFF
--- a/packages/infra/lib/shared/target-group.ts
+++ b/packages/infra/lib/shared/target-group.ts
@@ -1,4 +1,3 @@
-import { Duration } from "aws-cdk-lib";
 import { ComparisonOperator, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import { ApplicationTargetGroup, HttpCodeTarget } from "aws-cdk-lib/aws-elasticloadbalancingv2";
@@ -24,16 +23,6 @@ export function addDefaultMetricsToTargetGroup({
     metric: targetGroup.metrics.unhealthyHostCount(),
     alarmName: `${name}_UnhealthyRequestCount`,
     threshold: 1,
-    evaluationPeriods: 1,
-    comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-    treatMissingData: TreatMissingData.NOT_BREACHING,
-    alarmAction,
-  });
-  addAlarmToMetric({
-    scope,
-    metric: targetGroup.metrics.targetResponseTime(),
-    alarmName: `${name}_TargetResponseTime`,
-    threshold: Duration.seconds(29).toSeconds(),
     evaluationPeriods: 1,
     comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
     treatMissingData: TreatMissingData.NOT_BREACHING,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Remove alarms on TargetGroups - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1717159090929309)

### Testing

none

### Release Plan

- [ ] Merge this
