### PR TITLE
1634 Adjust E2E WH test for clarity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25059,7 +25059,7 @@
       }
     },
     "packages/api": {
-      "version": "1.18.1",
+      "version": "1.18.2-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -25142,12 +25142,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "8.1.1",
+      "version": "8.2.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^4.15.11",
-        "@metriport/shared": "^0.9.4",
+        "@metriport/commonwell-sdk": "^4.15.12-alpha.0",
+        "@metriport/shared": "^0.9.5-alpha.0",
         "axios": "^1.3.4",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -25203,10 +25203,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.8.2",
+      "version": "1.8.3-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.9.2",
+        "@metriport/ihe-gateway-sdk": "^0.9.3-alpha.0",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -25220,7 +25220,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.10.2",
+      "version": "0.10.3-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -25230,10 +25230,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.16.11",
+      "version": "1.16.12-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.15.11",
+        "@metriport/commonwell-sdk": "^4.15.12-alpha.0",
         "axios": "^1.3.5",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -25272,10 +25272,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.14.2",
+      "version": "1.14.3-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.15.11",
+        "@metriport/commonwell-sdk": "^4.15.12-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -25307,7 +25307,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.15.11",
+      "version": "4.15.12-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.5",
@@ -25357,7 +25357,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.13.4",
+      "version": "1.13.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -25433,17 +25433,17 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.9.2",
+      "version": "0.9.3-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.9.4",
+        "@metriport/shared": "^0.9.5-alpha.0",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.12.2",
+      "version": "1.12.3-alpha.0",
       "dependencies": {
         "aws-cdk-lib": "^2.122.0",
         "constructs": "^10.2.69",
@@ -25491,7 +25491,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.11.11",
+      "version": "1.11.12-alpha.0",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -26518,14 +26518,14 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.9.4",
+      "version": "0.9.5-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^8.0.2"
       }
     },
     "packages/utils": {
-      "version": "1.14.2",
+      "version": "1.14.3-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "8.1.1",
+  "version": "8.2.0-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -57,8 +57,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^4.15.11",
-    "@metriport/shared": "^0.9.4",
+    "@metriport/commonwell-sdk": "^4.15.12-alpha.0",
+    "@metriport/shared": "^0.9.5-alpha.0",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/src/index.ts
+++ b/packages/api-sdk/src/index.ts
@@ -13,7 +13,7 @@ export { User } from "./devices/models/user";
 
 // Medical API
 export {
-  WebhookRequestParsingError,
+  WebhookRequestParsingFailure,
   WebhookRequest,
   WebhookRequestStatus,
   WebhookType,

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -1,7 +1,7 @@
 import { Bundle, DocumentReference as FHIRDocumentReference, Resource } from "@medplum/fhirtypes";
 import {
   WebhookRequest,
-  WebhookRequestParsingError,
+  WebhookRequestParsingFailure,
   webhookRequestSchema,
   WebhookStatusResponse,
 } from "@metriport/shared/medical";
@@ -709,13 +709,13 @@ export class MetriportMedicalApi {
   static parseWebhookResponse(
     requestBody: unknown,
     throwOnError: false
-  ): WebhookRequest | WebhookRequestParsingError;
+  ): WebhookRequest | WebhookRequestParsingFailure;
   static parseWebhookResponse(reqBody: unknown, throwOnError: true): WebhookRequest;
   static parseWebhookResponse(reqBody: unknown): WebhookRequest;
   static parseWebhookResponse(
     reqBody: unknown,
     throwOnError = true
-  ): WebhookRequest | WebhookRequestParsingError {
+  ): WebhookRequest | WebhookRequestParsingFailure {
     if (throwOnError) {
       try {
         return webhookRequestSchema.parse(reqBody);
@@ -725,6 +725,6 @@ export class MetriportMedicalApi {
     }
     const parse = webhookRequestSchema.safeParse(reqBody);
     if (parse.success) return parse.data;
-    return new WebhookRequestParsingError(parse.error, parse.error.format());
+    return new WebhookRequestParsingFailure(parse.error, parse.error.format());
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.18.1",
+  "version": "1.18.2-alpha.0",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/src/__tests__/e2e/mapi/parts/document-query.test.part.ts
+++ b/packages/api/src/__tests__/e2e/mapi/parts/document-query.test.part.ts
@@ -29,7 +29,11 @@ export function runDocumentQueryTests(e2e: E2eContext) {
     );
     let status = await medicalApi.getDocumentQueryStatus(e2e.patient.id);
     let retryLimit = 0;
-    while (areDocumentsProcessing(status) && retryLimit++ < dqCheckStatusMaxRetries) {
+    while (areDocumentsProcessing(status)) {
+      if (retryLimit++ > dqCheckStatusMaxRetries) {
+        console.log(`Gave up waiting for Document Query`);
+        break;
+      }
       console.log(
         `Document query still processing, retrying in ${dqCheckStatusWaitTime.asSeconds} seconds...`
       );

--- a/packages/api/src/__tests__/e2e/mapi/parts/settings.test.part.ts
+++ b/packages/api/src/__tests__/e2e/mapi/parts/settings.test.part.ts
@@ -2,9 +2,9 @@ import { sleep } from "@metriport/shared";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import isBetween from "dayjs/plugin/isBetween";
-import { validate as validateUuid } from "uuid";
 import { medicalApi } from "../shared";
 import { getPingWebhookRequest } from "../webhook/settings";
+import { checkWebhookRequestMeta } from "../webhook/shared";
 import whServer from "../webhook/webhook-server";
 
 dayjs.extend(isBetween);
@@ -62,25 +62,8 @@ export function runSettingsTests() {
 
   it("receives ping WH with correct data", async () => {
     const whRequest = getPingWebhookRequest();
-    expect(whRequest).toBeTruthy();
+    checkWebhookRequestMeta(whRequest, "ping");
     if (!whRequest) throw new Error("Missing WH request");
-    expect(whRequest.meta).toBeTruthy();
-    expect(whRequest.meta).toEqual(
-      expect.objectContaining({
-        type: "ping",
-        messageId: expect.anything(),
-        when: expect.anything(),
-      })
-    );
-    expect(validateUuid(whRequest.meta.messageId)).toBeTrue();
-    const minDate = dayjs().subtract(1, "minute").toDate();
-    const maxDate = dayjs().add(1, "minute").toDate();
-    expect(dayjs(whRequest.meta.when).isBetween(minDate, maxDate)).toBeTrue();
-    expect(whRequest.meta).not.toEqual(
-      expect.objectContaining({
-        data: expect.toBeFalsy,
-      })
-    );
     expect(whRequest.ping).toBeTruthy();
     expect(whRequest.ping.length).toEqual(NANO_ID_LENGTH);
   });

--- a/packages/api/src/__tests__/e2e/mapi/webhook/consolidated.ts
+++ b/packages/api/src/__tests__/e2e/mapi/webhook/consolidated.ts
@@ -14,7 +14,11 @@ export function resetConsolidatedData(
 }
 
 export function handleConsolidated(whRequest: ConsolidatedWebhookRequest, res: Response) {
-  console.log(`[WH] ================> Handle Consolidated WH running...`);
+  console.log(
+    `[WH] ================> Handle Consolidated WH running... whRequest: ${
+      whRequest ? whRequest.patients?.length + " patients" : whRequest
+    }`
+  );
   webhookRequest = whRequest;
   return res.sendStatus(200);
 }

--- a/packages/api/src/__tests__/e2e/mapi/webhook/settings.ts
+++ b/packages/api/src/__tests__/e2e/mapi/webhook/settings.ts
@@ -12,7 +12,7 @@ export function resetPingData(value: PingWebhookRequest | undefined = undefined)
 }
 
 export function handlePing(whRequest: PingWebhookRequest, res: Response) {
-  console.log(`[WH] ================> Handle Ping WH running...`);
+  console.log(`[WH] ================> Handle Ping WH running... ping: ${whRequest.ping}`);
   webhookRequest = whRequest;
   return res.status(200).send({ pong: whRequest.ping });
 }

--- a/packages/api/src/__tests__/e2e/mapi/webhook/shared.ts
+++ b/packages/api/src/__tests__/e2e/mapi/webhook/shared.ts
@@ -1,0 +1,31 @@
+import { WebhookRequest } from "@metriport/shared/medical";
+import dayjs from "dayjs";
+import { validate as validateUuid } from "uuid";
+
+export function checkWebhookRequestMeta(
+  whRequest: WebhookRequest | undefined,
+  type: WebhookRequest["meta"]["type"]
+): void {
+  expect(whRequest).toBeTruthy();
+  if (!whRequest) throw new Error("Missing WH request");
+  expect(whRequest.meta).toBeTruthy();
+  expect(whRequest.meta).toEqual(
+    expect.objectContaining({
+      type,
+      messageId: expect.anything(),
+      when: expect.anything(),
+    })
+  );
+  expect(validateUuid(whRequest.meta.messageId)).toBeTrue();
+  const expectedRefDate = dayjs();
+  const expectedMminDate = expectedRefDate.subtract(1, "minute").toDate();
+  const expectedMaxDate = dayjs().add(1, "minute").toDate();
+  const receivedDate = dayjs(whRequest.meta.when).toDate();
+  expect(receivedDate).toBeAfterOrEqualTo(expectedMminDate);
+  expect(receivedDate).toBeBeforeOrEqualTo(expectedMaxDate);
+  expect(whRequest.meta).not.toEqual(
+    expect.objectContaining({
+      data: expect.toBeFalsy,
+    })
+  );
+}

--- a/packages/api/src/__tests__/e2e/mapi/webhook/webhook-handler.ts
+++ b/packages/api/src/__tests__/e2e/mapi/webhook/webhook-handler.ts
@@ -41,7 +41,7 @@ export async function handleRequest(req: Request, res: Response) {
     return res.status(400).send({ message: `Invalid WH` });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    console.log(`[WH] ====> Error parsing WH request - cause: ${error.cause} - error: ${error}`);
+    console.log(`[WH] ######> ERROR parsing WH request - cause: ${error.cause} - error: ${error}`);
     return res.status(400).send({ message: error.message });
   }
 }

--- a/packages/api/src/__tests__/e2e/mapi/webhook/webhook-server.ts
+++ b/packages/api/src/__tests__/e2e/mapi/webhook/webhook-server.ts
@@ -5,6 +5,7 @@ import { getEnvVar, getEnvVarOrFail, sleep } from "@metriport/shared";
 import ngrok, { Session } from "@ngrok/ngrok";
 import express, { Request, Response } from "express";
 import { Server } from "http";
+import { asyncHandler } from "../../../../routes/util";
 import whHandler from "./webhook-handler";
 
 const port = 8478;
@@ -12,9 +13,12 @@ const port = 8478;
 const app = express();
 app.use(express.json({ limit: "20mb" }));
 
-app.post("/", async (req: Request, res: Response) => {
-  await whHandler.handleRequest(req, res);
-});
+app.post(
+  "/",
+  asyncHandler(async (req: Request, res: Response) => {
+    await whHandler.handleRequest(req, res);
+  }, true)
+);
 
 let server: Server;
 let session: Session;

--- a/packages/api/src/routes/util.ts
+++ b/packages/api/src/routes/util.ts
@@ -1,10 +1,9 @@
+import { out } from "@metriport/core/util/log";
+import { errorToString, stringToBoolean } from "@metriport/shared";
 import { NextFunction, Request, Response } from "express";
 import BadRequestError from "../errors/bad-request";
 import { Config } from "../shared/config";
-import { errorToString } from "../shared/log";
 import { capture } from "../shared/notifications";
-import { stringToBoolean } from "@metriport/shared";
-import { out } from "@metriport/core/util/log";
 
 const { log } = out("asyncHandler");
 
@@ -14,14 +13,15 @@ export function asyncHandler(
     res: Response,
     next: NextFunction
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ) => Promise<Response<any, Record<string, any>> | void>
+  ) => Promise<Response<any, Record<string, any>> | void>,
+  logErrorDetails = !Config.isCloudEnv()
 ) {
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       await f(req, res, next);
     } catch (err) {
-      if (Config.isCloudEnv()) log(errorToString(err));
-      else log("", err);
+      if (logErrorDetails) log("", err);
+      else log(errorToString(err));
       next(err);
     }
   };

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.8.2",
+  "version": "1.8.3-alpha.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.9.2",
+    "@metriport/ihe-gateway-sdk": "^0.9.3-alpha.0",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.10.2",
+  "version": "0.10.3-alpha.0",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.16.11",
+  "version": "1.16.12-alpha.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.15.11",
+    "@metriport/commonwell-sdk": "^4.15.12-alpha.0",
     "axios": "^1.3.5",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.14.2",
+  "version": "1.14.3-alpha.0",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.15.11",
+    "@metriport/commonwell-sdk": "^4.15.12-alpha.0",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.15.11",
+  "version": "4.15.12-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.13.4",
+  "version": "1.13.5-alpha.0",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.9.2",
+  "version": "0.9.3-alpha.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -55,7 +55,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.9.4",
+    "@metriport/shared": "^0.9.5-alpha.0",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.12.2",
+  "version": "1.12.3-alpha.0",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.11.11",
+  "version": "1.11.12-alpha.0",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.9.4",
+  "version": "0.9.5-alpha.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/src/medical/webhook/webhook-request.ts
+++ b/packages/shared/src/medical/webhook/webhook-request.ts
@@ -106,7 +106,7 @@ export const webhookRequestSchema = z.union([
 ]);
 export type WebhookRequest = z.infer<typeof webhookRequestSchema>;
 
-export class WebhookRequestParsingError {
+export class WebhookRequestParsingFailure {
   constructor(
     readonly errors: ZodError<WebhookRequest>,
     readonly flattened: ZodFormattedError<WebhookRequest>

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.14.2",
+  "version": "1.14.3-alpha.0",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1634

### Dependencies

none

### Description

[context](https://metriport.slack.com/archives/C04DBBJSKGB/p1718060598203809?thread_ts=1718056080.495319&cid=C04DBBJSKGB)
- adjust E2E WH test for clarity - 
- improve logging to help debugging E2E tests 
- rename WH response error to failure to avoid confusion during error handling

### Testing

- Local
  - [x] Unit and E2E tests
- Staging
  - [ ] PD works
  - [ ] DQ/DR w/ WH works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [x] Publish NPM packages
- [ ] Merge this