### PR TITLE
fix(api): prevent existing docs from redownloading

### DIFF
--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -137,7 +137,7 @@ export async function processOutboundDocumentQueryResps({
       patientId,
       requestId,
       cxId,
-      resultsWithMetriportId: responseWithDocsToDownload,
+      responseWithDocsToDownload,
       log,
     });
 
@@ -356,19 +356,19 @@ async function replaceDqUrlWithDrUrl({
   patientId,
   requestId,
   cxId,
-  resultsWithMetriportId,
+  responseWithDocsToDownload,
   log,
 }: {
   patientId: string;
   requestId: string;
   cxId: string;
-  resultsWithMetriportId: OutboundDocumentQueryResp[];
+  responseWithDocsToDownload: OutboundDocumentQueryResp[];
   log: typeof console.log;
 }): Promise<OutboundDocumentQueryResp[]> {
   const resultsWithMetriportIdAndDrUrl: OutboundDocumentQueryResp[] = [];
 
   await executeAsynchronously(
-    resultsWithMetriportId,
+    responseWithDocsToDownload,
     async outboundDocumentQueryResp => {
       const gateway = await getCQDirectoryEntry(outboundDocumentQueryResp.gateway.homeCommunityId);
 

--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -56,32 +56,7 @@ export async function processOutboundDocumentQueryResps({
     const cqData = getCQData(patient.data.externalData);
     const docQueryStartedAt = cqData?.documentQueryProgress?.startedAt;
     const duration = elapsedTimeFromNow(docQueryStartedAt);
-
-    const addDocRefId = addMetriportDocRefID({ cxId, patientId, requestId });
-    const resultsWithMetriportId: OutboundDocumentQueryResp[] = [];
-
-    const updateResponseDocumentReferencesWithMetriportId = async (
-      response: OutboundDocumentQueryResp
-    ): Promise<void> => {
-      const updatedDocumentReferences = response.documentReference
-        ? await Promise.all(
-            response.documentReference.map(async docRef => {
-              return await addDocRefId(docRef);
-            })
-          )
-        : response.documentReference;
-
-      resultsWithMetriportId.push({
-        ...response,
-        documentReference: updatedDocumentReferences,
-      });
-    };
-
-    await executeAsynchronously(response, updateResponseDocumentReferencesWithMetriportId, {
-      numberOfParallelExecutions: 20,
-    });
-
-    const docRefs = resultsWithMetriportId.flatMap(result => result.documentReference ?? []);
+    const docRefs = response.flatMap(result => result.documentReference ?? []);
     const contentTypes = docRefs.map(getContentTypeOrUnknown);
     const contentTypeCounts = getDocumentReferenceContentTypeCounts(contentTypes);
 
@@ -98,9 +73,17 @@ export async function processOutboundDocumentQueryResps({
       },
     });
 
-    const docRefsWithMetriportId = filterDocRefsWithMetriportId(docRefs);
+    const responseWithDocsToDownload = await getRespWithDocsToDownload({
+      cxId,
+      patientId,
+      requestId,
+      response,
+    });
 
-    const docsToDownload = await getNonExistentDocRefs(docRefsWithMetriportId, patientId, cxId);
+    const docsToDownload = responseWithDocsToDownload.flatMap(
+      result => result.documentReference ?? []
+    );
+
     const convertibleDocCount = docsToDownload.filter(doc =>
       isConvertible(doc.contentType || undefined)
     ).length;
@@ -147,44 +130,15 @@ export async function processOutboundDocumentQueryResps({
     // Since we have most of the document contents when doing the document query,
     // we will store this in FHIR and then upsert the reference to the s3 object in FHIR
     // when doing the doc retrieval
+    const docRefsWithMetriportId = filterDocRefsWithMetriportId(docsToDownload);
     await storeInitDocRefInFHIR(docRefsWithMetriportId, cxId, patientId, log);
 
-    const resultsWithMetriportIdAndDrUrl: OutboundDocumentQueryResp[] = [];
-
-    const replaceDqUrlWithDrUrl = async (
-      outboundDocumentQueryResp: OutboundDocumentQueryResp
-    ): Promise<void> => {
-      const gateway = await getCQDirectoryEntry(outboundDocumentQueryResp.gateway.homeCommunityId);
-
-      if (!gateway) {
-        const msg = `Gateway not found - Doc Retrieval`;
-        log(`${msg}: ${outboundDocumentQueryResp.gateway.homeCommunityId} skipping...`);
-        capture.message(msg, {
-          extra: {
-            context: `cq.dq.getCQDirectoryEntry`,
-            patientId,
-            requestId,
-            cxId,
-            gateway: outboundDocumentQueryResp.gateway,
-          },
-        });
-        return;
-      } else if (!gateway.urlDR) {
-        log(`Gateway ${gateway.id} has no DR URL, skipping...`);
-        return;
-      }
-
-      resultsWithMetriportIdAndDrUrl.push({
-        ...outboundDocumentQueryResp,
-        gateway: {
-          ...outboundDocumentQueryResp.gateway,
-          url: gateway.urlDR,
-        },
-      });
-    };
-
-    await executeAsynchronously(resultsWithMetriportId, replaceDqUrlWithDrUrl, {
-      numberOfParallelExecutions: 20,
+    const resultsWithMetriportIdAndDrUrl = await replaceDqUrlWithDrUrl({
+      patientId,
+      requestId,
+      cxId,
+      resultsWithMetriportId: responseWithDocsToDownload,
+      log,
     });
 
     const outboundDocumentQueryResultsV1: OutboundDocumentQueryResp[] = [];
@@ -298,6 +252,160 @@ function buildInterrupt({
   };
 }
 
+async function getRespWithDocsToDownload({
+  cxId,
+  patientId,
+  requestId,
+  response,
+}: OutboundDocQueryRespParam): Promise<OutboundDocumentQueryResp[]> {
+  const respWithDocsToDownload: OutboundDocumentQueryResp[] = [];
+
+  await executeAsynchronously(
+    response,
+    async gwResp => {
+      const resultsWithMetriportId = await updateDocumentReferencesWithMetriportId({
+        cxId,
+        patientId,
+        requestId,
+        response: gwResp,
+      });
+      const docRefs = resultsWithMetriportId.flatMap(result => result.documentReference ?? []);
+      const docRefsWithMetriportId = filterDocRefsWithMetriportId(docRefs);
+      const docsToDownload = await getNonExistentDocRefs(docRefsWithMetriportId, patientId, cxId);
+
+      if (docsToDownload.length === 0) {
+        return;
+      }
+
+      respWithDocsToDownload.push({
+        ...gwResp,
+        documentReference: docsToDownload,
+      });
+    },
+    {
+      numberOfParallelExecutions: 20,
+    }
+  );
+
+  return respWithDocsToDownload;
+}
+
+async function updateDocumentReferencesWithMetriportId({
+  cxId,
+  patientId,
+  requestId,
+  response,
+}: {
+  cxId: string;
+  patientId: string;
+  requestId: string;
+  response: OutboundDocumentQueryResp;
+}): Promise<OutboundDocumentQueryResp[]> {
+  const resultsWithMetriportId: OutboundDocumentQueryResp[] = [];
+
+  const docRefs = response.documentReference ?? [];
+
+  const docRefsWithMetriportId = await Promise.all(
+    docRefs.map(docRef =>
+      addMetriportDocRefID({
+        cxId,
+        patientId,
+        requestId,
+        document: docRef,
+      })
+    )
+  );
+
+  resultsWithMetriportId.push({
+    ...response,
+    documentReference: docRefsWithMetriportId,
+  });
+
+  return resultsWithMetriportId;
+}
+
+async function addMetriportDocRefID({
+  cxId,
+  patientId,
+  requestId,
+  document,
+}: {
+  patientId: string;
+  cxId: string;
+  requestId: string;
+  document: DocumentReference;
+}) {
+  const documentId = document.docUniqueId;
+
+  const { metriportId, originalId } = await mapDocRefToMetriport({
+    cxId,
+    patientId,
+    documentId,
+    requestId,
+    source: MedicalDataSource.CAREQUALITY,
+  });
+
+  return {
+    ...document,
+    docUniqueId: originalId,
+    metriportId,
+  };
+}
+
+async function replaceDqUrlWithDrUrl({
+  patientId,
+  requestId,
+  cxId,
+  resultsWithMetriportId,
+  log,
+}: {
+  patientId: string;
+  requestId: string;
+  cxId: string;
+  resultsWithMetriportId: OutboundDocumentQueryResp[];
+  log: typeof console.log;
+}): Promise<OutboundDocumentQueryResp[]> {
+  const resultsWithMetriportIdAndDrUrl: OutboundDocumentQueryResp[] = [];
+
+  await executeAsynchronously(
+    resultsWithMetriportId,
+    async outboundDocumentQueryResp => {
+      const gateway = await getCQDirectoryEntry(outboundDocumentQueryResp.gateway.homeCommunityId);
+
+      if (!gateway) {
+        const msg = `Gateway not found - Doc Retrieval`;
+        log(`${msg}: ${outboundDocumentQueryResp.gateway.homeCommunityId} skipping...`);
+        capture.message(msg, {
+          extra: {
+            context: `cq.dq.getCQDirectoryEntry`,
+            patientId,
+            requestId,
+            cxId,
+            gateway: outboundDocumentQueryResp.gateway,
+          },
+        });
+        return;
+      } else if (!gateway.urlDR) {
+        log(`Gateway ${gateway.id} has no DR URL, skipping...`);
+        return;
+      }
+
+      resultsWithMetriportIdAndDrUrl.push({
+        ...outboundDocumentQueryResp,
+        gateway: {
+          ...outboundDocumentQueryResp.gateway,
+          url: gateway.urlDR,
+        },
+      });
+    },
+    {
+      numberOfParallelExecutions: 20,
+    }
+  );
+
+  return resultsWithMetriportIdAndDrUrl;
+}
+
 async function storeInitDocRefInFHIR(
   docRefs: DocumentReferenceWithMetriportId[],
   cxId: string,
@@ -330,31 +438,4 @@ async function storeInitDocRefInFHIR(
     },
     { numberOfParallelExecutions: parallelUpsertsToFhir }
   );
-}
-
-function addMetriportDocRefID({
-  cxId,
-  patientId,
-  requestId,
-}: {
-  patientId: string;
-  cxId: string;
-  requestId: string;
-}) {
-  return async (document: DocumentReference): Promise<DocumentReferenceWithMetriportId> => {
-    const documentId = document.docUniqueId;
-
-    const { metriportId, originalId } = await mapDocRefToMetriport({
-      cxId,
-      patientId,
-      documentId,
-      requestId,
-      source: MedicalDataSource.CAREQUALITY,
-    });
-    return {
-      ...document,
-      docUniqueId: originalId,
-      metriportId,
-    };
-  };
 }

--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -84,7 +84,9 @@ export async function processOutboundDocumentQueryResps({
       result => result.documentReference ?? []
     );
 
-    const convertibleDocCount = docsToDownload.filter(doc => isConvertible(doc.contentType)).length;
+    const convertibleDocCount = docsToDownload.filter(doc =>
+      isConvertible(doc.contentType || undefined)
+    ).length;
 
     log(`I have ${docsToDownload.length} docs to download (${convertibleDocCount} convertible)`);
 


### PR DESCRIPTION
Ref. metriport/metriport#2209

Ticket: #2209 

### Dependencies

- Upstream: none
- Downstream: none

### Description

Prevent doc refs that exist in the system from being redownloaded in CQ

### Testing

- Local
  - [x] Filters out existing docs
- Staging
  - [ ] Filters out existing docs
- Production
  - [ ] Filters out existing docs

### Release Plan

- [ ] Merge this
