### PR TITLE
PATCH RELEASE Increase limit of webhook urls - v2

### DIFF
--- a/packages/api/src/command/settings/updateSettings.ts
+++ b/packages/api/src/command/settings/updateSettings.ts
@@ -1,9 +1,9 @@
 import { limitStringLength } from "@metriport/shared";
 import { nanoid } from "nanoid";
+import { maxWebhookStatusLength } from "../../domain/settings";
 import { processAsyncError } from "../../errors";
 import WebhookError from "../../errors/webhook";
 import { Settings, WEBHOOK_STATUS_BAD_RESPONSE, WEBHOOK_STATUS_OK } from "../../models/settings";
-import { MAX_VARCHAR_LENGTH } from "../../models/_default";
 import { capture } from "../../shared/notifications";
 import { Util } from "../../shared/util";
 import { errorToWhStatusDetails, sendTestPayload } from "../webhook/webhook";
@@ -47,7 +47,7 @@ export const updateWebhookStatus = async ({
   webhookEnabled,
   webhookStatusDetail,
 }: UpdateWebhookStatusCommand): Promise<void> => {
-  const statusDetail = limitStringLength(webhookStatusDetail, MAX_VARCHAR_LENGTH);
+  const statusDetail = limitStringLength(webhookStatusDetail, maxWebhookStatusLength);
   await Settings.update(
     {
       webhookEnabled,

--- a/packages/api/src/command/webhook/webhook-request.ts
+++ b/packages/api/src/command/webhook/webhook-request.ts
@@ -1,8 +1,12 @@
 import { limitStringLength, NotFoundError } from "@metriport/shared";
 import { v4 as uuidv4 } from "uuid";
-import { WebhookRequestStatus, WebhookType } from "../../domain/webhook";
+import {
+  maxRequestUrlLength,
+  maxStatusDetailLength,
+  WebhookRequestStatus,
+  WebhookType,
+} from "../../domain/webhook";
 import { WebhookRequest } from "../../models/webhook-request";
-import { MAX_VARCHAR_LENGTH } from "../../models/_default";
 
 export type CreateWebhookRequestCommand = {
   cxId: string;
@@ -63,8 +67,8 @@ export async function updateWebhookRequest({
 }: UpdateWebhookRequestCommand): Promise<void> {
   const whRequest = await WebhookRequest.findOne({ where: { id } });
   if (!whRequest) throw new NotFoundError(`Could not find webhook request ${id}`);
-  const statusDetailParsed = limitStringLength(statusDetail, MAX_VARCHAR_LENGTH);
-  const requestUrlParsed = limitStringLength(requestUrl, MAX_VARCHAR_LENGTH);
+  const statusDetailParsed = limitStringLength(statusDetail, maxStatusDetailLength);
+  const requestUrlParsed = limitStringLength(requestUrl, maxRequestUrlLength);
   await WebhookRequest.update(
     {
       status,

--- a/packages/api/src/domain/settings.ts
+++ b/packages/api/src/domain/settings.ts
@@ -1,5 +1,8 @@
 import { BaseDomain, BaseDomainCreate } from "@metriport/core/domain/base-domain";
 
+export const maxWebhookUrlLength = 2048;
+export const maxWebhookStatusLength = 2048;
+
 export interface SettingsCreate extends Omit<BaseDomainCreate, "id"> {
   webhookUrl: string;
   webhookKey: string;

--- a/packages/api/src/domain/webhook.ts
+++ b/packages/api/src/domain/webhook.ts
@@ -5,6 +5,9 @@ import {
 } from "@metriport/shared/medical";
 import { Product } from "./product";
 
+export const maxRequestUrlLength = 2048;
+export const maxStatusDetailLength = 2048;
+
 // TODO: 1411 - remove this section when DAPI is fully discontinued
 export const dapiWHPrefix = Product.devices;
 export const dapiWebhookType = [

--- a/packages/api/src/routes/settings.ts
+++ b/packages/api/src/routes/settings.ts
@@ -7,10 +7,11 @@ import { getSettings, getSettingsOrFail } from "../command/settings/getSettings"
 import { updateSettings } from "../command/settings/updateSettings";
 import { countFailedAndProcessingRequests } from "../command/webhook/count-failed";
 import { retryFailedRequests } from "../command/webhook/retry-failed";
+import { maxWebhookUrlLength } from "../domain/settings";
 import BadRequestError from "../errors/bad-request";
 import { Settings } from "../models/settings";
-import { asyncHandler, getCxIdOrFail } from "./util";
 import { requestLogger } from "./helpers/request-logger";
+import { asyncHandler, getCxIdOrFail } from "./util";
 
 const router = Router();
 const webhookURLIncludeBlacklist = [
@@ -112,7 +113,7 @@ router.get(
 
 const updateSettingsSchema = z
   .object({
-    webhookUrl: z.string().url().max(255).or(z.literal("").nullable().optional()),
+    webhookUrl: z.string().url().max(maxWebhookUrlLength).or(z.literal("").nullable().optional()),
   })
   .strict();
 

--- a/packages/api/src/routes/settings.ts
+++ b/packages/api/src/routes/settings.ts
@@ -112,7 +112,7 @@ router.get(
 
 const updateSettingsSchema = z
   .object({
-    webhookUrl: z.string().url().or(z.literal("").nullable().optional()),
+    webhookUrl: z.string().url().max(255).or(z.literal("").nullable().optional()),
   })
   .strict();
 

--- a/packages/api/src/sequelize/migrations/2024-06-13_00_alter-settings-increase-columns-length.ts
+++ b/packages/api/src/sequelize/migrations/2024-06-13_00_alter-settings-increase-columns-length.ts
@@ -1,0 +1,40 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "settings";
+const whUrl = "webhook_url";
+const whStatusDetail = "webhook_status_detail";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.changeColumn(
+      tableName,
+      whUrl,
+      { type: DataTypes.STRING(2048), allowNull: true },
+      { transaction }
+    );
+    await queryInterface.changeColumn(
+      tableName,
+      whStatusDetail,
+      { type: DataTypes.STRING(2048), allowNull: true },
+      { transaction }
+    );
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.changeColumn(
+      tableName,
+      whStatusDetail,
+      { type: DataTypes.STRING, allowNull: true },
+      { transaction }
+    );
+    await queryInterface.changeColumn(
+      tableName,
+      whUrl,
+      { type: DataTypes.STRING, allowNull: true },
+      { transaction }
+    );
+  });
+};

--- a/packages/api/src/sequelize/migrations/2024-06-13_01_alter-webhook-request-increase-columns-length.ts
+++ b/packages/api/src/sequelize/migrations/2024-06-13_01_alter-webhook-request-increase-columns-length.ts
@@ -1,0 +1,40 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "webhook_request";
+const requestUrl = "request_url";
+const statusDetail = "status_detail";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.changeColumn(
+      tableName,
+      requestUrl,
+      { type: DataTypes.STRING(2048), allowNull: true },
+      { transaction }
+    );
+    await queryInterface.changeColumn(
+      tableName,
+      statusDetail,
+      { type: DataTypes.STRING(2048), allowNull: true },
+      { transaction }
+    );
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.changeColumn(
+      tableName,
+      statusDetail,
+      { type: DataTypes.STRING, allowNull: true },
+      { transaction }
+    );
+    await queryInterface.changeColumn(
+      tableName,
+      requestUrl,
+      { type: DataTypes.STRING, allowNull: true },
+      { transaction }
+    );
+  });
+};


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1030

### Dependencies

none

### Description

Increase the limit of webhook URLs and status details to 2048 chars - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1718315046939229?thread_ts=1718311948.783149&cid=C04T256DQPQ)

### Testing

- Local
  - [x] URLs shorter than 256 chars get updated
  - [x] URLs longer than 256 chars get updated
  - [x] URLs longer than 2048 chars throw 4xx

### Release Plan

- :warning: Points to `master`
- :warning: Contains a DB migration
- [x] Merge this
