### PR TITLE
1040 Update DLQs visibilityTimeout from 12h to 1min

### DIFF
--- a/packages/infra/lib/shared/sqs.ts
+++ b/packages/infra/lib/shared/sqs.ts
@@ -183,7 +183,7 @@ export function defaultDLQ(
     retentionPeriod: Duration.days(14),
     deliveryDelay: Duration.millis(0),
     receiveMessageWaitTime: Duration.millis(0),
-    visibilityTimeout: Duration.hours(12), // in case we need time to process this manually
+    visibilityTimeout: Duration.minutes(1),
   });
 
   addMessageCountAlarmToQueue({


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Update DLQs visibilityTimeout from 12h to 1min - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1718313072659319?thread_ts=1718283008.568789&cid=C04T256DQPQ)

### Testing

none

### Release Plan

- [ ] Merge this
