### PR TITLE
1040 Add E2E tests to branch-to-staging

### DIFF
--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -81,3 +81,30 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       IHE_GW_KEYSTORE_STOREPASS: ${{ secrets.IHE_GW_KEYSTORE_STOREPASS_STAGING }}
       IHE_GW_KEYSTORE_KEYPASS: ${{ secrets.IHE_GW_KEYSTORE_KEYPASS_STAGING }}
+
+  e2e-tests:
+    uses: ./.github/workflows/_e2e-tests.yml
+    needs: [api, infra-api-lambdas, infra-ihe-gw, ihe-gw-server]
+    # run even if one of the dependencies didn't
+    # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."
+    # can't use ${{ ! failure() && contains(needs.*.result, 'success') }} because if anything that came before succeeded, even if not a direct dependency, it will run
+    if: ${{ !failure() && (needs.api.result == 'success' || needs.infra-api-lambdas.result == 'success' || needs.infra-ihe-gw.result == 'success' || needs.ihe-gw-server.result == 'success') }}
+    with:
+      deploy_env: "staging"
+      api_url: ${{ vars.API_URL_STAGING }}
+      fhir_url: ${{ vars.FHIR_SERVER_URL_STAGING }}
+      test_patient_id: ${{ vars.TEST_PATIENT_ID }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      TEST_API_KEY: ${{ secrets.TEST_API_KEY_STAGING }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
+      CW_CERTIFICATE: ${{ secrets.CW_CERTIFICATE_STAGING }}
+      CW_PRIVATE_KEY: ${{ secrets.CW_PRIVATE_KEY_STAGING }}
+      CW_MEMBER_CERTIFICATE: ${{ secrets.CW_MEMBER_CERTIFICATE_STAGING }}
+      CW_MEMBER_PRIVATE_KEY: ${{ secrets.CW_MEMBER_PRIVATE_KEY_STAGING }}
+      CW_MEMBER_NAME: ${{ secrets.CW_MEMBER_NAME_STAGING }}
+      CW_MEMBER_OID: ${{ secrets.CW_MEMBER_OID_STAGING }}
+    


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Add E2E tests to `branch-to-staging`

### Testing

- Local
  - none
- Staging
  - [ ] branch to staging runs E2E tests
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
