### PR TITLE
fix(ihev2): bump dr lambda duration, bump attempt up on dq retries

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dr.test.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dr.test.ts
@@ -149,14 +149,14 @@ describe("processDrResponse", () => {
     expect(response.documentReference?.length).toBe(2);
     expect(response?.documentReference?.[0]?.contentType).toEqual("application/octet-stream");
     expect(response?.documentReference?.[0]?.docUniqueId).toEqual("123456789");
-    expect(response?.documentReference?.[0]?.homeCommunityId).toEqual("2.16.840.1.113883.3.8391");
+    expect(response?.documentReference?.[0]?.homeCommunityId).toEqual("2.16.840.1.113883.3.9621");
     expect(response?.documentReference?.[0]?.repositoryUniqueId).toEqual(
       "urn:oid:2.16.840.1.113883.3.9621"
     );
 
     expect(response?.documentReference?.[1]?.contentType).toEqual("application/octet-stream");
     expect(response?.documentReference?.[1]?.docUniqueId).toEqual("987654321");
-    expect(response?.documentReference?.[1]?.homeCommunityId).toEqual("2.16.840.1.113883.3.8391");
+    expect(response?.documentReference?.[1]?.homeCommunityId).toEqual("2.16.840.1.113883.3.9621");
     expect(response?.documentReference?.[1]?.repositoryUniqueId).toEqual(
       "urn:oid:2.16.840.1.113883.3.9621"
     );

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/dr_success.xml
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/dr_success.xml
@@ -16,14 +16,14 @@
         <ihe:RetrieveDocumentSetResponse xmlns:ihe="urn:ihe:iti:xds-b:2007">
             <RegistryResponse xmlns="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success"/>
             <DocumentResponse>
-                <HomeCommunityId>urn:oid:urn:oid:2.16.840.1.113883.3.9621</HomeCommunityId>
+                <HomeCommunityId>urn:oid:2.16.840.1.113883.3.9621</HomeCommunityId>
                 <RepositoryUniqueId>urn:oid:2.16.840.1.113883.3.9621</RepositoryUniqueId>
                 <DocumentUniqueId>123456789</DocumentUniqueId>
                 <mimeType>application/pdf</mimeType>
                 <Document>Metriport Rocks!</Document>
             </DocumentResponse>
             <DocumentResponse>
-                <HomeCommunityId>urn:oid:urn:oid:2.16.840.1.113883.3.9621</HomeCommunityId>
+                <HomeCommunityId>urn:oid:2.16.840.1.113883.3.9621</HomeCommunityId>
                 <RepositoryUniqueId>urn:oid:2.16.840.1.113883.3.9621</RepositoryUniqueId>
                 <DocumentUniqueId>987654321</DocumentUniqueId>
                 <mimeType>application/xml</mimeType>

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
@@ -130,7 +130,7 @@ async function processDocumentReference({
       docUniqueId: documentResponse.DocumentUniqueId.toString(),
       metriportId: metriportId,
       fileLocation: bucket,
-      homeCommunityId: outboundRequest.gateway.homeCommunityId,
+      homeCommunityId: documentResponse.HomeCommunityId,
       repositoryUniqueId: documentResponse.RepositoryUniqueId,
       newDocumentUniqueId: documentResponse.NewDocumentUniqueId,
       newRepositoryUniqueId: documentResponse.NewRepositoryUniqueId,

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
@@ -130,7 +130,7 @@ async function processDocumentReference({
       docUniqueId: documentResponse.DocumentUniqueId.toString(),
       metriportId: metriportId,
       fileLocation: bucket,
-      homeCommunityId: documentResponse.HomeCommunityId,
+      homeCommunityId: stripUrnPrefix(documentResponse.HomeCommunityId),
       repositoryUniqueId: documentResponse.RepositoryUniqueId,
       newDocumentUniqueId: documentResponse.NewDocumentUniqueId,
       newRepositoryUniqueId: documentResponse.NewRepositoryUniqueId,

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/send/dq-requests.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/send/dq-requests.ts
@@ -33,6 +33,7 @@ export async function sendSignedDqRequest({
       signedXml: request.signedRequest,
       url: request.gateway.url,
       samlCertsAndKeys,
+      isDq: true,
     });
     log(
       `Request ${index + 1} sent successfully to: ${request.gateway.url} + oid: ${

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests.ts
@@ -30,6 +30,7 @@ export async function sendSignedXCPDRequests({
         signedXml: request.signedRequest,
         url: request.gateway.url,
         samlCertsAndKeys,
+        isDq: false,
       });
       log(
         `Request ${index + 1} sent successfully to: ${request.gateway.url} + oid: ${

--- a/packages/core/src/external/carequality/ihe-gateway-v2/saml/saml-client.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/saml/saml-client.ts
@@ -69,10 +69,12 @@ export async function sendSignedXml({
   signedXml,
   url,
   samlCertsAndKeys,
+  isDq,
 }: {
   signedXml: string;
   url: string;
   samlCertsAndKeys: SamlCertsAndKeys;
+  isDq: boolean;
 }): Promise<{ response: string; contentType: string }> {
   const trustedKeyStore = await getTrustedKeyStore();
   const agent = new https.Agent({
@@ -100,9 +102,9 @@ export async function sendSignedXml({
     },
     {
       initialDelay: initialDelay.asMilliseconds(),
-      maxAttempts: 3,
+      maxAttempts: isDq ? 4 : 3,
       //TODO: This introduces retry on timeout without needing to specify the http Code: https://github.com/metriport/metriport/pull/2285. Remove once PR is merged
-      httpCodesToRetry: ["ECONNREFUSED", "ECONNRESET", "ETIMEDOUT"],
+      httpCodesToRetry: ["ECONNREFUSED", "ECONNRESET", "ETIMEDOUT", "ECONNABORTED"],
     }
   );
 

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -274,7 +274,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
       },
       layers: [lambdaLayers.shared],
       memory: 1024,
-      timeout: Duration.minutes(5),
+      timeout: Duration.minutes(15),
       vpc,
     });
 


### PR DESCRIPTION
Refs: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- bump up DR lambda timeout duration - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1718767347974169)
- increase dq lambda # of retries - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1718741158598569?thread_ts=1718736573.506549&cid=C04T256DQPQ)
- fix parsing nit bug where using request homeCommunityId in DR response instead of response id. Helpful for debugging in DB results

### Testing

- [ ] Staging


### Release Plan

- [ ] Merge this
