### PR TITLE
1040 - 2/3 Add ALB behind API's NLB to avoid errors on restart

### DIFF
--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -99,12 +99,12 @@ async function prepareAndTriggerPD({
     );
 
     if (numGatewaysV1 > 0) {
-      log(`Kicking off patient discovery Gateway V1`);
+      log(`Kicking off patient discovery Gateway V1 - ${numGatewaysV1} gateways`);
       await enabledIHEGW.startPatientDiscovery(pdRequestGatewayV1);
     }
 
     if (numGatewaysV2 > 0) {
-      log(`Kicking off patient discovery Gateway V2`);
+      log(`Kicking off patient discovery Gateway V2 - ${numGatewaysV2} gateways`);
       const iheGatewayV2 = makeIHEGatewayV2();
       await iheGatewayV2.startPatientDiscovery({
         pdRequestGatewayV2,

--- a/packages/infra/lib/api-stack/document-upload.ts
+++ b/packages/infra/lib/api-stack/document-upload.ts
@@ -1,5 +1,4 @@
 import * as ec2 from "aws-cdk-lib/aws-ec2";
-import * as ecs_patterns from "aws-cdk-lib/aws-ecs-patterns";
 import { S3EventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
@@ -11,7 +10,7 @@ export function createLambda({
   lambdaLayers,
   stack,
   vpc,
-  apiService,
+  apiAddress,
   envType,
   medicalDocumentsUploadBucket,
   medicalDocumentsBucket,
@@ -20,7 +19,7 @@ export function createLambda({
   lambdaLayers: LambdaLayers;
   stack: Construct;
   vpc: ec2.IVpc;
-  apiService: ecs_patterns.NetworkLoadBalancedFargateService;
+  apiAddress: string;
   envType: EnvType;
   medicalDocumentsBucket: s3.IBucket;
   medicalDocumentsUploadBucket: s3.Bucket;
@@ -34,7 +33,7 @@ export function createLambda({
     layers: [lambdaLayers.shared],
     envType,
     envVars: {
-      API_URL: `http://${apiService.loadBalancer.loadBalancerDnsName}`,
+      API_URL: `http://${apiAddress}`,
       MEDICAL_DOCUMENTS_DESTINATION_BUCKET: medicalDocumentsBucket.bucketName,
       ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
     },

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -1,18 +1,17 @@
-import { NestedStack, NestedStackProps } from "aws-cdk-lib";
-import * as s3 from "aws-cdk-lib/aws-s3";
+import { Duration, NestedStack, NestedStackProps } from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { Function as Lambda } from "aws-cdk-lib/aws-lambda";
+import * as s3 from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import { EnvType } from "./env-type";
+import { createLambda } from "./shared/lambda";
 import { LambdaLayers } from "./shared/lambda-layers";
 import { Secrets } from "./shared/secrets";
-import { createLambda } from "./shared/lambda";
-import * as ec2 from "aws-cdk-lib/aws-ec2";
-import { Duration } from "aws-cdk-lib";
-import { NetworkLoadBalancedFargateService } from "aws-cdk-lib/aws-ecs-patterns";
 
 interface IHEGatewayV2LambdasNestedStackProps extends NestedStackProps {
   lambdaLayers: LambdaLayers;
-  apiService: NetworkLoadBalancedFargateService;
+  apiTaskRole: iam.IRole;
   vpc: ec2.IVpc;
   secrets: Secrets;
   cqOrgCertificate: string | undefined;
@@ -52,9 +51,9 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
     );
 
     // granting lambda invoke access to api service
-    patientDiscoveryLambda.grantInvoke(props.apiService.taskDefinition.taskRole);
-    documentQueryLambda.grantInvoke(props.apiService.taskDefinition.taskRole);
-    documentRetrievalLambda.grantInvoke(props.apiService.taskDefinition.taskRole);
+    patientDiscoveryLambda.grantInvoke(props.apiTaskRole);
+    documentQueryLambda.grantInvoke(props.apiTaskRole);
+    documentRetrievalLambda.grantInvoke(props.apiTaskRole);
   }
 
   private grantSecretsReadAccess(
@@ -74,7 +73,6 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
     ownProps: {
       lambdaLayers: LambdaLayers;
       vpc: ec2.IVpc;
-      apiService: NetworkLoadBalancedFargateService;
       secrets: Secrets;
       cqOrgCertificate: string | undefined;
       cqOrgPrivateKey: string | undefined;


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2303
- Downstream: https://github.com/metriport/metriport/pull/2305

### Description

Point infra to use the ALB version of the API's - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1718755941062309)

### Testing

- Local
  - [x] cdk diff successful
- Staging
  - [ ] API through API GW works
  - [ ] Dash through API GW works
  - [ ] ECS restart script leads to near zero errors upon restart of API
     - `executeWithNetworkRetries` is not on base branch yet (`develop`)
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
