### PR TITLE
Patch pd lambda timeout

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/saml/saml-client.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/saml/saml-client.ts
@@ -108,7 +108,7 @@ export async function sendSignedXml({
       initialDelay: initialDelay.asMilliseconds(),
       maxAttempts: isDq ? 4 : 3,
       //TODO: This introduces retry on timeout without needing to specify the http Code: https://github.com/metriport/metriport/pull/2285. Remove once PR is merged
-      httpCodesToRetry: ["ECONNREFUSED", "ECONNRESET", "ETIMEDOUT"],
+      httpCodesToRetry: ["ECONNREFUSED", "ECONNRESET", "ETIMEDOUT", "ECONNABORTED"],
     }
   );
 

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -127,7 +127,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
       },
       layers: [lambdaLayers.shared],
       memory: 4096,
-      timeout: Duration.minutes(5),
+      timeout: Duration.minutes(10),
       vpc,
     });
 
@@ -200,7 +200,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
       },
       layers: [lambdaLayers.shared],
       memory: 1024,
-      timeout: Duration.minutes(5),
+      timeout: Duration.minutes(10),
       vpc,
     });
 


### PR DESCRIPTION
Ticket: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- bump pd lambda duration to 10 mins
- shorten http timeout to 60s
- [context](https://metriport.slack.com/archives/C04T256DQPQ/p1718817800568869)
 

### Testing

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
