### PR TITLE
1040 - 1/3 Create ALB version of the API

### DIFF
--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -76,6 +76,10 @@ type EnvConfigBase = {
     alarmThresholds: RDSAlarmThresholds;
   };
   loadBalancerDnsName: string;
+  /**
+   * Introduced when we had to recreate the Fargate service, so we could keep using the existing log group.
+   */
+  logArn: string;
   apiGatewayUsagePlanId?: string; // optional since we need to create the stack first, then update this and redeploy
   usageReportUrl?: string;
   fhirServerUrl: string;

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -25,6 +25,7 @@ export const config: EnvConfigNonSandbox = {
     },
   },
   loadBalancerDnsName: "<your-load-balancer-dns-name>",
+  logArn: "<your-log-arn>",
   fhirToMedicalLambda: {
     nodeRuntimeArn: "arn:aws:lambda:<region>::runtime:<id>",
   },

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -396,6 +396,7 @@ export class APIStack extends Stack {
       service: apiService,
       loadBalancerAddress: apiLoadBalancerAddress,
       serverAddress: apiServerUrl,
+      apiServiceAdditional,
     } = createAPIService({
       stack: this,
       props,
@@ -456,6 +457,8 @@ export class APIStack extends Stack {
 
     // Access grant for Aurora DB
     dbCluster.connections.allowDefaultPortFrom(apiService.service);
+    // TODO remove this on 3/3
+    dbCluster.connections.allowDefaultPortFrom(apiServiceAdditional);
 
     // setup a private link so the API can talk to the NLB
     const link = new apig.VpcLink(this, "link", {

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -6,6 +6,7 @@ import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Repository } from "aws-cdk-lib/aws-ecr";
 import * as ecs from "aws-cdk-lib/aws-ecs";
+import { FargateService } from "aws-cdk-lib/aws-ecs";
 import * as ecs_patterns from "aws-cdk-lib/aws-ecs-patterns";
 import {
   ApplicationProtocol,
@@ -98,6 +99,7 @@ export function createAPIService({
   service: ecs_patterns.NetworkLoadBalancedFargateService;
   serverAddress: string;
   loadBalancerAddress: string;
+  apiServiceAdditional: FargateService;
 } {
   // Create a new Amazon Elastic Container Service (ECS) cluster
   const cluster = new ecs.Cluster(stack, "APICluster", { vpc, containerInsights: true });
@@ -561,5 +563,6 @@ export function createAPIService({
     service: fargateService,
     serverAddress: apiUrl,
     loadBalancerAddress: serverAddress,
+    apiServiceAdditional: fargateServiceAlb.service,
   };
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1899
- Downstream: https://github.com/metriport/metriport/pull/2299

### Description

Create ALB version of the API - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1718755941062309).

Next PR will point things to it. The last one will remove the NLB based API.

### Testing

- Local
  - [x] cdk diff successful
- Staging
  - [x] API through API GW works
  - [x] Dash through API GW works
  - [x] ECS restart script leads to near zero errors upon restart of API
     - `executeWithNetworkRetries` is not on base branch yet (`develop`)
- Sandbox
  - none
- Production
  - none

### Release Plan

- [x] Merge this
