### PR TITLE
feat(retry): 3x initial delay on 429s

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/ihe-gateway-v2-logic.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/ihe-gateway-v2-logic.ts
@@ -118,7 +118,9 @@ export async function createSignSendProcessXCPDRequest({
   for (const result of results) {
     try {
       // TODO not sure if we should retry on timeout
-      await executeWithNetworkRetries(async () => axios.post(pdResponseUrl, result));
+      await executeWithNetworkRetries(async () => axios.post(pdResponseUrl, result), {
+        httpCodesToRetry: ["ERR_BAD_RESPONSE"],
+      });
     } catch (error) {
       const msg = "Failed to send PD response to internal CQ endpoint";
       const extra = { cxId, patientId, result };
@@ -167,7 +169,9 @@ export async function createSignSendProcessDqRequests({
   for (const result of successfulResults) {
     try {
       // TODO not sure if we should retry on timeout
-      await executeWithNetworkRetries(async () => axios.post(dqResponseUrl, result));
+      await executeWithNetworkRetries(async () => axios.post(dqResponseUrl, result), {
+        httpCodesToRetry: ["ERR_BAD_RESPONSE"],
+      });
     } catch (error) {
       const msg = "Failed to send DQ response to internal CQ endpoint";
       const extra = { cxId, patientId, result };
@@ -217,7 +221,9 @@ export async function createSignSendProcessDrRequests({
   for (const result of successfulResults) {
     try {
       // TODO not sure if we should retry on timeout
-      await executeWithNetworkRetries(async () => axios.post(drResponseUrl, result));
+      await executeWithNetworkRetries(async () => axios.post(drResponseUrl, result), {
+        httpCodesToRetry: ["ERR_BAD_RESPONSE"],
+      });
     } catch (error) {
       const msg = "Failed to send DR response to internal CQ endpoint";
       const extra = { cxId, patientId, result };

--- a/packages/core/src/external/carequality/ihe-gateway-v2/ihe-gateway-v2-logic.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/ihe-gateway-v2-logic.ts
@@ -119,7 +119,7 @@ export async function createSignSendProcessXCPDRequest({
     try {
       // TODO not sure if we should retry on timeout
       await executeWithNetworkRetries(async () => axios.post(pdResponseUrl, result), {
-        httpCodesToRetry: ["ERR_BAD_RESPONSE"],
+        httpStatusCodesToRetry: [502, 504],
       });
     } catch (error) {
       const msg = "Failed to send PD response to internal CQ endpoint";
@@ -170,7 +170,7 @@ export async function createSignSendProcessDqRequests({
     try {
       // TODO not sure if we should retry on timeout
       await executeWithNetworkRetries(async () => axios.post(dqResponseUrl, result), {
-        httpCodesToRetry: ["ERR_BAD_RESPONSE"],
+        httpStatusCodesToRetry: [502, 504],
       });
     } catch (error) {
       const msg = "Failed to send DQ response to internal CQ endpoint";
@@ -222,7 +222,7 @@ export async function createSignSendProcessDrRequests({
     try {
       // TODO not sure if we should retry on timeout
       await executeWithNetworkRetries(async () => axios.post(drResponseUrl, result), {
-        httpCodesToRetry: ["ERR_BAD_RESPONSE"],
+        httpStatusCodesToRetry: [502, 504],
       });
     } catch (error) {
       const msg = "Failed to send DR response to internal CQ endpoint";

--- a/packages/shared/src/common/__tests__/retry.test.ts
+++ b/packages/shared/src/common/__tests__/retry.test.ts
@@ -71,12 +71,14 @@ describe("retry", () => {
           getTimeToWait,
         })
       ).rejects.toThrow();
-      expect(getTimeToWait).toHaveBeenCalledWith({
-        initialDelay: 10,
-        backoffMultiplier: 2,
-        attempt: 1,
-        maxDelay: Infinity,
-      });
+      expect(getTimeToWait).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialDelay: 10,
+          backoffMultiplier: 2,
+          attempt: 1,
+          maxDelay: Infinity,
+        })
+      );
     });
 
     test("uses provided initialDelay", async () => {

--- a/packages/shared/src/common/retry.ts
+++ b/packages/shared/src/common/retry.ts
@@ -49,6 +49,7 @@ export type GetTimeToWaitParams = {
   backoffMultiplier: number;
   attempt: number;
   maxDelay: number;
+  error?: unknown;
 };
 
 /**
@@ -107,7 +108,13 @@ export async function executeWithRetries<T>(
         throw error;
       }
       log(`${msg}, retrying... (attempt: ${attempt})`);
-      const timeToWait = getTimeToWait({ initialDelay, backoffMultiplier, attempt, maxDelay });
+      const timeToWait = getTimeToWait({
+        initialDelay,
+        backoffMultiplier,
+        attempt,
+        maxDelay,
+        error,
+      });
       await sleep(timeToWait);
     }
   }

--- a/packages/shared/src/net/retry.ts
+++ b/packages/shared/src/net/retry.ts
@@ -30,7 +30,7 @@ const defaultOptions: ExecuteWithNetworkRetriesOptions = {
     "ECONNREFUSED", // (Connection refused): No connection could be made because the target machine actively refused it. This usually results from trying to connect to a service that is inactive on the foreign host.
     "ECONNRESET", //  (Connection reset by peer): A connection was forcibly closed by a peer. This normally results from a loss of the connection on the remote socket due to a timeout or reboot. Commonly encountered via the http and net modules.
   ],
-  httpStatusCodesToRetry: [tooManyRequestsStatus], // 429 Too Many Requests
+  httpStatusCodesToRetry: [tooManyRequestsStatus],
   retryOnTimeout: false,
 };
 
@@ -59,21 +59,14 @@ function networkGetTimeToWait({
   error,
 }: GetTimeToWaitParams) {
   const status = getHttpStatusFromError(error);
-  if (status === tooManyRequestsStatus) {
-    return defaultGetTimeToWait({
-      initialDelay: initialDelay * tooManyRequestsMultiplier,
-      backoffMultiplier,
-      attempt,
-      maxDelay,
-    });
-  } else {
-    return defaultGetTimeToWait({
-      initialDelay,
-      backoffMultiplier,
-      attempt,
-      maxDelay,
-    });
-  }
+  const effectiveInitialDelay =
+    status === tooManyRequestsStatus ? initialDelay * tooManyRequestsMultiplier : initialDelay;
+  return defaultGetTimeToWait({
+    initialDelay: effectiveInitialDelay,
+    backoffMultiplier,
+    attempt,
+    maxDelay,
+  });
 }
 
 /**

--- a/packages/shared/src/net/retry.ts
+++ b/packages/shared/src/net/retry.ts
@@ -3,8 +3,13 @@ import {
   defaultOptions as defaultRetryWithBackoffOptions,
   executeWithRetries,
   ExecuteWithRetriesOptions,
+  GetTimeToWaitParams,
+  defaultGetTimeToWait,
 } from "../common/retry";
 import { NetworkError, networkTimeoutErrors } from "./error";
+
+const tooManyRequestsStatus = 429;
+const tooManyRequestsMultiplier = 3;
 
 export type ExecuteWithNetworkRetriesOptions = Omit<
   ExecuteWithRetriesOptions<unknown>,
@@ -25,9 +30,51 @@ const defaultOptions: ExecuteWithNetworkRetriesOptions = {
     "ECONNREFUSED", // (Connection refused): No connection could be made because the target machine actively refused it. This usually results from trying to connect to a service that is inactive on the foreign host.
     "ECONNRESET", //  (Connection reset by peer): A connection was forcibly closed by a peer. This normally results from a loss of the connection on the remote socket due to a timeout or reboot. Commonly encountered via the http and net modules.
   ],
-  httpStatusCodesToRetry: [429], // 429 Too Many Requests
+  httpStatusCodesToRetry: [tooManyRequestsStatus], // 429 Too Many Requests
   retryOnTimeout: false,
 };
+
+function getHttpStatusFromError(error: unknown): number | undefined {
+  return axios.isAxiosError(error) ? error.response?.status : undefined;
+}
+
+function getHttpCodeFromError(error: unknown): string | undefined {
+  return axios.isAxiosError(error) ? error.code : undefined;
+}
+
+/**
+ * Custom getTimeToWait function for network retries. Has special handling for 429 Too Many Requests. Else regular backoff.
+ * @param initialDelay The initial delay in milliseconds.
+ * @param backoffMultiplier The backoff multiplier.
+ * @param attempt The current attempt number.
+ * @param maxDelay The maximum delay in milliseconds.
+ * @param error The error that occurred.
+ * @returns The time to wait before the next retry.
+ */
+function networkGetTimeToWait({
+  initialDelay,
+  backoffMultiplier,
+  attempt,
+  maxDelay,
+  error,
+}: GetTimeToWaitParams) {
+  const status = getHttpStatusFromError(error);
+  if (status === tooManyRequestsStatus) {
+    return defaultGetTimeToWait({
+      initialDelay: initialDelay * tooManyRequestsMultiplier,
+      backoffMultiplier,
+      attempt,
+      maxDelay,
+    });
+  } else {
+    return defaultGetTimeToWait({
+      initialDelay,
+      backoffMultiplier,
+      attempt,
+      maxDelay,
+    });
+  }
+}
 
 /**
  * Executes a function with retries and backoff with jitter. If the function throws a network
@@ -63,13 +110,14 @@ export async function executeWithNetworkRetries<T>(
   return executeWithRetries(fn, {
     ...actualOptions,
     shouldRetry: (_, error: unknown) => {
-      const networkCode = axios.isAxiosError(error) ? error.code : undefined;
-      const networkStatus = axios.isAxiosError(error) ? error.response?.status : undefined;
+      const networkCode = getHttpCodeFromError(error);
+      const networkStatus = getHttpStatusFromError(error);
       return (
         (networkCode && codesAsString.includes(networkCode)) ||
         (networkStatus && httpStatusCodesToRetry.includes(networkStatus)) ||
         false
       );
     },
+    getTimeToWait: networkGetTimeToWait,
   });
 }


### PR DESCRIPTION
Refs: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- longer initial delay on 429s 

### Testing

- Local
  - [x] added unit tests

### Release Plan

- [ ] Merge this
