### PR TITLE
1040 Send a single alert to sentry when MR generation fails

### DIFF
--- a/packages/lambdas/src/fhir-to-medical-record.ts
+++ b/packages/lambdas/src/fhir-to-medical-record.ts
@@ -178,13 +178,6 @@ const convertStoreAndReturnPdfUrl = async ({
         ContentType: "application/pdf",
       })
       .promise();
-  } catch (error) {
-    console.log(`Error while converting to pdf: `, error);
-
-    capture.error(error, {
-      extra: { context: "convertStoreAndReturnPdfDocUrl", lambdaName, error },
-    });
-    throw error;
   } finally {
     // Close the puppeteer browser
     if (browser !== null) {


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Send a single alert to sentry when MR generation fails.

### Testing

none

### Release Plan

- [ ] Merge this
