### PR TITLE
fix(ihe): ihe gw results are incomplete for dr

### DIFF
--- a/packages/api/src/external/carequality/document/__tests__/create-outbound-document-retrieval-req.test.ts
+++ b/packages/api/src/external/carequality/document/__tests__/create-outbound-document-retrieval-req.test.ts
@@ -11,12 +11,14 @@ import { makeOrganization } from "../../../../domain/medical/__tests__/organizat
 import { makePatient } from "../../../../domain/medical/__tests__/patient";
 import { Facility, FacilityType } from "../../../../domain/medical/facility";
 import { HieInitiator } from "../../../hie/get-hie-initiator";
-import {
-  createOutboundDocumentRetrievalReqs,
-  maxDocRefsPerDocRetrievalRequest,
-} from "../create-outbound-document-retrieval-req";
+import { createOutboundDocumentRetrievalReqs } from "../create-outbound-document-retrieval-req";
+import { defaultDocRefsPerRequest } from "@metriport/core/external/carequality/ihe-gateway-v2/gateways";
 import { makeDocumentReferenceWithMetriportId } from "./make-document-reference-with-metriport-id";
 import { makeOutboundDocumentQueryResp, makeXcaGateway } from "./shared";
+import {
+  epicOidPrefix,
+  surescriptsOid,
+} from "@metriport/core/external/carequality/ihe-gateway-v2/gateways";
 
 let requestId: string;
 let facilityId: string;
@@ -67,7 +69,7 @@ describe("outboundDocumentRetrievalRequest", () => {
   it("returns 1 req with 6 doc refs when we have an epic gw", async () => {
     const outboundDocumentQueryResps: OutboundDocumentQueryResp[] = [
       makeOutboundDocumentQueryResp({
-        gateway: makeXcaGateway({ homeCommunityId: "1.2.840.114350.1.13" }),
+        gateway: makeXcaGateway({ homeCommunityId: epicOidPrefix }),
         documentReference: [
           makeDocumentReferenceWithMetriportId(),
           makeDocumentReferenceWithMetriportId(),
@@ -92,7 +94,7 @@ describe("outboundDocumentRetrievalRequest", () => {
   it("returns 2 req with 11 doc refs when we have an epic gw", async () => {
     const outboundDocumentQueryResps: OutboundDocumentQueryResp[] = [
       makeOutboundDocumentQueryResp({
-        gateway: makeXcaGateway({ homeCommunityId: "1.2.840.114350.1.13" }),
+        gateway: makeXcaGateway({ homeCommunityId: epicOidPrefix }),
         documentReference: [
           makeDocumentReferenceWithMetriportId(),
           makeDocumentReferenceWithMetriportId(),
@@ -117,6 +119,28 @@ describe("outboundDocumentRetrievalRequest", () => {
     expect(res).toBeTruthy();
     expect(res.length).toEqual(2);
     expect(res[0].documentReference.length).toEqual(10);
+    expect(res[1].documentReference.length).toEqual(1);
+  });
+
+  it("returns 1 req with 6 doc refs when we have an epic gw", async () => {
+    const outboundDocumentQueryResps: OutboundDocumentQueryResp[] = [
+      makeOutboundDocumentQueryResp({
+        gateway: makeXcaGateway({ homeCommunityId: surescriptsOid }),
+        documentReference: [
+          makeDocumentReferenceWithMetriportId(),
+          makeDocumentReferenceWithMetriportId(),
+        ],
+      }),
+    ];
+    const res: OutboundDocumentRetrievalReq[] = createOutboundDocumentRetrievalReqs({
+      patient,
+      requestId,
+      initiator,
+      outboundDocumentQueryResults: outboundDocumentQueryResps,
+    });
+    expect(res).toBeTruthy();
+    expect(res.length).toEqual(2);
+    expect(res[0].documentReference.length).toEqual(1);
     expect(res[1].documentReference.length).toEqual(1);
   });
 
@@ -150,7 +174,7 @@ describe("outboundDocumentRetrievalRequest", () => {
     const outboundDocumentQueryResps: OutboundDocumentQueryResp[] = [
       makeOutboundDocumentQueryResp({
         gateway: makeXcaGateway({ homeCommunityId }),
-        documentReference: [...Array(maxDocRefsPerDocRetrievalRequest + 1).keys()].map(() =>
+        documentReference: [...Array(defaultDocRefsPerRequest + 1).keys()].map(() =>
           makeDocumentReferenceWithMetriportId({ homeCommunityId })
         ),
       }),
@@ -169,7 +193,7 @@ describe("outboundDocumentRetrievalRequest", () => {
     const outboundDocumentQueryResps: OutboundDocumentQueryResp[] = [
       makeOutboundDocumentQueryResp({
         gateway: makeXcaGateway({ homeCommunityId }),
-        documentReference: [...Array(maxDocRefsPerDocRetrievalRequest * 2 + 1).keys()].map(() =>
+        documentReference: [...Array(defaultDocRefsPerRequest * 2 + 1).keys()].map(() =>
           makeDocumentReferenceWithMetriportId({ homeCommunityId })
         ),
       }),

--- a/packages/api/src/external/carequality/document/create-outbound-document-retrieval-req.ts
+++ b/packages/api/src/external/carequality/document/create-outbound-document-retrieval-req.ts
@@ -4,10 +4,7 @@ import {
   OutboundDocumentQueryResp,
   OutboundDocumentRetrievalReq,
 } from "@metriport/ihe-gateway-sdk";
-import {
-  isEpicGateway,
-  maxDocRefsPerEpicDocRetrievalRequest,
-} from "@metriport/core/external/carequality/ihe-gateway-v2/gateways";
+import { getGatewaySpecificDocRefsPerRequest } from "@metriport/core/external/carequality/ihe-gateway-v2/gateways";
 import { v4 as uuidv4 } from "uuid";
 
 import dayjs from "dayjs";
@@ -17,7 +14,6 @@ import { createPurposeOfUse, getSystemUserName, isGWValid } from "../shared";
 
 const SUBJECT_ROLE_CODE = "106331006";
 const SUBJECT_ROLE_DISPLAY = "Administrative AND/OR managerial worker";
-export const maxDocRefsPerDocRetrievalRequest = 5;
 
 export function createOutboundDocumentRetrievalReqs({
   requestId,
@@ -66,9 +62,7 @@ export function createOutboundDocumentRetrievalReqs({
         },
       };
 
-      const docRefsPerRequest = isEpicGateway(gateway)
-        ? maxDocRefsPerEpicDocRetrievalRequest
-        : maxDocRefsPerDocRetrievalRequest;
+      const docRefsPerRequest = getGatewaySpecificDocRefsPerRequest(gateway);
       const docRefChunks = chunk(documentReference, docRefsPerRequest);
       const request: OutboundDocumentRetrievalReq[] = docRefChunks.map(chunk => {
         return {

--- a/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
@@ -21,7 +21,8 @@ const specialNamespaceRequiredUrl =
 const pointClickCareOid = "2.16.840.1.113883.3.6448";
 const redoxOid = "2.16.840.1.113883.3.6147.458";
 const redoxGatewayOid = "2.16.840.1.113883.3.6147.458.2";
-const surescriptsOid = "2.16.840.1.113883.3.2054.2.1.1";
+export const surescriptsOid = "2.16.840.1.113883.3.2054.2.1.1";
+export const epicOidPrefix = "1.2.840.114350.1.13";
 
 /*
  * These gateways only accept a single document reference per request.
@@ -33,8 +34,19 @@ const gatewaysThatAcceptOneDocRefPerRequest = [
   surescriptsOid,
 ];
 
-const epicOidPrefix = "1.2.840.114350.1.13";
-export const maxDocRefsPerEpicDocRetrievalRequest = 10;
+const docRefsPerRequestByGateway: Record<string, number> = {
+  [pointClickCareOid]: 1,
+  [redoxOid]: 1,
+  [redoxGatewayOid]: 1,
+  [surescriptsOid]: 1,
+  [epicOidPrefix]: 10,
+};
+
+export const defaultDocRefsPerRequest = 5;
+
+export function getGatewaySpecificDocRefsPerRequest(gateway: XCAGateway): number {
+  return docRefsPerRequestByGateway[gateway.homeCommunityId] || defaultDocRefsPerRequest;
+}
 
 /*
  * These gateways require a urn:uuid prefix before document Unique ids formatted as lowercase uuids
@@ -84,8 +96,4 @@ export function requiresUrnInSoapBody(gateway: XCPDGateway): boolean {
 
 export function requiresOnlyOneDocRefPerRequest(gateway: XCAGateway): boolean {
   return gatewaysThatAcceptOneDocRefPerRequest.includes(gateway.homeCommunityId);
-}
-
-export function isEpicGateway(gateway: XCAGateway): boolean {
-  return gateway.homeCommunityId.startsWith(epicOidPrefix);
 }

--- a/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
@@ -45,7 +45,7 @@ const docRefsPerRequestByGateway: Record<string, number> = {
 export const defaultDocRefsPerRequest = 5;
 
 export function getGatewaySpecificDocRefsPerRequest(gateway: XCAGateway): number {
-  return docRefsPerRequestByGateway[gateway.homeCommunityId] || defaultDocRefsPerRequest;
+  return docRefsPerRequestByGateway[gateway.homeCommunityId] ?? defaultDocRefsPerRequest;
 }
 
 /*

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/create/iti39-envelope.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/create/iti39-envelope.ts
@@ -1,5 +1,4 @@
 import dayjs from "dayjs";
-import { chunk } from "lodash";
 import { XMLBuilder } from "fast-xml-parser";
 import { OutboundDocumentRetrievalReq, XCAGateway } from "@metriport/ihe-gateway-sdk";
 import { createSecurityHeader } from "../../../saml/security/security-header";
@@ -8,16 +7,9 @@ import { SamlCertsAndKeys } from "../../../saml/security/types";
 import { namespaces, expiresIn } from "../../../constants";
 import { ORGANIZATION_NAME_DEFAULT as metriportOrganization, replyTo } from "../../../../shared";
 import { wrapIdInUrnUuid, wrapIdInUrnOid } from "../../../../../../util/urn";
-import {
-  requiresOnlyOneDocRefPerRequest,
-  getHomeCommunityId,
-  getDocumentUniqueIdFunctionByGateway,
-} from "../../../gateways";
+import { getHomeCommunityId, getDocumentUniqueIdFunctionByGateway } from "../../../gateways";
 
 const action = "urn:ihe:iti:2007:CrossGatewayRetrieve";
-
-const minDocumentReferencesPerDrRequest = 1;
-const maxDocumentReferencesPerDrRequest = 10;
 
 export type SignedDrRequest = {
   gateway: XCAGateway;
@@ -121,22 +113,11 @@ export function createAndSignBulkDRRequests({
   const signedRequests: SignedDrRequest[] = [];
 
   for (const bodyData of bulkBodyData) {
-    const documentReferencesPerRequest = requiresOnlyOneDocRefPerRequest(bodyData.gateway)
-      ? minDocumentReferencesPerDrRequest
-      : maxDocumentReferencesPerDrRequest;
-    const documentReferences = bodyData.documentReference;
-    const chunks = chunk(documentReferences, documentReferencesPerRequest);
-    chunks.forEach(docRefs => {
-      const chunkedBodyData = {
-        ...bodyData,
-        documentReference: docRefs,
-      };
-      const signedRequest = createAndSignDRRequest(chunkedBodyData, samlCertsAndKeys);
-      signedRequests.push({
-        gateway: bodyData.gateway,
-        signedRequest,
-        outboundRequest: chunkedBodyData,
-      });
+    const signedRequest = createAndSignDRRequest(bodyData, samlCertsAndKeys);
+    signedRequests.push({
+      gateway: bodyData.gateway,
+      signedRequest,
+      outboundRequest: bodyData,
     });
   }
 


### PR DESCRIPTION
Ticket: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2315

### Description

- fix IHE GW Results are incomplete for Document Retrieval - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1716922220738429) 
- basically we were getting more results back than expecting, and the reason was that for several gateways the logic was in the lambdas to split them up into more 1 docRef requests. So then we would expect 10 results but get back 11 and then throw this warning. This PR moves that logic into the api so that the requests are fully broken up before being sent to the lambdas 

### Testing

- local
  - [ ] unit tests

### Release Plan

- [ ] Merge this
