### PR TITLE
fix(fhir): deduplicate document references upstream of fhir upsert

### DIFF
--- a/packages/api/src/external/carequality/document/__tests__/shared.test.ts
+++ b/packages/api/src/external/carequality/document/__tests__/shared.test.ts
@@ -2,7 +2,7 @@ import {
   makeDocumentReferenceWithMetriportId,
   makeDocumentReference,
 } from "./make-document-reference-with-metriport-id";
-import { containsMetriportId } from "../shared";
+import { containsMetriportId, containsDuplicateMetriportId } from "../shared";
 import { faker } from "@faker-js/faker";
 
 describe("filterDocRefsWithMetriportId", () => {
@@ -20,5 +20,19 @@ describe("filterDocRefsWithMetriportId", () => {
     expect(filteredDocRefs.length).toBe(2);
     expect(filteredDocRefs[0].metriportId).toBe(metriportId1);
     expect(filteredDocRefs[1].metriportId).toBe(metriportId2);
+  });
+
+  it("should filter out identical docRefs", async () => {
+    const seenMetriportIds = new Set<string>();
+    const docRefsWithMetriportId = [
+      makeDocumentReferenceWithMetriportId({ metriportId: "123" }),
+      makeDocumentReferenceWithMetriportId({ metriportId: "123" }),
+    ];
+
+    const deduplicatedDocRefsWithMetriportId = docRefsWithMetriportId.filter(
+      docRef => !containsDuplicateMetriportId(docRef, seenMetriportIds)
+    );
+
+    expect(deduplicatedDocRefsWithMetriportId.length).toBe(1);
   });
 });

--- a/packages/api/src/external/carequality/document/__tests__/shared.test.ts
+++ b/packages/api/src/external/carequality/document/__tests__/shared.test.ts
@@ -2,7 +2,7 @@ import {
   makeDocumentReferenceWithMetriportId,
   makeDocumentReference,
 } from "./make-document-reference-with-metriport-id";
-import { filterDocRefsWithMetriportId } from "../shared";
+import { containsMetriportId } from "../shared";
 import { faker } from "@faker-js/faker";
 
 describe("filterDocRefsWithMetriportId", () => {
@@ -15,7 +15,7 @@ describe("filterDocRefsWithMetriportId", () => {
       makeDocumentReferenceWithMetriportId({ metriportId: metriportId2 }),
     ];
 
-    const filteredDocRefs = filterDocRefsWithMetriportId(docRefs);
+    const filteredDocRefs = docRefs.filter(containsMetriportId);
 
     expect(filteredDocRefs.length).toBe(2);
     expect(filteredDocRefs[0].metriportId).toBe(metriportId1);

--- a/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
@@ -98,9 +98,22 @@ export async function processOutboundDocumentRetrievalResps({
 
         if (docRefs) {
           const validDocRefs = docRefs.filter(containsMetriportId);
-          const deduplicatedDocRefs = validDocRefs.filter(
-            docRef => !containsDuplicateMetriportId(docRef, seenMetriportIds)
-          );
+          const deduplicatedDocRefs = validDocRefs.filter(docRef => {
+            const isDuplicate = containsDuplicateMetriportId(docRef, seenMetriportIds);
+            if (isDuplicate) {
+              capture.message(`Duplicate docRef found in DR Resp`, {
+                extra: {
+                  context: `cq.processOutboundDocumentRetrievalResps`,
+                  patientId,
+                  requestId,
+                  cxId,
+                  docRef,
+                },
+                level: "warning",
+              });
+            }
+            return !isDuplicate;
+          });
 
           await handleDocReferences(
             deduplicatedDocRefs,

--- a/packages/api/src/external/carequality/document/shared.ts
+++ b/packages/api/src/external/carequality/document/shared.ts
@@ -21,12 +21,16 @@ export function containsMetriportId(
   return docRef.metriportId != undefined;
 }
 
-export function filterDocRefsWithMetriportId(
-  documentReferences: DocumentReference[]
-): DocumentReferenceWithMetriportId[] {
-  return documentReferences.filter((docRef): docRef is DocumentReferenceWithMetriportId => {
-    return docRef.metriportId != undefined;
-  });
+export function containsDuplicateMetriportId(
+  docRef: DocumentReferenceWithMetriportId,
+  seenMetriportIds: Set<string>
+): boolean {
+  if (seenMetriportIds.has(docRef.metriportId)) {
+    return true;
+  } else {
+    seenMetriportIds.add(docRef.metriportId);
+    return false;
+  }
 }
 
 export const cqToFHIR = (


### PR DESCRIPTION
Ticket: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- deduplicate document references upstream of upsert to fhir 

### Testing
- local
  - [x] write a unit test
- Staging
  - [ ] test 

### Release Plan

- [ ] Merge this
