### PR TITLE
1040 executeWithNetworkRetries check error causes as well

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -8,7 +8,7 @@ Unit tests can be executed with:
 $ npm run test
 ```
 
-To run integration tests, first have these services running local, each with its own dependencies:
+To run E2E (end-to-end) tests, first have these services running local, each with its own dependencies:
 
 - API server
 - FHIR Server
@@ -16,11 +16,17 @@ To run integration tests, first have these services running local, each with its
 Set this environment variable on your local `.env` file with a valid API key from your local environment:
 
 ```shell
-$ echo "API_KEY=XXXXXXXX" >> .env
+$ echo "TEST_API_KEY=XXXXXXXX" >> .env
 ```
 
-Then execute integration tests with:
+Then execute E2E tests with:
 
 ```shell
 $ npm run test:e2e
+```
+
+To run a specific test/group:
+
+```shell
+npm run test:e2e -- -t 'MAPI E2E Tests'
 ```

--- a/packages/api/src/command/medical/admin/hie-overview.ts
+++ b/packages/api/src/command/medical/admin/hie-overview.ts
@@ -136,7 +136,7 @@ async function getCqData(
     const gatewayName = getGatewayName(entry);
     const existingErrorEntry = cqErrors.find(a => a.error === rowErrorDetail);
     if (existingErrorEntry) {
-      existingErrorEntry.gatewayNames.push(gatewayName);
+      existingErrorEntry.gatewayNames = [...existingErrorEntry.gatewayNames, gatewayName].sort();
       continue;
     }
     cqErrors.push({

--- a/packages/shared/src/net/__tests__/axios.ts
+++ b/packages/shared/src/net/__tests__/axios.ts
@@ -1,0 +1,87 @@
+import axios, { AxiosHeaders, AxiosResponse } from "axios";
+jest.mock("axios");
+
+export function mockAxios() {
+  const mockedAxios = jest.mocked(axios);
+  return {
+    axios: mockedAxios.mockImplementation(),
+    get: mockedAxios.get.mockImplementation(),
+    post: mockedAxios.post.mockImplementation(),
+    put: mockedAxios.put.mockImplementation(),
+    delete: mockedAxios.delete.mockImplementation(),
+  };
+}
+
+export function makeAxiosResponse({
+  method,
+  status,
+  data,
+  statusText,
+  headers,
+  config,
+}: { method?: AxiosResponse["config"]["method"] } & Partial<
+  Pick<AxiosResponse, "status" | "data" | "statusText" | "headers" | "config">
+>): AxiosResponse {
+  return {
+    status: status ?? 200,
+    data: data ?? {},
+    statusText: statusText ?? "OK",
+    headers: headers ?? {},
+    config: config ?? {
+      headers: new AxiosHeaders(),
+      method: method ?? "get",
+    },
+  };
+}
+
+export const errorWithCauseAxiosError = {
+  errorType: "Error",
+  errorMessage: "CW - Error downloading document",
+  cause: {
+    errorType: "Error",
+    errorMessage: "Error retrieve document",
+    cause: {
+      message: "connect ETIMEDOUT 107.21.162.233:443",
+      name: "Error",
+      stack: "Error: connect ETIMEDOUT 107.21.162.233:443...",
+      code: "ETIMEDOUT",
+      status: null,
+      isAxiosError: true,
+    },
+    additionalInfo: {
+      headers: {
+        Authorization: "Bearer ...",
+      },
+      inputUrl: "https://rest.api.commonwellalliance.org/v2/Binary/xxxxxx",
+      outputStream: "[object]",
+    },
+    stack: [
+      "Error: Error retrieve document",
+      "    at Object.retrieve (/opt/nodejs/node_modules/@metriport/commonwell-sdk/dist/client/document.js:64:15)",
+      "    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)",
+      "    at async executeWithRetries (/opt/nodejs/node_modules/@metriport/shared/dist/common/retry.js:46:28)",
+      "    at async DocumentDownloaderLocal.downloadDocumentFromCW (/opt/nodejs/node_modules/@metriport/core/dist/external/commonwell/document/document-downloader-local.js:225:13)",
+      "    at async DocumentDownloaderLocal.downloadFromCommonwellIntoS3 (/opt/nodejs/node_modules/@metriport/core/dist/external/commonwell/document/document-downloader-local.js:188:9)",
+      "    at async executeWithRetries (/opt/nodejs/node_modules/@metriport/shared/dist/common/retry.js:46:28)",
+      "    at async DocumentDownloaderLocal.download (/opt/nodejs/node_modules/@metriport/core/dist/external/commonwell/document/document-downloader-local.js:58:30)",
+      "    at async /var/task/document-downloader.js:79:20",
+      "    at async Runtime.handler (/opt/nodejs/node_modules/@sentry/serverless/cjs/awslambda.js:280:12)",
+    ],
+  },
+  additionalInfo: {
+    documentLocation: "https://rest.api.commonwellalliance.org/v2/Binary/xxxxxx",
+    details:
+      "Error retrieve document ({ headers: { Authorization: 'Bearer ...' }, inputUrl: 'https://rest.api.commonwellalliance.org/v2/Binary/xxxxxx', outputStream: '[object]' }); caused by connect ETIMEDOUT 107.21.162.233:443 (ETIMEDOUT); caused by connect ETIMEDOUT 107.21.162.233:443 (ETIMEDOUT)",
+  },
+  status: 500,
+  stack: [
+    "Error: CW - Error downloading document",
+    "    at DocumentDownloaderLocal.downloadDocumentFromCW (/opt/nodejs/node_modules/@metriport/core/dist/external/commonwell/document/document-downloader-local.js:244:19)",
+    "    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)",
+    "    at async DocumentDownloaderLocal.downloadFromCommonwellIntoS3 (/opt/nodejs/node_modules/@metriport/core/dist/external/commonwell/document/document-downloader-local.js:188:9)",
+    "    at async executeWithRetries (/opt/nodejs/node_modules/@metriport/shared/dist/common/retry.js:46:28)",
+    "    at async DocumentDownloaderLocal.download (/opt/nodejs/node_modules/@metriport/core/dist/external/commonwell/document/document-downloader-local.js:58:30)",
+    "    at async /var/task/document-downloader.js:79:20",
+    "    at async Runtime.handler (/opt/nodejs/node_modules/@sentry/serverless/cjs/awslambda.js:280:12)",
+  ],
+};

--- a/packages/shared/src/net/__tests__/retry.test.ts
+++ b/packages/shared/src/net/__tests__/retry.test.ts
@@ -1,225 +1,281 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { faker } from "@faker-js/faker";
 import { AxiosError, AxiosHeaders } from "axios";
-import { executeWithNetworkRetries } from "../retry";
 import * as retry from "../../common/retry";
+import { MetriportError } from "../../error/metriport-error";
+import { executeWithNetworkRetries, getHttpCodeFromError, getHttpStatusFromError } from "../retry";
+import { errorWithCauseAxiosError, makeAxiosResponse } from "./axios";
 
-describe("executeWithNetworkRetries", () => {
-  const fn = jest.fn();
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it("returns when no error", async () => {
-    const expectedResult = faker.lorem.word();
-    fn.mockImplementation(() => expectedResult);
-    const resp = await executeWithNetworkRetries(fn, {
-      initialDelay: 1,
-      maxAttempts: 2,
+describe("net retry", () => {
+  describe("executeWithNetworkRetries", () => {
+    const fn = jest.fn();
+    afterEach(() => {
+      jest.resetAllMocks();
     });
-    expect(resp).toEqual(expectedResult);
-  });
 
-  it("retries on ECONNREFUSED", async () => {
-    fn.mockImplementation(() => {
-      const error = new AxiosError("mock error");
-      error.code = "ECONNREFUSED";
-      throw error;
-    });
-    await expect(async () =>
-      executeWithNetworkRetries(fn, {
+    it("returns when no error", async () => {
+      const expectedResult = faker.lorem.word();
+      fn.mockImplementation(() => expectedResult);
+      const resp = await executeWithNetworkRetries(fn, {
         initialDelay: 1,
         maxAttempts: 2,
-      })
-    ).rejects.toThrow();
-    expect(fn).toHaveBeenCalledTimes(2);
-  });
-
-  it("retries on ECONNRESET", async () => {
-    fn.mockImplementation(() => {
-      const error = new AxiosError("mock error");
-      error.code = "ECONNRESET";
-      throw error;
-    });
-    await expect(async () =>
-      executeWithNetworkRetries(fn, {
-        initialDelay: 1,
-        maxAttempts: 2,
-      })
-    ).rejects.toThrow();
-    expect(fn).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not retry on AxiosError.ETIMEDOUT", async () => {
-    fn.mockImplementation(() => {
-      const error = new AxiosError("mock error");
-      error.code = "ETIMEDOUT";
-      throw error;
-    });
-    await expect(async () =>
-      executeWithNetworkRetries(fn, {
-        initialDelay: 1,
-        maxAttempts: 2,
-      })
-    ).rejects.toThrow();
-    expect(fn).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not retry on AxiosError.ECONNABORTED", async () => {
-    fn.mockImplementation(() => {
-      const error = new AxiosError("mock error");
-      error.code = "ECONNABORTED";
-      throw error;
-    });
-    await expect(async () =>
-      executeWithNetworkRetries(fn, {
-        initialDelay: 1,
-        maxAttempts: 2,
-      })
-    ).rejects.toThrow();
-    expect(fn).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not retry on ECONNREFUSED when gets array of status without ECONNREFUSED", async () => {
-    fn.mockImplementation(() => {
-      const error = new AxiosError("mock error");
-      error.code = "ECONNREFUSED";
-      throw error;
-    });
-    await expect(async () =>
-      executeWithNetworkRetries(fn, {
-        initialDelay: 1,
-        maxAttempts: 2,
-        httpCodesToRetry: ["ECONNRESET"],
-      })
-    ).rejects.toThrow();
-    expect(fn).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not retry on ECONNRESET when gets array of status without ECONNRESET", async () => {
-    fn.mockImplementation(() => {
-      const error = new AxiosError("mock error");
-      error.code = "ECONNRESET";
-      throw error;
-    });
-    await expect(async () =>
-      executeWithNetworkRetries(fn, {
-        initialDelay: 1,
-        maxAttempts: 2,
-        httpCodesToRetry: ["ECONNREFUSED"],
-      })
-    ).rejects.toThrow();
-    expect(fn).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not retry when error is not AxiosError", async () => {
-    fn.mockImplementation(() => {
-      throw new Error("mock error");
-    });
-    await expect(async () =>
-      executeWithNetworkRetries(fn, {
-        initialDelay: 1,
-        maxAttempts: 2,
-      })
-    ).rejects.toThrow();
-    expect(fn).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not retry when retryOnTimeout is false and error is timeout", async () => {
-    fn.mockImplementation(() => {
-      const error = new AxiosError("mock error");
-      error.code = AxiosError.ETIMEDOUT;
-      throw error;
-    });
-    await expect(async () =>
-      executeWithNetworkRetries(fn, {
-        initialDelay: 1,
-        maxAttempts: 2,
-        retryOnTimeout: false,
-      })
-    ).rejects.toThrow();
-    expect(fn).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not retry when retryOnTimeout is empty and error is timeout", async () => {
-    fn.mockImplementation(() => {
-      const error = new AxiosError("mock error");
-      error.code = AxiosError.ETIMEDOUT;
-      throw error;
-    });
-    await expect(async () =>
-      executeWithNetworkRetries(fn, {
-        initialDelay: 1,
-        maxAttempts: 2,
-      })
-    ).rejects.toThrow();
-    expect(fn).toHaveBeenCalledTimes(1);
-  });
-
-  it("retries when retryOnTimeout is true and error is timeout", async () => {
-    fn.mockImplementation(() => {
-      const error = new AxiosError("mock error");
-      error.code = AxiosError.ETIMEDOUT;
-      throw error;
-    });
-    await expect(async () =>
-      executeWithNetworkRetries(fn, {
-        initialDelay: 1,
-        maxAttempts: 2,
-        retryOnTimeout: true,
-      })
-    ).rejects.toThrow();
-    expect(fn).toHaveBeenCalledTimes(2);
-  });
-
-  it("retries when retryOnTimeout is false and error is timeout and httpCodesToRetry contains timeout code", async () => {
-    fn.mockImplementation(() => {
-      const error = new AxiosError("mock error");
-      error.code = AxiosError.ETIMEDOUT;
-      throw error;
-    });
-    await expect(async () =>
-      executeWithNetworkRetries(fn, {
-        initialDelay: 1,
-        maxAttempts: 2,
-        retryOnTimeout: false,
-        httpCodesToRetry: [AxiosError.ETIMEDOUT],
-      })
-    ).rejects.toThrow();
-    expect(fn).toHaveBeenCalledTimes(2);
-  });
-
-  it("retries when 429 Too Many Requests and uses modified delay", async () => {
-    const spyDefaultGetTimeToWait = jest.spyOn(retry, "defaultGetTimeToWait");
-
-    fn.mockImplementation(() => {
-      const error = new AxiosError("mock error");
-      error.response = {
-        status: 429,
-        data: {},
-        statusText: "Too Many Requests",
-        headers: {},
-        config: {
-          headers: new AxiosHeaders(),
-          method: "post",
-          url: "",
-        },
-      };
-      throw error;
+      });
+      expect(resp).toEqual(expectedResult);
     });
 
-    await expect(async () =>
-      executeWithNetworkRetries(fn, {
-        initialDelay: 1,
-        maxAttempts: 2,
-      })
-    ).rejects.toThrow();
+    it("retries on ECONNREFUSED", async () => {
+      fn.mockImplementation(() => {
+        const error = new AxiosError("mock error");
+        error.code = "ECONNREFUSED";
+        throw error;
+      });
+      await expect(async () =>
+        executeWithNetworkRetries(fn, {
+          initialDelay: 1,
+          maxAttempts: 2,
+        })
+      ).rejects.toThrow();
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
 
-    expect(fn).toHaveBeenCalledTimes(2);
-    expect(spyDefaultGetTimeToWait).toHaveBeenCalledWith(
-      expect.objectContaining({
-        initialDelay: 3,
-      })
-    );
+    it("retries on ECONNRESET", async () => {
+      fn.mockImplementation(() => {
+        const error = new AxiosError("mock error");
+        error.code = "ECONNRESET";
+        throw error;
+      });
+      await expect(async () =>
+        executeWithNetworkRetries(fn, {
+          initialDelay: 1,
+          maxAttempts: 2,
+        })
+      ).rejects.toThrow();
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not retry on AxiosError.ETIMEDOUT", async () => {
+      fn.mockImplementation(() => {
+        const error = new AxiosError("mock error");
+        error.code = "ETIMEDOUT";
+        throw error;
+      });
+      await expect(async () =>
+        executeWithNetworkRetries(fn, {
+          initialDelay: 1,
+          maxAttempts: 2,
+        })
+      ).rejects.toThrow();
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry on AxiosError.ECONNABORTED", async () => {
+      fn.mockImplementation(() => {
+        const error = new AxiosError("mock error");
+        error.code = "ECONNABORTED";
+        throw error;
+      });
+      await expect(async () =>
+        executeWithNetworkRetries(fn, {
+          initialDelay: 1,
+          maxAttempts: 2,
+        })
+      ).rejects.toThrow();
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry on ECONNREFUSED when gets array of status without ECONNREFUSED", async () => {
+      fn.mockImplementation(() => {
+        const error = new AxiosError("mock error");
+        error.code = "ECONNREFUSED";
+        throw error;
+      });
+      await expect(async () =>
+        executeWithNetworkRetries(fn, {
+          initialDelay: 1,
+          maxAttempts: 2,
+          httpCodesToRetry: ["ECONNRESET"],
+        })
+      ).rejects.toThrow();
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry on ECONNRESET when gets array of status without ECONNRESET", async () => {
+      fn.mockImplementation(() => {
+        const error = new AxiosError("mock error");
+        error.code = "ECONNRESET";
+        throw error;
+      });
+      await expect(async () =>
+        executeWithNetworkRetries(fn, {
+          initialDelay: 1,
+          maxAttempts: 2,
+          httpCodesToRetry: ["ECONNREFUSED"],
+        })
+      ).rejects.toThrow();
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry when error is not AxiosError", async () => {
+      fn.mockImplementation(() => {
+        throw new Error("mock error");
+      });
+      await expect(async () =>
+        executeWithNetworkRetries(fn, {
+          initialDelay: 1,
+          maxAttempts: 2,
+        })
+      ).rejects.toThrow();
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry when retryOnTimeout is false and error is timeout", async () => {
+      fn.mockImplementation(() => {
+        const error = new AxiosError("mock error");
+        error.code = AxiosError.ETIMEDOUT;
+        throw error;
+      });
+      await expect(async () =>
+        executeWithNetworkRetries(fn, {
+          initialDelay: 1,
+          maxAttempts: 2,
+          retryOnTimeout: false,
+        })
+      ).rejects.toThrow();
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry when retryOnTimeout is empty and error is timeout", async () => {
+      fn.mockImplementation(() => {
+        const error = new AxiosError("mock error");
+        error.code = AxiosError.ETIMEDOUT;
+        throw error;
+      });
+      await expect(async () =>
+        executeWithNetworkRetries(fn, {
+          initialDelay: 1,
+          maxAttempts: 2,
+        })
+      ).rejects.toThrow();
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries when retryOnTimeout is true and error is timeout", async () => {
+      fn.mockImplementation(() => {
+        const error = new AxiosError("mock error");
+        error.code = AxiosError.ETIMEDOUT;
+        throw error;
+      });
+      await expect(async () =>
+        executeWithNetworkRetries(fn, {
+          initialDelay: 1,
+          maxAttempts: 2,
+          retryOnTimeout: true,
+        })
+      ).rejects.toThrow();
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries when retryOnTimeout is false and error is timeout and httpCodesToRetry contains timeout code", async () => {
+      fn.mockImplementation(() => {
+        const error = new AxiosError("mock error");
+        error.code = AxiosError.ETIMEDOUT;
+        throw error;
+      });
+      await expect(async () =>
+        executeWithNetworkRetries(fn, {
+          initialDelay: 1,
+          maxAttempts: 2,
+          retryOnTimeout: false,
+          httpCodesToRetry: [AxiosError.ETIMEDOUT],
+        })
+      ).rejects.toThrow();
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries when 429 Too Many Requests and uses modified delay", async () => {
+      const spyDefaultGetTimeToWait = jest.spyOn(retry, "defaultGetTimeToWait");
+
+      fn.mockImplementation(() => {
+        const error = new AxiosError("mock error");
+        error.response = {
+          status: 429,
+          data: {},
+          statusText: "Too Many Requests",
+          headers: {},
+          config: {
+            headers: new AxiosHeaders(),
+            method: "post",
+            url: "",
+          },
+        };
+        throw error;
+      });
+
+      await expect(async () =>
+        executeWithNetworkRetries(fn, {
+          initialDelay: 1,
+          maxAttempts: 2,
+        })
+      ).rejects.toThrow();
+
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(spyDefaultGetTimeToWait).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialDelay: 3,
+        })
+      );
+    });
+  });
+
+  describe("getHttpCodeFromError", () => {
+    it("returns undefined when error is not Axios", async () => {
+      const resp = getHttpCodeFromError(new Error("something"));
+      expect(resp).toBeFalsy();
+    });
+
+    it("returns code when error is Axios", async () => {
+      const expectedCode = faker.lorem.word();
+      const error = new AxiosError("something");
+      error.code = expectedCode;
+      const resp = getHttpCodeFromError(error);
+      expect(resp).toEqual(expectedCode);
+    });
+
+    it("returns code when error is not axios but the cause is", async () => {
+      const expectedCode = faker.lorem.word();
+      const error = new AxiosError("something");
+      error.code = expectedCode;
+      const resp = getHttpCodeFromError(new MetriportError("something", error));
+      expect(resp).toEqual(expectedCode);
+    });
+
+    it("returns code when error is not axios but the 2nd cause is", async () => {
+      const expectedCode = "ETIMEDOUT";
+      const resp = getHttpCodeFromError(errorWithCauseAxiosError);
+      expect(resp).toEqual(expectedCode);
+    });
+  });
+
+  describe("getHttpStatusFromError", () => {
+    it("returns undefined when error is not Axios", async () => {
+      const resp = getHttpStatusFromError(new Error("something"));
+      expect(resp).toBeFalsy();
+    });
+
+    it("returns status when error is Axios", async () => {
+      const expectedStatus = faker.number.int();
+      const error = new AxiosError("something");
+      error.response = makeAxiosResponse({ status: expectedStatus });
+      const resp = getHttpStatusFromError(error);
+      expect(resp).toEqual(expectedStatus);
+    });
+
+    it("returns status when error is not axios but the cause is", async () => {
+      const expectedStatus = faker.number.int();
+      const error = new AxiosError("something");
+      error.response = makeAxiosResponse({ status: expectedStatus });
+      const resp = getHttpStatusFromError(new MetriportError("something", error));
+      expect(resp).toEqual(expectedStatus);
+    });
   });
 });

--- a/packages/shared/src/net/retry.ts
+++ b/packages/shared/src/net/retry.ts
@@ -1,10 +1,10 @@
 import axios from "axios";
 import {
+  defaultGetTimeToWait,
   defaultOptions as defaultRetryWithBackoffOptions,
   executeWithRetries,
   ExecuteWithRetriesOptions,
   GetTimeToWaitParams,
-  defaultGetTimeToWait,
 } from "../common/retry";
 import { NetworkError, networkTimeoutErrors } from "./error";
 
@@ -35,12 +35,20 @@ const defaultOptions: ExecuteWithNetworkRetriesOptions = {
   retryOnTimeout: false,
 };
 
-function getHttpStatusFromError(error: unknown): number | undefined {
-  return axios.isAxiosError(error) ? error.response?.status : undefined;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getHttpStatusFromError(error: any): number | undefined {
+  if (!error) return undefined;
+  if (axios.isAxiosError(error)) return error.response?.status;
+  if ("cause" in error) return getHttpStatusFromError(error.cause);
+  return undefined;
 }
 
-function getHttpCodeFromError(error: unknown): string | undefined {
-  return axios.isAxiosError(error) ? error.code : undefined;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getHttpCodeFromError(error: any): string | undefined {
+  if (!error) return undefined;
+  if (axios.isAxiosError(error)) return error.code;
+  if ("cause" in error) return getHttpCodeFromError(error.cause);
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

none

### Description

- executeWithNetworkRetries check error causes as well
- update readme for E2E tests 
- sort GWs on Patient overview

### Testing

- Local
  - [x] unit tests
- Staging
  - [ ] patient overview w/ `errors` works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
