### PR TITLE
1040 Add error handler on async lambda invocations

### DIFF
--- a/packages/core/src/external/aws/document-signing/document-bulk-signer-lambda.ts
+++ b/packages/core/src/external/aws/document-signing/document-bulk-signer-lambda.ts
@@ -1,5 +1,5 @@
 import * as AWS from "aws-sdk";
-import { makeLambdaClient } from "../lambda";
+import { defaultLambdaInvocationResponseHandler, makeLambdaClient } from "../lambda";
 import { DocumentBulkSigner, DocumentBulkSignerRequest } from "./document-bulk-signer";
 
 export class DocumentBulkSignerLambda extends DocumentBulkSigner {
@@ -24,6 +24,7 @@ export class DocumentBulkSignerLambda extends DocumentBulkSigner {
         Payload: JSON.stringify(payload),
       })
       .promise()
+      .then(defaultLambdaInvocationResponseHandler)
       .catch(error => {
         throw error;
       });

--- a/packages/core/src/external/carequality/ihe-gateway-v2/ihe-gateway-v2-async.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/ihe-gateway-v2-async.ts
@@ -1,16 +1,16 @@
-import chunk from "lodash/chunk";
 import {
-  OutboundPatientDiscoveryReq,
   OutboundDocumentQueryReq,
   OutboundDocumentRetrievalReq,
+  OutboundPatientDiscoveryReq,
 } from "@metriport/ihe-gateway-sdk";
 import { sleep } from "@metriport/shared";
-import { makeLambdaClient } from "../../aws/lambda";
-import { Config } from "../../../util/config";
-import { processAsyncError } from "../../../util/error/shared";
-import { IHEGatewayV2 } from "./ihe-gateway-v2";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
+import chunk from "lodash/chunk";
+import { Config } from "../../../util/config";
+import { processAsyncError } from "../../../util/error/shared";
+import { defaultLambdaInvocationResponseHandler, makeLambdaClient } from "../../aws/lambda";
+import { IHEGatewayV2 } from "./ihe-gateway-v2";
 
 dayjs.extend(duration);
 
@@ -61,6 +61,7 @@ export class IHEGatewayV2Async extends IHEGatewayV2 {
           Payload: JSON.stringify(params),
         })
         .promise()
+        .then(defaultLambdaInvocationResponseHandler)
         .catch(processAsyncError("Failed to invoke iheGatewayV2 lambda for patient discovery"));
     }
   }
@@ -93,6 +94,7 @@ export class IHEGatewayV2Async extends IHEGatewayV2 {
           Payload: JSON.stringify(params),
         })
         .promise()
+        .then(defaultLambdaInvocationResponseHandler)
         .catch(processAsyncError("Failed to invoke iheGWV2 lambda for document query"));
     }
   }
@@ -129,6 +131,7 @@ export class IHEGatewayV2Async extends IHEGatewayV2 {
           Payload: JSON.stringify(params),
         })
         .promise()
+        .then(defaultLambdaInvocationResponseHandler)
         .catch(processAsyncError("Failed to invoke iheGWV2 lambda for document retrieval"));
     }
   }

--- a/packages/core/src/external/carequality/ihe-gateway/outbound-result-poller-lambda.ts
+++ b/packages/core/src/external/carequality/ihe-gateway/outbound-result-poller-lambda.ts
@@ -1,6 +1,6 @@
 import { Config } from "../../../util/config";
 import { processAsyncError } from "../../../util/error/shared";
-import { makeLambdaClient } from "../../aws/lambda";
+import { defaultLambdaInvocationResponseHandler, makeLambdaClient } from "../../aws/lambda";
 import { OutboundResultPoller, PollOutboundResults } from "./outbound-result-poller";
 
 const region = Config.getAWSRegion();
@@ -44,6 +44,7 @@ export class OutboundResultPollerLambda extends OutboundResultPoller {
         Payload: JSON.stringify(params),
       })
       .promise()
+      .then(defaultLambdaInvocationResponseHandler)
       .catch(
         processAsyncError("Failed to invoke lambda to poll outbound patient discovery responses")
       );
@@ -65,6 +66,7 @@ export class OutboundResultPollerLambda extends OutboundResultPoller {
         Payload: JSON.stringify(params),
       })
       .promise()
+      .then(defaultLambdaInvocationResponseHandler)
       .catch(
         processAsyncError("Failed to invoke lambda to poll outbound document query responses")
       );
@@ -86,6 +88,7 @@ export class OutboundResultPollerLambda extends OutboundResultPoller {
         Payload: JSON.stringify(params),
       })
       .promise()
+      .then(defaultLambdaInvocationResponseHandler)
       .catch(
         processAsyncError("Failed to invoke lambda to poll outbound document query responses")
       );


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Add error handler on async lambda invocations - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1719089049079019?thread_ts=1719084355.633919&cid=C04T256DQPQ).

### Testing

- Local
  - none
- Staging
  - [ ] PD works
  - [ ] DQ works
  - [ ] DR works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
