### PR TITLE
1827 Don't retry on S3 404

### DIFF
--- a/packages/core/src/external/aws/__tests__/s3.test.ts
+++ b/packages/core/src/external/aws/__tests__/s3.test.ts
@@ -1,0 +1,21 @@
+import { S3Utils } from "../s3";
+
+beforeAll(() => {
+  jest.restoreAllMocks();
+});
+
+// integration test
+describe.skip("S3Utils", () => {
+  const s3Utils = new S3Utils("us-west-2");
+  describe("getFileInfoFromS3", () => {
+    it("returns empty string when gets empty string", async () => {
+      const res = await s3Utils.getFileInfoFromS3("non-existing-key", "nonexisting-bucket");
+      expect(res).toEqual({ exists: false });
+    });
+
+    it("works when exists", async () => {
+      const res = await s3Utils.getFileInfoFromS3("...", "...");
+      expect(res).toEqual(expect.objectContaining({ exists: true }));
+    });
+  });
+});


### PR DESCRIPTION
Ref. metriport/metriport-internal#1827

### Dependencies

none

### Description

Don't retry on S3 404 - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1719097324861709).

### Testing

- Local
  - [x] `getFileInfoFromS3` doesn't retry when file doesn't exist
  - [x] `getFileInfoFromS3` returns false when file doesn't exist
  - [x] `getFileInfoFromS3` returns true when file exists
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
