### PR TITLE
1040 Don't network retry on outbound PD and more

### DIFF
--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -242,6 +242,7 @@ export function createAPIService({
       protocol: ApplicationProtocol.HTTP,
       listenerPort,
       publicLoadBalancer: false,
+      idleTimeout: Duration.minutes(10),
     }
   );
   const serverAddress = fargateService.loadBalancer.loadBalancerDnsName;

--- a/packages/shared/src/common/retry.ts
+++ b/packages/shared/src/common/retry.ts
@@ -12,7 +12,7 @@ export const defaultOptions: Required<ExecuteWithRetriesOptions<unknown>> = {
   initialDelay: 10,
   maxDelay: Infinity,
   backoffMultiplier: 2,
-  maxAttempts: 10,
+  maxAttempts: 5,
   shouldRetry: defaultShouldRetry,
   getTimeToWait: defaultGetTimeToWait,
   log: console.log,

--- a/packages/shared/src/net/error.ts
+++ b/packages/shared/src/net/error.ts
@@ -8,7 +8,12 @@ export type NodeConnRefusedNetworkError = (typeof nodeConnRefusedErrorCodes)[num
 export const nodeTimeoutErrorCodes = ["ETIMEDOUT"] as const;
 export type NodeTimeoutNetworkError = (typeof nodeTimeoutErrorCodes)[number];
 
-export type NodeNetworkError = NodeTimeoutNetworkError | NodeConnRefusedNetworkError | "ENOTFOUND";
+export const nodeNetworkErrorCodes = [
+  ...nodeConnRefusedErrorCodes,
+  ...nodeTimeoutErrorCodes,
+  "ENOTFOUND",
+] as const;
+export type NodeNetworkError = (typeof nodeNetworkErrorCodes)[number];
 
 // Axios error codes that are timeout errors
 
@@ -18,14 +23,16 @@ export type AxiosTimeoutError = (typeof axiosTimeoutErrorCodes)[number];
 export const axiosResponseErrorCodes = [AxiosError.ERR_BAD_RESPONSE] as const;
 export type AxiosResponseError = (typeof axiosResponseErrorCodes)[number];
 
-export type AxiosNetworkError = AxiosTimeoutError | AxiosResponseError;
+export const axiosNetworkErrors = [...axiosResponseErrorCodes, ...axiosTimeoutErrorCodes] as const;
+export type AxiosNetworkError = (typeof axiosNetworkErrors)[number];
 
 // General Network errors
 
 export const networkTimeoutErrors = [...nodeTimeoutErrorCodes, ...axiosTimeoutErrorCodes];
 export type NetworkTimeoutError = (typeof networkTimeoutErrors)[number];
 
-export type NetworkError = NodeNetworkError | AxiosNetworkError;
+export const networkErrors = [...nodeNetworkErrorCodes, ...axiosNetworkErrors] as const;
+export type NetworkError = (typeof networkErrors)[number];
 
 export function getNetworkErrorDetails(error: unknown): {
   details: string;


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

- don't network retry on outbound PD - [context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1719272500023269?thread_ts=1719018618.154209&cid=C04GEQ1GH9D)
- update OSS API ALB's idle timeout from 1 to 10min - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1719264089265279?thread_ts=1718882863.214939&cid=C04T256DQPQ)
- update retry default attempt from 10 to 5 - [context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1719269603670079?thread_ts=1719018618.154209&cid=C04GEQ1GH9D)

### Testing

- Local
  - none
- Staging
  - [ ] ...
- Sandbox
  - [ ] ...
- Production
  - [ ] ...

### Release Plan

- [ ] Merge this
