### PR TITLE
1905 ccd async

### DIFF
--- a/packages/api/src/external/cda/process-ccd-request.ts
+++ b/packages/api/src/external/cda/process-ccd-request.ts
@@ -6,6 +6,7 @@ import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import { Config } from "../../shared/config";
 import { generateCcd } from "./generate-ccd";
+import { generateEmptyCcd } from "./generate-empty-ccd";
 
 const medicalBucket = Config.getMedicalDocumentsBucketName();
 const awsRegion = Config.getAWSRegion();
@@ -47,6 +48,31 @@ export async function processCcdRequest(patient: Patient, organization: Organiza
     log(`CCD uploaded into ${medicalBucket}`);
   } catch (error) {
     const msg = `Error creating and uploading CCD`;
+    log(`${msg}: error - ${error}`);
+    capture.error(msg, { extra: { error, cxId: patient.cxId, patientId: patient.id } });
+    throw error;
+  }
+}
+
+export async function processEmptyCcdRequest(patient: Patient, organization: Organization) {
+  const { log } = out(`Generate empty CCD cxId: ${patient.cxId}, patientId: ${patient.id}`);
+  try {
+    const ccd = await generateEmptyCcd(patient);
+    const docRef = createDocRef(patient.id);
+    log(`Empty CCD generated. Starting the upload...`);
+    await cdaDocumentUploaderHandler({
+      cxId: patient.cxId,
+      patientId: patient.id,
+      bundle: ccd,
+      medicalDocumentsBucket: medicalBucket,
+      region: awsRegion,
+      organization,
+      docId: CCD_FILE_NAME,
+      docRef,
+    });
+    log(`CCD uploaded into ${medicalBucket}`);
+  } catch (error) {
+    const msg = `Error creating and uploading empty CCD`;
     log(`${msg}: error - ${error}`);
     capture.error(msg, { extra: { error, cxId: patient.cxId, patientId: patient.id } });
     throw error;

--- a/packages/api/src/external/cda/process-ccd-request.ts
+++ b/packages/api/src/external/cda/process-ccd-request.ts
@@ -67,7 +67,7 @@ export async function processEmptyCcdRequest(patient: Patient, organization: Org
       medicalDocumentsBucket: medicalBucket,
       region: awsRegion,
       organization,
-      docId: CCD_FILE_NAME,
+      docId: CCD_SUFFIX,
       docRef,
     });
     log(`CCD uploaded into ${medicalBucket}`);

--- a/packages/api/src/routes/medical/internal-docs.ts
+++ b/packages/api/src/routes/medical/internal-docs.ts
@@ -27,7 +27,7 @@ import { appendDocQueryProgress } from "../../command/medical/patient/append-doc
 import { appendBulkGetDocUrlProgress } from "../../command/medical/patient/bulk-get-doc-url-progress";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
 import BadRequestError from "../../errors/bad-request";
-import { processCcdRequest } from "../../external/cda/process-ccd-request";
+import { processCcdRequest, processEmptyCcdRequest } from "../../external/cda/process-ccd-request";
 import { parseJobId } from "../../external/fhir/connector/connector";
 import { toFHIR as toFhirOrganization } from "../../external/fhir/organization";
 import { setDocQueryProgress } from "../../external/hie/set-doc-query-progress";
@@ -429,6 +429,31 @@ router.post(
 
     const fhirOrganization = toFhirOrganization(organization);
     const ccd = await processCcdRequest(patient, fhirOrganization);
+    return res.type("application/xml").status(httpStatus.OK).send(ccd);
+  })
+);
+
+/**
+ * POST /internal/docs/empty-ccd
+ *
+ * Generates an empty CCD document and uploads it for the specified patient.
+ * @param req.query.cxId - The customer/account's ID.
+ * @param req.query.patientId - The patient's ID.
+ * @return The CCD document string in XML format.
+ */
+router.post(
+  "/empty-ccd",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getFrom("query").orFail("cxId", req);
+    const patientId = getFrom("query").orFail("patientId", req);
+    const [patient, organization] = await Promise.all([
+      getPatientOrFail({ cxId, id: patientId }),
+      getOrganizationOrFail({ cxId }),
+    ]);
+
+    const fhirOrganization = toFhirOrganization(organization);
+    const ccd = await processEmptyCcdRequest(patient, fhirOrganization);
     return res.type("application/xml").status(httpStatus.OK).send(ccd);
   })
 );

--- a/packages/core/src/domain/document/upload.ts
+++ b/packages/core/src/domain/document/upload.ts
@@ -1,6 +1,6 @@
 import { createFileName, createFolderName } from "../filename";
 
-const UPLOADS_FOLDER = "uploads";
+export const UPLOADS_FOLDER = "uploads";
 export const CCD_SUFFIX = "ccd";
 export const FHIR_BUNDLE_SUFFIX = "FHIR_BUNDLE";
 

--- a/packages/core/src/external/aws/s3.ts
+++ b/packages/core/src/external/aws/s3.ts
@@ -24,7 +24,7 @@ const defaultS3RetriesConfig = {
   initialDelay: 500,
 };
 
-async function executeWithRetriesS3<T>(
+export async function executeWithRetriesS3<T>(
   fn: () => Promise<T>,
   options?: ExecuteWithRetriesOptions<T>
 ): Promise<T> {
@@ -354,41 +354,6 @@ export class S3Utils {
       console.error(`Error during file deletion: ${JSON.stringify(error)}`);
       throw error;
     }
-  }
-
-  async retrieveDocumentIdsFromS3(
-    cxId: string,
-    patientId: string,
-    bucketName: string
-  ): Promise<string[]> {
-    const Prefix = `${cxId}/${patientId}/uploads/`;
-
-    const params = {
-      Bucket: bucketName,
-      Prefix,
-    };
-
-    const data = await executeWithRetriesS3(() => this._s3.listObjectsV2(params).promise());
-    const documentContents = (
-      await Promise.all(
-        data.Contents?.filter(item => item.Key && item.Key.endsWith("_metadata.xml")).map(
-          async item => {
-            if (item.Key) {
-              const params = {
-                Bucket: bucketName,
-                Key: item.Key,
-              };
-
-              const data = await executeWithRetriesS3(() => this._s3.getObject(params).promise());
-              return data.Body?.toString();
-            }
-            return undefined;
-          }
-        ) || []
-      )
-    ).filter((item): item is string => Boolean(item));
-
-    return documentContents;
   }
 
   async listObjects(bucket: string, prefix: string): Promise<AWS.S3.ObjectList | undefined> {

--- a/packages/core/src/external/carequality/dq/process-inbound-dq.ts
+++ b/packages/core/src/external/carequality/dq/process-inbound-dq.ts
@@ -1,11 +1,11 @@
 import { InboundDocumentQueryReq, InboundDocumentQueryResp } from "@metriport/ihe-gateway-sdk";
 import { executeWithNetworkRetries } from "@metriport/shared";
 import axios from "axios";
-import { CCD_SUFFIX, createUploadFilePath } from "../../../domain/document/upload";
+import { CCD_SUFFIX, UPLOADS_FOLDER, createUploadFilePath } from "../../../domain/document/upload";
 import { Config } from "../../../util/config";
 import { out } from "../../../util/log";
 import { capture } from "../../../util/notifications";
-import { S3Utils } from "../../aws/s3";
+import { S3Utils, executeWithRetriesS3 } from "../../aws/s3";
 import {
   IHEGatewayError,
   XDSRegistryError,
@@ -14,6 +14,7 @@ import {
 } from "../error";
 import { validateBasePayload } from "../shared";
 import { decodePatientId } from "./utils";
+import { createFolderName } from "../../../domain/filename";
 
 const region = Config.getAWSRegion();
 const s3Utils = new S3Utils(region);
@@ -77,12 +78,48 @@ export async function processInboundDocumentQuery(
 }
 
 async function getDocumentContents(cxId: string, patientId: string): Promise<string[]> {
-  const documentContents = await s3Utils.retrieveDocumentIdsFromS3(cxId, patientId, bucket);
+  const documentContents = await retrieveXmlContentsFromMetadataFilesOnS3(cxId, patientId, bucket);
 
   if (!documentContents.length) {
     const msg = `Error getting document contents`;
     capture.error(msg, { extra: { cxId, patientId } });
     throw new XDSRegistryError("Internal Server Error");
   }
+  return documentContents;
+}
+
+async function retrieveXmlContentsFromMetadataFilesOnS3(
+  cxId: string,
+  patientId: string,
+  bucketName: string
+): Promise<string[]> {
+  const folderName = createFolderName(cxId, patientId);
+  const Prefix = `${folderName}/${UPLOADS_FOLDER}/`;
+
+  const params = {
+    Bucket: bucketName,
+    Prefix,
+  };
+
+  const data = await executeWithRetriesS3(() => s3Utils._s3.listObjectsV2(params).promise());
+  const documentContents = (
+    await Promise.all(
+      data.Contents?.filter(item => item.Key && item.Key.endsWith("_metadata.xml")).map(
+        async item => {
+          if (item.Key) {
+            const params = {
+              Bucket: bucketName,
+              Key: item.Key,
+            };
+
+            const data = await executeWithRetriesS3(() => s3Utils._s3.getObject(params).promise());
+            return data.Body?.toString();
+          }
+          return undefined;
+        }
+      ) || []
+    )
+  ).filter((item): item is string => Boolean(item));
+
   return documentContents;
 }


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1905

### Dependencies
- Upstream: https://github.com/metriport/metriport/pull/2332

### Description
- Making the CCD gen on DQ async
- In the meantime, quickly generating an empty CCD

### Testing
- Local
  - [ ] Test generation on patient without contributed data
  - [ ] Test generation on patient with contributed data (see that empty is generated before real one)

### Release Plan
- [ ] Merge this
