### PR TITLE
1040 Fix error handler on lambda async invocation + Disable SQS retries

### DIFF
--- a/packages/core/src/external/aws/document-signing/document-bulk-signer-lambda.ts
+++ b/packages/core/src/external/aws/document-signing/document-bulk-signer-lambda.ts
@@ -24,7 +24,11 @@ export class DocumentBulkSignerLambda extends DocumentBulkSigner {
         Payload: JSON.stringify(payload),
       })
       .promise()
-      .then(defaultLambdaInvocationResponseHandler)
+      .then(
+        defaultLambdaInvocationResponseHandler({
+          lambdaName: this.lambdaName,
+        })
+      )
       .catch(error => {
         throw error;
       });

--- a/packages/core/src/external/carequality/ihe-gateway-v2/ihe-gateway-v2-async.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/ihe-gateway-v2-async.ts
@@ -61,7 +61,11 @@ export class IHEGatewayV2Async extends IHEGatewayV2 {
           Payload: JSON.stringify(params),
         })
         .promise()
-        .then(defaultLambdaInvocationResponseHandler)
+        .then(
+          defaultLambdaInvocationResponseHandler({
+            lambdaName: iheGatewayV2OutboundPatientDiscoveryLambdaName,
+          })
+        )
         .catch(processAsyncError("Failed to invoke iheGatewayV2 lambda for patient discovery"));
     }
   }
@@ -94,7 +98,11 @@ export class IHEGatewayV2Async extends IHEGatewayV2 {
           Payload: JSON.stringify(params),
         })
         .promise()
-        .then(defaultLambdaInvocationResponseHandler)
+        .then(
+          defaultLambdaInvocationResponseHandler({
+            lambdaName: iheGatewayV2OutboundDocumentQueryLambdaName,
+          })
+        )
         .catch(processAsyncError("Failed to invoke iheGWV2 lambda for document query"));
     }
   }
@@ -131,7 +139,11 @@ export class IHEGatewayV2Async extends IHEGatewayV2 {
           Payload: JSON.stringify(params),
         })
         .promise()
-        .then(defaultLambdaInvocationResponseHandler)
+        .then(
+          defaultLambdaInvocationResponseHandler({
+            lambdaName: iheGatewayV2OutboundDocumentRetrievalLambdaName,
+          })
+        )
         .catch(processAsyncError("Failed to invoke iheGWV2 lambda for document retrieval"));
     }
   }

--- a/packages/core/src/external/carequality/ihe-gateway-v2/ihe-gateway-v2-logic.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/ihe-gateway-v2-logic.ts
@@ -157,6 +157,8 @@ export async function createSignSendProcessXCPDRequest({
     try {
       // TODO not sure if we should retry on timeout
       await executeWithNetworkRetries(async () => axios.post(pdResponseUrl, result), {
+        initialDelay: 100,
+        maxAttempts: 5,
         httpStatusCodesToRetry: [502, 504],
         log,
       });

--- a/packages/core/src/external/carequality/ihe-gateway/outbound-result-poller-lambda.ts
+++ b/packages/core/src/external/carequality/ihe-gateway/outbound-result-poller-lambda.ts
@@ -28,67 +28,80 @@ export class OutboundResultPollerLambda extends OutboundResultPoller {
     this.docRetrievalLambdaName = docRetrievalLambdaName;
   }
 
-  isPDEnabled(): boolean {
-    return (this.patientDiscoveryLambdaName ?? "").trim().length > 0;
+  isPDEnabled(
+    lambdaName: string | undefined = this.patientDiscoveryLambdaName
+  ): lambdaName is string {
+    return (lambdaName ?? "").trim().length > 0;
   }
 
   async pollOutboundPatientDiscoveryResults(params: PollOutboundResults): Promise<void> {
-    if (!this.isPDEnabled()) throw new Error(`PD polling is not enabled`);
+    if (!this.isPDEnabled(this.patientDiscoveryLambdaName))
+      throw new Error(`PD polling is not enabled`);
 
     // Intentionally asynchronous.
     lambdaClient
       .invoke({
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        FunctionName: this.patientDiscoveryLambdaName!, // couldn't make a type guard on isPDEnabled w/ object attributes
+        FunctionName: this.patientDiscoveryLambdaName,
         InvocationType: "Event",
         Payload: JSON.stringify(params),
       })
       .promise()
-      .then(defaultLambdaInvocationResponseHandler)
+      .then(
+        defaultLambdaInvocationResponseHandler({
+          lambdaName: this.patientDiscoveryLambdaName,
+        })
+      )
       .catch(
         processAsyncError("Failed to invoke lambda to poll outbound patient discovery responses")
       );
   }
 
-  isDQEnabled(): boolean {
-    return (this.docQueryLambdaName ?? "").trim().length > 0;
+  isDQEnabled(lambdaName: string | undefined = this.docQueryLambdaName): lambdaName is string {
+    return (lambdaName ?? "").trim().length > 0;
   }
 
   async pollOutboundDocQueryResults(params: PollOutboundResults): Promise<void> {
-    if (!this.isDQEnabled()) throw new Error(`DQ polling is not enabled`);
+    if (!this.isDQEnabled(this.docQueryLambdaName)) throw new Error(`DQ polling is not enabled`);
 
     // Intentionally asynchronous.
     lambdaClient
       .invoke({
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        FunctionName: this.docQueryLambdaName!, // couldn't make a type guard on isDQEnabled w/ object attributes
+        FunctionName: this.docQueryLambdaName,
         InvocationType: "Event",
         Payload: JSON.stringify(params),
       })
       .promise()
-      .then(defaultLambdaInvocationResponseHandler)
+      .then(
+        defaultLambdaInvocationResponseHandler({
+          lambdaName: this.docQueryLambdaName,
+        })
+      )
       .catch(
         processAsyncError("Failed to invoke lambda to poll outbound document query responses")
       );
   }
 
-  isDREnabled(): boolean {
-    return (this.docRetrievalLambdaName ?? "").trim().length > 0;
+  isDREnabled(lambdaName: string | undefined = this.docRetrievalLambdaName): lambdaName is string {
+    return (lambdaName ?? "").trim().length > 0;
   }
 
   async pollOutboundDocRetrievalResults(params: PollOutboundResults): Promise<void> {
-    if (!this.isDREnabled()) throw new Error(`DR polling is not enabled`);
+    if (!this.isDREnabled(this.docRetrievalLambdaName))
+      throw new Error(`DR polling is not enabled`);
 
     // Intentionally asynchronous.
     lambdaClient
       .invoke({
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        FunctionName: this.docRetrievalLambdaName!, // couldn't make a type guard on isDREnabled w/ object attributes
+        FunctionName: this.docRetrievalLambdaName,
         InvocationType: "Event",
         Payload: JSON.stringify(params),
       })
       .promise()
-      .then(defaultLambdaInvocationResponseHandler)
+      .then(
+        defaultLambdaInvocationResponseHandler({
+          lambdaName: this.docRetrievalLambdaName,
+        })
+      )
       .catch(
         processAsyncError("Failed to invoke lambda to poll outbound document query responses")
       );

--- a/packages/core/src/external/carequality/ihe-gateway/outbound-result-poller.ts
+++ b/packages/core/src/external/carequality/ihe-gateway/outbound-result-poller.ts
@@ -7,12 +7,12 @@ export type PollOutboundResults = {
 };
 
 export abstract class OutboundResultPoller {
-  abstract isPDEnabled(): boolean;
+  abstract isPDEnabled(lambdaName?: string | undefined): boolean;
   abstract pollOutboundPatientDiscoveryResults(params: PollOutboundResults): Promise<void>;
 
-  abstract isDQEnabled(): boolean;
+  abstract isDQEnabled(lambdaName?: string | undefined): boolean;
   abstract pollOutboundDocQueryResults(params: PollOutboundResults): Promise<void>;
 
-  abstract isDREnabled(): boolean;
+  abstract isDREnabled(lambdaName?: string | undefined): boolean;
   abstract pollOutboundDocRetrievalResults(params: PollOutboundResults): Promise<void>;
 }

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -1,9 +1,5 @@
 import { S3Utils } from "@metriport/core/external/aws/s3";
-import {
-  executeWithNetworkRetries,
-  executeWithRetries,
-  getNetworkErrorDetails,
-} from "@metriport/shared";
+import { executeWithNetworkRetries, executeWithRetries } from "@metriport/shared";
 import * as Sentry from "@sentry/serverless";
 import { SQSEvent } from "aws-lambda";
 import axios from "axios";
@@ -11,7 +7,6 @@ import * as uuid from "uuid";
 import { capture } from "./shared/capture";
 import { CloudWatchUtils, Metrics } from "./shared/cloudwatch";
 import { getEnvOrFail } from "./shared/env";
-import { isAxiosBadGateway, isAxiosTimeout } from "./shared/http";
 import { Log, prefixedLog } from "./shared/log";
 import { apiClient } from "./shared/oss-api";
 import { SQSUtils } from "./shared/sqs";
@@ -27,7 +22,7 @@ const region = getEnvOrFail("AWS_REGION");
 const metricsNamespace = getEnvOrFail("METRICS_NAMESPACE");
 const apiURL = getEnvOrFail("API_URL");
 const axiosTimeoutSeconds = Number(getEnvOrFail("AXIOS_TIMEOUT_SECONDS"));
-const maxTimeoutRetries = Number(getEnvOrFail("MAX_TIMEOUT_RETRIES"));
+// const maxTimeoutRetries = Number(getEnvOrFail("MAX_TIMEOUT_RETRIES"));
 const delayWhenRetryingSeconds = Number(getEnvOrFail("DELAY_WHEN_RETRY_SECONDS"));
 const sourceQueueURL = getEnvOrFail("QUEUE_URL");
 const dlqURL = getEnvOrFail("DLQ_URL");
@@ -167,169 +162,169 @@ export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent) => {
       const log = prefixedLog(`${i}, patient ${patientId}, job ${jobId}`);
       const lambdaParams = { cxId, patientId, jobId, source };
 
+      // try {
+      log(`Body: ${message.body}`);
+      const { s3BucketName, s3FileName, documentExtension } = parseBody(message.body);
+      const metrics: Metrics = {};
+
+      await cloudWatchUtils.reportMemoryUsage();
+      log(`Getting contents from bucket ${s3BucketName}, key ${s3FileName}`);
+      const downloadStart = Date.now();
+      const payloadRaw = await s3Utils.getFileContentsAsString(s3BucketName, s3FileName);
+      if (payloadRaw.includes("nonXMLBody")) {
+        const msg = "XML document is unstructured CDA with nonXMLBody";
+        console.log(`${msg}, skipping...`);
+        capture.message(msg, {
+          extra: { message, ...lambdaParams, context: lambdaName, fileName: s3FileName },
+          level: "warning",
+        });
+        await ossApi.notifyApi({ ...lambdaParams, status: "failed" }, log);
+        return;
+      }
+      const payloadClean = cleanUpPayload(payloadRaw);
+      metrics.download = {
+        duration: Date.now() - downloadStart,
+        timestamp: new Date(),
+      };
+
+      if (!payloadClean.trim().length) {
+        console.log("XML document is empty, skipping...");
+        capture.message("XML document is empty", {
+          extra: { message, ...lambdaParams, context: lambdaName, fileName: s3FileName },
+          level: "warning",
+        });
+        await ossApi.notifyApi({ ...lambdaParams, status: "failed" }, log);
+        return;
+      }
+
+      await cloudWatchUtils.reportMemoryUsage();
+      const conversionStart = Date.now();
+
+      const converterUrl = attrib.serverUrl?.stringValue;
+      if (!converterUrl) throw new Error(`Missing converterUrl`);
+      const unusedSegments = attrib.unusedSegments?.stringValue;
+      const invalidAccess = attrib.invalidAccess?.stringValue;
+      const converterParams = { patientId, fileName: s3FileName, unusedSegments, invalidAccess };
+      log(
+        `Calling converter on url ${converterUrl} with params ${JSON.stringify(converterParams)}`
+      );
+      const res = await executeWithNetworkRetries(
+        () =>
+          fhirConverter.post(converterUrl, payloadClean, {
+            params: converterParams,
+            headers: { "Content-Type": "text/plain" },
+          }),
+        {
+          // No retries on timeout b/c we want to re-enqueue instead of trying within the same lambda run,
+          // it could lead to timing out the lambda execution.
+          log,
+        }
+      );
+      const conversionResult = res.data.fhirResource as FHIRBundle;
+      metrics.conversion = {
+        duration: Date.now() - conversionStart,
+        timestamp: new Date(),
+      };
+
+      const preProcessedFilename = `${s3FileName}.from_converter.json`;
+
       try {
-        log(`Body: ${message.body}`);
-        const { s3BucketName, s3FileName, documentExtension } = parseBody(message.body);
-        const metrics: Metrics = {};
-
-        await cloudWatchUtils.reportMemoryUsage();
-        log(`Getting contents from bucket ${s3BucketName}, key ${s3FileName}`);
-        const downloadStart = Date.now();
-        const payloadRaw = await s3Utils.getFileContentsAsString(s3BucketName, s3FileName);
-        if (payloadRaw.includes("nonXMLBody")) {
-          const msg = "XML document is unstructured CDA with nonXMLBody";
-          console.log(`${msg}, skipping...`);
-          capture.message(msg, {
-            extra: { message, ...lambdaParams, context: lambdaName, fileName: s3FileName },
-            level: "warning",
-          });
-          await ossApi.notifyApi({ ...lambdaParams, status: "failed" }, log);
-          return;
-        }
-        const payloadClean = cleanUpPayload(payloadRaw);
-        metrics.download = {
-          duration: Date.now() - downloadStart,
-          timestamp: new Date(),
-        };
-
-        if (!payloadClean.trim().length) {
-          console.log("XML document is empty, skipping...");
-          capture.message("XML document is empty", {
-            extra: { message, ...lambdaParams, context: lambdaName, fileName: s3FileName },
-            level: "warning",
-          });
-          await ossApi.notifyApi({ ...lambdaParams, status: "failed" }, log);
-          return;
-        }
-
-        await cloudWatchUtils.reportMemoryUsage();
-        const conversionStart = Date.now();
-
-        const converterUrl = attrib.serverUrl?.stringValue;
-        if (!converterUrl) throw new Error(`Missing converterUrl`);
-        const unusedSegments = attrib.unusedSegments?.stringValue;
-        const invalidAccess = attrib.invalidAccess?.stringValue;
-        const converterParams = { patientId, fileName: s3FileName, unusedSegments, invalidAccess };
-        log(
-          `Calling converter on url ${converterUrl} with params ${JSON.stringify(converterParams)}`
-        );
-        const res = await executeWithNetworkRetries(
+        await executeWithRetries(
           () =>
-            fhirConverter.post(converterUrl, payloadClean, {
-              params: converterParams,
-              headers: { "Content-Type": "text/plain" },
-            }),
+            s3Utils.s3
+              .upload({
+                Bucket: conversionResultBucketName,
+                Key: preProcessedFilename,
+                Body: JSON.stringify(conversionResult),
+                ContentType: "application/fhir+json",
+              })
+              .promise(),
           {
-            // No retries on timeout b/c we want to re-enqueue instead of trying within the same lambda run,
-            // it could lead to timing out the lambda execution.
+            ...defaultS3RetriesConfig,
             log,
           }
         );
-        const conversionResult = res.data.fhirResource as FHIRBundle;
-        metrics.conversion = {
-          duration: Date.now() - conversionStart,
-          timestamp: new Date(),
-        };
-
-        const preProcessedFilename = `${s3FileName}.from_converter.json`;
-
-        try {
-          await executeWithRetries(
-            () =>
-              s3Utils.s3
-                .upload({
-                  Bucket: conversionResultBucketName,
-                  Key: preProcessedFilename,
-                  Body: JSON.stringify(conversionResult),
-                  ContentType: "application/fhir+json",
-                })
-                .promise(),
-            {
-              ...defaultS3RetriesConfig,
-              log,
-            }
-          );
-        } catch (error) {
-          console.log(`Error uploading pre-processed file: ${error}`);
-          capture.error(error, {
-            extra: {
-              message,
-              ...lambdaParams,
-              preProcessedFilename,
-              context: lambdaName,
-              error,
-            },
-          });
-        }
-
-        await cloudWatchUtils.reportMemoryUsage();
-
-        // post-process conversion result
-        const postProcessStart = Date.now();
-        const updatedConversionResult = replaceIDs(conversionResult, patientId);
-        addExtensionToConversion(updatedConversionResult, documentExtension);
-        removePatientFromConversion(updatedConversionResult);
-        addMissingRequests(updatedConversionResult);
-        metrics.postProcess = {
-          duration: Date.now() - postProcessStart,
-          timestamp: new Date(),
-        };
-
-        await cloudWatchUtils.reportMemoryUsage();
-        await sendConversionResult(
-          cxId,
-          patientId,
-          s3FileName,
-          updatedConversionResult,
-          jobStartedAt,
-          jobId,
-          source,
-          log
-        );
-
-        await cloudWatchUtils.reportMemoryUsage();
-        await cloudWatchUtils.reportMetrics(metrics);
       } catch (error) {
-        // If it timed-out let's just reenqueue for future processing - NOTE: the destination MUST be idempotent!
-        const count = message.attributes?.ApproximateReceiveCount
-          ? Number(message.attributes?.ApproximateReceiveCount)
-          : undefined;
-        const isWithinRetryRange = count == null || count <= maxTimeoutRetries;
-        const isRetryError = axios.isAxiosError(error)
-          ? isAxiosTimeout(error) || isAxiosBadGateway(error)
-          : false;
-        const networkErrorDetails = getNetworkErrorDetails(error);
-        const { details, code, status } = networkErrorDetails;
-        if (isRetryError && isWithinRetryRange) {
-          console.log(
-            `Timed out (${code}/${status}), reenqueue (${count} of ` +
-              `${maxTimeoutRetries}), lambdaParams ${lambdaParams}`
-          );
-          capture.message("Conversion timed out - retrying", {
-            extra: { message, ...lambdaParams, context: lambdaName, retryCount: count },
-            level: "info",
-          });
-          await sqsUtils.reEnqueue(message);
-        } else {
-          const msg = "Error processing message on " + lambdaName;
-          console.log(
-            `${msg} - lambdaParams: ${lambdaParams} - ` +
-              `error: ${JSON.stringify(networkErrorDetails)}`
-          );
-          if (axios.isAxiosError(error)) {
-            const responseData = error.response?.data
-              ? JSON.stringify(error.response.data)
-              : "undefined";
-            console.log(`Response body: ${responseData}`);
-          }
-          capture.error(msg, {
-            extra: { message, ...lambdaParams, context: lambdaName, networkErrorDetails, error },
-          });
-          await sqsUtils.sendToDLQ(message);
-
-          await ossApi.notifyApi({ ...lambdaParams, status: "failed", details }, log);
-        }
+        console.log(`Error uploading pre-processed file: ${error}`);
+        capture.error(error, {
+          extra: {
+            message,
+            ...lambdaParams,
+            preProcessedFilename,
+            context: lambdaName,
+            error,
+          },
+        });
       }
+
+      await cloudWatchUtils.reportMemoryUsage();
+
+      // post-process conversion result
+      const postProcessStart = Date.now();
+      const updatedConversionResult = replaceIDs(conversionResult, patientId);
+      addExtensionToConversion(updatedConversionResult, documentExtension);
+      removePatientFromConversion(updatedConversionResult);
+      addMissingRequests(updatedConversionResult);
+      metrics.postProcess = {
+        duration: Date.now() - postProcessStart,
+        timestamp: new Date(),
+      };
+
+      await cloudWatchUtils.reportMemoryUsage();
+      await sendConversionResult(
+        cxId,
+        patientId,
+        s3FileName,
+        updatedConversionResult,
+        jobStartedAt,
+        jobId,
+        source,
+        log
+      );
+
+      await cloudWatchUtils.reportMemoryUsage();
+      await cloudWatchUtils.reportMetrics(metrics);
+      // } catch (error) {
+      //   // If it timed-out let's just reenqueue for future processing - NOTE: the destination MUST be idempotent!
+      //   const count = message.attributes?.ApproximateReceiveCount
+      //     ? Number(message.attributes?.ApproximateReceiveCount)
+      //     : undefined;
+      //   const isWithinRetryRange = count == null || count <= maxTimeoutRetries;
+      //   const isRetryError = axios.isAxiosError(error)
+      //     ? isAxiosTimeout(error) || isAxiosBadGateway(error)
+      //     : false;
+      //   const networkErrorDetails = getNetworkErrorDetails(error);
+      //   const { details, code, status } = networkErrorDetails;
+      //   if (isRetryError && isWithinRetryRange) {
+      //     console.log(
+      //       `Timed out (${code}/${status}), reenqueue (${count} of ` +
+      //         `${maxTimeoutRetries}), lambdaParams ${lambdaParams}`
+      //     );
+      //     capture.message("Conversion timed out - retrying", {
+      //       extra: { message, ...lambdaParams, context: lambdaName, retryCount: count },
+      //       level: "info",
+      //     });
+      //     await sqsUtils.reEnqueue(message);
+      //   } else {
+      //     const msg = "Error processing message on " + lambdaName;
+      //     console.log(
+      //       `${msg} - lambdaParams: ${lambdaParams} - ` +
+      //         `error: ${JSON.stringify(networkErrorDetails)}`
+      //     );
+      //     if (axios.isAxiosError(error)) {
+      //       const responseData = error.response?.data
+      //         ? JSON.stringify(error.response.data)
+      //         : "undefined";
+      //       console.log(`Response body: ${responseData}`);
+      //     }
+      //     capture.error(msg, {
+      //       extra: { message, ...lambdaParams, context: lambdaName, networkErrorDetails, error },
+      //     });
+      //     await sqsUtils.sendToDLQ(message);
+
+      //     await ossApi.notifyApi({ ...lambdaParams, status: "failed", details }, log);
+      //   }
+      // }
     }
     console.log(`Done`);
   } catch (error) {


### PR DESCRIPTION
Ticket: 

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2326
- Downstream: none

### Description

[context](https://metriport.slack.com/archives/C04T5Q9JHFX/p1719331694970869?thread_ts=1719331458.061259&cid=C04T5Q9JHFX):
- get result lambda payload checks for 2xx instead of 200
- `defaultLambdaInvocationResponseHandler` has the correct lambda name

Just avoiding hitting the OSS API too much if its already failing
- response from outbound PD IHE GW lambda to try max 5 attempts to OSS API

[context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1719347777789909?thread_ts=1719338701.693029&cid=C04GEQ1GH9D):
- disable retries on FHIR converter and server lambdas

### Testing

upstream PR
 
### Release Plan

- [ ] Merge this
