### PR TITLE
feat(logs): adding metrics and logs to inbound ihe

### DIFF
--- a/packages/infra/lib/ihe-stack.ts
+++ b/packages/infra/lib/ihe-stack.ts
@@ -1,10 +1,10 @@
 import { CfnOutput, Stack, StackProps } from "aws-cdk-lib";
 import { CfnStage } from "aws-cdk-lib/aws-apigatewayv2";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Function as Lambda } from "aws-cdk-lib/aws-lambda";
 import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
 import * as cert from "aws-cdk-lib/aws-certificatemanager";
-import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
-import { Function as Lambda } from "aws-cdk-lib/aws-lambda";
 import * as r53 from "aws-cdk-lib/aws-route53";
 import * as r53_targets from "aws-cdk-lib/aws-route53-targets";
 import * as s3 from "aws-cdk-lib/aws-s3";

--- a/packages/infra/lib/ihe-stack.ts
+++ b/packages/infra/lib/ihe-stack.ts
@@ -111,7 +111,7 @@ export class IHEStack extends Stack {
     const latencyMetric = apigw2.metricLatency();
 
     const dashboard = new cloudwatch.Dashboard(this, "IHEDashboard", {
-      dashboardName: "IHE-Dashboard",
+      dashboardName: "IHE-Inbound-Dashboard",
     });
 
     dashboard.addWidgets(


### PR DESCRIPTION
Refs: #[1928](https://github.com/metriport/metriport-internal/issues/1928)

### Description

- adding metrics/dash and logs to inbound IHE gateway. First step in debugging 502s on inbound since we dont really have any visibility into the API Gateway right now.
- Used a custom construct copied from https://github.com/aws/aws-cdk/issues/11100 for enabling logging, since HTTPApi doesnt have easy logging support for some reason

### Testing

- Staging
  - [x] branch to staging
  - [ ] look at metrics and logs

### Release Plan

- [ ] Merge this
