### PR TITLE
1040 Remove retry on lambdas

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -661,6 +661,8 @@ export class APIStack extends Stack {
       bucket: medicalDocumentsBucket,
     });
 
+    // TODO move this to its own stack/nested stack, name it accordingly so it doesn't
+    // confuse with the regular FHIRConverter service/lambda
     // CONVERT API
     const convertResource = api.root.addResource("convert");
     const convertBaseResource = convertResource.addResource("v1");

--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -37,14 +37,11 @@ function settings() {
     lambdaTimeout,
     // How long will it take before Axios returns a timeout error - should be less than the lambda timeout
     axiosTimeout: lambdaTimeout.minus(Duration.seconds(5)), // give the lambda some time to deal with the timeout
-    // Number of times we want to retry a message, this includes throttles!
-    maxReceiveCount: 5,
-    // Number of times we want to retry a message that timed out when trying to be processed
-    maxTimeoutRetries: 15,
+    // The number of times a message can be unsuccesfully dequeued before being moved to the dead-letter queue.
+    maxReceiveCount: 1,
     // How long messages should be invisible for other consumers, based on the lambda timeout
     // We don't care if the message gets reprocessed, so no need to have a huge visibility timeout that makes it harder to move messages to the DLQ
     visibilityTimeout: Duration.seconds(lambdaTimeout.toSeconds() * 2 + 1),
-    delayWhenRetrying: Duration.seconds(10),
   };
 }
 
@@ -128,8 +125,6 @@ export function createLambda({
     lambdaBatchSize,
     maxConcurrency,
     axiosTimeout,
-    maxTimeoutRetries,
-    delayWhenRetrying,
   } = settings();
   const conversionLambda = defaultCreateLambda({
     stack,
@@ -143,8 +138,6 @@ export function createLambda({
     envVars: {
       METRICS_NAMESPACE,
       AXIOS_TIMEOUT_SECONDS: axiosTimeout.toSeconds().toString(),
-      MAX_TIMEOUT_RETRIES: String(maxTimeoutRetries),
-      DELAY_WHEN_RETRY_SECONDS: delayWhenRetrying.toSeconds().toString(),
       ...(config.lambdasSentryDSN ? { SENTRY_DSN: config.lambdasSentryDSN } : {}),
       API_URL: `http://${apiServiceDnsAddress}`,
       QUEUE_URL: sourceQueue.queueUrl,

--- a/packages/infra/lib/api-stack/fhir-converter-service.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-service.ts
@@ -127,7 +127,7 @@ export function createFHIRConverterService(
     maxCapacity: taskCountMax,
   });
   scaling.scaleOnCpuUtilization("autoscale_cpu", {
-    targetUtilizationPercent: 70,
+    targetUtilizationPercent: 60,
     scaleInCooldown: Duration.minutes(2),
     scaleOutCooldown: Duration.seconds(30),
   });

--- a/packages/infra/lib/api-stack/fhir-server-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-server-connector.ts
@@ -28,13 +28,10 @@ function settings() {
     // How long can the lambda run for, max is 900 seconds (15 minutes)
     lambdaTimeout,
     // Number of times we want to retry a message, this includes throttles!
-    maxReceiveCount: 5,
-    // Number of times we want to retry a message that timed out when trying to be processed
-    maxTimeoutRetries: 15,
+    maxReceiveCount: 1,
     // How long messages should be invisible for other consumers, based on the lambda timeout
     // We don't care if the message gets reprocessed, so no need to have a huge visibility timeout that makes it harder to move messages to the DLQ
     visibilityTimeout: Duration.seconds(lambdaTimeout.toSeconds() * 2 + 1),
-    delayWhenRetrying: Duration.seconds(10),
   };
 }
 
@@ -72,8 +69,6 @@ export function createConnector({
     maxConcurrency,
     maxReceiveCount,
     visibilityTimeout,
-    maxTimeoutRetries,
-    delayWhenRetrying,
   } = settings();
   const queue = defaultCreateQueue({
     stack,
@@ -105,11 +100,7 @@ export function createConnector({
     envType,
     envVars: {
       METRICS_NAMESPACE,
-      MAX_TIMEOUT_RETRIES: String(maxTimeoutRetries),
-      DELAY_WHEN_RETRY_SECONDS: delayWhenRetrying.toSeconds().toString(),
       ...(config.lambdasSentryDSN ? { SENTRY_DSN: config.lambdasSentryDSN } : {}),
-      QUEUE_URL: queue.queueUrl,
-      DLQ_URL: dlq.queue.queueUrl,
       FHIR_SERVER_URL: fhirServerUrl,
       API_URL: apiURL,
     },

--- a/packages/lambdas/src/shared/sqs.ts
+++ b/packages/lambdas/src/shared/sqs.ts
@@ -1,8 +1,7 @@
-import { SQSMessageAttributes, SQSRecord } from "aws-lambda";
+import { SQSMessageAttributes } from "aws-lambda";
 import * as AWS from "aws-sdk";
 import { SQS } from "aws-sdk";
 import { MessageBodyAttributeMap } from "aws-sdk/clients/sqs";
-import { capture } from "./capture";
 
 export class SQSUtils {
   public readonly _sqs: SQS;
@@ -17,58 +16,6 @@ export class SQSUtils {
 
   get sqs(): SQS {
     return this._sqs;
-  }
-
-  async sendToDLQ(message: SQSRecord) {
-    if (!this.dlqURL) throw new Error(`Missing dlqURL`);
-    await this.dequeue(message);
-    const sendParams: AWS.SQS.SendMessageRequest = {
-      MessageBody: message.body,
-      QueueUrl: this.dlqURL,
-      MessageAttributes: SQSUtils.attributesToSend(message.messageAttributes),
-    };
-    try {
-      console.log(`Sending message to DLQ: ${JSON.stringify(sendParams)}`);
-      await this.sqs.sendMessage(sendParams).promise();
-    } catch (err) {
-      console.log(`Failed to send message to queue: `, message, err);
-      capture.error(err, {
-        extra: { message, sendParams, context: "sendToDLQ" },
-      });
-    }
-  }
-
-  async reEnqueue(message: SQSRecord) {
-    await this.dequeue(message);
-    const sendParams = {
-      MessageBody: message.body,
-      QueueUrl: this.sourceQueueURL,
-      MessageAttributes: SQSUtils.attributesToSend(message.messageAttributes),
-      DelaySeconds: this.delayWhenRetryingSeconds, // wait at least that long before retrying
-    };
-    try {
-      await this.sqs.sendMessage(sendParams).promise();
-    } catch (err) {
-      console.log(`Failed to re-enqueue message: `, message, err);
-      capture.error(err, {
-        extra: { message, sendParams, context: "reEnqueue" },
-      });
-    }
-  }
-
-  async dequeue(message: SQSRecord) {
-    const deleteParams = {
-      QueueUrl: this.sourceQueueURL,
-      ReceiptHandle: message.receiptHandle,
-    };
-    try {
-      await this.sqs.deleteMessage(deleteParams).promise();
-    } catch (err) {
-      console.log(`Failed to remove message from queue: `, message, err);
-      capture.error(err, {
-        extra: { message, deleteParams, context: "dequeue" },
-      });
-    }
   }
 
   static attributesToSend(inboundMessageAttribs: SQSMessageAttributes): MessageBodyAttributeMap {

--- a/packages/lambdas/src/shared/sqs.ts
+++ b/packages/lambdas/src/shared/sqs.ts
@@ -25,7 +25,7 @@ export class SQSUtils {
     const sendParams: AWS.SQS.SendMessageRequest = {
       MessageBody: message.body,
       QueueUrl: this.dlqURL,
-      MessageAttributes: this.attributesToSend(message.messageAttributes),
+      MessageAttributes: SQSUtils.attributesToSend(message.messageAttributes),
     };
     try {
       console.log(`Sending message to DLQ: ${JSON.stringify(sendParams)}`);
@@ -43,7 +43,7 @@ export class SQSUtils {
     const sendParams = {
       MessageBody: message.body,
       QueueUrl: this.sourceQueueURL,
-      MessageAttributes: this.attributesToSend(message.messageAttributes),
+      MessageAttributes: SQSUtils.attributesToSend(message.messageAttributes),
       DelaySeconds: this.delayWhenRetryingSeconds, // wait at least that long before retrying
     };
     try {
@@ -71,18 +71,18 @@ export class SQSUtils {
     }
   }
 
-  attributesToSend(inboundMessageAttribs: SQSMessageAttributes): MessageBodyAttributeMap {
+  static attributesToSend(inboundMessageAttribs: SQSMessageAttributes): MessageBodyAttributeMap {
     let res = {};
     for (const [key, value] of Object.entries(inboundMessageAttribs)) {
       res = {
         ...res,
-        ...this.singleAttributeToSend(key, value.stringValue),
+        ...SQSUtils.singleAttributeToSend(key, value.stringValue),
       };
     }
     return res;
   }
 
-  singleAttributeToSend(key: string, value: string | undefined): MessageBodyAttributeMap {
+  static singleAttributeToSend(key: string, value: string | undefined): MessageBodyAttributeMap {
     return {
       [key]: {
         DataType: "String",

--- a/packages/lambdas/src/sqs-to-opensearch-xml.ts
+++ b/packages/lambdas/src/sqs-to-opensearch-xml.ts
@@ -1,8 +1,7 @@
 import { getSecret } from "@aws-lambda-powertools/parameters/secrets";
 import { OpenSearchFileIngestorDirect } from "@metriport/core/external/opensearch/file-ingestor-direct";
 import { FileIngestorSQSPayload } from "@metriport/core/external/opensearch/file-ingestor-sqs";
-import { executeWithRetries } from "@metriport/shared";
-import * as Sentry from "@sentry/serverless";
+import { errorToString, executeWithRetries, MetriportError } from "@metriport/shared";
 import { SQSEvent } from "aws-lambda";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
@@ -10,7 +9,6 @@ import { capture } from "./shared/capture";
 import { CloudWatchUtils, Metrics } from "./shared/cloudwatch";
 import { getEnvOrFail } from "./shared/env";
 import { prefixedLog } from "./shared/log";
-import { SQSUtils } from "./shared/sqs";
 
 dayjs.extend(duration);
 
@@ -34,51 +32,47 @@ const lambdaName = getEnvOrFail("AWS_LAMBDA_FUNCTION_NAME");
 const region = getEnvOrFail("AWS_REGION");
 // Set by us
 const metricsNamespace = getEnvOrFail("METRICS_NAMESPACE");
-const delayWhenRetryingSeconds = Number(getEnvOrFail("DELAY_WHEN_RETRY_SECONDS"));
-const sourceQueueURL = getEnvOrFail("QUEUE_URL");
-const dlqURL = getEnvOrFail("DLQ_URL");
-
 const host = getEnvOrFail("SEARCH_HOST");
 const username = getEnvOrFail("SEARCH_USER");
 const secretName = getEnvOrFail("SEARCH_SECRET_NAME");
 const indexName = getEnvOrFail("SEARCH_INDEX_NAME");
 
-const sqsUtils = new SQSUtils(region, sourceQueueURL, dlqURL, delayWhenRetryingSeconds);
 const cloudWatchUtils = new CloudWatchUtils(region, lambdaName, metricsNamespace);
 
 type EventBody = FileIngestorSQSPayload;
 
-export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent) => {
-  // Process messages from SQS
-  const records = event.Records;
-  if (!records || records.length < 1) {
-    console.log(`No records, discarding this event: ${JSON.stringify(event)}`);
-    return;
-  }
+// Don't use Sentry's default error handler b/c we want to use our own and send more context-aware data
+export async function handler(event: SQSEvent) {
+  try {
+    // Process messages from SQS
+    const records = event.Records;
+    if (!records || records.length < 1) {
+      console.log(`No records, discarding this event: ${JSON.stringify(event)}`);
+      return;
+    }
 
-  const password = (await getSecret(secretName)) as string;
-  if (!password) {
-    throw new Error(`Config error - secret ${secretName} is empty/could not be retrieved`);
-  }
-  if (typeof password !== "string") {
-    throw new Error(`Config error - secret ${secretName} is not a string`);
-  }
-  const openSearch = new OpenSearchFileIngestorDirect({
-    region,
-    endpoint: "https://" + host,
-    indexName,
-    username,
-    password,
-  });
+    const password = (await getSecret(secretName)) as string;
+    if (!password) {
+      throw new Error(`Config error - secret ${secretName} is empty/could not be retrieved`);
+    }
+    if (typeof password !== "string") {
+      throw new Error(`Config error - secret ${secretName} is not a string`);
+    }
+    const openSearch = new OpenSearchFileIngestorDirect({
+      region,
+      endpoint: "https://" + host,
+      indexName,
+      username,
+      password,
+    });
 
-  console.log(`Processing ${records.length} records...`);
-  for (const [i, message] of records.entries()) {
-    // Process one record from the SQS message
-    console.log(`Record ${i}, messageId: ${message.messageId}`);
-    if (!message.body) throw new Error(`Missing message body`);
-    console.log(`Body: ${message.body}`);
+    console.log(`Processing ${records.length} records...`);
+    for (const [i, message] of records.entries()) {
+      // Process one record from the SQS message
+      console.log(`Record ${i}, messageId: ${message.messageId}`);
+      if (!message.body) throw new Error(`Missing message body`);
+      console.log(`Body: ${message.body}`);
 
-    try {
       const params = parseBody(message.body);
       const { patientId, s3FileName, s3BucketName, requestId } = params;
       const log = prefixedLog(`${i}, patient ${patientId}, requestId ${requestId}`);
@@ -103,17 +97,17 @@ export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent) => {
 
       log(`Metrics: ${JSON.stringify(metrics)}`);
       await cloudWatchUtils.reportMetrics(metrics);
-    } catch (error) {
-      const msg = "Error ingesting message into OpenSearch";
-      console.log(`${msg}: ${JSON.stringify(message)};\n${error}`);
-      capture.error(msg, {
-        extra: { message, context: lambdaName, error },
-      });
-      await sqsUtils.sendToDLQ(message);
     }
+    console.log(`Done`);
+  } catch (error) {
+    const msg = "Error ingesting message into OpenSearch";
+    console.log(`${msg}: ${errorToString(error)}`);
+    capture.error(msg, {
+      extra: { event, context: lambdaName, error },
+    });
+    throw new MetriportError(msg, error);
   }
-  console.log(`Done`);
-});
+}
 
 function parseBody(body: unknown): EventBody {
   const bodyString = typeof body === "string" ? (body as string) : undefined;


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

- related: https://github.com/metriport/metriport/pull/2344

### Description

- don't retry on fhir converter and server lambdas
- don't retry on open search lambdas
- single report of issue to Sentry upon error for those lambdas ^
- autoscaling CPU threshold of FHIRConverter moved from 70 to 60 

[Context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1719338701693029)

### Testing

- Local
  - none
- Staging
  - [ ] PD works
  - [ ] DQ/DR works
  - [ ] FHIR conversion works (new resources on FHIR server)
  - [ ] OpenSearch ingestion works
  - [ ] Forced error on FHIR conversion results in message sent to DLQ w/o retry
  - [ ] autoscaling threshold for FHIR Converter updated from 70 to 60
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
