### PR TITLE
feat(ihev2): fix for allscripts auth and athena sha1

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/saml/saml-client.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/saml/saml-client.ts
@@ -51,6 +51,7 @@ async function getTrustedKeyStore(): Promise<string> {
 export function setRejectUnauthorized(value: boolean): void {
   rejectUnauthorized = value;
 }
+// TODO: remove false here once allscripts patches their endpoints
 export function getRejectUnauthorized(): boolean {
   return false && rejectUnauthorized;
 }

--- a/packages/core/src/external/carequality/ihe-gateway-v2/saml/saml-client.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/saml/saml-client.ts
@@ -52,7 +52,7 @@ export function setRejectUnauthorized(value: boolean): void {
   rejectUnauthorized = value;
 }
 export function getRejectUnauthorized(): boolean {
-  return rejectUnauthorized;
+  return false && rejectUnauthorized;
 }
 
 export type SamlClientResponse = {

--- a/packages/core/src/external/carequality/ihe-gateway-v2/saml/security/sign.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/saml/security/sign.ts
@@ -25,11 +25,11 @@ function createSignature({
   const sig = new SignedXml({ privateKey });
   sig.addReference({
     xpath: xpath,
-    digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    digestAlgorithm: "http://www.w3.org/2001/04/xmlenc#sha256",
     transforms: transforms,
   });
   sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
-  sig.signatureAlgorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+  sig.signatureAlgorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
   sig.computeSignature(xml, {
     prefix: "ds",
     location: { reference: locationReference, action: action },


### PR DESCRIPTION
Refs: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- fixes for allscripts and athena

### Testing

- Local
  - [x] tested with prod endpoints

### Release Plan

- :warning: Points to `master`
- turn on ihev2 fully for (all?) customers 
- monitor analytics: we shouldnt have an event lasting greater than 300000 ms again  
- [ ] Merge this
