### PR TITLE
1040 Rename polling lambdas

### DIFF
--- a/packages/core/src/external/aws/s3.ts
+++ b/packages/core/src/external/aws/s3.ts
@@ -311,6 +311,7 @@ export class S3Utils {
     file: Buffer;
     contentType?: string;
   }): Promise<AWS.S3.ManagedUpload.SendData> {
+    const { log } = out("uploadFile");
     const uploadParams: AWS.S3.PutObjectRequest = {
       Bucket: bucket,
       Key: key,
@@ -321,10 +322,10 @@ export class S3Utils {
     }
     try {
       const resp = await executeWithRetriesS3(() => this._s3.upload(uploadParams).promise());
-      console.log("Upload successful");
+      log("Upload successful");
       return resp;
     } catch (error) {
-      console.error(`Error during upload: ${JSON.stringify(error)}`);
+      log(`Error during upload: ${JSON.stringify(error)}`);
       throw error;
     }
   }
@@ -338,7 +339,8 @@ export class S3Utils {
       const resp = await executeWithRetriesS3(() => this._s3.getObject(params).promise());
       return resp.Body as Buffer;
     } catch (error) {
-      console.error(`Error during download: ${JSON.stringify(error)}`);
+      const { log } = out("downloadFile");
+      log(`Error during download: ${JSON.stringify(error)}`);
       throw error;
     }
   }
@@ -351,7 +353,8 @@ export class S3Utils {
     try {
       await executeWithRetriesS3(() => this._s3.deleteObject(deleteParams).promise());
     } catch (error) {
-      console.error(`Error during file deletion: ${JSON.stringify(error)}`);
+      const { log } = out("deleteFile");
+      log(`Error during file deletion: ${JSON.stringify(error)}`);
       throw error;
     }
   }

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -629,7 +629,12 @@ export class APIStack extends Stack {
       apiKeyRequired: true,
     });
 
-    this.setupTestLambda(lambdaLayers, props.config.environmentType, props.config.lambdasSentryDSN);
+    this.setupTestLambda(
+      lambdaLayers,
+      props.config.environmentType,
+      apiDirectUrl,
+      props.config.lambdasSentryDSN
+    );
 
     // token auth for connect sessions
     const tokenAuth = this.setupTokenAuthLambda(
@@ -884,6 +889,7 @@ export class APIStack extends Stack {
   private setupTestLambda(
     lambdaLayers: LambdaLayers,
     envType: EnvType,
+    apiAddress: string,
     sentryDsn: string | undefined
   ) {
     return createLambda({
@@ -895,6 +901,7 @@ export class APIStack extends Stack {
       entry: "tester",
       envType,
       envVars: {
+        API_URL: apiAddress,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
       architecture: lambda.Architecture.ARM_64,

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -274,8 +274,7 @@ export class LambdasNestedStack extends NestedStack {
 
     const outboundPatientDiscoveryLambda = createLambda({
       stack: this,
-      name: "OutboundPatientDiscovery",
-      nameSuffix: "v2",
+      name: "PollOutboundPatientDiscovery",
       entry: "ihe-outbound-patient-discovery",
       envType,
       envVars: {
@@ -319,8 +318,7 @@ export class LambdasNestedStack extends NestedStack {
 
     const outboundDocumentQueryLambda = createLambda({
       stack: this,
-      name: "OutboundDocumentQuery",
-      nameSuffix: "v2",
+      name: "PollOutboundDocumentQuery",
       entry: "ihe-outbound-document-query",
       envType,
       envVars: {
@@ -364,8 +362,7 @@ export class LambdasNestedStack extends NestedStack {
 
     const outboundDocumentRetrievalLambda = createLambda({
       stack: this,
-      name: "OutboundDocumentRetrieval",
-      nameSuffix: "v2",
+      name: "PollOutboundDocumentRetrieval",
       entry: "ihe-outbound-document-retrieval",
       envType,
       envVars: {

--- a/packages/lambdas/src/tester.ts
+++ b/packages/lambdas/src/tester.ts
@@ -1,3 +1,4 @@
+import { getEnvVarOrFail } from "@metriport/shared";
 import * as Sentry from "@sentry/serverless";
 import axios from "axios";
 import { capture } from "./shared/capture";
@@ -6,12 +7,15 @@ import { capture } from "./shared/capture";
 capture.init();
 
 const api = axios.create({ timeout: 10_000 });
-// OSS API
-const url = "http://Stagi-APIFa-L2I135INABM3-e3a33dd4470439f2.elb.us-east-2.amazonaws.com";
 
 // Test lambda, to validate/test stuff on the cloud env
 export const handler = Sentry.AWSLambda.wrapHandler(async () => {
-  console.log(`Running, calling ${url}...`);
+  console.log(`Running...`);
+
+  // OSS API
+  const url = getEnvVarOrFail("API_URL");
+
+  console.log(`Calling ${url}...`);
   const res = await api.get(url);
   console.log(`Success! Response status: ${res.status}, body: ${JSON.stringify(res.data)}`);
 


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

none

### Description

- Rename polling lambdas
- s3 utils to log w/ req ID
- dynamically set tester lambda API URL 

### Testing

- Local
  - none
- Staging
  - [ ] PD works
  - [ ] upload doc works
  - [ ] tester lambda works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
