### PR TITLE
feat(core): constucting results tables from observations ref by diagreports

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -622,7 +622,7 @@ function combineStrings(
 function createDiagnosticReportsWithB64Notes(
   diagnosticReports: DiagnosticReport[],
   observations: Observation[]
-) {
+): string {
   const mappedObservations = mapResourceToId<Observation>(observations);
 
   if (!diagnosticReports) {
@@ -665,7 +665,7 @@ function createDiagnosticReportsWithB64Notes(
           ?.join("<br/>") ?? "";
 
       const formattedTime = dayjs(reportWithObs.time).format(ISO_DATE);
-      return { time: formattedTime, notes: note };
+      return note ? { time: formattedTime, notes: note } : undefined;
     });
 
   return `${timedNotes.map(note => createDiagnosticTable(note)).join("")}`;
@@ -687,7 +687,10 @@ function cleanUp(valueString: string): string {
     .replace(/<ID>.*?<\/ID>/g, "");
 }
 
-function createDiagnosticTable(timedNote: { time: string | undefined; notes: string }) {
+function createDiagnosticTable(
+  timedNote: { time: string | undefined; notes: string } | undefined
+): string {
+  if (!timedNote) return "";
   return `<table><thead><th>${timedNote.time}</th></thead><tbody><tr><td>${timedNote.notes}</td></tr></tbody></table>`;
 }
 

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -23,7 +23,7 @@ import {
 } from "@medplum/fhirtypes";
 import dayjs from "dayjs";
 import { uniqWith } from "lodash";
-import { BASE_64_EXTENSION_URL } from "../../fhir/shared/extensions/base-64-extension";
+import { BASE_64_EXTENSION_URL } from "../../fhir/shared/extensions/base64-extension";
 
 const ISO_DATE = "YYYY-MM-DD";
 
@@ -599,7 +599,7 @@ function createDiagnosticReportsSection(
         <a href="#mr-header">&#x25B2; Back to Top</a>
       </div>
       <div class="section-content">
-        ${combineStrings(nonAWEreports, reportsFromB64, noReportsPlaceholder)}
+        ${combineStrings(nonAWEreports, reportsFromB64) ?? noReportsPlaceholder} 
       </div>
     </div>
   `;
@@ -607,9 +607,8 @@ function createDiagnosticReportsSection(
 
 function combineStrings(
   stringA: string | undefined,
-  stringB: string | undefined,
-  placeholder = "default"
-) {
+  stringB: string | undefined
+): string | undefined {
   if (stringA && stringA.length > 0 && stringB && stringB.length > 0) {
     return stringA + stringB;
   } else if (stringA && stringA.length > 0) {
@@ -617,7 +616,7 @@ function combineStrings(
   } else if (stringB && stringB.length > 0) {
     return stringB;
   }
-  return placeholder;
+  return undefined;
 }
 
 function createDiagnosticReportsWithB64Notes(
@@ -630,44 +629,49 @@ function createDiagnosticReportsWithB64Notes(
     return "";
   }
 
-  const timedNotes = diagnosticReports
-    .sort((a, b) => {
-      const timeA = a.effectiveDateTime ?? a.effectivePeriod?.start;
-      const timeB = b.effectiveDateTime ?? b.effectivePeriod?.start;
-      return dayjs(timeA).isBefore(dayjs(timeB)) ? -1 : 1;
-    })
-    .map(report => {
-      let time = report.effectiveDateTime ?? report.effectivePeriod?.start;
+  const reportsWithObservations = diagnosticReports.map(report => {
+    const obsRefs = report.result?.flatMap(obsRef => obsRef.reference || []);
+    const observations = obsRefs?.flatMap(obsRef => {
+      const obsRefId = obsRef?.split("Observation/")[1];
+      if (!obsRefId) return [];
+      return mappedObservations[obsRefId] || [];
+    });
 
-      const obsRefs = report.result?.flatMap(obsRef => obsRef.reference || []);
-      const notes =
-        obsRefs
-          ?.flatMap(obsRef => {
-            const obsRefId = obsRef?.split("/")[1];
-            if (!obsRefId) return;
-            const referencedObs = mappedObservations[obsRefId];
-            if (!time) {
-              time = referencedObs?.effectiveDateTime ?? referencedObs?.effectivePeriod?.start;
-            }
-            const valueString = referencedObs?.valueString ?? "";
-            const cleanedUp = removeJunk(valueString);
-            const obsExtensions = referencedObs?.extension;
+    let time = report.effectiveDateTime ?? report.effectivePeriod?.start;
+    if (!time) {
+      time = observations?.[0]?.effectiveDateTime ?? observations?.[0]?.effectivePeriod?.start;
+    }
+
+    return { report, observations, time };
+  });
+
+  const timedNotes = reportsWithObservations
+    .sort((a, b) => {
+      return dayjs(a.time).isBefore(dayjs(b.time)) ? -1 : 1;
+    })
+    .map(reportWithObs => {
+      const note =
+        reportWithObs.observations
+          ?.map(obs => {
+            const valueString = obs.valueString ?? "";
+            const valueStringWithoutEncoded = removeEncodedStrings(valueString);
+            const obsExtensions = obs.extension;
             const resString = containsB64(obsExtensions)
-              ? Buffer.from(cleanedUp, "base64").toString("utf-8")
-              : cleanedUp;
+              ? Buffer.from(valueStringWithoutEncoded, "base64").toString("utf-8")
+              : valueStringWithoutEncoded;
 
             return cleanUp(resString);
           })
           ?.join("<br/>") ?? "";
 
-      const formattedTime = dayjs(time).format(ISO_DATE);
-      return { time: formattedTime, notes };
+      const formattedTime = dayjs(reportWithObs.time).format(ISO_DATE);
+      return { time: formattedTime, notes: note };
     });
 
   return `${timedNotes.map(note => createDiagnosticTable(note)).join("")}`;
 }
 
-function removeJunk(valueString: string): string {
+function removeEncodedStrings(valueString: string): string {
   return valueString.replace(/&#x3D;/g, "").trim();
 }
 
@@ -678,7 +682,6 @@ function containsB64(extension: Extension[] | undefined) {
 function cleanUp(valueString: string): string {
   const htmlString = valueString.replace(/root/g, "div").replace(/<\/content>/g, "</content><br/>");
   const noId = htmlString.replace(/<ID>.*?<\/ID>/g, "");
-  console.log(noId);
   return noId;
 }
 

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -238,6 +238,7 @@ export const bundleToHtml = (fhirBundle: Bundle): string => {
           ${createDiagnosticReportsSection(
             diagnosticReports,
             practitioners,
+            observationLaboratory,
             aweVisits,
             organizations
           )}
@@ -566,6 +567,7 @@ function createAWESection(
 function createDiagnosticReportsSection(
   diagnosticReports: DiagnosticReport[],
   practitioners: Practitioner[],
+  observations: Observation[],
   aweVisits: Condition[],
   organizations: Organization[]
 ) {
@@ -587,7 +589,7 @@ function createDiagnosticReportsSection(
   );
 
   const hasNonAWEreports = nonAWEreports.length > 0;
-
+  const reportsFromB64 = createDiagnosticReportsWithB64Notes(diagnosticReports, observations);
   return `
     <div id="reports" class="section">
       <div class="section-title">
@@ -600,9 +602,63 @@ function createDiagnosticReportsSection(
             ? nonAWEreports
             : `<table><tbody><tr><td>No reports found</td></tr></tbody></table>`
         }
+        ${reportsFromB64}
       </div>
     </div>
   `;
+}
+
+function createDiagnosticReportsWithB64Notes(
+  diagnosticReports: DiagnosticReport[],
+  observations: Observation[]
+) {
+  const mappedObservations = mapResourceToId<Observation>(observations);
+
+  if (!diagnosticReports) {
+    return "";
+  }
+
+  const timedNotes = diagnosticReports
+    .sort((a, b) => {
+      const timeA = a.effectiveDateTime ?? a.effectivePeriod?.start;
+      const timeB = b.effectiveDateTime ?? b.effectivePeriod?.start;
+      return dayjs(timeA).isBefore(dayjs(timeB)) ? -1 : 1;
+    })
+    .map(report => {
+      const time = report.effectiveDateTime ?? report.effectivePeriod?.start;
+      const obsRefs = report.result?.flatMap(obsRef => obsRef.reference || []);
+      const notes =
+        obsRefs
+          ?.flatMap(obsRef => {
+            const obsRefId = obsRef?.split("/")[1];
+            if (!obsRefId) return;
+            const valueString = mappedObservations[obsRefId]?.valueString ?? "";
+            const cleanedUp = valueString.replace(/&#x3D;/g, "").trim();
+            let resString;
+            try {
+              resString = Buffer.from(cleanedUp, "base64").toString("utf-8");
+            } catch {
+              resString = cleanedUp;
+            }
+            return resString.replace(/root/g, "div").replace(/<\/content>/g, "</content><br/>");
+          })
+          ?.join("<br/>") ?? "";
+
+      console.log(notes);
+      return { time, notes };
+    });
+
+  return `
+    ${
+      timedNotes
+        ? timedNotes.map(note => createDiagnosticTable(note)).join("")
+        : `<table><tbody><tr><td>No reports found</td></tr></tbody></table>`
+    }
+  `;
+}
+
+function createDiagnosticTable(timedNote: { time: string | undefined; notes: string }) {
+  return `<table><thead><th>${timedNote.time}</th></thead><tbody><tr><td>${timedNote.notes}</td></tr></tbody></table>`;
 }
 
 function buildEncounterSections(

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -680,9 +680,11 @@ function containsB64(extension: Extension[] | undefined) {
 }
 
 function cleanUp(valueString: string): string {
-  const htmlString = valueString.replace(/root/g, "div").replace(/<\/content>/g, "</content><br/>");
-  const noId = htmlString.replace(/<ID>.*?<\/ID>/g, "");
-  return noId;
+  return valueString
+    .replace(/root/g, "div")
+    .replace(/<\/content>/g, "</content><br/>")
+    .replace(/<styleCode>.*?<\/styleCode>/g, "")
+    .replace(/<ID>.*?<\/ID>/g, "");
 }
 
 function createDiagnosticTable(timedNote: { time: string | undefined; notes: string }) {

--- a/packages/core/src/external/fhir/shared/extensions/base-64-extension.ts
+++ b/packages/core/src/external/fhir/shared/extensions/base-64-extension.ts
@@ -1,0 +1,8 @@
+import { BASE_EXTENSION_URL } from "./base-extension";
+
+export const BASE_64_EXTENSION_URL = `${BASE_EXTENSION_URL}/is-base-64-encoded.json`;
+
+export const BASE_64_EXTENSION = {
+  url: BASE_64_EXTENSION_URL,
+  valueBoolean: true,
+};

--- a/packages/core/src/external/fhir/shared/extensions/base64-extension.ts
+++ b/packages/core/src/external/fhir/shared/extensions/base64-extension.ts
@@ -1,5 +1,8 @@
 import { BASE_EXTENSION_URL } from "./base-extension";
 
+/**
+ * If this is changed in any way, it must be updated in the CDA to FHIR converter as well.
+ */
 export const BASE_64_EXTENSION_URL = `${BASE_EXTENSION_URL}/is-base-64-encoded.json`;
 
 export const BASE_64_EXTENSION = {

--- a/packages/fhir-converter/src/templates/cda/Resources/Observation.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/Observation.hbs
@@ -87,6 +87,12 @@
             "valueString":"{{{parseReferenceData observationEntry.value._}}}",
         {{!-- in some cases text is here in the b64 field. Adding so no data loss but not sure if thats the way its supposed to be. also how it renders I do not know      --}}
         {{else if observationEntry.value._b64}}
+            "extension": [
+                {
+                    "url": "https://public.metriport.com/fhir/StructureDefinition/is-base-64-encoded.json",
+                    "valueBoolean": true
+                }
+            ],
             "valueString":"{{observationEntry.value._b64}}",
         {{else if observationEntry.value.translation.value}}
             {{#if observationEntry.value.translation.originalText._}}

--- a/packages/fhir-converter/src/templates/cda/Resources/Observation.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/Observation.hbs
@@ -89,6 +89,7 @@
         {{else if observationEntry.value._b64}}
             "extension": [
                 {
+                    {{!-- This must be identical to `@metriport/core/external/fhir/shared/extensions/base64-extension. We're avoiding adding a dependency on that package.` --}}
                     "url": "https://public.metriport.com/fhir/StructureDefinition/is-base-64-encoded.json",
                     "valueBoolean": true
                 }


### PR DESCRIPTION
refs. metriport/metriport#2302

### Description
- `DiagnosticReport` sometimes references an `Observation` resource for results. Here, I'm introducing functionality to get those results, decode them, and create new tables from them. 

### Testing
- Local
  - [x] Tested with a FHIR bundle where a DiagnosticReport references an Observation for the results
  - [x] ...

### Release Plan
- [ ] Merge this
