### PR TITLE
1911 Publish NPM package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25059,7 +25059,7 @@
       }
     },
     "packages/api": {
-      "version": "1.18.5",
+      "version": "1.18.6",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -25142,12 +25142,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "9.0.2",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^4.15.15",
-        "@metriport/shared": "^0.9.8",
+        "@metriport/commonwell-sdk": "^4.15.16",
+        "@metriport/shared": "^0.9.9",
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -25203,10 +25203,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.9.6",
+        "@metriport/ihe-gateway-sdk": "^0.9.7",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -25220,7 +25220,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -25230,10 +25230,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.16.15",
+      "version": "1.16.16",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.15.15",
+        "@metriport/commonwell-sdk": "^4.15.16",
         "axios": "^1.4.0",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -25272,10 +25272,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.14.6",
+      "version": "1.14.7",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^4.15.15",
+        "@metriport/commonwell-sdk": "^4.15.16",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -25307,10 +25307,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "4.15.15",
+      "version": "4.15.16",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.9.8",
+        "@metriport/shared": "^0.9.9",
         "axios": "^1.4.0",
         "http-status": "^1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -25358,7 +25358,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.13.8",
+      "version": "1.13.9",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.435.0",
@@ -25434,17 +25434,17 @@
     "packages/core/packages/ihe-gateway-sdk": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.9.8",
+        "@metriport/shared": "^0.9.9",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.12.6",
+      "version": "1.12.7",
       "dependencies": {
         "aws-cdk-lib": "^2.122.0",
         "constructs": "^10.2.69",
@@ -25492,7 +25492,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.11.15",
+      "version": "1.11.16",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -26519,14 +26519,14 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^8.0.2"
       }
     },
     "packages/utils": {
-      "version": "1.14.6",
+      "version": "1.14.7",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "9.0.2",
+  "version": "10.0.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -57,8 +57,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^4.15.15",
-    "@metriport/shared": "^0.9.8",
+    "@metriport/commonwell-sdk": "^4.15.16",
+    "@metriport/shared": "^0.9.9",
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.18.5",
+  "version": "1.18.6",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.9.6",
+    "@metriport/ihe-gateway-sdk": "^0.9.7",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.16.15",
+  "version": "1.16.16",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.15.15",
+    "@metriport/commonwell-sdk": "^4.15.16",
     "axios": "^1.4.0",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.14.6",
+  "version": "1.14.7",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^4.15.15",
+    "@metriport/commonwell-sdk": "^4.15.16",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "4.15.15",
+  "version": "4.15.16",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -59,7 +59,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.9.8",
+    "@metriport/shared": "^0.9.9",
     "axios": "^1.4.0",
     "http-status": "^1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.13.8",
+  "version": "1.13.9",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -52,7 +52,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.9.8",
+    "@metriport/shared": "^0.9.9",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.11.15",
+  "version": "1.11.16",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.14.6",
+  "version": "1.14.7",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1911

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2324
- Downstream: none

### Description

 - api@1.18.6
 - @metriport/api-sdk@10.0.0
 - @metriport/carequality-cert-runner@1.8.7
 - @metriport/carequality-sdk@0.10.7
 - @metriport/commonwell-cert-runner@1.16.16
 - @metriport/commonwell-jwt-maker@1.14.7
 - @metriport/commonwell-sdk@4.15.16
 - @metriport/core@1.13.9
 - @metriport/ihe-gateway-sdk@0.9.7
 - infrastructure@1.12.7
 - @metriport/react-native-sdk@1.11.16
 - @metriport/shared@0.9.9
 - utils@1.14.7

### Testing

none

### Release Plan

- [x] Release NPM packages
- [x] Merge this
