### PR TITLE
1936 Add access log to API's ALB

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -416,6 +416,7 @@ export class APIStack extends Stack {
       outboundPatientDiscoveryLambda,
       outboundDocumentQueryLambda,
       outboundDocumentRetrievalLambda,
+      generalBucket,
       medicalDocumentsUploadBucket,
       fhirToMedicalRecordLambda,
       fhirToCdaConverterLambda,

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -330,7 +330,7 @@ export class APIStack extends Stack {
     if (!isSandbox(props.config)) {
       fhirConverter = createFHIRConverterService(
         this,
-        props,
+        { ...props, generalBucket },
         this.vpc,
         slackNotification?.alarmAction
       );

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -27,6 +27,7 @@ import { IQueue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
 import { EnvConfig } from "../../config/env-config";
 import { DnsZones } from "../shared/dns";
+import { buildLbAccessLogPrefix } from "../shared/s3";
 import { Secrets, secretsToECS } from "../shared/secrets";
 import { provideAccessToQueue } from "../shared/sqs";
 import { isProd, isSandbox } from "../shared/util";
@@ -55,6 +56,7 @@ export function createAPIService({
   outboundPatientDiscoveryLambda,
   outboundDocumentQueryLambda,
   outboundDocumentRetrievalLambda,
+  generalBucket,
   medicalDocumentsUploadBucket,
   fhirToMedicalRecordLambda,
   fhirToCdaConverterLambda,
@@ -83,6 +85,7 @@ export function createAPIService({
   outboundPatientDiscoveryLambda: ILambda;
   outboundDocumentQueryLambda: ILambda;
   outboundDocumentRetrievalLambda: ILambda;
+  generalBucket: s3.Bucket;
   medicalDocumentsUploadBucket: s3.Bucket;
   fhirToMedicalRecordLambda: ILambda | undefined;
   fhirToCdaConverterLambda: ILambda | undefined;
@@ -256,6 +259,8 @@ export function createAPIService({
   });
 
   const alb = fargateService.loadBalancer;
+  alb.logAccessLogs(generalBucket, buildLbAccessLogPrefix("api"));
+
   const nlb = new NetworkLoadBalancer(stack, `ApiNetworkLoadBalancer`, {
     vpc,
     internetFacing: false,

--- a/packages/infra/lib/api-stack/fhir-converter-service.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-service.ts
@@ -6,11 +6,13 @@ import * as ecr_assets from "aws-cdk-lib/aws-ecr-assets";
 import * as ecs from "aws-cdk-lib/aws-ecs";
 import { FargateService } from "aws-cdk-lib/aws-ecs";
 import * as ecs_patterns from "aws-cdk-lib/aws-ecs-patterns";
+import { Bucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import { EnvConfig } from "../../config/env-config";
 import { getConfig } from "../shared/config";
 import { vCPU } from "../shared/fargate";
 import { MAXIMUM_LAMBDA_TIMEOUT } from "../shared/lambda";
+import { buildLbAccessLogPrefix } from "../shared/s3";
 import { addDefaultMetricsToTargetGroup } from "../shared/target-group";
 import { isProd } from "../shared/util";
 
@@ -34,6 +36,7 @@ export function settings() {
 interface FhirConverterServiceProps extends StackProps {
   config: EnvConfig;
   version: string | undefined;
+  generalBucket: Bucket;
 }
 
 export function createFHIRConverterService(
@@ -77,6 +80,11 @@ export function createFHIRConverterService(
     }
   );
   const serverAddress = fargateService.loadBalancer.loadBalancerDnsName;
+
+  fargateService.loadBalancer.logAccessLogs(
+    props.generalBucket,
+    buildLbAccessLogPrefix("fhir-converter")
+  );
 
   // CloudWatch Alarms and Notifications
   const fargateCPUAlarm = fargateService.service

--- a/packages/infra/lib/shared/s3.ts
+++ b/packages/infra/lib/shared/s3.ts
@@ -1,0 +1,3 @@
+export function buildLbAccessLogPrefix(prefix: string): string {
+  return `load-balancers/access-logs/${prefix}/`;
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1936

### Dependencies

none

### Description

- Add access log to API's ALB 
- Add access log to FHIRConverter's ALB 

### Testing

- Local
  - none
- Staging
  - [ ] Successful access API from API GW
  - [ ] API ALB's access log populated on S3 and accessible through CloudWatch logs
  - [ ] Successful access FHIRConverter from API GW
  - [ ] FHIRConverter ALB's access log populated on S3 and accessible through CloudWatch logs
- Sandbox
  - none
- Production
  - [ ] API ALB's access log populated on S3 and accessible through CloudWatch logs

### Release Plan

- [ ] Merge this
