### PR TITLE
1040 Single alert on CW 404

### DIFF
--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -607,7 +607,7 @@ async function downloadDocsAndUpsertFHIR({
             log(`${msg}: (docId ${doc.id}): ${errorToString(error)}`);
             capture.error(msg, {
               extra: {
-                context: `s3.documentUpload`,
+                context: `cw.downloadDocsAndUpsertFHIR.downloadFromCWAndUploadToS3`,
                 patientId: patient.id,
                 documentReference: doc,
                 requestId,

--- a/packages/core/src/external/commonwell/document/document-downloader-local.ts
+++ b/packages/core/src/external/commonwell/document/document-downloader-local.ts
@@ -308,12 +308,9 @@ export class DocumentDownloaderLocal extends DocumentDownloader {
       if (error instanceof CommonwellError && error.cause?.response?.status === 404) {
         const msg = "CW - Document not found";
         console.log(`${msg} - ${JSON.stringify(additionalInfo)}`);
-        throw new NotFoundError(msg, undefined, additionalInfo);
+        throw new NotFoundError(msg, error, additionalInfo);
       }
-      const msg = `CW - Error downloading document`;
-      this.config.capture &&
-        this.config.capture.message(msg, { extra: { ...additionalInfo, error }, level: "error" });
-      throw new MetriportError(msg, error, additionalInfo);
+      throw new MetriportError(`CW - Error downloading document`, error, additionalInfo);
     }
   }
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

- single alert on CW 404
- pass cause to NotFoundError

### Testing

- Local
  - none
- Staging
  - none (CW integration is down and this doesn't change any logic)
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
