### PR TITLE
1936 Remove trailing slash from ALB access log prefix

### DIFF
--- a/packages/infra/lib/shared/s3.ts
+++ b/packages/infra/lib/shared/s3.ts
@@ -1,3 +1,3 @@
 export function buildLbAccessLogPrefix(prefix: string): string {
-  return `load-balancers/access-logs/${prefix}/`;
+  return `load-balancers/access-logs/${prefix}`;
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#1936

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2363
- Downstream: none

### Description

Remove trailing slash from ALB access log prefix - [context](https://metriport.slack.com/archives/C04FZ9859FZ/p1719872509670939?thread_ts=1719871033.675699&cid=C04FZ9859FZ).

### Testing

none

### Release Plan

- [ ] Merge this
