### PR TITLE
799 query inactive cq orgs

### DIFF
--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -105,6 +105,7 @@ router.post(
  *
  * Retrieves the organization with the specified OID from the Carequality Directory.
  * @param req.params.oid The OID of the organization to retrieve.
+ * @param req.params.getInactive Optional, indicates whether to get the inactive organization(s). If not provided, will fetch active organizations.
  * @returns Returns the organization with the specified OID.
  */
 router.get(

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -115,8 +115,8 @@ router.get(
     const cq = makeCarequalityManagementAPI();
     if (!cq) throw new Error("Carequality API not initialized");
     const oid = getFrom("params").orFail("oid", req);
-    const isActive = getFromQueryAsBoolean("isActive", req);
-    const resp = await cq.listOrganizations({ count: 1, oid, isActive });
+    const getInactive = getFromQueryAsBoolean("getInactive", req);
+    const resp = await cq.listOrganizations({ count: 1, oid, active: !getInactive });
     const org = parseCQDirectoryEntries(resp);
 
     if (org.length > 1) {

--- a/packages/api/src/routes/medical/internal-cq.ts
+++ b/packages/api/src/routes/medical/internal-cq.ts
@@ -115,7 +115,8 @@ router.get(
     const cq = makeCarequalityManagementAPI();
     if (!cq) throw new Error("Carequality API not initialized");
     const oid = getFrom("params").orFail("oid", req);
-    const resp = await cq.listOrganizations({ count: 1, oid });
+    const isActive = getFromQueryAsBoolean("isActive", req);
+    const resp = await cq.listOrganizations({ count: 1, oid, isActive });
     const org = parseCQDirectoryEntries(resp);
 
     if (org.length > 1) {

--- a/packages/carequality-sdk/src/client/carequality-api.ts
+++ b/packages/carequality-sdk/src/client/carequality-api.ts
@@ -5,10 +5,12 @@ export interface CarequalityManagementAPI {
     count,
     start,
     oid,
+    isActive,
   }: {
     count?: number;
     start?: number;
     oid?: string;
+    isActive?: boolean | undefined;
   }): Promise<Organization[]>;
   registerOrganization(org: string): Promise<string>;
   updateOrganization(org: string, oid: string): Promise<string>;

--- a/packages/carequality-sdk/src/client/carequality-api.ts
+++ b/packages/carequality-sdk/src/client/carequality-api.ts
@@ -5,12 +5,12 @@ export interface CarequalityManagementAPI {
     count,
     start,
     oid,
-    isActive,
+    active,
   }: {
     count?: number;
     start?: number;
     oid?: string;
-    isActive?: boolean | undefined;
+    active?: boolean | undefined;
   }): Promise<Organization[]>;
   registerOrganization(org: string): Promise<string>;
   updateOrganization(org: string, oid: string): Promise<string>;

--- a/packages/carequality-sdk/src/client/carequality.ts
+++ b/packages/carequality-sdk/src/client/carequality.ts
@@ -147,6 +147,7 @@ export class CarequalityManagementAPIImpl implements CarequalityManagementAPI {
    * @param count Optional, number of organizations to fetch. Defaults to 1000.
    * @param start Optional, the index of the directory to start querying from. Defaults to 0.
    * @param oid Optional, the OID of the organization to fetch.
+   * @param isActive Optional, indicates whether to list active or inactive organizations. Defaults to true.
    * @returns
    */
   async listOrganizations({

--- a/packages/carequality-sdk/src/client/carequality.ts
+++ b/packages/carequality-sdk/src/client/carequality.ts
@@ -153,10 +153,12 @@ export class CarequalityManagementAPIImpl implements CarequalityManagementAPI {
     count = MAX_COUNT,
     start = 0,
     oid,
+    isActive = true,
   }: {
     count?: number;
     start?: number;
     oid?: string;
+    isActive?: boolean;
   }): Promise<Organization[]> {
     if (count < 1 || count > MAX_COUNT)
       throw new Error(`Count value must be between 1 and ${MAX_COUNT}`);
@@ -165,6 +167,7 @@ export class CarequalityManagementAPIImpl implements CarequalityManagementAPI {
     query.append("_format", JSON_FORMAT);
     query.append("_count", count.toString());
     query.append("_start", start.toString());
+    if (!isActive) query.append("_active", isActive.toString());
     oid && query.append("_id", oid);
     const queryString = query.toString();
 

--- a/packages/carequality-sdk/src/client/carequality.ts
+++ b/packages/carequality-sdk/src/client/carequality.ts
@@ -147,19 +147,19 @@ export class CarequalityManagementAPIImpl implements CarequalityManagementAPI {
    * @param count Optional, number of organizations to fetch. Defaults to 1000.
    * @param start Optional, the index of the directory to start querying from. Defaults to 0.
    * @param oid Optional, the OID of the organization to fetch.
-   * @param isActive Optional, indicates whether to list active or inactive organizations. Defaults to true.
+   * @param active Optional, indicates whether to list active or inactive organizations. Defaults to true.
    * @returns
    */
   async listOrganizations({
     count = MAX_COUNT,
     start = 0,
     oid,
-    isActive = true,
+    active = true,
   }: {
     count?: number;
     start?: number;
     oid?: string;
-    isActive?: boolean;
+    active?: boolean;
   }): Promise<Organization[]> {
     if (count < 1 || count > MAX_COUNT)
       throw new Error(`Count value must be between 1 and ${MAX_COUNT}`);
@@ -168,7 +168,7 @@ export class CarequalityManagementAPIImpl implements CarequalityManagementAPI {
     query.append("_format", JSON_FORMAT);
     query.append("_count", count.toString());
     query.append("_start", start.toString());
-    if (!isActive) query.append("_active", isActive.toString());
+    if (!active) query.append("_active", active.toString());
     oid && query.append("_id", oid);
     const queryString = query.toString();
 


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/799

### Description

- Adding the param to allow querying for inactive CQ orgs
- Context: Sometimes, we need to query for inactive orgs with the endpoint on Postman, and there was no support for it prior to this PR

### Testing

- Local
  - [x] Was able to fetch both active and inactive orgs locally

### Release Plan
- [ ] Merge this
