### PR TITLE
1824 Add action to OpenSearch alarms

### DIFF
--- a/packages/infra/lib/api-stack/ccda-search-connector.ts
+++ b/packages/infra/lib/api-stack/ccda-search-connector.ts
@@ -74,6 +74,7 @@ export function setup({
     region: config.region,
     vpc,
     ...openSearchConfig,
+    alarmAction: alarmSnsAction,
   });
 
   // setup queue and lambda to process the ccda files

--- a/packages/infra/lib/shared/open-search-construct.ts
+++ b/packages/infra/lib/shared/open-search-construct.ts
@@ -1,5 +1,6 @@
 import { CfnOutput, RemovalPolicy } from "aws-cdk-lib";
 import { ComparisonOperator, Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as iam from "aws-cdk-lib/aws-iam";
 import {
@@ -33,6 +34,7 @@ export interface OpenSearchConstructProps {
   ebs: EbsOptions;
   encryptionAtRest?: boolean;
   alarmThresholds?: OpenSearchAlarmThresholds;
+  alarmAction?: SnsAction | undefined;
 }
 
 export default class OpenSearchConstruct extends Construct {
@@ -119,7 +121,7 @@ export default class OpenSearchConstruct extends Construct {
       enableAutoSoftwareUpdate: true,
     });
 
-    this.createAlarms(id, props.alarmThresholds);
+    this.createAlarms(id, props.alarmThresholds, props.alarmAction);
 
     new CfnOutput(this, `${id}DomainID`, {
       description: `OpenSearch ${id} Domain ID`,
@@ -141,7 +143,8 @@ export default class OpenSearchConstruct extends Construct {
       cpuUtilization,
       jvmMemoryPressure,
       searchLatency,
-    }: OpenSearchAlarmThresholds = {}
+    }: OpenSearchAlarmThresholds = {},
+    alarmAction?: SnsAction
   ) {
     const createAlarm = ({
       metric,
@@ -156,12 +159,14 @@ export default class OpenSearchConstruct extends Construct {
       evaluationPeriods: number;
       comparisonOperator?: ComparisonOperator;
     }) => {
-      metric.createAlarm(this, `${id}${name}`, {
+      const alarm = metric.createAlarm(this, `${id}${name}`, {
         threshold,
         evaluationPeriods,
         alarmName: `${id}${name}`,
         comparisonOperator,
       });
+      alarmAction && alarm.addAlarmAction(alarmAction);
+      alarmAction && alarm.addOkAction(alarmAction);
     };
 
     (statusRed == null || statusRed) &&
@@ -183,7 +188,7 @@ export default class OpenSearchConstruct extends Construct {
       metric: this.domain.metricFreeStorageSpace(),
       name: "FreeStorage",
       threshold: freeStorageMB ?? 5_000,
-      evaluationPeriods: 1,
+      evaluationPeriods: 3,
       comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
     });
 
@@ -210,7 +215,7 @@ export default class OpenSearchConstruct extends Construct {
       metric: this.domain.metricSearchLatency(),
       name: "SearchLatency",
       threshold: searchLatency ?? 300,
-      evaluationPeriods: 1,
+      evaluationPeriods: 2,
     });
   }
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#1824

### Dependencies

none

### Description

Add action to OpenSearch alarms - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1719940278082699).

### Testing

- Local
  - none
- Staging
  - [ ] OS alarm have an action associated w/ it
- Sandbox
  - [ ] OS alarm have an action associated w/ it
- Production
  - [ ] OS alarm have an action associated w/ it

### Release Plan

- [ ] Merge this
