### PR TITLE
1040 DB pool settings per environment

### DIFF
--- a/packages/api/src/models/db.ts
+++ b/packages/api/src/models/db.ts
@@ -2,6 +2,9 @@ import * as AWS from "aws-sdk";
 import { Sequelize } from "sequelize";
 import { CQDirectoryEntryModel } from "../external/carequality/models/cq-directory";
 import { CQPatientDataModel } from "../external/carequality/models/cq-patient-data";
+import { OutboundDocumentQueryRespModel } from "../external/carequality/models/outbound-document-query-resp";
+import { OutboundDocumentRetrievalRespModel } from "../external/carequality/models/outbound-document-retrieval-resp";
+import { OutboundPatientDiscoveryRespModel } from "../external/carequality/models/outbound-patient-discovery-resp";
 import { CwPatientDataModel } from "../external/commonwell/models/cw-patient-data";
 import { FacilityModel } from "../models/medical/facility";
 import { OrganizationModel } from "../models/medical/organization";
@@ -11,9 +14,6 @@ import { ConnectedUser } from "./connected-user";
 import { initDDBDev, initLocalCxAccount } from "./db-dev";
 import { CoverageEnhancementModel } from "./medical/coverage-enhancement";
 import { DocRefMappingModel } from "./medical/docref-mapping";
-import { OutboundDocumentQueryRespModel } from "../external/carequality/models/outbound-document-query-resp";
-import { OutboundPatientDiscoveryRespModel } from "../external/carequality/models/outbound-patient-discovery-resp";
-import { OutboundDocumentRetrievalRespModel } from "../external/carequality/models/outbound-document-retrieval-resp";
 import { MAPIAccess } from "./medical/mapi-access";
 import { PatientModel } from "./medical/patient";
 import { Settings } from "./settings";
@@ -39,10 +39,18 @@ const models: ModelSetup[] = [
   CoverageEnhancementModel.setup,
 ];
 
+export type DbPoolProps = {
+  max: number;
+  min: number;
+  acquire: number;
+  idle: number;
+};
+
 export type MetriportDB = {
   sequelize: Sequelize;
   doc: AWS.DynamoDB.DocumentClient;
 };
+
 let db: MetriportDB | undefined;
 export const getDB = (): MetriportDB => {
   if (!db) throw new Error("DB not initialized");
@@ -54,11 +62,12 @@ export interface DocTableNames {
 }
 export let docTableNames: DocTableNames;
 
-const initDB = async (): Promise<void> => {
+async function initDB(): Promise<void> {
   // make sure we have the env vars we need
   const sqlDBCreds = Config.getDBCreds();
   const tokenTableName = Config.getTokenTableName();
   const logDBOperations = Config.isCloudEnv() ? false : true;
+  const dbPoolSettings = getDbPoolSettings();
 
   docTableNames = {
     token: tokenTableName,
@@ -71,12 +80,7 @@ const initDB = async (): Promise<void> => {
     host: dbCreds.host,
     port: dbCreds.port,
     dialect: dbCreds.engine,
-    pool: {
-      max: 300,
-      min: 50,
-      acquire: 30000,
-      idle: 10000,
-    },
+    pool: dbPoolSettings,
     logging: logDBOperations,
     logQueryParameters: logDBOperations,
   });
@@ -107,6 +111,37 @@ const initDB = async (): Promise<void> => {
     console.log(err);
     throw err;
   }
-};
+}
+
+function getDbPoolSettings(): DbPoolProps {
+  function getAndParseSettings(): Partial<Record<keyof DbPoolProps, string>> {
+    try {
+      const rawProps = Config.getDbPoolSettings();
+      const parsedProps = rawProps ? JSON.parse(rawProps) : {};
+      return parsedProps;
+    } catch (error) {
+      console.log("Error parsing db pool settings", error);
+      return {};
+    }
+  }
+  const parsedProps = getAndParseSettings();
+  const max = getOptionalInteger(parsedProps.max) ?? 500;
+  const min = getOptionalInteger(parsedProps.min) ?? 50;
+  const acquire = getOptionalInteger(parsedProps.acquire) ?? 10_000;
+  const idle = getOptionalInteger(parsedProps.idle) ?? 10_000;
+  return {
+    max,
+    min,
+    acquire,
+    idle,
+  };
+}
+
+function getOptionalInteger(prop: string | undefined): number | undefined {
+  if (!prop) return undefined;
+  const resp = parseInt(prop);
+  if (isNaN(resp)) return undefined;
+  return resp;
+}
 
 export default initDB;

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -122,6 +122,10 @@ export class Config {
     return getEnvVarOrFail("DB_CREDS");
   }
 
+  static getDbPoolSettings(): string | undefined {
+    return getEnvVar("DB_POOL_SETTINGS");
+  }
+
   static getDbReadReplicaEndpoint(): string {
     return getEnvVarOrFail("DB_READ_REPLICA_ENDPOINT");
   }

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -75,6 +75,24 @@ type EnvConfigBase = {
      * The thresholds for the RDS alarms.
      */
     alarmThresholds: RDSAlarmThresholds;
+    /**
+     * Sequelize DB pool settings.
+     */
+    poolSettings: {
+      /**
+       * Maximum number of connections in pool. Default is 5.
+       * It should be lower than the DB's max connections.
+       * For Aurora Serverless v2, that's tied to `maxCapacity`.
+       * @see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html#aurora-serverless-v2.max-connections
+       */
+      max: number;
+      /** Minimum number of connections in pool. Default is 0. */
+      min: number;
+      /** The maximum time, in milliseconds, that pool will try to get connection before throwing error. */
+      acquire: number;
+      /** The maximum time, in milliseconds, that a connection can be idle before being released. */
+      idle: number;
+    };
   };
   loadBalancerDnsName: string;
   /**

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -25,6 +25,12 @@ export const config: EnvConfigNonSandbox = {
       volumeReadIops: 2_000,
       volumeWriteIops: 2_000,
     },
+    poolSettings: {
+      max: 200,
+      min: 10,
+      acquire: 5_000,
+      idle: 5_000,
+    },
   },
   loadBalancerDnsName: "<your-load-balancer-dns-name>",
   logArn: "<your-log-arn>",

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -128,6 +128,7 @@ export function createAPIService({
     host: dbReadReplicaEndpoint.hostname,
     port: dbReadReplicaEndpoint.port,
   });
+  const dbPoolSettings = JSON.stringify(props.config.apiDatabase.poolSettings);
   // Run some servers on fargate containers
   const listenerPort = 80;
   const containerPort = 8080;
@@ -160,6 +161,7 @@ export function createAPIService({
           ...(props.version ? { METRIPORT_VERSION: props.version } : undefined),
           AWS_REGION: props.config.region,
           DB_READ_REPLICA_ENDPOINT: dbReadReplicaEndpointAsString,
+          DB_POOL_SETTINGS: dbPoolSettings,
           TOKEN_TABLE_NAME: dynamoDBTokenTable.tableName,
           API_URL: `https://${props.config.subdomain}.${props.config.domain}`,
           ...(props.config.apiGatewayUsagePlanId


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1952
- Downstream: none

### Description

Adjust db capacity and pool settings per env - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1720042146210979).

### Testing

- Local
  - [x] DB Pool settings are loaded when set
  - [x] Uses default config when no DB Pool settings are provided
- Staging
  - See upstream
- Sandbox
  - See upstream
- Production
  - See upstream

### Release Plan

- [ ] Merge upstream
- [ ] Merge this
