### PR TITLE
1040 Remove new lines from error logger

### DIFF
--- a/packages/api/src/routes/util.ts
+++ b/packages/api/src/routes/util.ts
@@ -21,10 +21,14 @@ export function asyncHandler(
       await f(req, res, next);
     } catch (err) {
       if (logErrorDetails) log("", err);
-      else log(errorToString(err));
+      else log(removeNewLines(errorToString(err)));
       next(err);
     }
   };
+}
+
+function removeNewLines(s: string): string {
+  return (s ?? "").replace(/\n/g, " ");
 }
 
 // https://www.rfc-editor.org/rfc/rfc7807 w/ Metriport extension, { name?: string }


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

We're not logging details about 400s - [context](https://metriport.slack.com/archives/C05UXMPAVS8/p1720063851064029?thread_ts=1720060697.055119&cid=C05UXMPAVS8)

This removes new lines from error logging on the `asyncHandler`. My hypothesis is that new lines are being "cut out" from CloudWatch logs, that's why we're not logging ZodErrors ([that's how they get logged](https://zod.dev/ERROR_HANDLING)).

### Testing

- Local
  - [x] log errors w/ max detail on local env
  - [x] log errors w/ min detail on cloud env
- Staging
  - [ ] ZodErrors are logged
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
