### PR TITLE
1040 Tester lambda gets protocol in front of api url

### DIFF
--- a/packages/lambdas/src/tester.ts
+++ b/packages/lambdas/src/tester.ts
@@ -13,7 +13,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(async () => {
   console.log(`Running...`);
 
   // OSS API
-  const url = getEnvVarOrFail("API_URL");
+  const url = "http://" + getEnvVarOrFail("API_URL");
 
   console.log(`Calling ${url}...`);
   const res = await api.get(url);


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Tester lambda gets protocol in front of api url.

### Testing

- Staging
  - [ ] Tester lambda works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
