### PR TITLE
PATCH_RELEASE 2024_07_04 FHIR Converter fix 

### DIFF
--- a/packages/core/src/external/cda/remove-b64.ts
+++ b/packages/core/src/external/cda/remove-b64.ts
@@ -1,17 +1,16 @@
 import { toArray } from "@metriport/shared";
 import { XMLBuilder, XMLParser } from "fast-xml-parser";
-import { OCTET_MIME_TYPE, PDF_MIME_TYPE } from "../../util/mime";
+import { BASE64_ENCODED_MIME_TYPES } from "../../util/mime";
 
 const notesTemplateId = "2.16.840.1.113883.10.20.22.2.65";
 const b64Representation = "B64";
 
-const parser = new XMLParser({
-  ignoreAttributes: false,
-  attributeNamePrefix: "@_",
-  removeNSPrefix: true,
-});
-
 export function removeBase64PdfEntries(payloadRaw: string): string {
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_",
+    removeNSPrefix: true,
+  });
   const json = parser.parse(payloadRaw);
 
   let removedEntry = 0;
@@ -28,10 +27,11 @@ export function removeBase64PdfEntries(payloadRaw: string): string {
         if (comp.section.entry) {
           //eslint-disable-next-line @typescript-eslint/no-explicit-any
           comp.section.entry = toArray(comp.section.entry).filter((entry: any) => {
-            const mediaType = entry.act?.text?.["@_mediaType"]?.toLowerCase();
+            const mediaType = entry.act?.text?.["@_mediaType"]?.trim().toLowerCase();
             if (
-              (mediaType === PDF_MIME_TYPE || mediaType === OCTET_MIME_TYPE) &&
-              entry.act.text["@_representation"]?.toLowerCase() === b64Representation.toLowerCase()
+              BASE64_ENCODED_MIME_TYPES.includes(mediaType) &&
+              entry.act.text["@_representation"]?.trim().toLowerCase() ===
+                b64Representation.toLowerCase()
             ) {
               removedEntry++;
               return false;

--- a/packages/core/src/external/cda/remove-b64.ts
+++ b/packages/core/src/external/cda/remove-b64.ts
@@ -1,6 +1,6 @@
 import { toArray } from "@metriport/shared";
 import { XMLBuilder, XMLParser } from "fast-xml-parser";
-import { BASE64_ENCODED_MIME_TYPES } from "../../util/mime";
+import { BINARY_MIME_TYPES } from "../../util/mime";
 
 const notesTemplateId = "2.16.840.1.113883.10.20.22.2.65";
 const b64Representation = "B64";
@@ -29,7 +29,7 @@ export function removeBase64PdfEntries(payloadRaw: string): string {
           comp.section.entry = toArray(comp.section.entry).filter((entry: any) => {
             const mediaType = entry.act?.text?.["@_mediaType"]?.trim().toLowerCase();
             if (
-              BASE64_ENCODED_MIME_TYPES.includes(mediaType) &&
+              BINARY_MIME_TYPES.includes(mediaType) &&
               entry.act.text["@_representation"]?.trim().toLowerCase() ===
                 b64Representation.toLowerCase()
             ) {

--- a/packages/core/src/util/mime.ts
+++ b/packages/core/src/util/mime.ts
@@ -40,7 +40,7 @@ export const OCTET_FILE_EXTENSION = ".bin";
 export const HTML_MIME_TYPE = "text/html";
 export const HTML_FILE_EXTENSION = ".html";
 
-export const BASE64_ENCODED_MIME_TYPES = [
+export const BINARY_MIME_TYPES = [
   PDF_MIME_TYPE,
   TIFF_MIME_TYPE,
   TIF_MIME_TYPE,

--- a/packages/core/src/util/mime.ts
+++ b/packages/core/src/util/mime.ts
@@ -40,6 +40,17 @@ export const OCTET_FILE_EXTENSION = ".bin";
 export const HTML_MIME_TYPE = "text/html";
 export const HTML_FILE_EXTENSION = ".html";
 
+export const BASE64_ENCODED_MIME_TYPES = [
+  PDF_MIME_TYPE,
+  TIFF_MIME_TYPE,
+  TIF_MIME_TYPE,
+  PNG_MIME_TYPE,
+  JPEG_MIME_TYPE,
+  JPG_MIME_TYPE,
+  BMP_MIME_TYPE,
+  OCTET_MIME_TYPE,
+];
+
 /**
  * Returns a file extension based on a given MIME type.
  */


### PR DESCRIPTION
refs. metriport/metriport-internal#1925

### Context
- We've ran into a file that stores B64-encoded data with the `_mediaType` indicated as an `octet-stream`.

### Description
- Added checks for an array of different mime types that may be encoded as B64

### Release Plan
- :warning: Points to `master`
- [x] Merge this
