### PR TITLE
1151 Remove x-webhook-key header

### DIFF
--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -253,7 +253,6 @@ export async function sendPayload(
     const before = Date.now();
     const res = await axios.post(url, payload, {
       headers: {
-        "x-webhook-key": apiKey,
         "user-agent": "Metriport API",
         "x-metriport-signature": hmac,
       },


### PR DESCRIPTION
Ref. https://github.com/metriport/metriport/issues/1151

### Dependencies

none

### Description

Remove the deprecated `x-webhook-key` header.

### Testing

- Local
  - none
- Staging
  - [ ] Webhook processed
- Sandbox
  - none
- Production
  - none

### Release Plan

- [x] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (deprecates a feature that needs to be communicated with customers)
- [ ] Merge this
