### PR TITLE
1040 Proper handler for 404

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -10,12 +10,13 @@ import helmet from "helmet";
 import { initEvents } from "./event";
 import { initFeatureFlags } from "./external/aws/app-config";
 import initDB from "./models/db";
+import { VERSION_HEADER_NAME } from "./routes/header";
 import { errorHandler } from "./routes/helpers/default-error-handler";
+import { notFoundHandlers } from "./routes/helpers/not-found-handler";
 import mountRoutes from "./routes/index";
 import { initSentry, isSentryEnabled } from "./sentry";
 import { Config } from "./shared/config";
 import { isClientError } from "./shared/http";
-import { VERSION_HEADER_NAME } from "./routes/header";
 
 const app: Application = express();
 const version = Config.getVersion();
@@ -57,6 +58,8 @@ if (isSentryEnabled()) {
   );
 }
 app.use(errorHandler);
+
+app.all("*", ...notFoundHandlers);
 
 initEvents();
 

--- a/packages/api/src/routes/helpers/not-found-handler.ts
+++ b/packages/api/src/routes/helpers/not-found-handler.ts
@@ -1,0 +1,19 @@
+import { NextFunction, Request, Response } from "express";
+import { Config } from "../../shared/config";
+import { requestLogger } from "./request-logger";
+
+export const notFoundHandlers = [
+  (req: Request, res: Response, next: NextFunction): void => {
+    if (isLogClientErrors(req)) return requestLogger(req, res, next);
+    return next();
+  },
+  (req: Request, res: Response) => {
+    return res.status(404).send({ message: "Not Found" });
+  },
+];
+
+function isLogClientErrors(req: Request): boolean | undefined {
+  if (Config.isProdEnv() || Config.isSandbox()) return false;
+  const raw = req.headers["x-log-client-errors"];
+  return raw === "true";
+}

--- a/packages/api/src/routes/helpers/report-client-errors.ts
+++ b/packages/api/src/routes/helpers/report-client-errors.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 
-const reportClientErrorsProp = "reportClientErrors";
+const reportClientErrorsProp = "x-report-client-errors";
 
 export function setReportClientErrors(req: Request): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -12,7 +12,7 @@ export function isReportClientErrors(req: Request): boolean | undefined {
 }
 
 /**
- * Middleware to report client errors to Sentry.
+ * Middleware to report client errors.
  *
  * Under the hood it just sets a property on the request object, so it can be
  * checked later on by the default error handler - should an error occur.


### PR DESCRIPTION
Ref. metriport/metriport-internal#367

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport/pull/2389

### Description

Proper handler for 404s (return JSON based response).

### Testing

- Local
  - [x] On 404 returns JSON `{  "message": "Not Found" }` response instead of HTML
  - [x] On 404 doesn't log by default
  - [x] On 404 logs when header `x-log-client-errors` is set
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
