### PR TITLE
PATCH RELEASE 2024_07_09_2 - PUT consolidated

### DIFF
--- a/packages/api/src/command/medical/patient/handle-data-contributions.ts
+++ b/packages/api/src/command/medical/patient/handle-data-contributions.ts
@@ -58,22 +58,19 @@ export async function handleDataContribution({
     fhirBundle: validatedBundle,
   });
 
-  if (hasCompositionResource(validatedBundle)) {
-    const converted = await convertFhirToCda({
-      cxId,
-      validatedBundle,
-    });
-    await uploadCdaDocuments({
-      cxId,
-      patientId,
-      cdaBundles: converted,
-      organization: fhirOrganization,
-      docId: requestId,
-    });
+  if (!Config.isSandbox()) {
+    if (hasCompositionResource(validatedBundle)) {
+      const converted = await convertFhirToCda({ cxId, validatedBundle });
+      uploadCdaDocuments({
+        cxId,
+        patientId,
+        cdaBundles: converted,
+        organization: fhirOrganization,
+        docId: requestId,
+      });
+    }
+    processCcdRequest(patient, fhirOrganization);
   }
-
-  // TODO: To minimize generating CCDs, make it a delayed job (run it ~5min after it was initiated, only once for all requests within that time window)
-  if (!Config.isSandbox()) processCcdRequest(patient, fhirOrganization);
 
   return consolidatedDataUploadResults;
 }


### PR DESCRIPTION
refs. metriport/metriport-internal#1972

### Description
- No CCD gen on sandbox
- No CCD gen await on the `PUT /consolidated` route

### Testing
- Local
  - [x] Works locally
  - [x] When CCD throws an error, the route still responds fine 👌 
- Sandbox
  - [ ] TBD


### Release Plan
- :warning: Points to `master`
- [ ] Merge this
