### PR TITLE
1040 Add termination protection to infra stacks

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -72,6 +72,8 @@ export class APIStack extends Stack {
     const awsAccount = props.env?.account;
     if (!awsAccount) throw new Error("Missing AWS account");
 
+    this.terminationProtection = true;
+
     //-------------------------------------------
     // Secrets
     //-------------------------------------------

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -30,6 +30,8 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
   constructor(scope: Construct, id: string, props: IHEGatewayV2LambdasNestedStackProps) {
     super(scope, id, props);
 
+    this.terminationProtection = true;
+
     const iheResponsesBucket = new s3.Bucket(this, "IHEResponsesBucket", {
       bucketName: props.iheResponsesBucketName,
       publicReadAccess: false,

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -40,6 +40,8 @@ export class LambdasNestedStack extends NestedStack {
   constructor(scope: Construct, id: string, props: LambdasNestedStackProps) {
     super(scope, id, props);
 
+    this.terminationProtection = true;
+
     this.lambdaLayers = setupLambdasLayers(this);
 
     this.cdaToVisualizationLambda = this.setupCdaToVisualization({

--- a/packages/infra/lib/location-services-stack.ts
+++ b/packages/infra/lib/location-services-stack.ts
@@ -10,6 +10,9 @@ interface LocationServicesStackProps extends StackProps {
 export class LocationServicesStack extends Stack {
   constructor(scope: Construct, id: string, props: LocationServicesStackProps) {
     super(scope, id, props);
+
+    this.terminationProtection = true;
+
     //-------------------------------------------
     // API Gateway
     //-------------------------------------------

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -20,6 +20,8 @@ export class SecretsStack extends Stack {
   constructor(scope: Construct, id: string, props: SecretStackProps) {
     super(scope, id, props);
 
+    this.terminationProtection = true;
+
     //-------------------------------------------
     // Init secrets for the infra stack
     //-------------------------------------------


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Description

While helping to look into [this issue](https://metriport.slack.com/archives/C04DMKE9DME/p1720617675479379), I noticed [this](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-protect-stacks.html): there's a termination protection flag on the CloudFormation stacks.

This adds termination protection so we minimize the risk of someone accidentally terminating/removing an AWS stack.

### Testing

- Local
  - none
- Staging
  - [ ] Termination protection added to each stack
- Sandbox
  - none
- Production
  - [ ] Termination protection added to each stack

### Release Plan

- [ ] Merge this
- [ ] Replicate this to the internal repo as well
