### PR TITLE
feat(core): adding logging to inbound requests

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dq-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dq-request.ts
@@ -6,6 +6,7 @@ import { Slot } from "../../../schema";
 import { extractText } from "../../../utils";
 import { convertSamlHeaderToAttributes, extractTimestamp } from "../../shared";
 import { iti38RequestSchema } from "./schema";
+import { out } from "../../../../../../util/log";
 
 const externalGatewayPatientRegex = /(.+)\^\^\^(.+)/i;
 const externalGatewayIdRegex = /'/g;
@@ -27,7 +28,8 @@ function extractExternalGatewayPatient(slots: Slot[]): XCPDPatientId {
 }
 
 export function processInboundDqRequest(request: string): InboundDocumentQueryReq {
-  console.log(`Inbound request: ${JSON.stringify(request)}`);
+  const log = out("Inbound DQ Request").log;
+  log(JSON.stringify(request));
   try {
     const parser = new XMLParser({
       ignoreAttributes: false,
@@ -53,7 +55,7 @@ export function processInboundDqRequest(request: string): InboundDocumentQueryRe
     };
   } catch (error) {
     const msg = "Failed to parse ITI-38 request";
-    console.log(`${msg}: Error - ${errorToString(error)}`);
+    log(`${msg}: Error - ${errorToString(error)}`);
     throw new Error(`: ${error}`);
   }
 }

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dq-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dq-request.ts
@@ -56,6 +56,6 @@ export function processInboundDqRequest(request: string): InboundDocumentQueryRe
   } catch (error) {
     const msg = "Failed to parse ITI-38 request";
     log(`${msg}: Error - ${errorToString(error)}`);
-    throw new Error(`: ${error}`);
+    throw new Error(`${msg}: ${error}`);
   }
 }

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dq-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dq-request.ts
@@ -1,11 +1,11 @@
-import { XMLParser } from "fast-xml-parser";
-import { toArray } from "@metriport/shared";
 import { InboundDocumentQueryReq, XCPDPatientId } from "@metriport/ihe-gateway-sdk";
-import { iti38RequestSchema } from "./schema";
-import { convertSamlHeaderToAttributes, extractTimestamp } from "../../shared";
-import { extractText } from "../../../utils";
-import { Slot } from "../../../schema";
+import { errorToString, toArray } from "@metriport/shared";
+import { XMLParser } from "fast-xml-parser";
 import { stripUrnPrefix } from "../../../../../../util/urn";
+import { Slot } from "../../../schema";
+import { extractText } from "../../../utils";
+import { convertSamlHeaderToAttributes, extractTimestamp } from "../../shared";
+import { iti38RequestSchema } from "./schema";
 
 const externalGatewayPatientRegex = /(.+)\^\^\^(.+)/i;
 const externalGatewayIdRegex = /'/g;
@@ -27,6 +27,7 @@ function extractExternalGatewayPatient(slots: Slot[]): XCPDPatientId {
 }
 
 export function processInboundDqRequest(request: string): InboundDocumentQueryReq {
+  console.log(`Inbound request: ${JSON.stringify(request)}`);
   try {
     const parser = new XMLParser({
       ignoreAttributes: false,
@@ -51,6 +52,8 @@ export function processInboundDqRequest(request: string): InboundDocumentQueryRe
       ),
     };
   } catch (error) {
-    throw new Error(`Failed to parse ITI-38 request: ${error}`);
+    const msg = "Failed to parse ITI-38 request";
+    console.log(`${msg}: Error - ${errorToString(error)}`);
+    throw new Error(`: ${error}`);
   }
 }

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dr-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dr-request.ts
@@ -46,6 +46,6 @@ export function processInboundDrRequest(request: string): InboundDocumentRetriev
   } catch (error) {
     const msg = "Failed to parse ITI-39 request";
     log(`${msg}: Error - ${errorToString(error)}`);
-    throw new Error(`: ${error}`);
+    throw new Error(`${msg}: ${error}`);
   }
 }

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dr-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dr-request.ts
@@ -1,6 +1,7 @@
 import { DocumentReference, InboundDocumentRetrievalReq } from "@metriport/ihe-gateway-sdk";
 import { errorToString, toArray } from "@metriport/shared";
 import { XMLParser } from "fast-xml-parser";
+import { out } from "../../../../../../util/log";
 import { stripUrnPrefix } from "../../../../../../util/urn";
 import { extractText } from "../../../utils";
 import { convertSamlHeaderToAttributes, extractTimestamp } from "../../shared";
@@ -15,7 +16,8 @@ function extractDocumentReferences(documentRequest: DocumentRequest[]): Document
 }
 
 export function processInboundDrRequest(request: string): InboundDocumentRetrievalReq {
-  console.log(`Inbound DR request: ${JSON.stringify(request)}`);
+  const log = out("Inbound DR Request").log;
+  log(JSON.stringify(request));
   try {
     const parser = new XMLParser({
       ignoreAttributes: false,
@@ -43,7 +45,7 @@ export function processInboundDrRequest(request: string): InboundDocumentRetriev
     };
   } catch (error) {
     const msg = "Failed to parse ITI-39 request";
-    console.log(`${msg}: Error - ${errorToString(error)}`);
+    log(`${msg}: Error - ${errorToString(error)}`);
     throw new Error(`: ${error}`);
   }
 }

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dr-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dr-request.ts
@@ -1,10 +1,10 @@
+import { DocumentReference, InboundDocumentRetrievalReq } from "@metriport/ihe-gateway-sdk";
+import { errorToString, toArray } from "@metriport/shared";
 import { XMLParser } from "fast-xml-parser";
-import { toArray } from "@metriport/shared";
-import { iti39RequestSchema, DocumentRequest } from "./schema";
-import { InboundDocumentRetrievalReq, DocumentReference } from "@metriport/ihe-gateway-sdk";
-import { convertSamlHeaderToAttributes, extractTimestamp } from "../../shared";
 import { stripUrnPrefix } from "../../../../../../util/urn";
 import { extractText } from "../../../utils";
+import { convertSamlHeaderToAttributes, extractTimestamp } from "../../shared";
+import { DocumentRequest, iti39RequestSchema } from "./schema";
 
 function extractDocumentReferences(documentRequest: DocumentRequest[]): DocumentReference[] {
   return documentRequest.map(req => ({
@@ -15,6 +15,7 @@ function extractDocumentReferences(documentRequest: DocumentRequest[]): Document
 }
 
 export function processInboundDrRequest(request: string): InboundDocumentRetrievalReq {
+  console.log(`Inbound DR request: ${JSON.stringify(request)}`);
   try {
     const parser = new XMLParser({
       ignoreAttributes: false,
@@ -41,6 +42,8 @@ export function processInboundDrRequest(request: string): InboundDocumentRetriev
       ),
     };
   } catch (error) {
-    throw new Error(`Failed to parse ITI-39 request: ${error}`);
+    const msg = "Failed to parse ITI-39 request";
+    console.log(`${msg}: Error - ${errorToString(error)}`);
+    throw new Error(`: ${error}`);
   }
 }

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/process/xcpd-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/process/xcpd-request.ts
@@ -1,11 +1,12 @@
 import { XMLParser } from "fast-xml-parser";
 import dayjs from "dayjs";
 import { PatientResource, InboundPatientDiscoveryReq } from "@metriport/ihe-gateway-sdk";
-import { toArray } from "@metriport/shared";
+import { errorToString, toArray } from "@metriport/shared";
 import { Iti55Request, iti55RequestSchema } from "./schema";
 import { convertSamlHeaderToAttributes, extractTimestamp } from "../../shared";
 import { extractText } from "../../../utils";
 import { mapIheGenderToFhir } from "../../../../shared";
+import { out } from "../../../../../../util/log";
 
 export function transformIti55RequestToPatientResource(
   iti55Request: Iti55Request
@@ -49,7 +50,9 @@ export function transformIti55RequestToPatientResource(
 
   return patientResource;
 }
+
 export function processInboundXcpdRequest(request: string): InboundPatientDiscoveryReq {
+  const log = out("Inbound XCPD Request").log;
   const parser = new XMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: "_",
@@ -73,6 +76,8 @@ export function processInboundXcpdRequest(request: string): InboundPatientDiscov
       ),
     };
   } catch (error) {
-    throw new Error(`Failed to parse ITI-55 request: ${error}`);
+    const msg = "Failed to parse ITI-55 request";
+    log(`${msg}: Error - ${errorToString(error)}`);
+    throw new Error(`${msg}: ${error}`);
   }
 }


### PR DESCRIPTION
refs. metriport/metriport-internal#1766

### Description

- Logging the inbound DQ and DR requests
- Logging the errors

### Testing
- Local
  - [x] None
- Staging
  - [ ] Send an inbound DQ and see how it prints

### Release Plan
- [ ] Merge this
