### PR TITLE
PATCH: base64 encoded inbound reqs

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/process/schema.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/process/schema.ts
@@ -21,13 +21,11 @@ export const QueryByParameterSchema = z.object({
           _code: genderCodeSchema,
         })
         .optional(),
-      semanticsText: z.literal("LivingSubject.administrativeGender"),
     }),
     livingSubjectBirthTime: z.object({
       value: z.object({
         _value: z.string(),
       }),
-      semanticsText: z.literal("LivingSubject.birthTime"),
     }),
     livingSubjectId: z
       .object({
@@ -37,19 +35,16 @@ export const QueryByParameterSchema = z.object({
             _root: z.string(),
           })
         ).optional(),
-        semanticsText: z.literal("LivingSubject.id"),
       })
       .optional(),
     livingSubjectName: schemaOrArray(
       z.object({
         value: nameSchema,
-        semanticsText: z.literal("LivingSubject.name").optional(),
       })
     ),
     patientAddress: z
       .object({
         value: schemaOrArrayOrEmpty(addressSchema).optional(),
-        semanticsText: z.literal("Patient.addr").optional(),
       })
       .optional(),
     patientTelecom: z
@@ -59,7 +54,6 @@ export const QueryByParameterSchema = z.object({
             _value: z.string(),
           })
         ).optional(),
-        semanticsText: z.literal("Patient.telecom"),
       })
       .optional(),
     principalCareProviderId: z
@@ -70,7 +64,6 @@ export const QueryByParameterSchema = z.object({
             _root: z.string(),
           })
         ).optional(),
-        semanticsText: z.literal("AssignedProvider.id"),
       })
       .optional(),
   }),

--- a/packages/lambdas/src/ihe-gateway-v2-inbound-document-query.ts
+++ b/packages/lambdas/src/ihe-gateway-v2-inbound-document-query.ts
@@ -21,7 +21,10 @@ export async function handler(event: APIGatewayProxyEventV2) {
   try {
     if (!event.body) return buildResponse(400, { message: "The request body is empty" });
     try {
-      const dqRequest: InboundDocumentQueryReq = await processInboundDqRequest(event.body);
+      const body = event.isBase64Encoded
+        ? Buffer.from(event.body, "base64").toString()
+        : event.body;
+      const dqRequest: InboundDocumentQueryReq = await processInboundDqRequest(body);
       const result: InboundDocumentQueryResp = await processInboundDq(dqRequest, apiUrl);
       const xmlResponse = createInboundDqResponse(result);
 

--- a/packages/lambdas/src/ihe-gateway-v2-inbound-patient-discovery.ts
+++ b/packages/lambdas/src/ihe-gateway-v2-inbound-patient-discovery.ts
@@ -29,7 +29,10 @@ export async function handler(event: APIGatewayProxyEventV2) {
     if (!event.body) return buildResponse(400, { message: "The request body is empty" });
 
     try {
-      const pdRequest: InboundPatientDiscoveryReq = await processInboundXcpdRequest(event.body);
+      const body = event.isBase64Encoded
+        ? Buffer.from(event.body, "base64").toString()
+        : event.body;
+      const pdRequest: InboundPatientDiscoveryReq = await processInboundXcpdRequest(body);
       const result: InboundPatientDiscoveryResp = await processInboundXcpd(pdRequest, mpi);
       const xmlResponse = createInboundXcpdResponse({
         request: pdRequest,


### PR DESCRIPTION
Ticket: #[2223](https://github.com/metriport/metriport-internal/issues/1766)

### Description

- b64 decode requests if they are b64 encoded. 
- remove part of saml schema that others dont seem to follow and doesnt matter for processing requests
- logs for [context](https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252FIHEInboundPatientDiscoveryV2Lambda/log-events/2024$252F07$252F11$252F$255B$2524LATEST$255D6906ff59fe6c4dfca573e6a05036e74d$3FfilterPattern$3D$2522Failed+to+parse+ITI-55+request$253A+Error+-+$255B$2522)

### Release Plan

- [ ] Merge this
