### PR TITLE
PATCH RELEASE - Correct Medication Statement Status

### DIFF
--- a/packages/fhir-converter/src/templates/cda/ValueSet/MedicationStatementStatus.hbs
+++ b/packages/fhir-converter/src/templates/cda/ValueSet/MedicationStatementStatus.hbs
@@ -30,10 +30,16 @@
   {{#with (toLower code) as |normalizedCode|}}
     {{#if normalizedCode}}
       {{#if (or (eq normalizedCode "aborted") (eq normalizedCode "discontinued"))}}
-        "entered-in-error"
+        "stopped"
       {{else if (eq normalizedCode "stopped")}}
-        "entered-in-error"
+        "stopped"
       {{else if (eq normalizedCode "failed")}}
+        "stopped"
+      {{else if (eq normalizedCode "in-progress")}}
+        "on-hold"
+      {{else if (eq normalizedCode "active")}}
+        "on-hold"
+      {{else if (eq normalizedCode "not-done")}}
         "entered-in-error"
       {{else if (eq normalizedCode "entered-in-error")}}
         "entered-in-error"
@@ -41,26 +47,14 @@
         "entered-in-error"
       {{else if (eq normalizedCode "nullified")}}
         "entered-in-error"
-      {{else if (eq normalizedCode "draft")}}
-        "draft"
       {{else if (eq normalizedCode "on-hold")}}
-        "draft"
-      {{else if (eq normalizedCode "in-progress")}}
-        "draft"
-      {{else if (eq normalizedCode "active")}}
-        "draft"
-      {{else if (eq normalizedCode "not-done")}}
-        "draft"
+        "on-hold"
       {{else if (eq normalizedCode "suspended")}}
-        "draft"
-      {{else if (eq normalizedCode "recorded")}}
-        "recorded"
-      {{else if (eq normalizedCode "record")}}
-        "recorded"
+        "on-hold"
       {{else if (eq normalizedCode "complete")}}
-        "recorded"
+        "completed"
       {{else if (eq normalizedCode "completed")}}
-        "recorded"
+        "completed"
       {{else}}
         "unknown"
       {{/if}}

--- a/packages/fhir-converter/src/templates/cda/ValueSet/MedicationStatementStatus.hbs
+++ b/packages/fhir-converter/src/templates/cda/ValueSet/MedicationStatementStatus.hbs
@@ -40,7 +40,7 @@
       {{else if (eq normalizedCode "active")}}
         "on-hold"
       {{else if (eq normalizedCode "not-done")}}
-        "entered-in-error"
+        "on-hold"
       {{else if (eq normalizedCode "entered-in-error")}}
         "entered-in-error"
       {{else if (eq normalizedCode "error")}}

--- a/packages/fhir-converter/src/templates/cda/ValueSet/MedicationStatementStatus.hbs
+++ b/packages/fhir-converter/src/templates/cda/ValueSet/MedicationStatementStatus.hbs
@@ -30,31 +30,37 @@
   {{#with (toLower code) as |normalizedCode|}}
     {{#if normalizedCode}}
       {{#if (or (eq normalizedCode "aborted") (eq normalizedCode "discontinued"))}}
-        "stopped"
+        "entered-in-error"
       {{else if (eq normalizedCode "stopped")}}
-        "stopped"
+        "entered-in-error"
       {{else if (eq normalizedCode "failed")}}
-        "stopped"
-      {{else if (eq normalizedCode "in-progress")}}
-        "in-progress"
-      {{else if (eq normalizedCode "active")}}
-        "in-progress"
-      {{else if (eq normalizedCode "not-done")}}
-        "not-done"
+        "entered-in-error"
       {{else if (eq normalizedCode "entered-in-error")}}
         "entered-in-error"
       {{else if (eq normalizedCode "error")}}
         "entered-in-error"
       {{else if (eq normalizedCode "nullified")}}
         "entered-in-error"
+      {{else if (eq normalizedCode "draft")}}
+        "draft"
       {{else if (eq normalizedCode "on-hold")}}
-        "on-hold"
+        "draft"
+      {{else if (eq normalizedCode "in-progress")}}
+        "draft"
+      {{else if (eq normalizedCode "active")}}
+        "draft"
+      {{else if (eq normalizedCode "not-done")}}
+        "draft"
       {{else if (eq normalizedCode "suspended")}}
-        "on-hold"
+        "draft"
+      {{else if (eq normalizedCode "recorded")}}
+        "recorded"
+      {{else if (eq normalizedCode "record")}}
+        "recorded"
       {{else if (eq normalizedCode "complete")}}
-        "completed"
+        "recorded"
       {{else if (eq normalizedCode "completed")}}
-        "completed"
+        "recorded"
       {{else}}
         "unknown"
       {{/if}}

--- a/packages/fhir-converter/src/templates/cda/ValueSet/MedicationStatementStatus.hbs
+++ b/packages/fhir-converter/src/templates/cda/ValueSet/MedicationStatementStatus.hbs
@@ -36,11 +36,11 @@
       {{else if (eq normalizedCode "failed")}}
         "stopped"
       {{else if (eq normalizedCode "in-progress")}}
-        "on-hold"
+        "active"
       {{else if (eq normalizedCode "active")}}
-        "on-hold"
+        "active"
       {{else if (eq normalizedCode "not-done")}}
-        "on-hold"
+        "active"
       {{else if (eq normalizedCode "entered-in-error")}}
         "entered-in-error"
       {{else if (eq normalizedCode "error")}}


### PR DESCRIPTION
Ref. metriport/metriport#2295

Ticket: #2295

### Dependencies

- Upstream: none
- Downstream: none

### Description

Remove invalid status values for medication statement -[context](https://metriport.slack.com/archives/C04T256DQPQ/p1720797061650859?thread_ts=1719935155.694079&cid=C04T256DQPQ)

### Testing

_[Regular PRs:]_

- Local
  - [x] Works with validator
- Production
  - [ ] Monitor

### Release Plan


- :warning: Points to `master`
- reprocess docs
- [ ] Merge this
