### PR TITLE
1040 Store pre FHIR conversion payload on S3

### DIFF
--- a/packages/core/src/util/mime.ts
+++ b/packages/core/src/util/mime.ts
@@ -9,10 +9,11 @@ import { contentType, extension } from "mime-types";
  * See: https://en.wikipedia.org/wiki/XML_and_MIME
  */
 export function isMimeTypeXML(mimeType?: string | undefined | null): boolean {
-  return mimeType === "application/xml" || mimeType === "text/xml";
+  return mimeType === XML_APP_MIME_TYPE || mimeType === XML_TXT_MIME_TYPE;
 }
 
 // define exportable constants for all the different file types
+export const FHIR_APP_MIME_TYPE = "application/fhir+json";
 export const JSON_APP_MIME_TYPE = "application/json";
 export const JSON_TXT_MIME_TYPE = "text/json";
 export const JSON_FILE_EXTENSION = ".json";


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Store pre FHIR conversion payload on s3 - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1720806786409359?thread_ts=1719940286.197409&cid=C04T256DQPQ)

### Testing

- Local
  - none
- Staging
  - [ ] FHIR conversion works and results stored on the FHIR server
  - [ ] pre-conversion payload stored on S3
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
