### PR TITLE
1973 Adj server timeout and keep alive, and scaling/db pool settings

### DIFF
--- a/packages/api/src/models/db.ts
+++ b/packages/api/src/models/db.ts
@@ -125,6 +125,7 @@ function getDbPoolSettings(): DbPoolProps {
     }
   }
   const parsedProps = getAndParseSettings();
+  // https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html#aurora-serverless-v2.max-connections
   const max = getOptionalInteger(parsedProps.max) ?? 500;
   const min = getOptionalInteger(parsedProps.min) ?? 50;
   const acquire = getOptionalInteger(parsedProps.acquire) ?? 10_000;

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -49,6 +49,12 @@ export class Config {
     return getEnvVarOrFail("AWS_REGION");
   }
 
+  static getLbTimeoutInMillis(): number | undefined {
+    const timeoutAsString = getEnvVar("LB_TIMEOUT_IN_MILLIS");
+    if (timeoutAsString) return parseInt(timeoutAsString);
+    return undefined;
+  }
+
   /**
    * @deprecated Use core's Config instead
    */

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -86,7 +86,10 @@ type EnvConfigBase = {
        * @see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html#aurora-serverless-v2.max-connections
        */
       max: number;
-      /** Minimum number of connections in pool. Default is 0. */
+      /**
+       * Minimum number of connections in pool. Default is 0.
+       * @see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html#aurora-serverless-v2.max-connections
+       */
       min: number;
       /** The maximum time, in milliseconds, that pool will try to get connection before throwing error. */
       acquire: number;

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -37,6 +37,8 @@ interface ApiServiceProps extends StackProps {
   version: string | undefined;
 }
 
+const loadBalancerIdleTimeout = Duration.minutes(10);
+
 export function createAPIService({
   stack,
   props,
@@ -160,6 +162,7 @@ export function createAPIService({
           ENV_TYPE: props.config.environmentType, // staging, production, sandbox
           ...(props.version ? { METRIPORT_VERSION: props.version } : undefined),
           AWS_REGION: props.config.region,
+          LB_TIMEOUT_IN_MILLIS: loadBalancerIdleTimeout.toMilliseconds().toString(),
           DB_READ_REPLICA_ENDPOINT: dbReadReplicaEndpointAsString,
           DB_POOL_SETTINGS: dbPoolSettings,
           TOKEN_TABLE_NAME: dynamoDBTokenTable.tableName,
@@ -241,7 +244,7 @@ export function createAPIService({
       protocol: ApplicationProtocol.HTTP,
       listenerPort,
       publicLoadBalancer: false,
-      idleTimeout: Duration.minutes(10),
+      idleTimeout: loadBalancerIdleTimeout,
     }
   );
   const serverAddress = fargateService.loadBalancer.loadBalancerDnsName;


### PR DESCRIPTION
Ref. metriport/metriport-internal#1973

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1997
- Downstream: none

### Description

Changes:
- Set server timeout and keep alive to match LB's.
- Adjust OSS api scaling 

Context: [link](https://metriport.slack.com/archives/C04DMKE9DME/p1720815510266579?thread_ts=1720657415.437769&cid=C04DMKE9DME)

### Testing

- Local
  - [x] Hit staging w/ 1,000 requests distributed over 100 threads, 3 times
      ```
      date && time ab -c 100 -n 100000 -H ‘x-api-key: …’ $oss-api-lb/medical/v1/organization && date
      ```
      - 1st: 6 failed requests
      - 2nd: 2 failed requests
      - 3rd: 0 failed requests
  - [x] Hit staging w/ 100,000 requests distributed over 100 threads, once
      ```
      date && time ab -c 100 -n 100000 -H ‘x-api-key: …’ $oss-api-lb/medical/v1/organization && date
      ```
      - 59 failed requests
- Staging
  - [ ] Hit staging w/ 1,000 requests distributed over 100 threads, 3 times
      ```
      date && time ab -c 100 -n 100000 -H ‘x-api-key: …’ $oss-api-lb/medical/v1/organization && date
      ```
      - 1st: 
      - 2nd: 
      - 3rd: 
  - [ ] Hit staging w/ 100,000 requests distributed over 100 threads, once
      ```
      date && time ab -c 100 -n 100000 -H ‘x-api-key: …’ $oss-api-lb/medical/v1/organization && date
      ```
      - 
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge upstream
- [ ] Merge this
