### PR TITLE
1040 Don't stringify pre-convert payload when storing on S3

### DIFF
--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -463,7 +463,7 @@ async function storePreConversionPayloadInS3({
           .upload({
             Bucket: conversionResultBucketName,
             Key: preProcessedFilename,
-            Body: JSON.stringify(payload),
+            Body: payload,
             ContentType: XML_APP_MIME_TYPE,
           })
           .promise(),


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2463
- Downstream: none

### Description

Don't stringify pre-convert payload when storing on S3

### Testing

- Local
  - none
- Staging
  - [ ] pre-conversion payload stored on S3
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
