### PR TITLE
1969 Add propelauth config

### DIFF
--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -202,6 +202,12 @@ type EnvConfigBase = {
 
 export type EnvConfigNonSandbox = EnvConfigBase & {
   environmentType: EnvType.staging | EnvType.production;
+  propelAuth: {
+    authUrl: string;
+    secrets: {
+      PROPELAUTH_API_KEY: string;
+    };
+  };
   fhirToMedicalLambda: {
     nodeRuntimeArn: string;
   };

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -34,6 +34,12 @@ export const config: EnvConfigNonSandbox = {
   },
   loadBalancerDnsName: "<your-load-balancer-dns-name>",
   logArn: "<your-log-arn>",
+  propelAuth: {
+    authUrl: "url-to-propel-auth",
+    secrets: {
+      PROPELAUTH_API_KEY: "key-name",
+    },
+  },
   fhirToMedicalLambda: {
     nodeRuntimeArn: "arn:aws:lambda:<region>::runtime:<id>",
   },


### PR DESCRIPTION
Ref. metriport/metriport-internal#1969

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/1999
- Downstream: none

### Description

Add propelauth config - [context](https://metriport.slack.com/archives/C04FZ9859FZ/p1720924058905129?thread_ts=1720911320.166369&cid=C04FZ9859FZ)

### Testing

- Local
  - [x] develop compiles
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
