### PR TITLE
fix(cicd): add install deps for fhir converter

### DIFF
--- a/.github/workflows/_deploy-cdk.yml
+++ b/.github/workflows/_deploy-cdk.yml
@@ -138,6 +138,11 @@ jobs:
       - name: Build root dependencies
         run: npm run build:cloud
         working-directory: "metriport/"
+
+      - name: Build fhir converter dependencies
+        run: npm install --only=production --no-fund --no-optional --no-audit
+        working-directory: "metriport/packages/fhir-converter"
+
       - name: Lambdas build shared layer
         run: npm run prep-deploy
         working-directory: "metriport/packages/lambdas/"


### PR DESCRIPTION
Refs: #[2004](https://github.com/metriport/metriport-internal/issues/2004)

### Description

- install deps so fhir converter tests in cicd run: [context](https://metriport.slack.com/archives/C04FZ9859FZ/p1721158108812649)

### Testing

- Staging:
- [x] branch to staging
- [ ] staging

### Release Plan

- [ ] Merge this