### PR TITLE
feat(api): request logger prints cxId, pt hie overview prints line2

### DIFF
--- a/packages/api/src/routes/helpers/request-logger.ts
+++ b/packages/api/src/routes/helpers/request-logger.ts
@@ -1,6 +1,7 @@
+import { getLocalStorage } from "@metriport/core/util/local-storage";
 import { NextFunction, Request, Response } from "express";
 import { customAlphabet } from "nanoid";
-import { getLocalStorage } from "@metriport/core/util/local-storage";
+import { getCxId } from "../util";
 import { analyzeRoute } from "./request-analytics";
 
 const asyncLocalStorage = getLocalStorage("reqId");
@@ -13,6 +14,8 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction): 
     const method = req.method;
     const url = req.baseUrl + req.path;
     const urlWithParams = replaceParamWithKey(url, req.params);
+
+    const cxId = getCxId(req);
     const query = req.query && Object.keys(req.query).length ? req.query : undefined;
     const params = req.params && Object.keys(req.params).length ? req.params : undefined;
 
@@ -22,7 +25,8 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction): 
       method,
       url,
       toString(params),
-      toString(query)
+      toString(query),
+      cxId ? `{"cxId":"${cxId}"}` : ""
     );
 
     const startHrTime = process.hrtime();

--- a/packages/api/src/routes/medical/dtos/linkDTO.ts
+++ b/packages/api/src/routes/medical/dtos/linkDTO.ts
@@ -77,6 +77,7 @@ function personToPatient(person: { id: string } & Person): PatientOnLinkDTO {
     address: [
       {
         addressLine1: address && address.line ? address.line[0] : "",
+        addressLine2: address && address.line ? address.line.slice(1).join(" ") : undefined,
         city: address && address.city ? address.city : "",
         state: address && address.state ? address.state : "",
         zip: address && address.zip ? address.zip : "",


### PR DESCRIPTION
refs. metriport/metriport-internal#799

### Description
- Request logger now prints the `cxId`, so it's easier to filter the logs
- The internal `Patient HIE Overview` endpoint now prints `addressLine2` for a more thorough pt demos comparison

### Testing
- Local
  - [x] Triggered normal and internal request to see that the cxId printing looks good
  - [x] Made sure the function for Pt HIE Overview works as expected - [link](https://www.typescriptlang.org/play/?#code/MYewdgzgLgBAhgEwQJwKYQgRhgXhgbwCgYSYAbASzFQC4YBtAImjVVkRXQkYF1CBfANyFCoSCDKoAdGRABzABSMOaDJhlVUmRgBp4SVVhgAyY-s5qN1GAH5zh9ZWr0ADDxh1GjAJSjwECWlZRWUDLkdNACZde3CTMxVwq1RbWMsnaQhKYFQFTG8pACsQKiUYHw8YAFcwBFQAM00EXz9IdjCMSNwCYlIMuiYWVDY07j1GGopYMCqAWwAjVGQY5hBZtgALKjkYVDIIVF4BYVaAyRl5JUTO5O09a4gu01HI5NSH14zXd08fU8CLiEPslovcOo94i83nZgRkpFkKDk8gViqVGOVvJUanVGtRmkA)

### Screenshots
Normal routes: 
<img width="1398" alt="Screenshot 2024-07-16 at 2 47 17 PM" src="https://github.com/user-attachments/assets/935e5375-0e93-467d-8a77-ae8c20f9e0cb">

Internal routes (unchanged cuz `cxId` is already often in the `query params`:
<img width="821" alt="Screenshot 2024-07-16 at 2 48 20 PM" src="https://github.com/user-attachments/assets/198d7e31-e687-4c4a-897a-40a8bfd0f05b">


### Release Plan
- [ ] Merge this
