### PR TITLE
1040 Fix concurrency prevention to not have the job id

### DIFF
--- a/.github/workflows/_deploy-api.yml
+++ b/.github/workflows/_deploy-api.yml
@@ -52,7 +52,7 @@ jobs:
     # https://serverlessfirst.com/emails/how-to-prevent-concurrent-deployments-of-serverless-stacks-in-github-actions/
     # TODO Consider the solution here: https://github.com/tj-actions/aws-cdk/blob/main/action.yml
     concurrency:
-      group: ${{ format('{0}-{1}-{2}', github.job, inputs.script_name, inputs.deploy_env) }}
+      group: ${{ format('{0}-{1}', inputs.script_name, inputs.deploy_env) }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy_env }}
     steps:

--- a/.github/workflows/_deploy-cdk.yml
+++ b/.github/workflows/_deploy-cdk.yml
@@ -63,7 +63,7 @@ jobs:
     # https://serverlessfirst.com/emails/how-to-prevent-concurrent-deployments-of-serverless-stacks-in-github-actions/
     # TODO Consider the solution here: https://github.com/tj-actions/aws-cdk/blob/main/action.yml
     concurrency:
-      group: ${{ format('{0}-{1}-{2}', github.job, inputs.cdk_stack, inputs.deploy_env) }}
+      group: ${{ format('{0}-{1}', inputs.cdk_stack, inputs.deploy_env) }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy_env }}
     steps:

--- a/.github/workflows/_restart-ecs.yml
+++ b/.github/workflows/_restart-ecs.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: "restart-ecs.sh"
+      deploy_env:
+        required: true
+        type: string
+        description: "the environment we're deploying to, either 'staging', 'production', or 'sandbox'"
       ECR_REPO_URI:
         description: "The URI of the ECR repository to push the Docker image to"
         required: true
@@ -39,8 +43,9 @@ jobs:
     # https://serverlessfirst.com/emails/how-to-prevent-concurrent-deployments-of-serverless-stacks-in-github-actions/
     # TODO Consider the solution here: https://github.com/tj-actions/aws-cdk/blob/main/action.yml
     concurrency:
-      group: ${{ format('{0}-{1}-{2}', github.job, inputs.script_name, inputs.deploy_env) }}
+      group: ${{ format('{0}-{1}', inputs.script_name, inputs.deploy_env) }}
     runs-on: ubuntu-latest
+    environment: ${{ inputs.deploy_env }}
     steps:
       - name: Log Environment
         run: |

--- a/.github/workflows/restart_api_prod.yml
+++ b/.github/workflows/restart_api_prod.yml
@@ -7,6 +7,7 @@ jobs:
   restart:
     uses: ./.github/workflows/_restart-ecs.yml
     with:
+      deploy_env: "production"
       ECR_REPO_URI: ${{ vars.ECR_REPO_URI_PRODUCTION }}
       ECS_CLUSTER: ${{ vars.ECS_CLUSTER_PRODUCTION }}
       ECS_SERVICE: ${{ vars.ECS_SERVICE_PRODUCTION }}

--- a/.github/workflows/restart_api_sandbox.yml
+++ b/.github/workflows/restart_api_sandbox.yml
@@ -7,6 +7,7 @@ jobs:
   restart:
     uses: ./.github/workflows/_restart-ecs.yml
     with:
+      deploy_env: "sandbox"
       ECR_REPO_URI: ${{ vars.ECR_REPO_URI_SANDBOX }}
       ECS_CLUSTER: ${{ vars.ECS_CLUSTER_SANDBOX }}
       ECS_SERVICE: ${{ vars.ECS_SERVICE_SANDBOX }}

--- a/.github/workflows/restart_api_staging.yml
+++ b/.github/workflows/restart_api_staging.yml
@@ -7,6 +7,7 @@ jobs:
   restart:
     uses: ./.github/workflows/_restart-ecs.yml
     with:
+      deploy_env: "staging"
       ECR_REPO_URI: ${{ vars.ECR_REPO_URI_STAGING }}
       ECS_CLUSTER: ${{ vars.ECS_CLUSTER_STAGING }}
       ECS_SERVICE: ${{ vars.ECS_SERVICE_STAGING }}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

While implementing https://github.com/metriport/metriport/pull/2492, I've noticed these issues w/ the CICD workflows:

- the concurrency control is using the Job ID as part of the key, it means that we can have the same stack being attempted to be deployed by diff CICD runs, for example;
- we're not passing the deploy env to the reusable restart workflow.

So this:

- Fix concurrency prevention to not have the job id
- Pass the deploy env to the restart ecs workflow

### Testing

- Local
  - [ ] branch to staging works
- Staging
  - [ ] deploying to staging works
- Sandbox
  - [ ] deploying to sandbox works
- Production
  - [ ] deploying to production works

### Release Plan

- [ ] Merge this
