### PR TITLE
PATCH: Fix Webhook URL type

### DIFF
--- a/packages/api/src/command/medical/patient/get-consolidated-webhook.ts
+++ b/packages/api/src/command/medical/patient/get-consolidated-webhook.ts
@@ -71,7 +71,7 @@ export async function getConsolidatedWebhook({
   const webhookPayload: any = webhookData.payload;
 
   const url =
-    webhookPayload.patients?.[0].bundle?.entry?.[0].resource?.content?.[0].attachment?.url;
+    webhookPayload.patients?.[0]?.bundle?.entry?.[0]?.resource?.content?.[0]?.attachment?.url;
 
   if (!url) {
     return {


### PR DESCRIPTION
Ref. metriport/metriport#2485

Ticket: #2485

### Dependencies

- Upstream: none
- Downstream: none

### Description

Fix issue with getting resource from webhook

### Testing


- Local
  - [x] unit tests
- Production
  - [ ] monitor

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
