### PR TITLE
1932 Re-deploy API GW upon infra changes

### DIFF
--- a/.github/workflows/_redeploy_api-gw.yml
+++ b/.github/workflows/_redeploy_api-gw.yml
@@ -1,0 +1,55 @@
+name: Re-deploy API Gateway
+
+on:
+  workflow_call:
+    inputs:
+      deploy_env:
+        required: true
+        type: string
+        description: "the environment we're DEPLOYING to, either 'staging', 'production', or 'sandbox'"
+      AWS_REGION:
+        required: true
+        type: string
+        description: "the AWS region we're deploying to"
+      API_GW_ID:
+        required: true
+        type: string
+        description: "the API Gateway ID to redeploy after CDK deployment"
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+jobs:
+  redeploy-api-gw:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.deploy_env }}
+    steps:
+      - name: Log Environment
+        run: |
+          env
+        shell: bash
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Re-deploy API GW
+        run: |
+          ./packages/scripts/redeploy-api-gateway.sh
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ inputs.AWS_REGION }}
+          API_GW_ID: ${{ inputs.API_GW_ID }}

--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -40,13 +40,26 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
+  redeploy-api-gw:
+    uses: ./.github/workflows/_redeploy_api-gw.yml
+    needs: [infra-api-lambdas]
+    with:
+      deploy_env: "staging"
+      AWS_REGION: ${{ vars.API_REGION_STAGING }}
+      API_GW_ID: ${{ vars.API_GW_ID_STAGING }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
   e2e-tests:
     uses: ./.github/workflows/_e2e-tests.yml
-    needs: [api, infra-api-lambdas]
+    needs: [api, infra-api-lambdas, redeploy-api-gw]
     # run even if one of the dependencies didn't
     # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."
     # can't use ${{ ! failure() && contains(needs.*.result, 'success') }} because if anything that came before succeeded, even if not a direct dependency, it will run
-    if: ${{ !failure() && (needs.api.result == 'success' || needs.infra-api-lambdas.result == 'success') }}
+    if: ${{ !failure() && (needs.api.result == 'success' || needs.infra-api-lambdas.result == 'success' || needs.redeploy-api-gw.result == 'success') }}
     with:
       deploy_env: "staging"
       api_url: ${{ vars.API_URL_STAGING }}
@@ -65,4 +78,3 @@ jobs:
       CW_MEMBER_PRIVATE_KEY: ${{ secrets.CW_MEMBER_PRIVATE_KEY_STAGING }}
       CW_MEMBER_NAME: ${{ secrets.CW_MEMBER_NAME_STAGING }}
       CW_MEMBER_OID: ${{ secrets.CW_MEMBER_OID_STAGING }}
-    

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -137,13 +137,38 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
+  redeploy-api-gw-prod:
+    uses: ./.github/workflows/_redeploy_api-gw.yml
+    needs: [infra-api-lambdas]
+    with:
+      deploy_env: "production"
+      AWS_REGION: ${{ vars.API_REGION_PRODUCTION }}
+      API_GW_ID: ${{ vars.API_GW_ID_PRODUCTION }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  redeploy-api-gw-sandbox:
+    uses: ./.github/workflows/_redeploy_api-gw.yml
+    needs: [infra-api-lambdas-sandbox]
+    with:
+      deploy_env: "sandbox"
+      AWS_REGION: ${{ vars.API_REGION_SANDBOX }}
+      API_GW_ID: ${{ vars.API_GW_ID_SANDBOX }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
   e2e-tests:
     uses: ./.github/workflows/_e2e-tests.yml
-    needs: [api-sandbox, infra-api-lambdas-sandbox]
+    needs: [api-prod, infra-api-lambdas, redeploy-api-gw-prod]
     # run even if one of the dependencies didn't
     # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."
     # can't use ${{ ! failure() && contains(needs.*.result, 'success') }} because if anything that came before succeeded, even if not a direct dependency, it will run
-    if: ${{ !failure() && (needs.api-sandbox.result == 'success' || needs.infra-api-lambdas-sandbox.result == 'success') }}
+    if: ${{ !failure() && (needs.api-prod.result == 'success' || needs.infra-api-lambdas.result == 'success' || needs.redeploy-api-gw-prod.result == 'success') }}
     with:
       deploy_env: "production"
       api_url: ${{ vars.API_URL_PRODUCTION }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -101,13 +101,26 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
+  redeploy-api-gw:
+    uses: ./.github/workflows/_redeploy_api-gw.yml
+    needs: [infra-api-lambdas]
+    with:
+      deploy_env: "staging"
+      AWS_REGION: ${{ vars.API_REGION_STAGING }}
+      API_GW_ID: ${{ vars.API_GW_ID_STAGING }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
   e2e-tests:
     uses: ./.github/workflows/_e2e-tests.yml
-    needs: [api, infra-api-lambdas]
+    needs: [api, infra-api-lambdas, redeploy-api-gw]
     # run even if one of the dependencies didn't
     # can't use ${{ ! failure() && success() }} because `success()` "Returns true when none of the previous steps have failed or been canceled."
     # can't use ${{ ! failure() && contains(needs.*.result, 'success') }} because if anything that came before succeeded, even if not a direct dependency, it will run
-    if: ${{ !failure() && (needs.api.result == 'success' || needs.infra-api-lambdas.result == 'success') }}
+    if: ${{ !failure() && (needs.api.result == 'success' || needs.infra-api-lambdas.result == 'success' || needs.redeploy-api-gw.result == 'success') }}
     with:
       deploy_env: "staging"
       api_url: ${{ vars.API_URL_STAGING }}

--- a/packages/scripts/redeploy-api-gateway.sh
+++ b/packages/scripts/redeploy-api-gateway.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Run from the root of the repository.
+
+if [[ -z "${AWS_REGION}" ]]; then
+  echo "AWS_REGION is missing"
+  exit 1
+fi
+if [[ -z "${API_GW_ID}" ]]; then
+  echo "API_GW_ID is missing"
+  exit 1
+fi
+
+# Fail on error
+set -e
+
+# Echo commands
+set -x
+
+aws apigateway create-deployment \
+  --region $AWS_REGION \
+  --rest-api-id $API_GW_ID \
+  --stage-name prod \
+  --no-cli-pager
+
+echo -e "Done."


### PR DESCRIPTION
Ref. metriport/metriport-internal#1932

### Dependencies

none

### Description

Re-deploy API GW upon CICD run.

Based on https://github.com/metriport/metriport-internal/pull/1966

### Testing

- Local
  - none
- Staging
  - [ ] branch to staging re-deploys API GW
  - [ ] merge of PR w/ infra changes re-deploys API GW
- Production
  - [ ] merge of PR w/ infra changes re-deploys API GW

### Release Plan

- [ ] Merge this