### PR TITLE
1040 Provision S3 Bucket for Outbound Failures

### DIFF
--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -112,6 +112,7 @@ type EnvConfigBase = {
   medicalDocumentsBucketName: string;
   medicalDocumentsUploadBucketName: string;
   iheResponsesBucketName: string;
+  iheXcpdResponsesBucketName: string;
   iheRequestsBucketName: string;
   fhirConverterBucketName?: string;
   analyticsSecretNames?: {

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -112,7 +112,7 @@ type EnvConfigBase = {
   medicalDocumentsBucketName: string;
   medicalDocumentsUploadBucketName: string;
   iheResponsesBucketName: string;
-  iheXcpdResponsesBucketName: string;
+  iheParsedResponsesBucketName: string;
   iheRequestsBucketName: string;
   fhirConverterBucketName?: string;
   analyticsSecretNames?: {

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -140,7 +140,7 @@ export const config: EnvConfigNonSandbox = {
   medicalDocumentsBucketName: "test-bucket",
   medicalDocumentsUploadBucketName: "test-upload-bucket",
   iheResponsesBucketName: "test-ihe-responses-bucket",
-  iheXcpdResponsesBucketName: "test-ihe-xcpd-responses-bucket",
+  iheParsedResponsesBucketName: "test-ihe-parsed-responses-bucket",
   iheRequestsBucketName: "test-ihe-requests-bucket",
   engineeringCxId: "12345678-1234-1234-1234-123456789012",
 };

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -140,6 +140,7 @@ export const config: EnvConfigNonSandbox = {
   medicalDocumentsBucketName: "test-bucket",
   medicalDocumentsUploadBucketName: "test-upload-bucket",
   iheResponsesBucketName: "test-ihe-responses-bucket",
+  iheXcpdResponsesBucketName: "test-ihe-xcpd-responses-bucket",
   iheRequestsBucketName: "test-ihe-requests-bucket",
   engineeringCxId: "12345678-1234-1234-1234-123456789012",
 };

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -459,7 +459,7 @@ export class APIStack extends Stack {
         envType: props.config.environmentType,
         sentryDsn: props.config.lambdasSentryDSN,
         iheResponsesBucketName: props.config.iheResponsesBucketName,
-        iheXcpdResponsesBucketName: props.config.iheXcpdResponsesBucketName,
+        iheParsedResponsesBucketName: props.config.iheParsedResponsesBucketName,
       });
     }
 

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -459,6 +459,7 @@ export class APIStack extends Stack {
         envType: props.config.environmentType,
         sentryDsn: props.config.lambdasSentryDSN,
         iheResponsesBucketName: props.config.iheResponsesBucketName,
+        iheXcpdResponsesBucketName: props.config.iheXcpdResponsesBucketName,
       });
     }
 

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -134,7 +134,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
         MEDICAL_DOCUMENTS_BUCKET_NAME: medicalDocumentsBucket.bucketName,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
         IHE_RESPONSES_BUCKET_NAME: iheResponsesBucket.bucketName,
-        IHE_XCPD_RESPONES_BUCKET_NAME: iheXcpdResponsesBucket.bucketName,
+        IHE_XCPD_RESPONSES_BUCKET_NAME: iheXcpdResponsesBucket.bucketName,
       },
       layers: [lambdaLayers.shared],
       memory: 4096,

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -24,6 +24,7 @@ interface IHEGatewayV2LambdasNestedStackProps extends NestedStackProps {
   envType: EnvType;
   sentryDsn: string | undefined;
   iheResponsesBucketName: string;
+  iheXcpdResponsesBucketName: string;
 }
 
 export class IHEGatewayV2LambdasNestedStack extends NestedStack {
@@ -39,9 +40,17 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
       versioned: true,
     });
 
+    const iheXcpdResponsesBucket = new s3.Bucket(this, "IHEResponsesBucket", {
+      bucketName: props.iheXcpdResponsesBucketName,
+      publicReadAccess: false,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      versioned: true,
+    });
+
     const patientDiscoveryLambda = this.setupIHEGatewayV2PatientDiscoveryLambda(
       props,
-      iheResponsesBucket
+      iheResponsesBucket,
+      iheXcpdResponsesBucket
     );
     const documentQueryLambda = this.setupIHEGatewayV2DocumentQueryLambda(
       props,
@@ -86,7 +95,8 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
       envType: EnvType;
       sentryDsn: string | undefined;
     },
-    iheResponsesBucket: s3.Bucket
+    iheResponsesBucket: s3.Bucket,
+    iheXcpdResponsesBucket: s3.Bucket
   ): Lambda {
     const {
       lambdaLayers,
@@ -124,6 +134,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
         MEDICAL_DOCUMENTS_BUCKET_NAME: medicalDocumentsBucket.bucketName,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
         IHE_RESPONSES_BUCKET_NAME: iheResponsesBucket.bucketName,
+        IHE_XCPD_RESPONES_BUCKET_NAME: iheXcpdResponsesBucket.bucketName,
       },
       layers: [lambdaLayers.shared],
       memory: 4096,
@@ -139,6 +150,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
     ]);
 
     iheResponsesBucket.grantReadWrite(patientDiscoveryLambda);
+    iheXcpdResponsesBucket.grantReadWrite(patientDiscoveryLambda);
     medicalDocumentsBucket.grantRead(patientDiscoveryLambda);
     cqTrustBundleBucket.grantRead(patientDiscoveryLambda);
     return patientDiscoveryLambda;

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -24,7 +24,7 @@ interface IHEGatewayV2LambdasNestedStackProps extends NestedStackProps {
   envType: EnvType;
   sentryDsn: string | undefined;
   iheResponsesBucketName: string;
-  iheXcpdResponsesBucketName: string;
+  iheParsedResponsesBucketName: string;
 }
 
 export class IHEGatewayV2LambdasNestedStack extends NestedStack {
@@ -40,8 +40,8 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
       versioned: true,
     });
 
-    const iheXcpdResponsesBucket = new s3.Bucket(this, "IHEXcpdResponsesBucket", {
-      bucketName: props.iheXcpdResponsesBucketName,
+    const iheParsedResponsesBucket = new s3.Bucket(this, "iheParsedResponsesBucket", {
+      bucketName: props.iheParsedResponsesBucketName,
       publicReadAccess: false,
       encryption: s3.BucketEncryption.S3_MANAGED,
       versioned: true,
@@ -50,7 +50,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
     const patientDiscoveryLambda = this.setupIHEGatewayV2PatientDiscoveryLambda(
       props,
       iheResponsesBucket,
-      iheXcpdResponsesBucket
+      iheParsedResponsesBucket
     );
     const documentQueryLambda = this.setupIHEGatewayV2DocumentQueryLambda(
       props,
@@ -96,7 +96,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
       sentryDsn: string | undefined;
     },
     iheResponsesBucket: s3.Bucket,
-    iheXcpdResponsesBucket: s3.Bucket
+    iheParsedResponsesBucket: s3.Bucket
   ): Lambda {
     const {
       lambdaLayers,
@@ -134,7 +134,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
         MEDICAL_DOCUMENTS_BUCKET_NAME: medicalDocumentsBucket.bucketName,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
         IHE_RESPONSES_BUCKET_NAME: iheResponsesBucket.bucketName,
-        IHE_XCPD_RESPONSES_BUCKET_NAME: iheXcpdResponsesBucket.bucketName,
+        IHE_PARSED_RESPONSES_BUCKET_NAME: iheParsedResponsesBucket.bucketName,
       },
       layers: [lambdaLayers.shared],
       memory: 4096,
@@ -150,7 +150,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
     ]);
 
     iheResponsesBucket.grantReadWrite(patientDiscoveryLambda);
-    iheXcpdResponsesBucket.grantReadWrite(patientDiscoveryLambda);
+    iheParsedResponsesBucket.grantReadWrite(patientDiscoveryLambda);
     medicalDocumentsBucket.grantRead(patientDiscoveryLambda);
     cqTrustBundleBucket.grantRead(patientDiscoveryLambda);
     return patientDiscoveryLambda;

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -40,7 +40,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
       versioned: true,
     });
 
-    const iheXcpdResponsesBucket = new s3.Bucket(this, "IHEResponsesBucket", {
+    const iheXcpdResponsesBucket = new s3.Bucket(this, "IHEXcpdResponsesBucket", {
       bucketName: props.iheXcpdResponsesBucketName,
       publicReadAccess: false,
       encryption: s3.BucketEncryption.S3_MANAGED,


### PR DESCRIPTION
Ticket: #1040

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/2016
- Downstream: https://github.com/metriport/metriport/pull/2494

### Description

- Adding xcpd responses bucket for saving failure/error responses for outbound XCPD

### Testing

- Local
  - [x] cdk diff
- Staging
  - [ ] validate infra
- Sandbox
  - [ ] validate infra
- Production
  - [ ] validate infra


### Release Plan

- [ ] Upstream dependencies are met/released
- [ ] Merge this
