### PR TITLE
Patch shareback

### DIFF
--- a/packages/api/src/command/medical/patient/handle-data-contributions.ts
+++ b/packages/api/src/command/medical/patient/handle-data-contributions.ts
@@ -41,7 +41,7 @@ export async function handleDataContribution({
     patientId,
     `${requestId}_${FHIR_BUNDLE_SUFFIX}.json`
   );
-  const fullBundle = hydrateBundle(bundle, patient, fhirOrganization, fhirBundleDestinationKey);
+  const fullBundle = hydrateBundle(bundle, patient, fhirBundleDestinationKey);
 
   await uploadFhirBundleToS3({
     cxId,


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/2007

### Description
- Removed the addition of `Patient` and `Organization` resources to the Bundle upon data contributions, which was causing errors during upload to the FHIR server due to constant updates to those resources
- Initially, we added this due to how our FHIR-to-CDA conversion is built for data contributions centred around the `Composition`-based uploads. However, we're now realizing that this step can be moved downstream - directly before the CDA conversion begins

### Testing
- Local
  - [x] Add FHIR data for a patient
  - [x] Check that the CCD is still properly generated
- Production
  - [ ] Monitor the effects for CXs

### Release Plan
- :warning: Points to `master`
- [ ] Merge this
