### PR TITLE
2253 Check CW enabled for patient on sandbox

### DIFF
--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -449,16 +449,17 @@ export async function validateCWEnabled({
   const { cxId } = patient;
   const isSandbox = Config.isSandbox();
 
+  if (!isCommonwellEnabledForPatient(patient)) {
+    log(`CW disabled for patient, skipping...`);
+    return false;
+  }
+
   if (forceCW || isSandbox) {
     log(`CW forced, proceeding...`);
     return true;
   }
 
   try {
-    if (!isCommonwellEnabledForPatient(patient)) {
-      log(`CW disabled for patient, skipping...`);
-      return false;
-    }
     const [isCwEnabledGlobally, isCwEnabledForCx] = await Promise.all([
       isCommonwellEnabled(),
       isCWEnabledForCx(cxId),


### PR DESCRIPTION
Ref. metriport/metriport#2253

### Dependencies

none

### Description

Check CW enabled for patient on sandbox - [context](https://metriport.slack.com/archives/C0553DYC95L/p1721308116030269?thread_ts=1721133545.282949&cid=C0553DYC95L)

### Testing

- Local
  - [x] unit tests
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
