### PR TITLE
1040 Add tests for emailSchema

### DIFF
--- a/packages/api-sdk/src/medical/models/__tests__/contact.ts
+++ b/packages/api-sdk/src/medical/models/__tests__/contact.ts
@@ -1,0 +1,9 @@
+import { Contact } from "../demographics";
+import { faker } from "@faker-js/faker";
+
+export function makeContact(params: Partial<Contact> = {}): Contact {
+  return {
+    phone: params.phone ?? faker.phone.number("##########"),
+    email: params.email ?? faker.internet.email(),
+  };
+}

--- a/packages/api-sdk/src/medical/models/__tests__/demographics.test.ts
+++ b/packages/api-sdk/src/medical/models/__tests__/demographics.test.ts
@@ -1,0 +1,45 @@
+import { contactSchema, emailSchema } from "../demographics";
+import { makeContact } from "./contact";
+
+describe("demographicsSchema", () => {
+  describe("contactSchema", () => {
+    it("accepts simple email", async () => {
+      const contact = makeContact({ email: "test@metriport.com" });
+      expect(() => contactSchema.parse(contact)).not.toThrow();
+    });
+
+    it("accepts null email", async () => {
+      const contact = makeContact();
+      contact.email = null;
+      expect(() => contactSchema.parse(contact)).not.toThrow();
+    });
+
+    it("accepts undefined email", async () => {
+      const contact = makeContact();
+      contact.email = null;
+      expect(() => contactSchema.parse(contact)).not.toThrow();
+    });
+  });
+
+  describe("emailSchema", () => {
+    it("accepts simple email", async () => {
+      expect(() => emailSchema.parse("test@metriport.com")).not.toThrow();
+    });
+
+    it("fails when gets null", async () => {
+      expect(() => emailSchema.parse(null)).toThrow();
+    });
+
+    it("fails when gets undefined", async () => {
+      expect(() => emailSchema.parse(undefined)).toThrow();
+    });
+
+    it("accepts email with dot", async () => {
+      expect(() => emailSchema.parse("test.two@metriport.com")).not.toThrow();
+    });
+
+    it("fails when gets email with colon", async () => {
+      expect(() => emailSchema.parse("test:two@metriport.com")).toThrow();
+    });
+  });
+});

--- a/packages/api-sdk/src/medical/models/__tests__/demographics.test.ts
+++ b/packages/api-sdk/src/medical/models/__tests__/demographics.test.ts
@@ -16,30 +16,43 @@ describe("demographicsSchema", () => {
 
     it("accepts undefined email", async () => {
       const contact = makeContact();
-      contact.email = null;
+      contact.email = undefined;
       expect(() => contactSchema.parse(contact)).not.toThrow();
     });
   });
 
   describe("emailSchema", () => {
-    it("accepts simple email", async () => {
-      expect(() => emailSchema.parse("test@metriport.com")).not.toThrow();
-    });
-
-    it("fails when gets null", async () => {
-      expect(() => emailSchema.parse(null)).toThrow();
-    });
-
-    it("fails when gets undefined", async () => {
-      expect(() => emailSchema.parse(undefined)).toThrow();
-    });
-
-    it("accepts email with dot", async () => {
-      expect(() => emailSchema.parse("test.two@metriport.com")).not.toThrow();
-    });
-
-    it("fails when gets email with colon", async () => {
-      expect(() => emailSchema.parse("test:two@metriport.com")).toThrow();
-    });
+    const casesToSucceed: string[] = [
+      "t@m.co",
+      "test@metriport.com",
+      "test.second@metriport.com",
+      "test_second@metriport.com",
+      "test-second@metriport.com",
+      "user123@metriport.com",
+      "123user@metriport.com",
+      "user@metriport.com.br",
+    ];
+    const casesToFail: (string | null | undefined)[] = [
+      null,
+      undefined,
+      " test@metriport.com",
+      "test@metriport.com ",
+      "test:second@metriport.com",
+      "test second@metriport.com",
+      "test metriport.com",
+      "test@ metriport.com",
+      "test@metriport",
+      "test@.com",
+    ];
+    for (const email of casesToSucceed) {
+      it(`accepts '${email}'`, async () => {
+        expect(() => emailSchema.parse(email)).not.toThrow();
+      });
+    }
+    for (const email of casesToFail) {
+      it(`fails when gets '${email}'`, async () => {
+        expect(() => emailSchema.parse(email)).toThrow();
+      });
+    }
   });
 });

--- a/packages/api-sdk/src/medical/models/demographics.ts
+++ b/packages/api-sdk/src/medical/models/demographics.ts
@@ -55,6 +55,8 @@ export type PersonalIdentifier = z.infer<typeof personalIdentifierSchema>;
 
 export const genderAtBirthSchema = z.enum(["F", "M", "O", "U"]);
 
+export const emailSchema = z.string().email();
+
 export const contactSchema = z
   .object({
     phone: z.coerce
@@ -65,7 +67,7 @@ export const contactSchema = z
       })
       .or(z.null())
       .or(z.undefined()),
-    email: z.string().email().or(z.null()).or(z.undefined()),
+    email: emailSchema.nullish(),
   })
   .refine(c => c.email || c.phone, { message: "Either email or phone must be present" });
 export type Contact = z.infer<typeof contactSchema>;


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Add tests for emailSchema - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1721345749355369?thread_ts=1717952771.261659&cid=C04T256DQPQ)

### Testing

- Local
  - [x] unit tests
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
