### PR TITLE
PATCH RELEASE Offline PA setup

### DIFF
--- a/packages/api/src/routes/middlewares/propelauth.ts
+++ b/packages/api/src/routes/middlewares/propelauth.ts
@@ -1,3 +1,4 @@
+import { out } from "@metriport/core/util";
 import { getEnvVar } from "@metriport/shared";
 import { OrgMemberInfo, User } from "@propelauth/express";
 import { initBaseAuth } from "@propelauth/node";
@@ -7,11 +8,24 @@ export type PropelAuth = ReturnType<typeof initBaseAuth>;
 // TODO 1986 Move this back to getAuth() and make them required there - getAuth() doesn't return undefined anymore
 const authUrl = getEnvVar("PROPELAUTH_AUTH_URL");
 const apiKey = getEnvVar("PROPELAUTH_API_KEY");
+const publicKey = getEnvVar("PROPELAUTH_PUBLIC_KEY");
 
 let auth: PropelAuth | undefined;
 export function getAuth(): PropelAuth | undefined {
-  if (auth || !authUrl || !apiKey) return auth;
-  auth = initBaseAuth({ authUrl, apiKey });
+  out("PropelAuth").log(
+    `authUrl ${authUrl}, apiKey ${apiKey && apiKey.trim().length ? "***" : undefined}, publicKey ${
+      publicKey && publicKey.trim().length ? "***" : undefined
+    }`
+  );
+  if (auth || !authUrl || !apiKey || !publicKey) return auth;
+  auth = initBaseAuth({
+    authUrl,
+    apiKey,
+    manualTokenVerificationMetadata: {
+      verifierKey: publicKey,
+      issuer: authUrl,
+    },
+  });
   return auth;
 }
 

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -105,6 +105,7 @@ type EnvConfigBase = {
   apiGatewayUsagePlanId?: string; // optional since we need to create the stack first, then update this and redeploy
   propelAuth: {
     authUrl: string;
+    publicKey: string;
     secrets: {
       PROPELAUTH_API_KEY: string;
     };

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -230,6 +230,7 @@ export function createAPIService({
             SANDBOX_SEED_DATA_BUCKET_NAME: props.config.sandboxSeedDataBucketName,
           }),
           PROPELAUTH_AUTH_URL: props.config.propelAuth.authUrl,
+          PROPELAUTH_PUBLIC_KEY: props.config.propelAuth.publicKey,
           CONVERT_DOC_LAMBDA_NAME: cdaToVisualizationLambda.functionName,
           DOCUMENT_DOWNLOADER_LAMBDA_NAME: documentDownloaderLambda.functionName,
           OUTBOUND_PATIENT_DISCOVERY_LAMBDA_NAME: outboundPatientDiscoveryLambda.functionName,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1969

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/2049
- Downstream: none

### Description

Offline PA setup

### Testing

- Local
  - none
  - [x] ...
- Staging
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Sandbox
  - [ ] JWT based requests from the dash to OSS get authorized
     - [ ] OSS API sandbox inits auth properly
- Production
  - [ ] JWT based requests from the dash to OSS get authorized
     - [ ] OSS API sandbox inits auth properly

### Release Plan

- :warning: Points to `master`
- [ ] Merge upstream
- [ ] Merge this
