### PR TITLE
PATCH RELEASE Log execution time on handle-data-contributions

### DIFF
--- a/packages/api/src/command/medical/patient/handle-data-contributions.ts
+++ b/packages/api/src/command/medical/patient/handle-data-contributions.ts
@@ -2,7 +2,7 @@ import { Bundle, Resource } from "@medplum/fhirtypes";
 import { FHIR_BUNDLE_SUFFIX, createUploadFilePath } from "@metriport/core/domain/document/upload";
 import { Patient } from "@metriport/core/domain/patient";
 import { uploadCdaDocuments, uploadFhirBundleToS3 } from "@metriport/core/fhir-to-cda/upload";
-import { out } from "@metriport/core/util";
+import { out } from "@metriport/core/util/log";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import BadRequestError from "../../../errors/bad-request";
 import { processCcdRequest } from "../../../external/cda/process-ccd-request";


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Description

Log execution time on handle-data-contributions - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1722042794190369)

### Testing

none

### Release Plan

- [ ] Merge this
