### PR TITLE
1040 Improve processing of data contribution

### DIFF
--- a/docs/medical-api/api-reference/fhir/create-patient-consolidated.mdx
+++ b/docs/medical-api/api-reference/fhir/create-patient-consolidated.mdx
@@ -26,7 +26,7 @@ api: "PUT /medical/v1/patient/{id}/consolidated"
 
 <Info>
   At the moment there is a limit to how much data you can send in a single request. The
-  content-length must not exceed 1MB.
+  content-length must not exceed 1MB (and 50 resources when in `sandbox`).
 </Info>
 
 ## Response

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -423,8 +423,8 @@ export class MetriportMedicalApi {
    * Add patient data as FHIR resources. Those can later be queried with startConsolidatedQuery(),
    * and will be made available to HIEs.
    *
-   * Note: each call to this function is limited to 50 resources and 1Mb of data. You can make multiple
-   * calls to this function to add more data.
+   * Note: each call to this function is limited to 1Mb of data (and 50 resources when in sandbox).
+   * You can make multiple calls to this function to add more data.
    *
    * @param patientId The ID of the patient to associate resources to.
    * @param payload The FHIR Bundle to create resources.

--- a/packages/api/src/command/medical/patient/__tests__/consolidated-create.test.ts
+++ b/packages/api/src/command/medical/patient/__tests__/consolidated-create.test.ts
@@ -1,32 +1,53 @@
+import { faker } from "@faker-js/faker";
 import { Bundle, BundleEntry, DiagnosticReport } from "@medplum/fhirtypes";
+import { createUploadFilePath } from "@metriport/core/domain/document/upload";
 import { HapiFhirClient } from "@metriport/core/external/fhir/api/api-hapi";
+import * as s3Upload from "@metriport/core/fhir-to-cda/upload";
 import { v4 as uuidv4 } from "uuid";
 import { diagnosticReport, patient, transactionRespBundle } from "../../__tests__/fhir-payloads";
-import { createOrUpdateConsolidatedPatientData } from "../consolidated-create";
+import {
+  createOrUpdateConsolidatedPatientData,
+  sentToFhirServerPrefix,
+} from "../consolidated-create";
 
 let fhir_readResource: jest.SpyInstance;
 let fhir_executeBatch: jest.SpyInstance;
-beforeEach(() => {
+let uploadFhirBundleToS3_mock: jest.SpyInstance;
+beforeAll(() => {
   jest.restoreAllMocks();
   fhir_readResource = jest.spyOn(HapiFhirClient.prototype, "readResource");
   fhir_executeBatch = jest.spyOn(HapiFhirClient.prototype, "executeBatch");
+  uploadFhirBundleToS3_mock = jest.spyOn(s3Upload, "uploadFhirBundleToS3").mockResolvedValue();
+});
+afterAll(() => {
+  jest.restoreAllMocks();
 });
 
 describe("createConsolidateData", () => {
-  const cxId = uuidv4();
-  const patientId = uuidv4();
+  let cxId: string;
+  let patientId: string;
+  let requestId: string;
+  beforeEach(() => {
+    cxId = uuidv4();
+    patientId = uuidv4();
+    requestId = uuidv4();
+  });
 
   it("appends PUT transaction and patient when resource does exist and converting fhir bundle", async () => {
     fhir_readResource.mockReturnValueOnce(patient);
-
     fhir_executeBatch.mockReturnValueOnce(transactionRespBundle);
-    const DIAGNOSTIC_ID = "1234";
+    const diagnosticId = faker.number.int();
+    const toFhirServerBundleKey = createUploadFilePath(
+      cxId,
+      patientId,
+      `${requestId}_${sentToFhirServerPrefix}.json`
+    );
 
     const diagnosticReportWithId: BundleEntry<DiagnosticReport> = {
       resource: {
         ...diagnosticReport.resource,
         resourceType: "DiagnosticReport",
-        id: DIAGNOSTIC_ID,
+        id: diagnosticId.toString(),
       },
     };
 
@@ -39,7 +60,7 @@ describe("createConsolidateData", () => {
     const resp = await createOrUpdateConsolidatedPatientData({
       cxId,
       patientId,
-      requestId: uuidv4(),
+      requestId,
       fhirBundle: collectionBundle,
     });
 
@@ -51,10 +72,9 @@ describe("createConsolidateData", () => {
       },
       request: {
         method: "PUT",
-        url: diagnosticReportWithId?.resource?.resourceType + `/${DIAGNOSTIC_ID}`,
+        url: diagnosticReportWithId?.resource?.resourceType + `/${diagnosticId}`,
       },
     };
-
     const convertedFhirBundle: Bundle = {
       resourceType: "Bundle",
       type: "transaction",
@@ -65,5 +85,12 @@ describe("createConsolidateData", () => {
     expect(resp).toEqual(transactionRespBundle);
     expect(fhir_executeBatch).toHaveBeenCalledTimes(1);
     expect(fhir_executeBatch).toHaveBeenCalledWith(convertedFhirBundle);
+    expect(uploadFhirBundleToS3_mock).toHaveBeenCalledTimes(1);
+    expect(uploadFhirBundleToS3_mock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fhirBundle: convertedFhirBundle,
+        destinationKey: toFhirServerBundleKey,
+      })
+    );
   });
 });

--- a/packages/api/src/command/medical/patient/__tests__/consolidated-create.test.ts
+++ b/packages/api/src/command/medical/patient/__tests__/consolidated-create.test.ts
@@ -39,6 +39,7 @@ describe("createConsolidateData", () => {
     const resp = await createOrUpdateConsolidatedPatientData({
       cxId,
       patientId,
+      requestId: uuidv4(),
       fhirBundle: collectionBundle,
     });
 

--- a/packages/api/src/command/medical/patient/consolidated-create.ts
+++ b/packages/api/src/command/medical/patient/consolidated-create.ts
@@ -1,21 +1,32 @@
 import { Bundle, BundleEntry, Patient } from "@medplum/fhirtypes";
-import { makeFhirApi } from "../../../external/fhir/api/api-factory";
+import { createUploadFilePath } from "@metriport/core/domain/document/upload";
 import { OPERATION_OUTCOME_EXTENSION_URL } from "@metriport/core/external/fhir/shared/extensions/extension";
-import { Util } from "../../../shared/util";
-import { errorToString } from "@metriport/shared";
+import { uploadFhirBundleToS3 } from "@metriport/core/fhir-to-cda/upload";
 import { MetriportError } from "@metriport/core/util/error/metriport-error";
+import { out } from "@metriport/core/util/log";
+import { errorToString } from "@metriport/shared";
+import { makeFhirApi } from "../../../external/fhir/api/api-factory";
+
+const sentToFhirServerPrefix = "toFhirServer";
 
 export async function createOrUpdateConsolidatedPatientData({
   cxId,
   patientId,
+  requestId,
   fhirBundle,
 }: {
   cxId: string;
   patientId: string;
+  requestId: string;
   fhirBundle: Bundle;
 }): Promise<Bundle | undefined> {
-  const { log } = Util.out(
-    `createOrUpdateConsolidatedPatientData - cxId ${cxId}, patientId ${patientId}`
+  const { log } = out(
+    `createOrUpdateConsolidatedPatientData - cxId ${cxId}, patientId ${patientId}, requestId ${requestId}`
+  );
+  const toFhirServerBundleKey = createUploadFilePath(
+    cxId,
+    patientId,
+    `${requestId}_${sentToFhirServerPrefix}.json`
   );
 
   try {
@@ -28,16 +39,23 @@ export async function createOrUpdateConsolidatedPatientData({
       fhirBundle,
     });
 
-    const bundleResource = await fhir.executeBatch(fhirBundleTransaction);
+    const [bundleResource] = await Promise.all([
+      fhir.executeBatch(fhirBundleTransaction),
+      uploadFhirBundleToS3({
+        fhirBundle: fhirBundleTransaction,
+        destinationKey: toFhirServerBundleKey,
+      }),
+    ]);
     const transformedBundle = removeUnwantedFhirData(bundleResource);
 
     return transformedBundle;
   } catch (error) {
     const errorMsg = errorToString(error);
-    const msg = "Error converting and executing fhir bundle resources";
-    log(`${msg}: ${errorMsg}`);
-    if (errorMsg.includes("ID")) throw new MetriportError(errorMsg, error, { cxId, patientId });
-    throw new MetriportError(msg, error, { cxId, patientId });
+    const msg = "Error converting and storing fhir bundle resources";
+    const additionalInfo = { cxId, patientId, toFhirServerBundleKey };
+    log(`${msg}: ${errorMsg}, additionalInfo: ${JSON.stringify(additionalInfo)}`);
+    if (errorMsg.includes("ID")) throw new MetriportError(errorMsg, error, additionalInfo);
+    throw new MetriportError(msg, error, additionalInfo);
   }
 }
 

--- a/packages/api/src/command/medical/patient/consolidated-create.ts
+++ b/packages/api/src/command/medical/patient/consolidated-create.ts
@@ -7,7 +7,7 @@ import { out } from "@metriport/core/util/log";
 import { errorToString } from "@metriport/shared";
 import { makeFhirApi } from "../../../external/fhir/api/api-factory";
 
-const sentToFhirServerPrefix = "toFhirServer";
+export const sentToFhirServerPrefix = "toFhirServer";
 
 export async function createOrUpdateConsolidatedPatientData({
   cxId,

--- a/packages/api/src/command/medical/patient/handle-data-contributions.ts
+++ b/packages/api/src/command/medical/patient/handle-data-contributions.ts
@@ -1,7 +1,6 @@
 import { Bundle, Resource } from "@medplum/fhirtypes";
-import { FHIR_BUNDLE_SUFFIX, createUploadFilePath } from "@metriport/core/domain/document/upload";
+import { createUploadFilePath, FHIR_BUNDLE_SUFFIX } from "@metriport/core/domain/document/upload";
 import { Patient } from "@metriport/core/domain/patient";
-import { toFHIR as toFhirPatient } from "@metriport/core/external/fhir/patient/index";
 import { uploadCdaDocuments, uploadFhirBundleToS3 } from "@metriport/core/fhir-to-cda/upload";
 import { out } from "@metriport/core/util/log";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
@@ -33,70 +32,65 @@ export async function handleDataContribution({
   bundle: ValidBundle;
 }): Promise<Bundle<Resource> | undefined> {
   const { log } = out(`handleDataContribution - cxId ${cxId}, patientId ${patientId}`);
-  let startedAt = Date.now();
-  const [organization, patient] = await Promise.all([
-    getOrganizationOrFail({ cxId }),
-    getPatientOrFail({ id: patientId, cxId }),
-  ]);
-
-  const fhirOrganization = toFhirOrganization(organization);
   const fhirBundleDestinationKey = createUploadFilePath(
     cxId,
     patientId,
     `${requestId}_${FHIR_BUNDLE_SUFFIX}.json`
   );
+  let startedAt = Date.now();
+  const [, organization, patient] = await Promise.all([
+    uploadFhirBundleToS3({
+      fhirBundle: bundle,
+      destinationKey: fhirBundleDestinationKey,
+    }),
+    getOrganizationOrFail({ cxId }),
+    getPatientOrFail({ id: patientId, cxId }),
+  ]);
+  log(`${startedAt - Date.now()}ms to get org and patient, and store on S3`);
+  startedAt = Date.now();
+
+  const fhirOrganization = toFhirOrganization(organization);
   const fullBundle = hydrateBundle(bundle, patient, fhirBundleDestinationKey);
-
-  log(`${startedAt - Date.now()}ms to prepare before uploadFhirBundleToS3`);
-  startedAt = Date.now();
-  await uploadFhirBundleToS3({
-    cxId,
-    patientId,
-    fhirBundle: fullBundle,
-    destinationKey: fhirBundleDestinationKey,
-  });
-  log(`${startedAt - Date.now()}ms to execute uploadFhirBundleToS3`);
-  startedAt = Date.now();
-
   const validatedBundle = validateFhirEntries(fullBundle);
   const incomingAmount = validatedBundle.entry.length;
   await checkResourceLimit(incomingAmount, patient);
-
-  log(`${startedAt - Date.now()}ms to validate bundle and check resources`);
+  log(`${startedAt - Date.now()}ms to validate and check limits`);
   startedAt = Date.now();
+
+  if (!Config.isSandbox() && hasCompositionResource(validatedBundle)) {
+    const converted = await convertFhirToCda({ cxId, validatedBundle });
+    // intentionally async
+    uploadCdaDocuments({
+      cxId,
+      patientId,
+      cdaBundles: converted,
+      organization: fhirOrganization,
+      docId: requestId,
+    });
+    log(`${startedAt - Date.now()}ms to convert to CDA`);
+    startedAt = Date.now();
+  }
+
   const consolidatedDataUploadResults = await createOrUpdateConsolidatedPatientData({
     cxId,
     patientId: patient.id,
+    requestId,
     fhirBundle: validatedBundle,
   });
-  log(`${startedAt - Date.now()}ms to store bundle on FHIR server`);
+  log(`${startedAt - Date.now()}ms to store on FHIR server and S3`);
   startedAt = Date.now();
 
   if (!Config.isSandbox()) {
     // intentionally async
     processCcdRequest(patient, fhirOrganization, requestId);
-
-    if (hasCompositionResource(validatedBundle)) {
-      const fhirPatient = toFhirPatient(patient);
-      validatedBundle.entry.push({ resource: fhirPatient });
-      validatedBundle.entry.push({ resource: fhirOrganization });
-      const converted = await convertFhirToCda({ cxId, validatedBundle });
-
-      // intentionally async
-      uploadCdaDocuments({
-        cxId,
-        patientId,
-        cdaBundles: converted,
-        organization: fhirOrganization,
-        docId: requestId,
-      });
-      log(`${startedAt - Date.now()}ms to store bundle on FHIR server`);
-    }
   }
 
   return consolidatedDataUploadResults;
 }
 
+/**
+ * SANDBOX ONLY. Checks if the incoming amount of resources, plus what's already stored, exceeds the limit.
+ */
 async function checkResourceLimit(incomingAmount: number, patient: Patient) {
   if (!Config.isCloudEnv() || Config.isSandbox()) {
     const { total: currentAmount } = await countResources({

--- a/packages/api/src/command/medical/patient/handle-data-contributions.ts
+++ b/packages/api/src/command/medical/patient/handle-data-contributions.ts
@@ -57,6 +57,7 @@ export async function handleDataContribution({
   log(`${startedAt - Date.now()}ms to validate and check limits`);
   startedAt = Date.now();
 
+  // Do it before storing on the FHIR server since this also validates the bundle
   if (!Config.isSandbox() && hasCompositionResource(validatedBundle)) {
     const converted = await convertFhirToCda({ cxId, validatedBundle });
     // intentionally async

--- a/packages/core/src/fhir-to-cda/upload.ts
+++ b/packages/core/src/fhir-to-cda/upload.ts
@@ -1,4 +1,4 @@
-import { Bundle, Organization, Resource } from "@medplum/fhirtypes";
+import { Organization } from "@medplum/fhirtypes";
 import { errorToString } from "@metriport/shared";
 import { S3Utils } from "../external/aws/s3";
 import { cdaDocumentUploaderHandler } from "../shareback/cda-uploader";
@@ -51,19 +51,14 @@ export async function uploadCdaDocuments({
 }
 
 export async function uploadFhirBundleToS3({
-  cxId,
-  patientId,
   fhirBundle,
   destinationKey,
 }: {
-  cxId: string;
-  patientId: string;
-  fhirBundle: Bundle<Resource>;
+  fhirBundle: unknown;
   destinationKey: string;
 }): Promise<void> {
-  const { log } = out(`uploadFhirBundleToS3 - cxId: ${cxId}, patientId: ${patientId}`);
+  const { log } = out(`uploadFhirBundleToS3`);
   const s3Utils = new S3Utils(region);
-
   try {
     await s3Utils.uploadFile({
       bucket: Config.getMedicalDocumentsBucketName(),
@@ -73,7 +68,7 @@ export async function uploadFhirBundleToS3({
     });
     log(`Successfully uploaded the file to ${medicalDocumentsBucket} with key ${destinationKey}`);
   } catch (error) {
-    const msg = "Error uploading file to medical documents bucket";
+    const msg = "Error uploading contribution FHIR bundle to medical documents bucket";
     log(`${msg}: ${errorToString(error)}`);
     throw new MetriportError(msg, error, {
       medicalDocumentsBucket,


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

- Upstream: none
- Downstream: none

### Description

Improve the processing of data contribution (`PUT /consolidated`) - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1722042794190369)

- store original uploaded bundle
- store the actual bundle sent to the FHIR server
- (do these in parallel)
- validate the bundle considering the conversion to CDA before inserting on the FHIR server
- update Doc/TSDoc WRT to sandbox resource limits

### Testing

- Local
  - [x] unit test
- Staging
  - [ ] data contribution works
  - [ ] original payload stored on S3
  - [ ] processed payload stored on S3
- Sandbox
  - none
- Production
  - [ ] data contribution works

### Release Plan

- [ ] Merge this
