### PR TITLE
build: update fast-xml to 4.4.1

### DIFF
--- a/packages/fhir-converter/package-lock.json
+++ b/packages/fhir-converter/package-lock.json
@@ -17,7 +17,7 @@
         "cookie-parser": "^1.4.4",
         "deepmerge": "^4.2.2",
         "express": "^4.19.2",
-        "fast-xml-parser": "^4.3.3",
+        "fast-xml-parser": "^4.4.1",
         "fhir": "^4.7.9",
         "fs-extra": "^8.1.0",
         "handlebars": ">= 4.7.7",
@@ -4966,9 +4966,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.3.tgz",
-      "integrity": "sha512-coV/D1MhrShMvU6D0I+VAK3umz6hUaxxhL0yp/9RjfiYUfAv14rDhGQL+PLForhMdr0wq3PiV07WtkkNjJjNHg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "funding": [
         {
           "type": "github",

--- a/packages/fhir-converter/package.json
+++ b/packages/fhir-converter/package.json
@@ -102,7 +102,7 @@
     "cookie-parser": "^1.4.4",
     "deepmerge": "^4.2.2",
     "express": "^4.19.2",
-    "fast-xml-parser": "^4.3.3",
+    "fast-xml-parser": "^4.4.1",
     "fhir": "^4.7.9",
     "fs-extra": "^8.1.0",
     "handlebars": ">= 4.7.7",

--- a/packages/lambdas/package-lock.json
+++ b/packages/lambdas/package-lock.json
@@ -25,7 +25,7 @@
         "aws-sdk": "^2.1248.0",
         "axios": "^1.4.0",
         "dayjs": "^1.11.10",
-        "fast-xml-parser": "^4.3.6",
+        "fast-xml-parser": "^4.4.1",
         "formidable": "^3.5.1",
         "http-status": "^1.7.0",
         "jaro-winkler": "^0.2.8",
@@ -5404,9 +5404,9 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
-      "integrity": "sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "funding": [
         {
           "type": "github",

--- a/packages/lambdas/package.json
+++ b/packages/lambdas/package.json
@@ -36,7 +36,7 @@
     "aws-sdk": "^2.1248.0",
     "axios": "^1.4.0",
     "dayjs": "^1.11.10",
-    "fast-xml-parser": "^4.3.6",
+    "fast-xml-parser": "^4.4.1",
     "formidable": "^3.5.1",
     "http-status": "^1.7.0",
     "jaro-winkler": "^0.2.8",


### PR DESCRIPTION
Ref. https://github.com/metriport/metriport/security/dependabot/230

### Dependencies

none

### Description

Update fast-xml to 4.4.1

### Testing

- Local
  - [x] unit tests
- Staging
  - [ ] DQ works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
