### PR TITLE
1040 Limit the amount of images on ECR

### DIFF
--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -152,6 +152,7 @@ export function createAPIService({
   // Create an ECR repo where we'll deploy our Docker images to, and where ECS will pull from
   const ecrRepo = new Repository(stack, "APIRepo", {
     repositoryName: "metriport/api",
+    lifecycleRules: [{ maxImageCount: 5000 }],
   });
   new CfnOutput(stack, "APIECRRepoURI", {
     description: "API ECR repository URI",


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Related

- https://github.com/metriport/metriport-internal/pull/2073

### Description

Limit the amount of images on ECR to `5,000` - [context](https://metriport.slack.com/archives/C04FZ9859FZ/p1721334532211499?thread_ts=1721311737.404189&cid=C04FZ9859FZ)

### Testing

- Local
  - none
- Staging
  - [ ] new lifecycle policy [here](https://us-east-2.console.aws.amazon.com/ecr/repositories/private/463519787594/metriport/api/_/lifecycle-policy?region=us-east-2)
  - [ ] amount of images limited to 5,000, older ones removed
     - "Expiration is always ordered by pushed_at_time, and always expires older images before newer ones." - [source](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html)
- Production
  - [ ] new lifecycle policy [here](https://us-west-1.console.aws.amazon.com/ecr/repositories/private/463519787594/metriport/api/_/lifecycle-policy?region=us-west-1)
     - no changes in the amount of images since we have fewer images than the limit there

### Release Plan

- [ ] Merge this
