### PR TITLE
1040 Docker buildx to a single platform

### DIFF
--- a/packages/scripts/deploy-api.sh
+++ b/packages/scripts/deploy-api.sh
@@ -64,7 +64,7 @@ pushd ${API_FOLDER}
 
 # Build and push Docker images
 docker buildx build \
-  --platform linux/amd64,linux/arm64,linux/arm/v7 \
+  --platform linux/amd64 \
   --tag "$ECR_REPO_URI:latest" \
   --tag "$ECR_REPO_URI:$GITHUB_SHA" \
   --push \


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- related: https://github.com/metriport/metriport-internal/pull/2076

### Description

Docker buildx to a single platform linux/amd64 - [context](https://metriport.slack.com/archives/C04DBBJSKGB/p1722441011801579?thread_ts=1722436206.997679&cid=C04DBBJSKGB)

### Testing

- Local
  - none
- Staging
  - [ ] deploy works
- Production
  - [ ] deploy works

### Release Plan

- [ ] Merge this
- [ ] Manually trigger the deployment on CICD