### PR TITLE
1969 Deploy secrets stack w/ CICD

### DIFF
--- a/.github/workflows/_deploy-cdk.yml
+++ b/.github/workflows/_deploy-cdk.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         description: "the name of the Location Services CDK stack we're deploying"
+      secrets_cdk_stack:
+        required: true
+        type: string
+        description: "the name of the Secrets CDK stack we're deploying"
       cdk_stack:
         required: true
         type: string
@@ -181,6 +185,33 @@ jobs:
           sourcemaps: metriport/packages/lambdas/dist
           projects: lambdas-oss
 
+      # Secrets Stack
+      - name: Diff Secrets CDK Stack
+        uses: metriport/deploy-with-cdk@master
+        with:
+          cdk_action: "diff"
+          cdk_version: "2.122.0"
+          cdk_stack: "${{ inputs.secrets_cdk_stack }}"
+          cdk_env: "${{ inputs.deploy_env }}"
+        env:
+          INPUT_PATH: "metriport/packages/infra"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
+      - name: Deploy Secrets CDK Stack
+        uses: metriport/deploy-with-cdk@master
+        with:
+          cdk_action: "deploy --verbose --require-approval never"
+          cdk_version: "2.122.0"
+          cdk_stack: "${{ inputs.secrets_cdk_stack }}"
+          cdk_env: "${{ inputs.deploy_env }}"
+        env:
+          INPUT_PATH: "metriport/packages/infra"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
+          METRIPORT_VERSION: ${{ github.sha }}
+
       # Location Stack CDK DIFF
       - name: Diff Location Services CDK stack
         uses: metriport/deploy-with-cdk@master
@@ -238,7 +269,7 @@ jobs:
           AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
           METRIPORT_VERSION: ${{ github.sha }}
 
-      # IHE Stack 
+      # IHE Stack
       - name: Diff IHE Stack CDK
         uses: metriport/deploy-with-cdk@master
         if: inputs.ihe_stack != null

--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -27,6 +27,7 @@ jobs:
     with:
       deploy_env: "staging"
       is-branch-to-staging: true
+      secrets_cdk_stack: ${{ vars.SECRET_STACK_NAME_STAGING }}
       location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_STAGING }}
       cdk_stack: ${{ vars.API_STACK_NAME_STAGING }}
       ihe_stack: ${{ vars.IHE_STACK_NAME }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -108,6 +108,7 @@ jobs:
     needs: files-changed
     with:
       deploy_env: "production"
+      secrets_cdk_stack: ${{ vars.SECRET_STACK_NAME_PRODUCTION }}
       location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_PRODUCTION }}
       cdk_stack: ${{ vars.API_STACK_NAME_PRODUCTION }}
       ihe_stack: ${{ vars.IHE_STACK_NAME }}
@@ -126,6 +127,7 @@ jobs:
     if: ${{ !failure() && needs.infra-api-lambdas.result == 'success' }}
     with:
       deploy_env: "sandbox"
+      secrets_cdk_stack: ${{ vars.SECRET_STACK_NAME_SANDBOX }}
       cdk_stack: ${{ vars.API_STACK_NAME_SANDBOX }}
       AWS_REGION: ${{ vars.API_REGION_SANDBOX  }}
     secrets:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -88,6 +88,7 @@ jobs:
     needs: files-changed
     with:
       deploy_env: "staging"
+      secrets_cdk_stack: ${{ vars.SECRET_STACK_NAME_STAGING }}
       location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_STAGING }}
       cdk_stack: ${{ vars.API_STACK_NAME_STAGING }}
       ihe_stack: ${{ vars.IHE_STACK_NAME }}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1969

### Dependencies

- related: https://github.com/metriport/metriport-internal/pull/2000

### Description

Deploy secrets stack w/ CICD.

### Testing

- Local
  - none
- Staging
  - [ ] secrets stack is deployed
- Sandbox
  - [ ] secrets stack is deployed
- Production
  - [ ] secrets stack is deployed

### Release Plan

- [x] Create env vars on GH
   - [x] `SECRET_STACK_NAME_STAGING`
   - [x] `SECRET_STACK_NAME_SANDBOX`
   - [x] `SECRET_STACK_NAME_PRODUCTION`
- [ ] Merge this
