### PR TITLE
fix(api): removed templateIds from notes

### DIFF
--- a/packages/core/src/fhir-to-cda/cda-templates/components/notes.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/components/notes.ts
@@ -22,10 +22,10 @@ export function buildNotes(
   sectionCode: string
 ): NotesSection {
   const resultsSection: NotesSection = {
-    templateId: buildTemplateIds({
-      root: oids.resultsSection,
-      extension: extensionValue2015,
-    }),
+    // templateId: buildTemplateIds({
+    //   root: oids.resultsSection,
+    //   extension: extensionValue2015,
+    // }),
     code: buildCodeCe({
       code: sectionCode,
       codeSystem: "2.16.840.1.113883.6.1",

--- a/packages/core/src/fhir-to-cda/cda-templates/components/notes.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/components/notes.ts
@@ -22,10 +22,6 @@ export function buildNotes(
   sectionCode: string
 ): NotesSection {
   const resultsSection: NotesSection = {
-    // templateId: buildTemplateIds({
-    //   root: oids.resultsSection,
-    //   extension: extensionValue2015,
-    // }),
     code: buildCodeCe({
       code: sectionCode,
       codeSystem: "2.16.840.1.113883.6.1",

--- a/packages/core/src/fhir-to-cda/cda-types/sections.ts
+++ b/packages/core/src/fhir-to-cda/cda-types/sections.ts
@@ -15,7 +15,7 @@ import {
 type CdaSection<T> =
   | {
       _nullFlavor?: string;
-      templateId: CdaInstanceIdentifier | CdaInstanceIdentifier[];
+      templateId?: CdaInstanceIdentifier | CdaInstanceIdentifier[];
       code: CdaCodeCe;
       title: string;
       text: CdaTable | TextParagraph | TextUnstructured | string;


### PR DESCRIPTION
refs. metriport/metriport-internal#1951

### Description
- Removing template IDs from Notes as per Epic's request

### Testing

- Local
  - [x] No templates in Notes

### Release Plan

- [ ] Merge this
