### PR TITLE
1040 Replace console.log by out.log

### DIFF
--- a/packages/api/src/shared/external.ts
+++ b/packages/api/src/shared/external.ts
@@ -1,7 +1,7 @@
 import { MedicalDataSource } from "@metriport/core/external/index";
 import { getOrCreateDocRefMapping } from "../command/medical/docref-mapping/get-docref-mapping";
 
-export const mapDocRefToMetriport = async ({
+export async function mapDocRefToMetriport({
   cxId,
   patientId,
   requestId,
@@ -13,8 +13,8 @@ export const mapDocRefToMetriport = async ({
   requestId: string;
   documentId: string;
   source: MedicalDataSource;
-}): Promise<{ originalId: string; metriportId: string }> => {
+}): Promise<{ originalId: string; metriportId: string }> {
   const docRef = { cxId, patientId, requestId, externalId: documentId, source };
   const existingDocRef = await getOrCreateDocRefMapping(docRef);
   return { originalId: documentId, metriportId: existingDocRef.id };
-};
+}

--- a/packages/core/src/external/fhir/shared/extensions/metriport.ts
+++ b/packages/core/src/external/fhir/shared/extensions/metriport.ts
@@ -1,10 +1,11 @@
-import { Coding, DocumentReferenceContent, DocumentReference, Extension } from "@medplum/fhirtypes";
+import { Coding, DocumentReference, DocumentReferenceContent, Extension } from "@medplum/fhirtypes";
 import { DeepRequired } from "ts-essentials";
 import { METRIPORT } from "../../../../util/constants";
-import { isCommonwellContent } from "../../../commonwell/extension";
-import { isCarequalityContent } from "../../../carequality/extension";
-import { dataSourceExtensionDefaults } from "./extension";
+import { out } from "../../../../util/log";
 import { capture } from "../../../../util/notifications";
+import { isCarequalityContent } from "../../../carequality/extension";
+import { isCommonwellContent } from "../../../commonwell/extension";
+import { dataSourceExtensionDefaults } from "./extension";
 
 // URL is required: https://www.hl7.org/fhir/R4/extensibility.html#Extension.url
 export type MetriportDataSourceExtension = Omit<Extension, "url" | "valueCoding"> &
@@ -43,7 +44,8 @@ export function getMetriportContent(doc: DocumentReference): DocumentReferenceCo
       id: doc.id,
       metriport_contents: contents.length,
     };
-    console.log(`${msg}, returning the first one - ${JSON.stringify(extra)}`);
+    const { log } = out("getMetriportContent");
+    log(`${msg}, returning the first one - ${JSON.stringify(extra)}`);
     capture.message(msg, { extra, level: "warning" });
   }
   return contents[0];


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Description

Some things I adjusted while testing/reviewing another PR:

- Replace console.log by out.log
- mapDocRefToMetriport from const to function

### Testing

Test this along side to a larger PR.

### Release Plan

- [ ] Merge some larger PR
- [ ] Merge this
