### PR TITLE
1040 add demo aug ff

### DIFF
--- a/packages/api/src/command/internal/update-hie-enabled-feature-flags.ts
+++ b/packages/api/src/command/internal/update-hie-enabled-feature-flags.ts
@@ -24,11 +24,13 @@ export async function updateCxHieEnabledFFs({
   cwEnabled,
   cqEnabled,
   epicEnabled,
+  demoAugEnabled,
 }: {
   cxId: string;
   cwEnabled?: boolean;
   cqEnabled?: boolean;
   epicEnabled?: boolean;
+  demoAugEnabled?: boolean;
 }): Promise<CxFeatureFlagStatus> {
   const region = Config.getAWSRegion();
   const appId = Config.getAppConfigAppId();
@@ -52,9 +54,15 @@ export async function updateCxHieEnabledFFs({
   } else if (epicEnabled == false) {
     disableFeatureFlagForCustomer(featureFlags.cxsWithEpicEnabled, cxId);
   }
+  if (demoAugEnabled == true) {
+    enableFeatureFlagForCustomer(featureFlags.cxsWithDemoAugEnabled, cxId);
+  } else if (demoAugEnabled == false) {
+    disableFeatureFlagForCustomer(featureFlags.cxsWithDemoAugEnabled, cxId);
+  }
   deduplicateFeatureFlagValues(featureFlags.cxsWithCWFeatureFlag);
   deduplicateFeatureFlagValues(featureFlags.cxsWithCQDirectFeatureFlag);
   deduplicateFeatureFlagValues(featureFlags.cxsWithEpicEnabled);
+  deduplicateFeatureFlagValues(featureFlags.cxsWithDemoAugEnabled);
   const newFeatureFlags = await createAndDeployConfigurationContent({
     region,
     appId,
@@ -66,9 +74,14 @@ export async function updateCxHieEnabledFFs({
   const currentCwEnabled = newFeatureFlags.cxsWithCWFeatureFlag.values.includes(cxId);
   const currentCqEnabled = newFeatureFlags.cxsWithCQDirectFeatureFlag.values.includes(cxId);
   const currentEpicEnabled = newFeatureFlags.cxsWithEpicEnabled.values.includes(cxId);
+  const currentDemoAugEnabled = newFeatureFlags.cxsWithDemoAugEnabled.values.includes(cxId);
   const { log } = out(`Customer ${cxId}`);
   log(
-    `New HIE enabled state: CW: ${currentCwEnabled} CQ: ${currentCqEnabled} Epic: ${currentEpicEnabled}`
+    `New HIE enabled state: ` +
+      `CW: ${currentCwEnabled} ` +
+      `CQ: ${currentCqEnabled} ` +
+      `Epic: ${currentEpicEnabled} ` +
+      `Demo Aug: ${currentDemoAugEnabled}`
   );
   return {
     cxsWithCWFeatureFlag: {
@@ -82,6 +95,10 @@ export async function updateCxHieEnabledFFs({
     cxsWithEpicEnabled: {
       cxInFFValues: currentEpicEnabled,
       ffEnabled: newFeatureFlags.cxsWithEpicEnabled.enabled,
+    },
+    cxsWithDemoAugEnabled: {
+      cxInFFValues: currentDemoAugEnabled,
+      ffEnabled: newFeatureFlags.cxsWithDemoAugEnabled.enabled,
     },
   };
 }

--- a/packages/api/src/command/internal/update-hie-enabled-feature-flags.ts
+++ b/packages/api/src/command/internal/update-hie-enabled-feature-flags.ts
@@ -44,19 +44,19 @@ export async function updateCxHieEnabledFFs({
   } else if (cwEnabled === false) {
     disableFeatureFlagForCustomer(featureFlags.cxsWithCWFeatureFlag, cxId);
   }
-  if (cqEnabled == true) {
+  if (cqEnabled === true) {
     enableFeatureFlagForCustomer(featureFlags.cxsWithCQDirectFeatureFlag, cxId);
   } else if (cqEnabled === false) {
     disableFeatureFlagForCustomer(featureFlags.cxsWithCQDirectFeatureFlag, cxId);
   }
-  if (epicEnabled == true) {
+  if (epicEnabled === true) {
     enableFeatureFlagForCustomer(featureFlags.cxsWithEpicEnabled, cxId);
-  } else if (epicEnabled == false) {
+  } else if (epicEnabled === false) {
     disableFeatureFlagForCustomer(featureFlags.cxsWithEpicEnabled, cxId);
   }
-  if (demoAugEnabled == true) {
+  if (demoAugEnabled === true) {
     enableFeatureFlagForCustomer(featureFlags.cxsWithDemoAugEnabled, cxId);
-  } else if (demoAugEnabled == false) {
+  } else if (demoAugEnabled === false) {
     disableFeatureFlagForCustomer(featureFlags.cxsWithDemoAugEnabled, cxId);
   }
   deduplicateFeatureFlagValues(featureFlags.cxsWithCWFeatureFlag);

--- a/packages/api/src/external/aws/app-config.ts
+++ b/packages/api/src/external/aws/app-config.ts
@@ -68,9 +68,7 @@ async function getCxsWithFeatureFlagEnabled(
  *
  * @returns true if enabled; false otherwise
  */
-async function isFeatureFlagEnabledBoolean(
-  featureFlagName: keyof BooleanFeatureFlags
-): Promise<boolean> {
+async function isFeatureFlagEnabled(featureFlagName: keyof BooleanFeatureFlags): Promise<boolean> {
   try {
     const featureFlag = await getFeatureFlagValueBoolean(
       Config.getAWSRegion(),
@@ -167,9 +165,9 @@ export async function isDemoAugEnabledForCx(cxId: string): Promise<boolean> {
 }
 
 export async function isCommonwellEnabled(): Promise<boolean> {
-  return isFeatureFlagEnabledBoolean("commonwellFeatureFlag");
+  return isFeatureFlagEnabled("commonwellFeatureFlag");
 }
 
 export async function isCarequalityEnabled(): Promise<boolean> {
-  return isFeatureFlagEnabledBoolean("carequalityFeatureFlag");
+  return isFeatureFlagEnabled("carequalityFeatureFlag");
 }

--- a/packages/api/src/external/aws/app-config.ts
+++ b/packages/api/src/external/aws/app-config.ts
@@ -111,6 +111,10 @@ export async function getCxsWithEpicEnabled(): Promise<string[]> {
   return getCxsWithFeatureFlagEnabled("cxsWithEpicEnabled");
 }
 
+export async function getCxsWitDemoAugEnabled(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithDemoAugEnabled");
+}
+
 export async function getE2eCxIds(): Promise<string | undefined> {
   if (Config.isDev()) {
     const apiKey = getEnvVar("TEST_API_KEY");
@@ -154,6 +158,14 @@ export async function isEpicEnabledForCx(cxId: string): Promise<boolean> {
   const cxIdsWithEpicEnabled = await getCxsWithEpicEnabled();
 
   return cxIdsWithEpicEnabled.length === 0 ? true : cxIdsWithEpicEnabled.some(i => i === cxId);
+}
+
+export async function isDemoAugEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithDemoAugEnabled = await getCxsWitDemoAugEnabled();
+
+  return cxIdsWithDemoAugEnabled.length === 0
+    ? true
+    : cxIdsWithDemoAugEnabled.some(i => i === cxId);
 }
 
 export async function isCommonwellEnabled(): Promise<boolean> {

--- a/packages/api/src/external/aws/app-config.ts
+++ b/packages/api/src/external/aws/app-config.ts
@@ -68,32 +68,6 @@ async function getCxsWithFeatureFlagEnabled(
  *
  * @returns true if enabled; false otherwise
  */
-async function isFeatureFlagEnabledStringArray(
-  featureFlagName: keyof StringValueFeatureFlags
-): Promise<boolean> {
-  try {
-    const featureFlag = await getFeatureFlagValueStringArray(
-      Config.getAWSRegion(),
-      Config.getAppConfigAppId(),
-      Config.getAppConfigConfigId(),
-      Config.getEnvType(),
-      featureFlagName
-    );
-    if (featureFlag) return featureFlag.enabled;
-  } catch (error) {
-    const msg = `Failed to get Feature Flag Value`;
-    const extra = { featureFlagName };
-    log(`${msg} - ${JSON.stringify(extra)} - ${errorToString(error)}`);
-    capture.error(msg, { extra: { ...extra, error } });
-  }
-  return false;
-}
-
-/**
- * Checks whether the specified feature flag is enabled.
- *
- * @returns true if enabled; false otherwise
- */
 async function isFeatureFlagEnabledBoolean(
   featureFlagName: keyof BooleanFeatureFlags
 ): Promise<boolean> {
@@ -184,20 +158,12 @@ export async function isWebhookPongDisabledForCx(cxId: string): Promise<boolean>
 
 export async function isEpicEnabledForCx(cxId: string): Promise<boolean> {
   const cxIdsWithEpicEnabled = await getCxsWithEpicEnabled();
-  const globalEnabled = await isFeatureFlagEnabledStringArray("cxsWithEpicEnabled");
-  if (!globalEnabled) return false;
-
-  return cxIdsWithEpicEnabled.length === 0 ? true : cxIdsWithEpicEnabled.some(i => i === cxId);
+  return cxIdsWithEpicEnabled.some(i => i === cxId);
 }
 
 export async function isDemoAugEnabledForCx(cxId: string): Promise<boolean> {
   const cxIdsWithDemoAugEnabled = await getCxsWitDemoAugEnabled();
-  const globalEnabled = await isFeatureFlagEnabledStringArray("cxsWithDemoAugEnabled");
-  if (!globalEnabled) return false;
-
-  return cxIdsWithDemoAugEnabled.length === 0
-    ? true
-    : cxIdsWithDemoAugEnabled.some(i => i === cxId);
+  return cxIdsWithDemoAugEnabled.some(i => i === cxId);
 }
 
 export async function isCommonwellEnabled(): Promise<boolean> {

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -19,6 +19,7 @@ import { getCqInitiator, isCqEnabled } from "./shared";
 import { queryDocsIfScheduled } from "./process-outbound-patient-discovery-resps";
 import { createAugmentedPatient } from "../../domain/medical/patient-demographics";
 import { resetScheduledPatientDiscovery } from "../hie/reset-scheduled-patient-discovery-request";
+import { isDemoAugEnabledForCx } from "../aws/app-config";
 
 dayjs.extend(duration);
 
@@ -43,6 +44,9 @@ export async function discover({
 
   const enabledIHEGW = await isCqEnabled(patient, facilityId, forceEnabled, outerLog);
 
+  const demoAugEnabled = await isDemoAugEnabledForCx(patient.cxId);
+  const cxRerunPdOnNewDemographics = demoAugEnabled || rerunPdOnNewDemographics;
+
   if (enabledIHEGW) {
     const requestId = inputRequestId ?? uuidv7();
     const startedAt = new Date();
@@ -53,7 +57,7 @@ export async function discover({
         requestId,
         facilityId,
         startedAt,
-        rerunPdOnNewDemographics,
+        rerunPdOnNewDemographics: cxRerunPdOnNewDemographics,
       },
     });
 

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -28,6 +28,7 @@ import {
   isCommonwellEnabled,
   isCWEnabledForCx,
   isEnhancedCoverageEnabledForCx,
+  isDemoAugEnabledForCx,
 } from "../aws/app-config";
 import { isFacilityEnabledToQueryCW } from "../commonwell/shared";
 import { checkLinkDemographicsAcrossHies } from "../hie/check-patient-link-demographics";
@@ -119,6 +120,9 @@ export async function create({
     log,
   });
 
+  const demoAugEnabled = await isDemoAugEnabledForCx(patient.cxId);
+  const cxRerunPdOnNewDemographics = demoAugEnabled || rerunPdOnNewDemographics;
+
   if (cwCreateEnabled) {
     const requestId = inputRequestId ?? uuidv7();
     const startedAt = new Date();
@@ -129,7 +133,7 @@ export async function create({
         requestId,
         facilityId,
         startedAt,
-        rerunPdOnNewDemographics,
+        rerunPdOnNewDemographics: cxRerunPdOnNewDemographics,
       },
     });
 
@@ -137,7 +141,7 @@ export async function create({
       patient: createAugmentedPatient(updatedPatient),
       facilityId,
       getOrgIdExcludeList,
-      rerunPdOnNewDemographics,
+      rerunPdOnNewDemographics: cxRerunPdOnNewDemographics,
       requestId,
       startedAt,
       debug,
@@ -287,6 +291,9 @@ export async function update({
     log,
   });
 
+  const demoAugEnabled = await isDemoAugEnabledForCx(patient.cxId);
+  const cxRerunPdOnNewDemographics = demoAugEnabled || rerunPdOnNewDemographics;
+
   if (cwUpdateEnabled) {
     const requestId = inputRequestId ?? uuidv7();
     const startedAt = new Date();
@@ -297,7 +304,7 @@ export async function update({
         requestId,
         facilityId,
         startedAt,
-        rerunPdOnNewDemographics,
+        rerunPdOnNewDemographics: cxRerunPdOnNewDemographics,
       },
     });
 
@@ -305,7 +312,7 @@ export async function update({
       patient: createAugmentedPatient(updatedPatient),
       facilityId,
       getOrgIdExcludeList,
-      rerunPdOnNewDemographics,
+      rerunPdOnNewDemographics: cxRerunPdOnNewDemographics,
       requestId,
       startedAt,
       debug,

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -289,6 +289,7 @@ router.get(
  * @param req.query.cwEnabled - Whether to enabled CommonWell.
  * @param req.query.cqEnabled - Whether to enabled CareQuality.
  * @param req.query.epicEnabled - Whether to enabled Epic.
+ * @param req.query.demoAugEnabled - Whether to enabled Demo Aug.
  */
 router.put(
   "/cx-ff-status",
@@ -298,11 +299,13 @@ router.put(
     const cwEnabled = getFromQueryAsBoolean("cwEnabled", req);
     const cqEnabled = getFromQueryAsBoolean("cqEnabled", req);
     const epicEnabled = getFromQueryAsBoolean("epicEnabled", req);
+    const demoAugEnabled = getFromQueryAsBoolean("demoAugEnabled", req);
     const result = await updateCxHieEnabledFFs({
       cxId,
       cwEnabled,
       cqEnabled,
       epicEnabled,
+      demoAugEnabled,
     });
     return res.status(httpStatus.OK).json(result);
   })

--- a/packages/core/src/external/aws/app-config.ts
+++ b/packages/core/src/external/aws/app-config.ts
@@ -37,6 +37,7 @@ export const cxBasedFFsSchema = z.object({
   cxsWithNoWebhookPongFeatureFlag: ffStringValuesSchema,
   cxsWithIncreasedSandboxLimitFeatureFlag: ffStringValuesSchema,
   cxsWithEpicEnabled: ffStringValuesSchema,
+  cxsWithDemoAugEnabled: ffStringValuesSchema,
 });
 export type CxBasedFFsSchema = z.infer<typeof cxBasedFFsSchema>;
 


### PR DESCRIPTION
Ticket: #1040

### Dependencies

- Upstream: add the new FF to the config manually?

### Description

- adding new demo augmentation ff based on CX -- note that I followed the Epic approach of an empty cxId list maps to all customers in the list -- not sure if we want this for sure, but means we need to have at least one cxId in the list before we enable the FF at the global level.
- Fixed bug where Epic / Demo Aug would be classified as true even if the global enabled flag is false.
- adding the enabled status to the PD flow (note: done at HIE level)
- adding ability to update the new flag via the ops-dash internal endpoints

### Testing

- Local
  - [x] check that cx with new FF has demo aug true even if the query param is not set or set to false
- Staging
  - [ ] check that cx with new FF has demo aug true even if the query param is not set or set to false
- Production
  - [ ] check that cx with new FF has demo aug true even if the query param is not set or set to false

### Release Plan

- [ ] Execute this on staging, prod *BEFORE MERGING*
  - [ ] introduce new ff in the config as enabled FALSE + EMPTY LIST.
  - [ ] *MERGE*
  - [ ] Once we verify the app is working, edit manually the ff in the config as enabled TRUE + AT LEAST ONE CXID
- [ ] Merge this