### PR TITLE
feat(canvas): command api for resources in uncommited state

### DIFF
--- a/packages/core/src/external/canvas/data.ts
+++ b/packages/core/src/external/canvas/data.ts
@@ -71,8 +71,8 @@ export function generateFakeConditionData1(patientId: string): Condition[] {
       code: {
         coding: [
           {
-            system: "http://hl7.org/fhir/sid/icd-10-cm",
-            code: "O99.213",
+            system: "ICD-10",
+            code: "O99213",
             display: "Maternal obesity syndrome in third trimester",
           },
         ],
@@ -110,8 +110,8 @@ export function generateFakeConditionData1(patientId: string): Condition[] {
       code: {
         coding: [
           {
-            system: "http://hl7.org/fhir/sid/icd-10-cm",
-            code: "D17.9",
+            system: "ICD-10",
+            code: "D179",
             display: "Lipoma (Benign)",
           },
         ],
@@ -149,8 +149,8 @@ export function generateFakeConditionData1(patientId: string): Condition[] {
       code: {
         coding: [
           {
-            system: "http://hl7.org/fhir/sid/icd-10-cm",
-            code: "E66.01",
+            system: "ICD-10",
+            code: "E6601",
             display:
               "Class 1 obesity due to excess calories with serious comorbidity and body mass index (BMI) of 31.0 to 31.9 in adult",
           },
@@ -194,8 +194,8 @@ export function generateFakeConditionData2(patientId: string): Condition[] {
       code: {
         coding: [
           {
-            system: "http://hl7.org/fhir/sid/icd-10-cm",
-            code: "R63.5",
+            system: "ICD-10",
+            code: "R635",
             display: "Abnormal Weight Gain",
           },
         ],
@@ -233,8 +233,8 @@ export function generateFakeConditionData2(patientId: string): Condition[] {
       code: {
         coding: [
           {
-            system: "http://hl7.org/fhir/sid/icd-10-cm",
-            code: "E78.2",
+            system: "ICD-10",
+            code: "E782",
             display: "Hyperlipidemia (Mixed)",
           },
         ],
@@ -272,8 +272,8 @@ export function generateFakeConditionData2(patientId: string): Condition[] {
       code: {
         coding: [
           {
-            system: "http://hl7.org/fhir/sid/icd-10-cm",
-            code: "J45.909",
+            system: "ICD-10",
+            code: "J45909",
             display: "Asthma (disorder)",
           },
         ],
@@ -311,8 +311,8 @@ export function generateFakeConditionData2(patientId: string): Condition[] {
       code: {
         coding: [
           {
-            system: "http://hl7.org/fhir/sid/icd-10-cm",
-            code: "C73.03",
+            system: "ICD-10",
+            code: "C7303",
             display: "Medullary Thyroid Cancer",
           },
         ],

--- a/packages/core/src/external/canvas/note.ts
+++ b/packages/core/src/external/canvas/note.ts
@@ -17,7 +17,7 @@ export async function createFullNote({
   patientA: boolean;
   patientB: boolean;
   providerLastName: string;
-}) {
+}): Promise<string> {
   try {
     // TODO remove this as per https://github.com/metriport/metriport-internal/issues/2088
     const [canvasPractitioner, canvasLocation] = await Promise.all([
@@ -60,32 +60,28 @@ export async function createFullNote({
       }
       if (resource.resourceType === "AllergyIntolerance") {
         log("Creating allergy");
-        await canvas.createAllergy({
+        await canvas.createAllergyCommand({
           allergy: resource,
-          patientId: canvasPatientId,
-          practitionerId: canvasPractitionerId,
           noteId: canvasNoteId,
         });
       }
 
       if (resource.resourceType === "Condition") {
         log("Creating condition");
-        await canvas.createCondition({
+        await canvas.createConditionCommand({
           condition: resource,
-          patientId: canvasPatientId,
-          practitionerId: canvasPractitionerId,
           noteId: canvasNoteId,
         });
       }
       if (resource.resourceType === "MedicationStatement") {
         log("Creating medication statement");
-        await canvas.createMedicationStatement({
+        await canvas.createMedicationStatementCommand({
           medication: resource,
-          patientId: canvasPatientId,
           noteId: canvasNoteId,
         });
       }
     }
+    return canvasNoteId;
   } catch (error) {
     const msg = "Error in createFullNote Canvas";
     const extra = { canvasPatientId };


### PR DESCRIPTION
Ticket: #[2062](https://github.com/metriport/metriport-internal/issues/2062)

### Description

- use command api so that resources in the notes are in an "uncommitted state" and the provider can choose to select them
<img width="1910" alt="Screenshot 2024-08-02 at 17 36 34" src="https://github.com/user-attachments/assets/1f06f3c8-faea-44b3-a3a7-70e64c0f34d8">




### Testing

- Local
  - [x] lots of local testing
- Staging
  - [x] branch to staging
  - [ ] staging
- Sandbox
  - [ ] sandbox

### Release Plan

- [ ] Merge this
