### PR TITLE
fix(express): updating timeouts on fhir converter server

### DIFF
--- a/packages/fhir-converter/package-lock.json
+++ b/packages/fhir-converter/package-lock.json
@@ -15,6 +15,7 @@
         "codemirror": "^5.62.0",
         "convert-units": "^2.3.4",
         "cookie-parser": "^1.4.4",
+        "dayjs": "^1.11.12",
         "deepmerge": "^4.2.2",
         "express": "^4.19.2",
         "fast-xml-parser": "^4.4.1",
@@ -3695,6 +3696,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg=="
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/packages/fhir-converter/package.json
+++ b/packages/fhir-converter/package.json
@@ -100,6 +100,7 @@
     "codemirror": "^5.62.0",
     "convert-units": "^2.3.4",
     "cookie-parser": "^1.4.4",
+    "dayjs": "^1.11.12",
     "deepmerge": "^4.2.2",
     "express": "^4.19.2",
     "fast-xml-parser": "^4.4.1",

--- a/packages/fhir-converter/src/index.js
+++ b/packages/fhir-converter/src/index.js
@@ -27,6 +27,9 @@ require("events").EventEmitter.defaultMaxListeners = 20;
 var express = require("express");
 var app = require("./routes")(express());
 var dayjs = require('dayjs');
+var duration = require('dayjs/plugin/duration');
+
+dayjs.extend(duration);
 
 var port = process.env.PORT || 8080;
 

--- a/packages/fhir-converter/src/index.js
+++ b/packages/fhir-converter/src/index.js
@@ -26,6 +26,7 @@
 require("events").EventEmitter.defaultMaxListeners = 20;
 var express = require("express");
 var app = require("./routes")(express());
+var dayjs = require('dayjs');
 
 var port = process.env.PORT || 8080;
 
@@ -34,3 +35,13 @@ var server = app.listen(port, function () {
   console.log(`NODE_OPTIONS=${process.env.NODE_OPTIONS}`);
   console.log("FHIR Converter listening at http://%s:%s", host, port);
 });
+
+var loadbalancerTimeout = dayjs.duration({ minutes: 10 }).asMilliseconds();
+var oneSecond = dayjs.duration({ seconds: 1 }).asMilliseconds();
+
+var timeout = loadbalancerTimeout - oneSecond;
+server.setTimeout(timeout);
+
+var keepalive = loadbalancerTimeout + oneSecond;
+server.keepAliveTimeout = keepalive;
+server.headersTimeout = keepalive + oneSecond;

--- a/packages/fhir-converter/src/index.js
+++ b/packages/fhir-converter/src/index.js
@@ -36,7 +36,7 @@ var server = app.listen(port, function () {
   console.log("FHIR Converter listening at http://%s:%s", host, port);
 });
 
-var loadbalancerTimeout = dayjs.duration({ minutes: 10 }).asMilliseconds();
+var loadbalancerTimeout = dayjs.duration({ minutes: 15 }).asMilliseconds();
 var oneSecond = dayjs.duration({ seconds: 1 }).asMilliseconds();
 
 var timeout = loadbalancerTimeout - oneSecond;


### PR DESCRIPTION
Refs: #799

### Description

- adding timeouts to fhir converter server 
- see: https://github.com/metriport/metriport/pull/2464

### Testing

```
date && ab -c 100 -n 10000 -H "Host: <staging_url>" <staging_url> / && date
```
- tested 3 times all with 0 failed requests

### Release Plan

- [ ] Merge this
