### PR TITLE
fix(api): giving lambda access to env vars

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -375,6 +375,7 @@ export class APIStack extends Stack {
           appId: appConfigAppId,
           configId: appConfigConfigId,
         },
+        bedrock: props.config.bedrock,
         ...props.config.fhirToMedicalLambda,
       });
     }
@@ -1197,6 +1198,7 @@ export class APIStack extends Stack {
       appId: string;
       configId: string;
     };
+    bedrock: { modelId: string; region: string; anthropicVersion: string } | undefined;
   }): Lambda {
     const {
       nodeRuntimeArn,
@@ -1207,6 +1209,7 @@ export class APIStack extends Stack {
       alarmAction,
       medicalDocumentsBucket,
       appConfigEnvVars,
+      bedrock,
     } = ownProps;
 
     const lambdaTimeout = MAXIMUM_LAMBDA_TIMEOUT.minus(Duration.seconds(5));
@@ -1226,6 +1229,11 @@ export class APIStack extends Stack {
         PDF_CONVERT_TIMEOUT_MS: CDA_TO_VIS_TIMEOUT.toMilliseconds().toString(),
         APPCONFIG_APPLICATION_ID: appConfigEnvVars.appId,
         APPCONFIG_CONFIGURATION_ID: appConfigEnvVars.configId,
+        ...(bedrock && {
+          BEDROCK_REGION: bedrock?.region,
+          BEDROCK_VERSION: bedrock?.anthropicVersion,
+          AI_BRIEF_MODEL_ID: bedrock?.modelId,
+        }),
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
       layers: [lambdaLayers.shared, lambdaLayers.chromium],

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1261,6 +1261,12 @@ export class APIStack extends Stack {
 
     medicalDocumentsBucket.grantReadWrite(fhirToMedicalRecordLambda);
 
+    const bedrockPolicyStatement = new iam.PolicyStatement({
+      actions: ["bedrock:InvokeModel"],
+      resources: ["*"],
+    });
+
+    fhirToMedicalRecordLambda.addToRolePolicy(bedrockPolicyStatement);
     return fhirToMedicalRecordLambda;
   }
 

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -267,11 +267,6 @@ export function createAPIService({
             PLACE_INDEX_NAME: props.config.locationService.placeIndexName,
             PLACE_INDEX_REGION: props.config.locationService.placeIndexRegion,
           }),
-          ...(props.config.bedrock && {
-            BEDROCK_REGION: props.config.bedrock.region,
-            BEDROCK_VERSION: props.config.bedrock.anthropicVersion,
-            AI_BRIEF_MODEL_ID: props.config.bedrock.modelId,
-          }),
           // app config
           APPCONFIG_APPLICATION_ID: appConfigEnvVars.appId,
           APPCONFIG_CONFIGURATION_ID: appConfigEnvVars.configId,


### PR DESCRIPTION
refs. metriport/metriport-internal#2040

### Description

- FHIR to Medical Record Summary lambda getting env vars for Bedrock
- FHIR to Medical Record Summary lambda getting access to invoke Bedrock InvokeModel method

### Testing

- Staging
  - [x] Manually set the env vars and it resolved all issues
  - [ ] Make sure the programmatic approach is successful

### Release Plan
- [ ] Merge this
