### PR TITLE
PATCH RELEASE 799 Increase max concurrency FHIR server lambda

### DIFF
--- a/packages/infra/lib/api-stack/fhir-server-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-server-connector.ts
@@ -24,7 +24,7 @@ function settings() {
     // Number of messages the lambda pull from SQS at once
     lambdaBatchSize: 1,
     // Max number of concurrent instances of the lambda that an Amazon SQS event source can invoke [2 - 1000].
-    maxConcurrency: prod ? 128 : 4,
+    maxConcurrency: prod ? 384 : 4,
     // How long can the lambda run for, max is 900 seconds (15 minutes)
     lambdaTimeout,
     // Number of times we want to retry a message, this includes throttles!


### PR DESCRIPTION
refs. metriport/metriport-internal#799

### Dependencies

- Upstream: https://github.com/metriport/fhir-server/pull/69
- Downstream: none

### Description

Beef-up FHIR Server - [context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1723054102315689?thread_ts=1723042815.068539&cid=C04GEQ1GH9D)

### Testing

none

### Release Plan

- :warning: Points to `master`
- [x] Release upstream
- [ ] Merge this
