### PR TITLE
1040 Adjustments on CA scripts + other goodies

### DIFF
--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -293,7 +293,7 @@ export class MetriportMedicalApi {
   async createPatient(
     data: PatientCreate,
     facilityId: string,
-    additionalQueryParams: Record<string, string> = {}
+    additionalQueryParams: Record<string, string | number | boolean> = {}
   ): Promise<PatientDTO> {
     const resp = await this.api.post(`${PATIENT_URL}`, data, {
       params: { facilityId, ...additionalQueryParams },
@@ -342,7 +342,7 @@ export class MetriportMedicalApi {
   async updatePatient(
     patient: PatientUpdate,
     facilityId?: string,
-    additionalQueryParams: Record<string, string> = {}
+    additionalQueryParams: Record<string, string | number | boolean> = {}
   ): Promise<PatientDTO> {
     type FieldsToOmit = "id";
     const payload: Omit<PatientUpdate, FieldsToOmit> & Record<FieldsToOmit, undefined> = {

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -287,11 +287,16 @@ export class MetriportMedicalApi {
    *
    * @param data The data to be used to create a new patient.
    * @param facilityId The facility providing the NPI to support this operation.
+   * @param additionalQueryParams Optional, additional query parameters to be sent with the request.
    * @return The newly created patient.
    */
-  async createPatient(data: PatientCreate, facilityId: string): Promise<PatientDTO> {
+  async createPatient(
+    data: PatientCreate,
+    facilityId: string,
+    additionalQueryParams: Record<string, string> = {}
+  ): Promise<PatientDTO> {
     const resp = await this.api.post(`${PATIENT_URL}`, data, {
-      params: { facilityId },
+      params: { facilityId, ...additionalQueryParams },
     });
     if (!resp.data) throw new Error(NO_DATA_MESSAGE);
     return resp.data as PatientDTO;
@@ -331,16 +336,21 @@ export class MetriportMedicalApi {
    *
    * @param patient The patient data to be updated.
    * @param facilityId Optional. The facility providing the NPI to support this operation. If not provided and the patient has only one facility, that one will be used. If not provided and the patient has multiple facilities, an error will be thrown.
+   * @param additionalQueryParams Optional, additional query parameters to be sent with the request.
    * @return The updated patient.
    */
-  async updatePatient(patient: PatientUpdate, facilityId?: string): Promise<PatientDTO> {
+  async updatePatient(
+    patient: PatientUpdate,
+    facilityId?: string,
+    additionalQueryParams: Record<string, string> = {}
+  ): Promise<PatientDTO> {
     type FieldsToOmit = "id";
     const payload: Omit<PatientUpdate, FieldsToOmit> & Record<FieldsToOmit, undefined> = {
       ...patient,
       id: undefined,
     };
     const resp = await this.api.put(`${PATIENT_URL}/${patient.id}`, payload, {
-      params: { facilityId },
+      params: { facilityId, ...additionalQueryParams },
       headers: { ...getETagHeader(patient) },
     });
     if (!resp.data) throw new Error(NO_DATA_MESSAGE);

--- a/packages/core/src/external/aws/s3.ts
+++ b/packages/core/src/external/aws/s3.ts
@@ -25,7 +25,7 @@ dayjs.extend(duration);
 const pipeline = util.promisify(stream.pipeline);
 const DEFAULT_SIGNED_URL_DURATION = dayjs.duration({ minutes: 3 }).asSeconds();
 const defaultS3RetriesConfig = {
-  maxAttempts: 3,
+  maxAttempts: 5,
   initialDelay: 500,
 };
 

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dr.test.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dr.test.ts
@@ -1,40 +1,109 @@
 import fs from "fs";
 import path from "path";
 import { v4 as uuidv4 } from "uuid";
-import { processDrResponse } from "../xca/process/dr-response";
-import { outboundDrRequest, testFiles, outboundDrRequestMtom } from "./constants";
 import { S3Utils } from "../../../../aws/s3";
-import { createMtomMessageWithAttachments, createMtomMessageWithoutAttachments } from "./mtom";
 import { schemaErrorCode } from "../../../error";
+import { processDrResponse } from "../xca/process/dr-response";
+import { outboundDrRequest, outboundDrRequestMtom, testFiles } from "./constants";
+import { createMtomMessageWithAttachments, createMtomMessageWithoutAttachments } from "./mtom";
 
-describe("processDrResponse for MTOM with/without attachments and for different file types", () => {
-  beforeEach(() => {
-    jest.spyOn(S3Utils.prototype, "uploadFile").mockImplementation(() => {
-      return Promise.resolve({
-        Location: "http://example.com/mockurl",
-        ETag: '"mockedetag"',
-        Bucket: "mockedbucket",
-        Key: "mockedkey",
+beforeAll(() => {
+  jest.spyOn(S3Utils.prototype, "uploadFile").mockImplementation(() => {
+    return Promise.resolve({
+      Location: "http://example.com/mockurl",
+      ETag: '"mockedetag"',
+      Bucket: "mockedbucket",
+      Key: "mockedkey",
+    });
+  });
+
+  jest.spyOn(S3Utils.prototype, "getFileInfoFromS3").mockImplementation(() =>
+    Promise.resolve({
+      exists: false,
+    })
+  );
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe("dr-response", () => {
+  describe("processDrResponse for MTOM with/without attachments and for different file types", () => {
+    testFiles.forEach(({ name, mimeType, fileExtension }) => {
+      it(`[mtom without attachments]: should process the ${fileExtension} DR response correctly`, async () => {
+        const filePath = path.join(__dirname, "./files/", name);
+        const fileBuffer = fs.readFileSync(filePath);
+
+        const attachmentsData = [{ payload: fileBuffer, mimeType: mimeType }];
+        const mtomAttachments = await createMtomMessageWithAttachments(attachmentsData);
+        const response = await processDrResponse({
+          response: {
+            mtomResponse: mtomAttachments,
+            gateway: outboundDrRequestMtom.gateway,
+            outboundRequest: outboundDrRequestMtom,
+          },
+        });
+
+        expect(response).toBeDefined();
+        expect(response.documentReference).toHaveLength(1);
+        expect(response.documentReference?.[0]?.contentType).toBe(mimeType);
       });
     });
 
-    jest.spyOn(S3Utils.prototype, "getFileInfoFromS3").mockImplementation(() =>
-      Promise.resolve({
-        exists: false,
-      })
-    );
-  });
+    testFiles.forEach(({ name, mimeType, fileExtension }) => {
+      it(`[mtom with attachments]: should process the ${fileExtension} DR response correctly`, async () => {
+        const xmlTemplatePath = path.join(__dirname, "./xmls/dr-insert-b64.xml");
+        const xmlTemplate = fs.readFileSync(xmlTemplatePath, "utf8");
 
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
+        const fileContent = fs.readFileSync(path.join(__dirname, `./files/${name}`));
+        const fileContentB64 = fileContent.toString("base64");
+        const modifiedXml = xmlTemplate.replace(
+          "<Document></Document>",
+          `<Document>${fileContentB64}</Document>`
+        );
 
-  testFiles.forEach(({ name, mimeType, fileExtension }) => {
-    it(`[mtom without attachments]: should process the ${fileExtension} DR response correctly`, async () => {
-      const filePath = path.join(__dirname, "./files/", name);
-      const fileBuffer = fs.readFileSync(filePath);
+        const mtomResponse = await createMtomMessageWithoutAttachments(modifiedXml);
+        const response = await processDrResponse({
+          response: {
+            mtomResponse: mtomResponse,
+            gateway: outboundDrRequest.gateway,
+            outboundRequest: {
+              ...outboundDrRequest,
+              documentReference: outboundDrRequest.documentReference.map(docRef => ({
+                ...docRef,
+                metriportId: uuidv4(),
+              })),
+            },
+          },
+        });
+        expect(response?.documentReference?.[0]?.contentType).toEqual(mimeType);
+      });
+    });
 
-      const attachmentsData = [{ payload: fileBuffer, mimeType: mimeType }];
+    it("[mtom with multiple attachments]: should correctly create and parse MTOM message with XML, PDF, and TIFF attachments", async () => {
+      const xmlFile = testFiles.find(file => file.fileExtension === ".xml");
+      const pdfFile = testFiles.find(file => file.fileExtension === ".pdf");
+      const tiffFile = testFiles.find(file => file.fileExtension === ".tiff");
+
+      if (!xmlFile || !pdfFile || !tiffFile) {
+        throw new Error("Required test files not found");
+      }
+
+      const xmlFilePath = path.join(__dirname, "./files/", xmlFile.name);
+      const pdfFilePath = path.join(__dirname, "./files/", pdfFile.name);
+      const tiffFilePath = path.join(__dirname, "./files/", tiffFile.name);
+
+      const xmlBuffer = fs.readFileSync(xmlFilePath);
+      const pdfBuffer = fs.readFileSync(pdfFilePath);
+      const tiffBuffer = fs.readFileSync(tiffFilePath);
+
+      const attachmentsData = [
+        { payload: xmlBuffer, mimeType: xmlFile.mimeType },
+        { payload: pdfBuffer, mimeType: pdfFile.mimeType },
+        { payload: tiffBuffer, mimeType: tiffFile.mimeType },
+      ];
+
       const mtomAttachments = await createMtomMessageWithAttachments(attachmentsData);
       const response = await processDrResponse({
         response: {
@@ -44,174 +113,92 @@ describe("processDrResponse for MTOM with/without attachments and for different 
         },
       });
 
-      expect(response).toBeDefined();
-      expect(response.documentReference).toHaveLength(1);
-      expect(response.documentReference?.[0]?.contentType).toBe(mimeType);
+      expect(response.documentReference).toBeTruthy();
+      expect(response.documentReference).toHaveLength(3);
+      const contentTypes = response.documentReference?.map(d => d.contentType);
+      expect(contentTypes).toEqual(
+        expect.arrayContaining([xmlFile.mimeType, pdfFile.mimeType, tiffFile.mimeType])
+      );
+      expect(response.documentReference?.[0]?.contentType).toBe(xmlFile.mimeType);
     });
   });
-
-  testFiles.forEach(({ name, mimeType, fileExtension }) => {
-    it(`[mtom with attachments]: should process the ${fileExtension} DR response correctly`, async () => {
-      const xmlTemplatePath = path.join(__dirname, "./xmls/dr-insert-b64.xml");
-      const xmlTemplate = fs.readFileSync(xmlTemplatePath, "utf8");
-
-      const fileContent = fs.readFileSync(path.join(__dirname, `./files/${name}`));
-      const fileContentB64 = fileContent.toString("base64");
-      const modifiedXml = xmlTemplate.replace(
-        "<Document></Document>",
-        `<Document>${fileContentB64}</Document>`
-      );
-
-      const mtomResponse = await createMtomMessageWithoutAttachments(modifiedXml);
+  describe("processDrResponse", () => {
+    it("should process multiple DR responses correctly", async () => {
+      const xmlString = fs.readFileSync(path.join(__dirname, "xmls/dr_success.xml"), "utf8");
+      const mtomResponse = await createMtomMessageWithoutAttachments(xmlString);
       const response = await processDrResponse({
         response: {
           mtomResponse: mtomResponse,
           gateway: outboundDrRequest.gateway,
-          outboundRequest: {
-            ...outboundDrRequest,
-            documentReference: outboundDrRequest.documentReference.map(docRef => ({
-              ...docRef,
-              metriportId: uuidv4(),
-            })),
-          },
+          outboundRequest: outboundDrRequest,
         },
       });
-      expect(response?.documentReference?.[0]?.contentType).toEqual(mimeType);
-    });
-  });
+      expect(response.documentReference?.length).toBe(2);
+      expect(response?.documentReference?.[0]?.contentType).toEqual("application/octet-stream");
+      expect(response?.documentReference?.[0]?.docUniqueId).toEqual("123456789");
+      expect(response?.documentReference?.[0]?.homeCommunityId).toEqual("2.16.840.1.113883.3.9621");
+      expect(response?.documentReference?.[0]?.repositoryUniqueId).toEqual(
+        "2.16.840.1.113883.3.9621"
+      );
 
-  it("[mtom with multiple attachments]: should correctly create and parse MTOM message with XML, PDF, and TIFF attachments", async () => {
-    const xmlFile = testFiles.find(file => file.fileExtension === ".xml");
-    const pdfFile = testFiles.find(file => file.fileExtension === ".pdf");
-    const tiffFile = testFiles.find(file => file.fileExtension === ".tiff");
-
-    if (!xmlFile || !pdfFile || !tiffFile) {
-      throw new Error("Required test files not found");
-    }
-
-    const xmlFilePath = path.join(__dirname, "./files/", xmlFile.name);
-    const pdfFilePath = path.join(__dirname, "./files/", pdfFile.name);
-    const tiffFilePath = path.join(__dirname, "./files/", tiffFile.name);
-
-    const xmlBuffer = fs.readFileSync(xmlFilePath);
-    const pdfBuffer = fs.readFileSync(pdfFilePath);
-    const tiffBuffer = fs.readFileSync(tiffFilePath);
-
-    const attachmentsData = [
-      { payload: xmlBuffer, mimeType: xmlFile.mimeType },
-      { payload: pdfBuffer, mimeType: pdfFile.mimeType },
-      { payload: tiffBuffer, mimeType: tiffFile.mimeType },
-    ];
-
-    const mtomAttachments = await createMtomMessageWithAttachments(attachmentsData);
-    const response = await processDrResponse({
-      response: {
-        mtomResponse: mtomAttachments,
-        gateway: outboundDrRequestMtom.gateway,
-        outboundRequest: outboundDrRequestMtom,
-      },
+      expect(response?.documentReference?.[1]?.contentType).toEqual("application/octet-stream");
+      expect(response?.documentReference?.[1]?.docUniqueId).toEqual("987654321");
+      expect(response?.documentReference?.[1]?.homeCommunityId).toEqual("2.16.840.1.113883.3.9621");
+      expect(response?.documentReference?.[1]?.repositoryUniqueId).toEqual(
+        "2.16.840.1.113883.3.9621"
+      );
     });
 
-    expect(response.documentReference).toBeTruthy();
-    expect(response.documentReference).toHaveLength(3);
-    const contentTypes = response.documentReference?.map(d => d.contentType);
-    expect(contentTypes).toEqual(
-      expect.arrayContaining([xmlFile.mimeType, pdfFile.mimeType, tiffFile.mimeType])
-    );
-    expect(response.documentReference?.[0]?.contentType).toBe(xmlFile.mimeType);
-  });
-});
-describe("processDrResponse", () => {
-  beforeEach(() => {
-    jest.spyOn(S3Utils.prototype, "uploadFile").mockImplementation(() =>
-      Promise.resolve({
-        Location: "http://example.com/mockurl",
-        ETag: '"mockedetag"',
-        Bucket: "mockedbucket",
-        Key: "mockedkey",
-      })
-    );
-  });
+    it("should process the soap fault DR response correctly", async () => {
+      const xmlString = fs.readFileSync(path.join(__dirname, "xmls/dr_soap_error.xml"), "utf8");
+      const mtomResponse = await createMtomMessageWithoutAttachments(xmlString);
+      const response = await processDrResponse({
+        response: {
+          mtomResponse: mtomResponse,
+          gateway: outboundDrRequest.gateway,
+          outboundRequest: outboundDrRequest,
+        },
+      });
 
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it("should process multiple DR responses correctly", async () => {
-    const xmlString = fs.readFileSync(path.join(__dirname, "xmls/dr_success.xml"), "utf8");
-    const mtomResponse = await createMtomMessageWithoutAttachments(xmlString);
-    const response = await processDrResponse({
-      response: {
-        mtomResponse: mtomResponse,
-        gateway: outboundDrRequest.gateway,
-        outboundRequest: outboundDrRequest,
-      },
-    });
-    expect(response.documentReference?.length).toBe(2);
-    expect(response?.documentReference?.[0]?.contentType).toEqual("application/octet-stream");
-    expect(response?.documentReference?.[0]?.docUniqueId).toEqual("123456789");
-    expect(response?.documentReference?.[0]?.homeCommunityId).toEqual("2.16.840.1.113883.3.9621");
-    expect(response?.documentReference?.[0]?.repositoryUniqueId).toEqual(
-      "2.16.840.1.113883.3.9621"
-    );
-
-    expect(response?.documentReference?.[1]?.contentType).toEqual("application/octet-stream");
-    expect(response?.documentReference?.[1]?.docUniqueId).toEqual("987654321");
-    expect(response?.documentReference?.[1]?.homeCommunityId).toEqual("2.16.840.1.113883.3.9621");
-    expect(response?.documentReference?.[1]?.repositoryUniqueId).toEqual(
-      "2.16.840.1.113883.3.9621"
-    );
-  });
-
-  it("should process the soap fault DR response correctly", async () => {
-    const xmlString = fs.readFileSync(path.join(__dirname, "xmls/dr_soap_error.xml"), "utf8");
-    const mtomResponse = await createMtomMessageWithoutAttachments(xmlString);
-    const response = await processDrResponse({
-      response: {
-        mtomResponse: mtomResponse,
-        gateway: outboundDrRequest.gateway,
-        outboundRequest: outboundDrRequest,
-      },
+      expect(response?.operationOutcome?.issue[0]?.code).toEqual(schemaErrorCode);
     });
 
-    expect(response?.operationOutcome?.issue[0]?.code).toEqual(schemaErrorCode);
-  });
+    it("should process the registry error DR response correctly", async () => {
+      const xmlString = fs.readFileSync(path.join(__dirname, "xmls/dr_registry_error.xml"), "utf8");
+      const mtomResponse = await createMtomMessageWithoutAttachments(xmlString);
+      const response = await processDrResponse({
+        response: {
+          mtomResponse: mtomResponse,
+          gateway: outboundDrRequest.gateway,
+          outboundRequest: outboundDrRequest,
+        },
+      });
+      expect(response.operationOutcome?.issue[0]?.code).toEqual("XDSRegistryError");
+    });
 
-  it("should process the registry error DR response correctly", async () => {
-    const xmlString = fs.readFileSync(path.join(__dirname, "xmls/dr_registry_error.xml"), "utf8");
-    const mtomResponse = await createMtomMessageWithoutAttachments(xmlString);
-    const response = await processDrResponse({
-      response: {
-        mtomResponse: mtomResponse,
-        gateway: outboundDrRequest.gateway,
-        outboundRequest: outboundDrRequest,
-      },
+    it("should process the empty DR response correctly", async () => {
+      const xmlString = fs.readFileSync(path.join(__dirname, "xmls/dr_empty.xml"), "utf8");
+      const mtomResponse = await createMtomMessageWithoutAttachments(xmlString);
+      const response = await processDrResponse({
+        response: {
+          mtomResponse: mtomResponse,
+          gateway: outboundDrRequest.gateway,
+          outboundRequest: outboundDrRequest,
+        },
+      });
+      expect(response.operationOutcome?.issue[0]?.code).toEqual("no-documents-found");
     });
-    expect(response.operationOutcome?.issue[0]?.code).toEqual("XDSRegistryError");
-  });
-
-  it("should process the empty DR response correctly", async () => {
-    const xmlString = fs.readFileSync(path.join(__dirname, "xmls/dr_empty.xml"), "utf8");
-    const mtomResponse = await createMtomMessageWithoutAttachments(xmlString);
-    const response = await processDrResponse({
-      response: {
-        mtomResponse: mtomResponse,
-        gateway: outboundDrRequest.gateway,
-        outboundRequest: outboundDrRequest,
-      },
+    it("should process response that is not a string correctly", async () => {
+      const randomResponse = "This is a bad response and is not xml";
+      const mtomResponse = await createMtomMessageWithoutAttachments(randomResponse);
+      const response = await processDrResponse({
+        response: {
+          mtomResponse: mtomResponse,
+          gateway: outboundDrRequest.gateway,
+          outboundRequest: outboundDrRequest,
+        },
+      });
+      expect(response.operationOutcome?.issue[0]?.code).toEqual(schemaErrorCode);
     });
-    expect(response.operationOutcome?.issue[0]?.code).toEqual("no-documents-found");
-  });
-  it("should process response that is not a string correctly", async () => {
-    const randomResponse = "This is a bad response and is not xml";
-    const mtomResponse = await createMtomMessageWithoutAttachments(randomResponse);
-    const response = await processDrResponse({
-      response: {
-        mtomResponse: mtomResponse,
-        gateway: outboundDrRequest.gateway,
-        outboundRequest: outboundDrRequest,
-      },
-    });
-    expect(response.operationOutcome?.issue[0]?.code).toEqual(schemaErrorCode);
   });
 });

--- a/packages/utils/src/shared/file.ts
+++ b/packages/utils/src/shared/file.ts
@@ -1,0 +1,12 @@
+import fs from "fs";
+import path from "path";
+
+export function initFile(fileName: string, header?: string) {
+  const dirName = path.dirname(fileName);
+  if (!fs.existsSync(dirName)) {
+    fs.mkdirSync(dirName, { recursive: true });
+  }
+  if (header) {
+    fs.writeFileSync(fileName, header);
+  }
+}

--- a/packages/utils/src/shared/folder.ts
+++ b/packages/utils/src/shared/folder.ts
@@ -7,10 +7,16 @@ const runsFolderName = "runs";
  * Creates a symlink to the runs folder in the user's home directory
  */
 export function initRunsFolder() {
+  const homeDir = os.homedir();
+  const dest = `${homeDir}/Documents/phi/runs`;
+  if (!fs.existsSync(dest)) {
+    fs.mkdirSync(dest, { recursive: true });
+  }
   const pathName = `./${runsFolderName}`;
-  if (!fs.existsSync(pathName)) {
-    const homeDir = os.homedir();
-    fs.symlinkSync(`${homeDir}/Documents/phi/runs`, pathName);
+  try {
+    fs.lstatSync(pathName);
+  } catch (error) {
+    fs.symlinkSync(dest, pathName);
   }
 }
 

--- a/packages/utils/src/shared/log.ts
+++ b/packages/utils/src/shared/log.ts
@@ -1,5 +1,17 @@
+import fs from "fs";
+
+const errorSeparator = "----------------------------------------";
+
 export function logNotDryRun(log = console.log) {
   // The first chars there are to set color red on the terminal
   // See: // https://stackoverflow.com/a/41407246/2099911
   log("\n\x1b[31m%s\x1b[0m\n", "---- ATTENTION - THIS IS NOT A SIMULATED RUN ----");
+}
+
+export function logErrorToFile(fileName: string, msg: string, error: Error) {
+  const date = new Date().toISOString();
+  fs.appendFileSync(
+    fileName,
+    `${errorSeparator}\n${date} - ${msg}\n${error.message}\n${error.stack}\n\n`
+  );
 }


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Description

- Adjustments on CA scripts
- S3 attempts from 3 to 5 - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1723076882945709?thread_ts=1723068289.686479&cid=C04T256DQPQ)
- Add additional query params to create/update patient - [context](https://metriport.slack.com/archives/C04DBBJSKGB/p1723127363638609?thread_ts=1723082350.762469&cid=C04DBBJSKGB)
- fix unit tests of `processDrResponse`

### Testing

- Local
  - [x] CA scripts run successfully and store error on it's own file
  - [x] Create patient sends additional params to the server
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Release NPM packages
- [ ] Merge this
