### PR TITLE
fix(dq): analytics was counting no-documents-found as failures

### DIFF
--- a/packages/api/src/external/hie/__tests__/carequality-analytics.test.ts
+++ b/packages/api/src/external/hie/__tests__/carequality-analytics.test.ts
@@ -1,0 +1,80 @@
+import { OutboundDocumentQueryResp } from "@metriport/ihe-gateway-sdk";
+import { isSuccessfulOutboundDocQueryResponse } from "../carequality-analytics";
+
+describe("isSuccessfulOutboundDocQueryResponse", () => {
+  const baseResponse: OutboundDocumentQueryResp = {
+    id: "example-id-123",
+    gateway: {
+      url: "https://example-gateway.com/iti38/3.0",
+      homeCommunityId: "1.2.3.4.5.6.7.8.9.10",
+    },
+    duration: 29131,
+    patientId: "example-patient-id-456",
+    timestamp: "2024-08-09T16:18:05.695Z",
+    iheGatewayV2: true,
+    requestTimestamp: "2024-08-09T16:18:05.695Z",
+    responseTimestamp: "2024-08-09T16:18:34.826Z",
+    externalGatewayPatient: {
+      id: "example-external-id-789",
+      system: "1.2.3.4.5.6.7.8.9.10",
+    },
+  };
+
+  it("returns true when response has a documentReference", () => {
+    const response: OutboundDocumentQueryResp = {
+      ...baseResponse,
+      documentReference: [
+        {
+          title: "Summary of Episode Note",
+          language: "en-us",
+          contentType: "text/xml",
+          docUniqueId: "1.2.3.4.5.6.7.8.9.11",
+          homeCommunityId: "1.2.3.4.5.6.7.8.9.10",
+          authorInstitution: "Example Health CareConnect",
+          repositoryUniqueId: "1.2.3.4.5.6.7.8.9.12",
+        },
+      ],
+    };
+    expect(isSuccessfulOutboundDocQueryResponse(response)).toBe(true);
+  });
+
+  it("returns true when response has a 'no-documents-found' issue", () => {
+    const response: OutboundDocumentQueryResp = {
+      ...baseResponse,
+      operationOutcome: {
+        id: "123456",
+        issue: [
+          {
+            code: "no-documents-found",
+            details: {
+              text: "No documents found",
+            },
+            severity: "information",
+          },
+        ],
+        resourceType: "OperationOutcome",
+      },
+    };
+    expect(isSuccessfulOutboundDocQueryResponse(response)).toBe(true);
+  });
+
+  it("returns false when response has a different operation outcome", () => {
+    const response: OutboundDocumentQueryResp = {
+      ...baseResponse,
+      operationOutcome: {
+        id: "019131e3-16a1-770a-ac8b-c737dfc0c514",
+        issue: [
+          {
+            code: "http-error",
+            details: {
+              text: "Request failed with status code 500",
+            },
+            severity: "error",
+          },
+        ],
+        resourceType: "OperationOutcome",
+      },
+    };
+    expect(isSuccessfulOutboundDocQueryResponse(response)).toBe(false);
+  });
+});

--- a/packages/api/src/external/hie/carequality-analytics.ts
+++ b/packages/api/src/external/hie/carequality-analytics.ts
@@ -2,7 +2,6 @@ import {
   OutboundPatientDiscoveryResp,
   OutboundDocumentQueryResp,
   OutboundDocumentRetrievalResp,
-  isSuccessfulOutboundDocQueryResponse,
   isSuccessfulOutboundDocRetrievalResponse,
   isNonErroringOutboundPatientDiscoveryResponse,
   isSuccessfulOutboundPatientDiscoveryResponse,
@@ -151,6 +150,13 @@ export function getOutboundPatientDiscoverySuccessFailureCount(
     specificErrorCount,
     gatewayCounts,
   };
+}
+
+export function isSuccessfulOutboundDocQueryResponse(obj: OutboundDocumentQueryResp): boolean {
+  return (
+    "documentReference" in obj ||
+    (obj.operationOutcome?.issue?.some(issue => issue.code === "no-documents-found") ?? false)
+  );
 }
 
 export function getOutboundDocQuerySuccessFailureCount(response: OutboundDocumentQueryResp[]): {


### PR DESCRIPTION
Ticket: #[1667](https://github.com/metriport/metriport-internal/issues/1667)


### Description

- analytics was counting no-documents-found as failures on DQs making success rate lower than it should be
<img width="1700" alt="Screenshot 2024-08-09 at 09 42 28" src="https://github.com/user-attachments/assets/34abd9d8-b96a-413b-88eb-25408810a1c4">


### Testing

- Local
  - [x] added unit tests

### Release Plan

- [ ] Merge this
- [ ] make a note on posthog that we made a change here and using that to explain the jump in graph
