### PR TITLE
1040 Adjust max age of oldest message on queues

### DIFF
--- a/packages/api/src/__tests__/e2e/mapi/parts/patient.test.part.ts
+++ b/packages/api/src/__tests__/e2e/mapi/parts/patient.test.part.ts
@@ -31,6 +31,7 @@ export function runPatientTestsPart1(e2e: E2eContext) {
     if (!e2e.facility) throw new Error("Missing facility");
     e2e.patient = await medicalApi.createPatient(createPatient, e2e.facility.id);
     e2e.patientFhir = patientDtoToFhir(e2e.patient);
+    console.log(`Created patient: ${e2e.patient.id}`);
     await sleep(100);
     const [createdPatient, fhirPatient] = await Promise.all([
       getPatient(e2e.patient.id),

--- a/packages/infra/lib/api-stack/ccda-search-connector.ts
+++ b/packages/infra/lib/api-stack/ccda-search-connector.ts
@@ -89,8 +89,7 @@ export function setup({
     lambdaLayers: [lambdaLayers.shared],
     envType,
     alarmSnsAction,
-    alarmMaxAgeOfOldestMessage: Duration.minutes(1),
-    alarmMaxAgeOfOldestMessageDlq: Duration.minutes(5),
+    alarmMaxAgeOfOldestMessage: Duration.minutes(2),
   });
 
   const dlq = queue.deadLetterQueue;

--- a/packages/infra/lib/api-stack/fhir-server-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-server-connector.ts
@@ -81,8 +81,7 @@ export function createConnector({
     lambdaLayers: [lambdaLayers.shared],
     envType,
     alarmSnsAction,
-    alarmMaxAgeOfOldestMessage: Duration.minutes(2),
-    alarmMaxAgeOfOldestMessageDlq: Duration.minutes(5),
+    alarmMaxAgeOfOldestMessage: Duration.minutes(4),
     maxMessageCountAlarmThreshold: 2000,
   });
 

--- a/packages/infra/lib/shared/sqs.ts
+++ b/packages/infra/lib/shared/sqs.ts
@@ -24,6 +24,7 @@ const DEFAULT_VISIBILITY_TIMEOUT_MULTIPLIER = 6;
 
 const DEFAULT_MAX_RECEIVE_COUNT = 5;
 const DEFAULT_MAX_AGE_OF_OLDEST_MESSAGE = Duration.minutes(10);
+const DEFAULT_MAX_AGE_OF_OLDEST_MESSAGE_DLQ = Duration.hours(2);
 
 export type QueueProps = (StandardQueueProps | FifoQueueProps) & {
   dlq?: never;
@@ -186,7 +187,10 @@ export function defaultDLQ(
   scope: Construct,
   name: string,
   fifo?: boolean,
-  { alarmSnsAction, alarmMaxAgeOfOldestMessage = Duration.minutes(10) }: DefaultDLQProps = {}
+  {
+    alarmSnsAction,
+    alarmMaxAgeOfOldestMessage = DEFAULT_MAX_AGE_OF_OLDEST_MESSAGE_DLQ,
+  }: DefaultDLQProps = {}
 ): Queue {
   const dlq = new Queue(scope, name + "DLQ", {
     queueName: fifo ? name + "DLQ.fifo" : name + "DLQ",


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

[context](https://metriport.slack.com/archives/C04T256DQPQ/p1723302342464439?thread_ts=1723301243.898709&cid=C04T256DQPQ):
- adjust max age of oldest message for the FHIRServer queue (from 2 to 4min)
- adjust max age of oldest message for the OpenSearch queue (from 1 to 2min)
- remove custom max age of oldest message for DLQs
- increase default max age of oldest message for DLQs from 10min to 2h

[context](https://metriport.slack.com/archives/C04FZ9859FZ/p1723302719299519?thread_ts=1723300442.760389&cid=C04FZ9859FZ):
- log the patient ID on the MAPI E2E test

### Testing

- Local
  - none
- Staging
  - [ ] patient ID is logged on E2E test
  - [ ] FHIRServer's max age of oldest message is updated (4min)
  - [ ] FHIRServer DLQ's max age of oldest message is updated (2h)
  - [ ] CCDA Search's max age of oldest message is updated (2min)
  - [ ] CCDA Search DLQ's max age of oldest message is updated (2h)
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
