### PR TITLE
2040 Add API_URL to fhirToMedicalRecordLambda

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -516,6 +516,7 @@ export class APIStack extends Stack {
       : undefined;
 
     // Add ENV after the API service is created
+    fhirToMedicalRecordLambda?.addEnvironment("API_URL", `http://${apiDirectUrl}`);
     outboundPatientDiscoveryLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
     outboundDocumentQueryLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
     outboundDocumentRetrievalLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
@@ -1265,6 +1266,7 @@ export class APIStack extends Stack {
         APPCONFIG_APPLICATION_ID: appConfigEnvVars.appId,
         APPCONFIG_CONFIGURATION_ID: appConfigEnvVars.configId,
         ...(bedrock && {
+          // API_URL set on the api-stack after the OSS API is created
           BEDROCK_REGION: bedrock?.region,
           BEDROCK_VERSION: bedrock?.anthropicVersion,
           AI_BRIEF_MODEL_ID: bedrock?.modelId,


### PR DESCRIPTION
Ref. metriport/metriport-internal#2040

### Dependencies

none

### Description

Add API_URL to FHIR to Medical Record Lambda - [context](https://metriport.slack.com/archives/C04FZ9859FZ/p1723304177758009?thread_ts=1723300442.760389&cid=C04FZ9859FZ)

### Testing

- Staging
  - [ ] E2E test passes
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
