### PR TITLE
2040 Add dash url to MR lambda and fix feedback proxy

### DIFF
--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -224,6 +224,7 @@ type EnvConfigBase = {
 
 export type EnvConfigNonSandbox = EnvConfigBase & {
   environmentType: EnvType.staging | EnvType.production;
+  dashUrl: string;
   fhirToMedicalLambda: {
     nodeRuntimeArn: string;
   };

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -41,6 +41,7 @@ export const config: EnvConfigNonSandbox = {
       PROPELAUTH_API_KEY: "key-name",
     },
   },
+  dashUrl: "https://url-of-your-dashboard.com",
   fhirToMedicalLambda: {
     nodeRuntimeArn: "arn:aws:lambda:<region>::runtime:<id>",
   },

--- a/packages/lambdas/src/fhir-to-medical-record.ts
+++ b/packages/lambdas/src/fhir-to-medical-record.ts
@@ -39,6 +39,7 @@ const region = getEnvOrFail("AWS_REGION");
 // Set by us
 const bucketName = getEnvOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
 const apiURL = getEnvOrFail("API_URL");
+const dashURL = getEnvOrFail("DASH_URL");
 // converter config
 const pdfConvertTimeout = getEnvOrFail("PDF_CONVERT_TIMEOUT_MS");
 const appConfigAppID = getEnvOrFail("APPCONFIG_APPLICATION_ID");
@@ -354,7 +355,7 @@ async function storeMrSummaryAndBriefInS3({
 function prepareBriefToBundle({ aiBrief }: { aiBrief: string | undefined }): Brief | undefined {
   if (!aiBrief) return undefined;
   const feedbackId = uuidv7();
-  const feedbackLink = ossApi.getRetrieveFeedbackUrl(feedbackId);
+  const feedbackLink = `${dashURL}/feedback/${feedbackId}`;
   return {
     id: feedbackId,
     content: aiBrief,

--- a/packages/lambdas/src/shared/oss-api.ts
+++ b/packages/lambdas/src/shared/oss-api.ts
@@ -21,9 +21,6 @@ export function apiClient(apiURL: string) {
   function getCreateFeedbackUrl(id: string): string {
     return `${apiURL}/internal/feedback/${id}`;
   }
-  function getRetrieveFeedbackUrl(id: string): string {
-    return `${apiURL}/feedback/${id}`;
-  }
 
   async function notifyApi(params: NotificationParams, log: Log): Promise<void> {
     log(`Notifying API on ${docProgressURL} w/ ${JSON.stringify(params)}`);
@@ -45,6 +42,5 @@ export function apiClient(apiURL: string) {
       notifyApi,
       createFeedback,
     },
-    getRetrieveFeedbackUrl,
   };
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#2040

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/2102
- Downstream: none

### Description

- Add dash url to MR lambda
- Fix feedback proxy

### Testing

- Local
  - none
- Staging
  - [ ] Feedback page loads and finds feedback group
  - [ ] Submitting a feedback creates a feedback entry on the OSS DB
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge upstream
- [ ] Merge this
