### PR TITLE
2040 Notification url to point to the LB address of the API

### DIFF
--- a/packages/api/src/command/feedback/feedback-entry.ts
+++ b/packages/api/src/command/feedback/feedback-entry.ts
@@ -25,7 +25,8 @@ export async function createFeedbackEntry({
     authorName: normalizeString(authorName),
   });
 
-  const detailsUrl = Config.getApiUrl() + "/internal/feedback/entry/" + feedbackEntry.id;
+  const lbAddress = Config.getApiLoadBalancerAddress();
+  const detailsUrl = lbAddress ? lbAddress + "/internal/feedback/entry/" + feedbackEntry.id : "N/A";
   sendNotification({
     message: `Author: ${authorName}\nComment: ${comment.length} characters`,
     subject: `Feedback received about AI Brief - details on ${detailsUrl} (requires VPN)`,

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -87,6 +87,9 @@ export class Config {
   static getApiUrl(): string {
     return getEnvVarOrFail("API_URL");
   }
+  static getApiLoadBalancerAddress(): string | undefined {
+    return getEnvVar("API_LB_ADDRESS");
+  }
 
   static getApiGatewayUsagePlanId(): string | undefined {
     return getEnvVar("API_GW_USAGE_PLAN_ID");

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -209,6 +209,7 @@ export function createAPIService({
           DB_POOL_SETTINGS: dbPoolSettings,
           TOKEN_TABLE_NAME: dynamoDBTokenTable.tableName,
           API_URL: `https://${props.config.subdomain}.${props.config.domain}`,
+          API_LB_ADDRESS: props.config.loadBalancerDnsName,
           ...(props.config.apiGatewayUsagePlanId
             ? { API_GW_USAGE_PLAN_ID: props.config.apiGatewayUsagePlanId }
             : {}),


### PR DESCRIPTION
Ref. metriport/metriport-internal#2040

### Dependencies

none

### Description

Notification url to point to the LB address of the API - [context](https://metriport.slack.com/archives/C04GJPTTL82/p1723341303960659?thread_ts=1723340527.487859&cid=C04GJPTTL82)

### Testing

- Local
  - none
- Staging
  - [ ] notification of a feedback entry links to the right internal URL
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
