### PR TITLE
2040 Fix backmerge conflict

### DIFF
--- a/packages/api/src/command/medical/patient/__tests__/check-ai-brief.test.ts
+++ b/packages/api/src/command/medical/patient/__tests__/check-ai-brief.test.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { v4 as uuidv4 } from "uuid";
+import * as appConfig from "../../../../external/aws/app-config";
+import { checkAiBriefEnabled } from "../check-ai-brief-enabled";
+
+let isAiBriefEnabledForCx_mock: jest.SpyInstance;
+
+beforeAll(() => {
+  jest.restoreAllMocks();
+  isAiBriefEnabledForCx_mock = jest.spyOn(appConfig, "isAiBriefEnabledForCx");
+});
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe("checkAiBriefEnabled", () => {
+  const cxId = uuidv4();
+
+  describe("isAiBriefEnabledForCx is false", () => {
+    beforeEach(() => {
+      isAiBriefEnabledForCx_mock.mockReturnValue(false);
+    });
+
+    it("returns false when generateAiBrief is false", async () => {
+      const resp = await checkAiBriefEnabled({
+        cxId,
+        generateAiBrief: false,
+      });
+      expect(resp).toEqual(false);
+    });
+
+    it("returns false when generateAiBrief is undefined", async () => {
+      const resp = await checkAiBriefEnabled({
+        cxId,
+        generateAiBrief: undefined,
+      });
+      expect(resp).toEqual(false);
+    });
+
+    it("throws when generateAiBrief is true", async () => {
+      await expect(() =>
+        checkAiBriefEnabled({
+          cxId,
+          generateAiBrief: true,
+        })
+      ).rejects.toThrow("Contact Metriport to enable the AI Brief feature.");
+    });
+  });
+
+  describe("isAiBriefEnabledForCx is true", () => {
+    beforeEach(() => {
+      isAiBriefEnabledForCx_mock.mockReturnValue(true);
+    });
+
+    it("returns false when generateAiBrief is false", async () => {
+      const resp = await checkAiBriefEnabled({
+        cxId,
+        generateAiBrief: false,
+      });
+      expect(resp).toEqual(false);
+    });
+
+    it("returns true when generateAiBrief is undefined", async () => {
+      const resp = await checkAiBriefEnabled({
+        cxId,
+        generateAiBrief: undefined,
+      });
+      expect(resp).toEqual(true);
+    });
+
+    it("returns true when generateAiBrief is true", async () => {
+      const resp = await checkAiBriefEnabled({
+        cxId,
+        generateAiBrief: true,
+      });
+      expect(resp).toEqual(true);
+    });
+  });
+});

--- a/packages/api/src/command/medical/patient/check-ai-brief-enabled.ts
+++ b/packages/api/src/command/medical/patient/check-ai-brief-enabled.ts
@@ -2,17 +2,25 @@ import { capture, out } from "@metriport/core/util";
 import BadRequestError from "../../../errors/bad-request";
 import { isAiBriefEnabledForCx } from "../../../external/aws/app-config";
 
+// TODO merge this with lambda's isAiBriefEnabled and move it to Core
+/**
+ * If enabled to the customer, it defaults to true - they have to explicitly disable it for a
+ * given request if their account is enabled for it.
+ */
 export async function checkAiBriefEnabled({
   cxId,
   generateAiBrief,
 }: {
   cxId: string;
-  generateAiBrief: boolean;
-}): Promise<void> {
+  generateAiBrief: boolean | undefined;
+}): Promise<boolean> {
   const { log } = out(`AI Brief for cxId: ${cxId}`);
-  if (!generateAiBrief) return;
+  if (generateAiBrief === false) return false;
 
   const isAiBriefFeatureFlagEnabled = await isAiBriefEnabledForCx(cxId);
+  if (isAiBriefFeatureFlagEnabled) {
+    return true;
+  }
   if (!isAiBriefFeatureFlagEnabled && generateAiBrief) {
     const msg = `CX requires AI Brief feature`;
     log(msg);
@@ -26,4 +34,5 @@ export async function checkAiBriefEnabled({
     });
     throw new BadRequestError("Contact Metriport to enable the AI Brief feature.");
   }
+  return false;
 }

--- a/packages/api/src/command/medical/patient/consolidated-get.ts
+++ b/packages/api/src/command/medical/patient/consolidated-get.ts
@@ -74,9 +74,9 @@ export async function startConsolidatedQuery({
   dateTo,
   conversionType,
   cxConsolidatedRequestMetadata,
-  generateAiBrief = false,
+  generateAiBrief,
 }: ConsolidatedQueryParams): Promise<ConsolidatedQuery> {
-  await checkAiBriefEnabled({ cxId, generateAiBrief });
+  const isGenerateAiBrief = await checkAiBriefEnabled({ cxId, generateAiBrief });
 
   const { log } = Util.out(`startConsolidatedQuery - M patient ${patientId}`);
   const patient = await getPatientOrFail({ id: patientId, cxId });
@@ -137,7 +137,7 @@ export async function startConsolidatedQuery({
     dateTo,
     requestId,
     conversionType,
-    generateAiBrief,
+    generateAiBrief: isGenerateAiBrief,
   }).catch(emptyFunction);
 
   return progress;

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -23,7 +23,7 @@ import {
   getMedicalRecordSummary,
   getMedicalRecordSummaryStatus,
 } from "../../command/medical/patient/create-medical-record";
-import { PatientCreateCmd, createPatient } from "../../command/medical/patient/create-patient";
+import { createPatient, PatientCreateCmd } from "../../command/medical/patient/create-patient";
 import { deletePatient } from "../../command/medical/patient/delete-patient";
 import { getConsolidatedWebhook } from "../../command/medical/patient/get-consolidated-webhook";
 import {
@@ -341,7 +341,7 @@ router.post(
     const type = getFrom("query").optional("conversionType", req);
     const generateAiBrief = Config.isSandbox()
       ? false
-      : getFromQueryAsBoolean("generateAiBrief", req) ?? false;
+      : getFromQueryAsBoolean("generateAiBrief", req);
 
     const conversionType = type ? consolidationConversionTypeSchema.parse(type) : undefined;
     const cxConsolidatedRequestMetadata = cxRequestMetadataSchema.parse(req.body);

--- a/packages/lambdas/src/fhir-to-medical-record.ts
+++ b/packages/lambdas/src/fhir-to-medical-record.ts
@@ -69,7 +69,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(
       const cxsWithADHDFeatureFlagValue = await getCxsWithADHDFeatureFlagValue();
       const isADHDFeatureFlagEnabled = cxsWithADHDFeatureFlagValue.includes(cxId);
       const bundle = await getBundleFromS3(fhirFileName);
-      const isBriefFeatureFlagEnabled = await isBriefEnabled(generateAiBrief, cxId);
+      const isBriefFeatureFlagEnabled = await isAiBriefEnabled(generateAiBrief, cxId);
 
       // TODO: Condense this functionality under a single function and put it on `@metriport/core`, so this can be used both here, and on the Lambda.
       const aiBriefContent = isBriefFeatureFlagEnabled
@@ -139,11 +139,13 @@ async function getSignedUrl(fileName: string) {
   return coreGetSignedUrl({ fileName, bucketName, awsRegion: region });
 }
 
-async function isBriefEnabled(
+// TODO merge this with API's checkAiBriefEnabled and move it to Core
+async function isAiBriefEnabled(
   generateAiBrief: boolean | undefined,
   cxId: string
 ): Promise<boolean> {
   if (!generateAiBrief) return false;
+  // TODO checking for the FF, keep that no the OSS API
   const isAiBriefFeatureFlagEnabled = await isAiBriefFeatureFlagEnabledForCx(cxId);
   return isAiBriefFeatureFlagEnabled;
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#2040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2595
- Downstream: https://github.com/metriport/metriport/pull/2596

### Description

Fix conflicts from `master` into `develop` - https://github.com/metriport/metriport/pull/2596
- Cherry-picked [the commit ](https://github.com/metriport/metriport/pull/2596/commits/975ab7aad6da1dd3f3ebf4ed2ae72699bc7ef656) from [this PR](https://github.com/metriport/metriport/pull/2595) that patched `master` with defaulting AI Brief for cx's w/ that feature enabled.
- Fix conflict

### Testing

none

### Release Plan

- [ ] Merge this
