### PR TITLE
refactor(api): make consolidated lambda backwards compatible

### DIFF
--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -107,8 +107,9 @@ export class Config {
     return getEnvVar("IHE_PARSED_RESPONSES_BUCKET_NAME");
   }
 
-  static getFHIRtoBundleLambdaName(): string {
-    return getEnvVarOrFail("FHIR_TO_BUNDLE_LAMBDA_NAME");
+  // TODO 1319 Move this to required
+  static getFHIRtoBundleLambdaName(): string | undefined {
+    return getEnvVar("FHIR_TO_BUNDLE_LAMBDA_NAME");
   }
 
   static getBedrockRegion(): string | undefined {


### PR DESCRIPTION
Ref. metriport/metriport-internal#1319

### Description

The current version on `develop` will break the flows that use consolidated data while the release is in progress (the API gets deployed before the infra finishes updating the ECS task definition w/ the new env vars).

This makes it to rely on the local approach to get consolidated, inside the OSS API instead of the lambda.

An upcoming PR will remove this and require the lambda name again.

### Testing

- Local
  - none
- Staging
  - [ ] GET consolidated uses local impl if env var is not set
  - [ ] GET consolidated uses lambda if env var is set
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
