### PR TITLE
1319 Make consolidated lambda name required

### DIFF
--- a/packages/core/src/command/consolidated/consolidated-connector-lambda.ts
+++ b/packages/core/src/command/consolidated/consolidated-connector-lambda.ts
@@ -9,7 +9,6 @@ import {
   ConsolidatedDataResponse,
   ConsolidatedPatientDataRequest,
 } from "./consolidated-connector";
-import { ConsolidatedDataConnectorLocal } from "./consolidated-connector-local";
 
 dayjs.extend(duration);
 
@@ -21,8 +20,8 @@ export type ConsolidatedRequestLambda = ConsolidatedPatientDataRequest & {
 export const TIMEOUT_CALLING_CONVERTER_LAMBDA = dayjs.duration(15, "minutes").add(2, "seconds");
 
 export class ConsolidatedDataConnectorLambda implements ConsolidatedDataConnector {
-  lambdaName: string | undefined;
-  lambdaClient: AWS.Lambda;
+  readonly lambdaName: string;
+  readonly lambdaClient: AWS.Lambda;
   constructor() {
     const region = Config.getAWSRegion();
     this.lambdaName = Config.getFHIRtoBundleLambdaName();
@@ -32,13 +31,6 @@ export class ConsolidatedDataConnectorLambda implements ConsolidatedDataConnecto
   async execute(
     params: ConsolidatedDataRequestSync | ConsolidatedDataRequestAsync
   ): Promise<ConsolidatedDataResponse> {
-    // TODO 1319 Remove this once the first release has been shipped and the lambda name is requires
-    if (!this.lambdaName) {
-      const bucketName = Config.getMedicalDocumentsBucketName();
-      const apiURL = Config.getApiUrl();
-      const connector = new ConsolidatedDataConnectorLocal(bucketName, apiURL);
-      return connector.execute(params);
-    }
     const result = await this.lambdaClient
       .invoke({
         FunctionName: this.lambdaName,

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -107,9 +107,8 @@ export class Config {
     return getEnvVar("IHE_PARSED_RESPONSES_BUCKET_NAME");
   }
 
-  // TODO 1319 Move this to required
-  static getFHIRtoBundleLambdaName(): string | undefined {
-    return getEnvVar("FHIR_TO_BUNDLE_LAMBDA_NAME");
+  static getFHIRtoBundleLambdaName(): string {
+    return getEnvVarOrFail("FHIR_TO_BUNDLE_LAMBDA_NAME");
   }
 
   static getBedrockRegion(): string | undefined {


### PR DESCRIPTION
Ref. metriport/metriport-internal#1319

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2601
- Downstream: none

### Description

Make consolidated lambda name required - [context](https://metriport.slack.com/archives/C04CXLSAF7V/p1723589515518419?thread_ts=1722623737.720209&cid=C04CXLSAF7V)

### Testing

none

### Release Plan

- [ ] Merge this
