### PR TITLE
feat(bulk): bump bulk download duration

### DIFF
--- a/docs/medical-api/api-reference/document/download-url-bulk.mdx
+++ b/docs/medical-api/api-reference/document/download-url-bulk.mdx
@@ -10,7 +10,7 @@ Initially, the status will be `processing`, and when the process is finished, th
 `completed` or `failed`.
 
 Once completed, a webhook request will be sent [your configured URL](/home/api-reference/settings/post-settings)
-containing the document download URLs. The url will be valid for 10 minutes after which it will expire.
+containing the document download URLs. The URL will be valid for 10 minutes after which it will expire.
 
 Webhook message type - see [the respective section on the webhooks page](/medical-api/more-info/webhooks#bulk-downloadable-url-generation)
 for more details:

--- a/docs/medical-api/api-reference/document/download-url-bulk.mdx
+++ b/docs/medical-api/api-reference/document/download-url-bulk.mdx
@@ -10,7 +10,7 @@ Initially, the status will be `processing`, and when the process is finished, th
 `completed` or `failed`.
 
 Once completed, a webhook request will be sent [your configured URL](/home/api-reference/settings/post-settings)
-containing the document download URLs.
+containing the document download URLs. The url will be valid for 10 minutes after which it will expire.
 
 Webhook message type - see [the respective section on the webhooks page](/medical-api/more-info/webhooks#bulk-downloadable-url-generation)
 for more details:

--- a/packages/core/src/external/aws/document-signing/bulk-sign.ts
+++ b/packages/core/src/external/aws/document-signing/bulk-sign.ts
@@ -15,7 +15,7 @@ import { DocumentBulkSignerLambdaResponse } from "./document-bulk-signer-respons
 dayjs.extend(duration);
 
 const ossApi = axios.create();
-const SIGNED_URL_DURATION_SECONDS = dayjs.duration({ minutes: 3 }).asSeconds();
+const SIGNED_URL_DURATION_SECONDS = dayjs.duration({ minutes: 10 }).asSeconds();
 
 export type DocumentBulkSignerLambdaRequest = {
   patientId: string;


### PR DESCRIPTION
Refs: #[2604](https://github.com/metriport/metriport/issues/2604)

### Description

- bulk download presigned url expiry is too short, and some cxs don't have enough time to dl the docs

### Release Plan

- [ ] Merge this
