### PR TITLE
fix(fhir): using fast-xml-parser to handle unclosed tags cases

### DIFF
--- a/packages/fhir-converter/src/lib/cda/cda.js
+++ b/packages/fhir-converter/src/lib/cda/cda.js
@@ -27,6 +27,8 @@ let parseString = require("xml2js").parseString;
 let Builder = require("xml2js").Builder;
 let dataHandler = require("../dataHandler/dataHandler");
 let minifyXML = require("minify-xml");
+const { XMLParser } = require("fast-xml-parser");
+
 
 const elementTime00010101Regex = new RegExp('<time value="00010101000000+0000"s*/>', "g");
 const elementTime00010101Replacement = "";
@@ -167,7 +169,28 @@ module.exports = class cda extends dataHandler {
           parseString(data, parseOptions, (err, result) => {
             if (err) {
               // if still throwing an error, give up
-              reject(err);
+              const parser = new XMLParser({
+                ignoreAttributes: false,
+                attributeNamePrefix: "",
+                textNodeName: "_",
+                alwaysCreateTextNode: true,
+                parseAttributeValue: false,
+                removeNSPrefix: false,
+                trimValues: true,
+                numberParseOptions: {
+                  hex: false,
+                  leadingZeros: false,
+                },
+              });
+
+              try {
+                result = parser.parse(data);
+                this.findAndReplaceAllReferencesWithTextValues(result);
+                result._originalData = data;
+                fulfill(result);
+              } catch (err) {
+                reject(err);
+              }
             }
             this.findAndReplaceAllReferencesWithTextValues(result);
             result._originalData = data;


### PR DESCRIPTION
Refs: #[2107](https://github.com/metriport/metriport-internal/issues/2107)

### Description

- the issues with unclosed tags causing errors is because the library we are using in the fhir-converter xml2js is not that good. I added using fast-xml-parser in erroring cases (we use this library throughout the rest of the codebase as our defacto xml parsing library). 

### Testing

- Local
  - [x] tested on error xmls

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
- [ ] redrive DLQ
