### PR TITLE
fix(ihe): dr errors in prod for redox and ohio physicians too many docs requested

### DIFF
--- a/packages/api/src/external/carequality/document/__tests__/create-outbound-document-retrieval-req.test.ts
+++ b/packages/api/src/external/carequality/document/__tests__/create-outbound-document-retrieval-req.test.ts
@@ -12,7 +12,10 @@ import { makePatient } from "../../../../domain/medical/__tests__/patient";
 import { Facility, FacilityType } from "../../../../domain/medical/facility";
 import { HieInitiator } from "../../../hie/get-hie-initiator";
 import { createOutboundDocumentRetrievalReqs } from "../create-outbound-document-retrieval-req";
-import { defaultDocRefsPerRequest } from "@metriport/core/external/carequality/ihe-gateway-v2/gateways";
+import {
+  defaultDocRefsPerRequest,
+  redoxOidPrefix,
+} from "@metriport/core/external/carequality/ihe-gateway-v2/gateways";
 import { makeDocumentReferenceWithMetriportId } from "./make-document-reference-with-metriport-id";
 import { makeOutboundDocumentQueryResp, makeXcaGateway } from "./shared";
 import {
@@ -126,6 +129,28 @@ describe("outboundDocumentRetrievalRequest", () => {
     const outboundDocumentQueryResps: OutboundDocumentQueryResp[] = [
       makeOutboundDocumentQueryResp({
         gateway: makeXcaGateway({ homeCommunityId: surescriptsOid }),
+        documentReference: [
+          makeDocumentReferenceWithMetriportId(),
+          makeDocumentReferenceWithMetriportId(),
+        ],
+      }),
+    ];
+    const res: OutboundDocumentRetrievalReq[] = createOutboundDocumentRetrievalReqs({
+      patient,
+      requestId,
+      initiator,
+      outboundDocumentQueryResults: outboundDocumentQueryResps,
+    });
+    expect(res).toBeTruthy();
+    expect(res.length).toEqual(2);
+    expect(res[0].documentReference.length).toEqual(1);
+    expect(res[1].documentReference.length).toEqual(1);
+  });
+
+  it("returns 2 req with 1 doc refs when we have an redox prefix gw", async () => {
+    const outboundDocumentQueryResps: OutboundDocumentQueryResp[] = [
+      makeOutboundDocumentQueryResp({
+        gateway: makeXcaGateway({ homeCommunityId: redoxOidPrefix }),
         documentReference: [
           makeDocumentReferenceWithMetriportId(),
           makeDocumentReferenceWithMetriportId(),

--- a/packages/api/src/external/carequality/document/__tests__/create-outbound-document-retrieval-req.test.ts
+++ b/packages/api/src/external/carequality/document/__tests__/create-outbound-document-retrieval-req.test.ts
@@ -122,7 +122,7 @@ describe("outboundDocumentRetrievalRequest", () => {
     expect(res[1].documentReference.length).toEqual(1);
   });
 
-  it("returns 1 req with 6 doc refs when we have an epic gw", async () => {
+  it("returns 2 req with 1 doc refs when we have an surescripts gw", async () => {
     const outboundDocumentQueryResps: OutboundDocumentQueryResp[] = [
       makeOutboundDocumentQueryResp({
         gateway: makeXcaGateway({ homeCommunityId: surescriptsOid }),

--- a/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
@@ -57,13 +57,11 @@ const docRefsPerRequestByGateway: Record<string, number> = {
 export const defaultDocRefsPerRequest = 5;
 
 export function getGatewaySpecificDocRefsPerRequest(gateway: XCAGateway): number {
-  // Direct dictionary search
   if (gateway.homeCommunityId in docRefsPerRequestByGateway) {
     const numDocRefs = docRefsPerRequestByGateway[gateway.homeCommunityId];
     if (numDocRefs) return numDocRefs;
   }
 
-  // Prefix search
   for (const prefix in prefixDocRefsPerRequest) {
     if (gateway.homeCommunityId.startsWith(prefix)) {
       const numDocRefs = prefixDocRefsPerRequest[prefix];

--- a/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
@@ -21,7 +21,9 @@ const specialNamespaceRequiredUrl =
 export const eHexUrlPrefix = "https://hub002prodcq.ehealthexchange.org";
 
 export const pointClickCareOid = "2.16.840.1.113883.3.6448";
+export const centralOhioPrimaryCarePhysiciansOid = "1.2.840.114350.1.13.698.2.7.3.688884.100";
 export const surescriptsOid = "2.16.840.1.113883.3.2054.2.1.1";
+
 export const epicOidPrefix = "1.2.840.114350.1.13";
 export const redoxOidPrefix = "2.16.840.1.113883.3.6147";
 
@@ -43,23 +45,33 @@ const gatewaysThatAcceptOneDocRefPerRequest = [pointClickCareOid, surescriptsOid
 
 const prefixDocRefsPerRequest: Record<string, number> = {
   [epicOidPrefix]: 10,
-  [redoxOidPrefix]: 5,
+  [redoxOidPrefix]: 1,
 };
 
 const docRefsPerRequestByGateway: Record<string, number> = {
   [pointClickCareOid]: 1,
   [surescriptsOid]: 1,
+  [centralOhioPrimaryCarePhysiciansOid]: 9,
 };
 
 export const defaultDocRefsPerRequest = 5;
 
 export function getGatewaySpecificDocRefsPerRequest(gateway: XCAGateway): number {
+  // Direct dictionary search
+  if (gateway.homeCommunityId in docRefsPerRequestByGateway) {
+    const numDocRefs = docRefsPerRequestByGateway[gateway.homeCommunityId];
+    if (numDocRefs) return numDocRefs;
+  }
+
+  // Prefix search
   for (const prefix in prefixDocRefsPerRequest) {
     if (gateway.homeCommunityId.startsWith(prefix)) {
-      return prefixDocRefsPerRequest[prefix] ?? defaultDocRefsPerRequest;
+      const numDocRefs = prefixDocRefsPerRequest[prefix];
+      if (numDocRefs) return numDocRefs;
     }
   }
-  return docRefsPerRequestByGateway[gateway.homeCommunityId] ?? defaultDocRefsPerRequest;
+
+  return defaultDocRefsPerRequest;
 }
 
 export function doesGatewayNeedDateRanges(url: string): boolean {


### PR DESCRIPTION
Ticket: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- redox changed system to only accept one docRef per request
- on epic instance Ohio community care physicians randomly only accepts 9 doc refs instead of 10 

### Testing

- Local
  - [x] unit tests

### Release Plan

- [ ] Merge this
