### PR TITLE
1319 Async response from consolidated lambda

### DIFF
--- a/packages/api/src/routes/medical/internal-patient.ts
+++ b/packages/api/src/routes/medical/internal-patient.ts
@@ -2,6 +2,7 @@ import { genderAtBirthSchema } from "@metriport/api-sdk";
 import { getConsolidatedBundleFromS3 } from "@metriport/core/command/consolidated/consolidated-on-s3";
 import { consolidationConversionType } from "@metriport/core/domain/conversion/fhir-to-medical-record";
 import { MedicalDataSource } from "@metriport/core/external/index";
+import { processAsyncError } from "@metriport/core/util/error/shared";
 import { out } from "@metriport/core/util/log";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { internalSendConsolidatedSchema, sleep, stringToBoolean } from "@metriport/shared";
@@ -792,7 +793,7 @@ router.post(
       bundleFilename,
     });
 
-    await getConsolidatedAndSendToCx({
+    getConsolidatedAndSendToCx({
       patient,
       bundle,
       requestId,
@@ -801,7 +802,11 @@ router.post(
       resources,
       dateFrom,
       dateTo,
-    });
+    }).catch(
+      processAsyncError(
+        "POST /internal/patient/:id/consolidated, calling getConsolidatedAndSendToCx"
+      )
+    );
     return res.sendStatus(status.OK);
   })
 );

--- a/packages/core/src/util/error/shared.ts
+++ b/packages/core/src/util/error/shared.ts
@@ -1,4 +1,5 @@
 import { inspect } from "node:util";
+import { out } from "../log";
 import { capture } from "../notifications";
 
 /**
@@ -51,9 +52,11 @@ export function getErrorMessage(error: unknown) {
   return errorToString(error);
 }
 
-export function processAsyncError(msg: string, log = console.error) {
+export function processAsyncError(msg: string, log?: typeof console.log | undefined) {
+  if (!log) log = out().log;
   return (err: unknown) => {
-    log(`${msg}: ${getErrorMessage(err)}`);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    log!(`${msg}: ${getErrorMessage(err)}`);
     capture.error(err, { extra: { message: msg, err } });
   };
 }


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1319

### Description

Async response from consolidated lambda - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1723758171829449?thread_ts=1717078587.717249&cid=C04T256DQPQ)

### Testing

- Local
  - [x] Error on `getConsolidatedAndSendToCx` doesn't  result in failure on the endpoint
  - [x] Error on `getConsolidatedAndSendToCx` gets processed/logged
- Staging
  - [ ] Regular async consolidated gets processed by the OSS API after lambda calls it
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
