### PR TITLE
1319 Single import of processAsyncError

### DIFF
--- a/packages/api/src/routes/medical/internal-patient.ts
+++ b/packages/api/src/routes/medical/internal-patient.ts
@@ -6,17 +6,17 @@ import { processAsyncError } from "@metriport/core/util/error/shared";
 import { out } from "@metriport/core/util/log";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import {
-  sleep,
-  stringToBoolean,
+  internalSendConsolidatedSchema,
   normalizeDate,
+  normalizeEmailStrict,
+  normalizeExternalId,
   normalizeGender,
   normalizePhoneNumberStrict,
-  normalizeEmailStrict,
   normalizeState,
   normalizeZipCode,
-  normalizeExternalId,
+  sleep,
+  stringToBoolean,
   toTitleCase,
-  internalSendConsolidatedSchema,
 } from "@metriport/shared";
 import { errorToString } from "@metriport/shared/common/error";
 import dayjs from "dayjs";
@@ -28,11 +28,13 @@ import stringify from "json-stringify-safe";
 import { chunk } from "lodash";
 import { z } from "zod";
 import { getFacilityOrFail } from "../../command/medical/facility/get-facility";
-import { PatientCreateCmd } from "../../command/medical/patient/create-patient";
 import {
   getConsolidated,
   getConsolidatedAndSendToCx,
 } from "../../command/medical/patient/consolidated-get";
+import { createCoverageAssessments } from "../../command/medical/patient/converage-assessment-create";
+import { getCoverageAssessments } from "../../command/medical/patient/converage-assessment-get";
+import { PatientCreateCmd } from "../../command/medical/patient/create-patient";
 import { deletePatient } from "../../command/medical/patient/delete-patient";
 import {
   getPatientIds,
@@ -40,12 +42,10 @@ import {
   getPatients,
   getPatientStates,
 } from "../../command/medical/patient/get-patient";
-import { getCoverageAssessments } from "../../command/medical/patient/converage-assessment-get";
 import {
   PatientUpdateCmd,
   updatePatientWithoutHIEs,
 } from "../../command/medical/patient/update-patient";
-import { createCoverageAssessments } from "../../command/medical/patient/converage-assessment-create";
 import { getFacilityIdOrFail } from "../../domain/medical/patient-facility";
 import BadRequestError from "../../errors/bad-request";
 import {
@@ -88,7 +88,6 @@ import { dtoFromModel } from "./dtos/patientDTO";
 import { getResourcesQueryParam } from "./schemas/fhir";
 import { linkCreateSchema } from "./schemas/link";
 import { coverageAssessmentSchema } from "./schemas/patient";
-import { processAsyncError } from "@metriport/core/util/error/shared";
 
 dayjs.extend(duration);
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1319

### Dependencies

- Upstream: _[this PR points to another PR or depends on its release]_
- Downstream: _[PRs that depend on this one, either point to this or can only be released after this one is released]_

### Description

Single import of processAsyncError on internal patient routes - context.

The imports were not organized, so when we merged [this PR](https://github.com/metriport/metriport/pull/2621) into `develop` there were no conflicts and the merge was successful - even though I was expecting the merge queue to have caught this.

### Testing

- Local
  - none
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
