### PR TITLE
2040 Send AI Brief notif w/ full content

### DIFF
--- a/packages/api/src/command/feedback/feedback-entry.ts
+++ b/packages/api/src/command/feedback/feedback-entry.ts
@@ -1,13 +1,21 @@
+import { S3Utils } from "@metriport/core/external/aws/s3";
+import { sendToSlack } from "@metriport/core/external/slack";
 import { Config } from "@metriport/core/util/config";
-import { sendNotification } from "@metriport/core/util/notifications";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { NotFoundError } from "@metriport/shared";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
 import { FeedbackEntry, FeedbackEntryCreate } from "../../domain/feedback";
 import { FeedbackEntryModel } from "../../models/feedback-entry";
 import { normalizeString } from "../../models/_default";
 import { getFeedbackOrFail } from "./feedback";
 
+dayjs.extend(duration);
+
 const maxLargeColumnLength = 5_000;
+const region = Config.getAWSRegion();
+const s3Utils = new S3Utils(region);
+const mrLinkDuration = dayjs.duration(1, "hour");
 
 export type GetFeedback = { id: string };
 
@@ -16,7 +24,9 @@ export async function createFeedbackEntry({
   comment,
   authorName,
 }: FeedbackEntryCreate): Promise<FeedbackEntry> {
-  await getFeedbackOrFail({ id: feedbackId });
+  const feedback = await getFeedbackOrFail({ id: feedbackId });
+  const mrLocation = feedback.data.location;
+  const brief = feedback.data.content;
 
   const feedbackEntry = await FeedbackEntryModel.create({
     id: uuidv7(),
@@ -25,13 +35,17 @@ export async function createFeedbackEntry({
     authorName: normalizeString(authorName),
   });
 
-  const lbAddress = Config.getApiLoadBalancerAddress();
-  const detailsUrl = lbAddress ? lbAddress + "/internal/feedback/entry/" + feedbackEntry.id : "N/A";
-  sendNotification({
-    message: `Author: ${authorName}\nComment: ${comment.length} characters`,
-    subject: `Feedback received about AI Brief - details on ${detailsUrl} (requires VPN)`,
-    emoji: ":mega:",
-  });
+  const mrUrl = mrLocation
+    ? s3Utils.getSignedUrl({ location: mrLocation, durationSeconds: mrLinkDuration.asSeconds() })
+    : "N/A";
+  sendToSlack(
+    {
+      subject: `Feedback received about AI Brief`,
+      message: `Feedback author: ${authorName}\nOriginal MR (valid for 1h): ${mrUrl}\nAI Brief:${brief}\nComment: ${comment}`,
+      emoji: ":mega:",
+    },
+    Config.getSlackSensitiveDataChannelUrl()
+  );
 
   return feedbackEntry.dataValues;
 }

--- a/packages/core/src/external/aws/__tests__/s3.test.ts
+++ b/packages/core/src/external/aws/__tests__/s3.test.ts
@@ -1,13 +1,13 @@
-import { S3Utils } from "../s3";
+import { S3Utils, splitS3Location } from "../s3";
 
 beforeAll(() => {
   jest.restoreAllMocks();
 });
 
-// integration test
-describe.skip("S3Utils", () => {
-  const s3Utils = new S3Utils("us-west-2");
-  describe("getFileInfoFromS3", () => {
+describe("S3Utils", () => {
+  // integration test
+  describe.skip("getFileInfoFromS3", () => {
+    const s3Utils = new S3Utils("us-west-2");
     it("returns empty string when gets empty string", async () => {
       const res = await s3Utils.getFileInfoFromS3("non-existing-key", "nonexisting-bucket");
       expect(res).toEqual({ exists: false });
@@ -16,6 +16,42 @@ describe.skip("S3Utils", () => {
     it("works when exists", async () => {
       const res = await s3Utils.getFileInfoFromS3("...", "...");
       expect(res).toEqual(expect.objectContaining({ exists: true }));
+    });
+  });
+
+  describe("splitS3Location", () => {
+    it("returns undefined if it gets a location without server url", async () => {
+      const key = "123/456/789.txt";
+      const location = key;
+      const res = splitS3Location(location);
+      expect(res).toBeFalsy();
+    });
+
+    it("returns undefined if it gets a location without key", async () => {
+      const bucketName = "bucket-name";
+      const location = `https://${bucketName}.s3.us-east-2.amazonaws.com`;
+      const res = splitS3Location(location);
+      expect(res).toBeFalsy();
+    });
+
+    it("returns bucketName and key when it gets a valid S3 location with single key", async () => {
+      const bucketName = "bucket-name";
+      const key = "123";
+      const location = `https://${bucketName}.s3.us-east-2.amazonaws.com/${key}`;
+      const res = splitS3Location(location);
+      console.log(`res: ${JSON.stringify(res, null, 2)}`);
+      expect(res).toBeTruthy();
+      expect(res).toEqual(expect.objectContaining({ bucketName, key }));
+    });
+
+    it("returns bucketName and key when it gets a valid S3 location with longer key", async () => {
+      const bucketName = "bucket-name";
+      const key = "123/456/789.txt";
+      const location = `https://${bucketName}.s3.us-east-2.amazonaws.com/${key}`;
+      const res = splitS3Location(location);
+      console.log(`res: ${JSON.stringify(res, null, 2)}`);
+      expect(res).toBeTruthy();
+      expect(res).toEqual(expect.objectContaining({ bucketName, key }));
     });
   });
 });

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -38,6 +38,9 @@ export class Config {
   static getSlackNotificationUrl(): string | undefined {
     return getEnvVar("SLACK_NOTIFICATION_URL");
   }
+  static getSlackSensitiveDataChannelUrl(): string | undefined {
+    return getEnvVar("SLACK_SENSITIVE_DATA_URL");
+  }
 
   static getAWSRegion(): string {
     return getEnvVarOrFail("AWS_REGION");

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -206,6 +206,7 @@ type EnvConfigBase = {
   slack?: {
     SLACK_ALERT_URL?: string;
     SLACK_NOTIFICATION_URL?: string;
+    SLACK_SENSITIVE_DATA_URL?: string;
     workspaceId: string;
     alertsChannelId: string;
   };


### PR DESCRIPTION
Ref. metriport/metriport-internal#2040

### Dependencies

none

### Description

Send AI Brief notif w/ full content - [context](https://metriport.slack.com/archives/C07D712SW6R/p1723818927826839?thread_ts=1723814638.453529&cid=C07D712SW6R)

### Testing

- Local
  - [x] Unit tests
- Staging
  - [ ] Feedback entry gets stored
  - [ ] Notification contains feedback entry content 
  - [ ] Notification contains link to MR
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
