### PR TITLE
feat(api): remove lowest partition to decrease parition loading load

### DIFF
--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -82,7 +82,6 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
           { name: "patientid", type: "string" },
           { name: "stage", type: "string" },
           { name: "requestid", type: "string" },
-          { name: "gatewayoid", type: "string" },
         ],
         storageDescriptor: {
           columns: [


### PR DESCRIPTION
Ref: #2115

### Description

- the lowest level partition (gateway oid) is resulting in too many partitions and not loading in timely manner on athena -- this data is available in the raw data anyway so isn't necessary as a partition

### Testing

- Staging
  - [ ] check table still works as expected
- Production
  - [ ] check table still works as expected

### Release Plan

- [ ] Merge this
