### PR TITLE
feat(fhir-converter): added date mapping to med req

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Resources/MedicationRequest.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/MedicationRequest.hbs
@@ -43,6 +43,10 @@
             "authoredOn": "{{formatAsDateTime medicationRequest.effectiveTime.low.value}}",
         {{else if medicationRequest.author.time}}
             "authoredOn": "{{formatAsDateTime medicationRequest.author.time}}",
+        {{else if @encounterTimePeriod.low}}
+            "authoredOn": "{{formatAsDateTime @encounterTimePeriod.low.value}}",
+        {{else if @encounterTimePeriod.high}}
+            "authoredOn": "{{formatAsDateTime @encounterTimePeriod.high.value}}",
         {{/if}}
     },
     "request":{

--- a/packages/fhir-converter/src/templates/cda/Resources/MedicationRequest.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/MedicationRequest.hbs
@@ -37,6 +37,13 @@
         ],
         "intent":"order",
         "status":{{>ValueSet/MedicationRequestStatus.hbs code=medicationRequest.statusCode.code}},
+        {{#if medicationRequest.effectiveTime.high.value}}
+            "authoredOn": "{{formatAsDateTime medicationRequest.effectiveTime.high.value}}",
+        {{else if medicationRequest.effectiveTime.low.value}}
+            "authoredOn": "{{formatAsDateTime medicationRequest.effectiveTime.low.value}}",
+        {{else if medicationRequest.author.time}}
+            "authoredOn": "{{formatAsDateTime medicationRequest.author.time}}",
+        {{/if}}
     },
     "request":{
         "method":"PUT",


### PR DESCRIPTION
refs. metriport/metriport-internal#2128

### Description
- Added `authoredOn` field mapping for the `MedicationRequest` resource

### Testing

- Local
  - [x] Ran the FHIR test suite without insertion. 
  - [x] FHIR insert on a subfolder of the FHIR test suite - 91 files processed, no errors. 

### Release Plan
- [ ] Merge this
