### PR TITLE
feat(api): rename athena+ s3 table to force CDK recreate

### DIFF
--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -76,7 +76,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
       databaseName: "default",
       tableInput: {
         description: "Table used for debugging IHE parsed responses",
-        name: "ihe_parsed_respones_debug_table",
+        name: "ihe_parsed_respones_debug",
         partitionKeys: [
           { name: "cxid", type: "string" },
           { name: "patientid", type: "string" },


### PR DESCRIPTION
Ref: #1040

### Description

- rename table as it has to be recreated to properly properly drop partitions

### Testing

- Staging
  - [x] check new table
- Production
  - [ ] check new table

### Release Plan

- [ ] Merge this
