### PR TITLE
2040 Import full path of slack util from core

### DIFF
--- a/packages/api/src/command/feedback/feedback-entry.ts
+++ b/packages/api/src/command/feedback/feedback-entry.ts
@@ -1,5 +1,5 @@
 import { S3Utils } from "@metriport/core/external/aws/s3";
-import { sendToSlack } from "@metriport/core/external/slack";
+import { sendToSlack } from "@metriport/core/external/slack/index";
 import { Config } from "@metriport/core/util/config";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { NotFoundError } from "@metriport/shared";


### PR DESCRIPTION
Ref. metriport/metriport-internal#2040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2630
- Downstream: none

### Description

Import full path of slack util from core - [context](https://metriport.slack.com/archives/C04FZ9859FZ/p1724111720107379?thread_ts=1724109436.909239&cid=C04FZ9859FZ)

### Testing

It runs local

### Release Plan

- [ ] Merge this
