### PR TITLE
2040 Update AI Brief notification format

### DIFF
--- a/packages/api/src/command/feedback/feedback-entry.ts
+++ b/packages/api/src/command/feedback/feedback-entry.ts
@@ -36,12 +36,15 @@ export async function createFeedbackEntry({
   });
 
   const mrUrl = mrLocation
-    ? s3Utils.getSignedUrl({ location: mrLocation, durationSeconds: mrLinkDuration.asSeconds() })
+    ? await s3Utils.getSignedUrl({
+        location: mrLocation,
+        durationSeconds: mrLinkDuration.asSeconds(),
+      })
     : "N/A";
   sendToSlack(
     {
       subject: `Feedback received about AI Brief`,
-      message: `Feedback author: ${authorName}\nOriginal MR (valid for 1h): ${mrUrl}\nAI Brief:${brief}\nComment: ${comment}`,
+      message: `FEEDBACK AUTHOR: ${authorName}\n\nLINK TO MR (valid for 1h): ${mrUrl}\n\nAI BRIEF: ${brief}\n\nCOMMENT: ${comment}`,
       emoji: ":mega:",
     },
     Config.getSlackSensitiveDataChannelUrl()


### PR DESCRIPTION
Ref. metriport/metriport-internal#2040

### Dependencies

none

### Description

Update AI Brief notification format.

### Testing

- Local
  - [x] Test format on Slack
- Staging
  - [previous PR](https://github.com/metriport/metriport/pull/2630)
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
