### PR TITLE
fix(mr): filter out blacklisted condition codes

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -1095,6 +1095,13 @@ function createConditionSection(conditions: Condition[], encounter: Encounter[])
 
     return aDate === bDate && aText === bText;
   })
+    .filter(condition => {
+      const snomedCode = condition.code?.coding?.find(coding =>
+        coding.system?.toLowerCase().includes(SNOMED_CODE)
+      )?.code;
+      const blacklistCodes = ["55607006"];
+      return snomedCode && !blacklistCodes.includes(snomedCode);
+    })
     .reduce((acc, condition) => {
       const codeName = getSpecificCode(condition.code?.coding ?? [], [ICD_10_CODE, SNOMED_CODE]);
       const idc10Code = condition.code?.coding?.find(code =>

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -1099,7 +1099,8 @@ function createConditionSection(conditions: Condition[], encounter: Encounter[])
       const snomedCode = condition.code?.coding?.find(coding =>
         coding.system?.toLowerCase().includes(SNOMED_CODE)
       )?.code;
-      const blacklistCodes = ["55607006"];
+      const genericSnomedProblemCode = "55607006";
+      const blacklistCodes = [genericSnomedProblemCode];
       return snomedCode && !blacklistCodes.includes(snomedCode);
     })
     .reduce((acc, condition) => {


### PR DESCRIPTION
Refs: #[1792](https://github.com/metriport/metriport-internal/issues/1792)

### Description

- filter out generic snomed code as part of condition blacklist, so that MR summary is empty and cx doesn't receive MR in this case

### Testing

- Local
  - [x] tested on offending patient data

### Release Plan

- [ ] Merge this
- [ ] update cx that the issue has been fixed
