### PR TITLE
1040 Indicate missing date for DiagnosticReport

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
@@ -24,8 +24,13 @@ import dayjs from "dayjs";
 import { uniqWith } from "lodash";
 import { Brief } from "./bundle-to-brief";
 import { createBrief } from "./bundle-to-html";
-
-const ISO_DATE = "YYYY-MM-DD";
+import {
+  buildEncounterSections,
+  formatDateForDisplay,
+  ISO_DATE,
+  MISSING_DATE_KEY,
+  MISSING_DATE_TEXT,
+} from "./bundle-to-html-shared";
 
 const RX_NORM_CODE = "rxnorm";
 const NDC_CODE = "ndc";
@@ -328,10 +333,6 @@ export function bundleToHtmlADHD(fhirBundle: Bundle, brief?: Brief): string {
   return htmlPage;
 }
 
-function formatDateForDisplay(date?: string | undefined): string {
-  return date ? dayjs(date).format(ISO_DATE) : "";
-}
-
 type FhirTypes = {
   diagnosticReports: DiagnosticReport[];
   patient?: Patient | undefined;
@@ -470,7 +471,7 @@ function createMRHeader(patient: Patient) {
         <img src="https://raw.githubusercontent.com/metriport/metriport/develop/assets/logo-black.png" alt="Logo">
       </div>
       <h1 class="title">
-        Medical Record Summary (${dayjs().format(ISO_DATE)})
+        Medical Record Summary (${formatDateForDisplay(new Date())})
       </h1>
       <div class="header-tables">
         <div style="margin-right: 10px" class="header-table">
@@ -493,7 +494,7 @@ function createMRHeader(patient: Patient) {
             <table class="header-table-author">
               <tbody>
                 ${createHeaderTableRow("Name", "Metriport")}
-                ${createHeaderTableRow("Authored On", dayjs().format(ISO_DATE))}
+                ${createHeaderTableRow("Authored On", formatDateForDisplay(new Date()))}
               </tbody>
             </table>
           </div>
@@ -608,20 +609,18 @@ function createDiagnosticReportsSection(
 
   const visitDateDict = getConditionDatesFromEncounters(encounters);
 
-  const encounterSections: EncounterSection = buildEncounterSections({}, diagnosticReports);
+  const encounterSections = buildEncounterSections({}, diagnosticReports);
 
   const encountersWithoutAWEAndADHD = Object.entries(encounterSections)
     .filter(([key]) => {
-      const encounterDateFormatted = dayjs(key).format(ISO_DATE);
+      const encounterDate = key;
       const leftOverVisit = aweAndADHDVisits.find(visit => {
         const visitId = visit.id ?? "";
         const visitVisitDate = visit.onsetDateTime
           ? visit.onsetDateTime
           : visitDateDict[visitId]?.start;
 
-        const visitVisitDateFormatted = dayjs(visitVisitDate).format(ISO_DATE);
-
-        return visitVisitDateFormatted === encounterDateFormatted;
+        return visitVisitDate === encounterDate;
       });
 
       return !leftOverVisit;
@@ -684,22 +683,20 @@ function createFilteredReportSection(
     return "";
   }
 
-  const encounterSections: EncounterSection = buildEncounterSections({}, diagnosticReports);
+  const encounterSections = buildEncounterSections({}, diagnosticReports);
 
   const conditionDateDict = getConditionDatesFromEncounters(encounters);
 
   const encountersWithCondition = Object.entries(encounterSections)
     .filter(([key]) => {
-      const encounterDateFormatted = dayjs(key).format(ISO_DATE);
+      const encounterDate = key;
       const conditionVisit = filterConditions.find(condition => {
         const conditionId = condition.id ?? "";
         const conditionVisitDate = condition.onsetDateTime
           ? condition.onsetDateTime
           : conditionDateDict[conditionId]?.start;
 
-        const conditionVisitDateFormatted = dayjs(conditionVisitDate).format(ISO_DATE);
-
-        return conditionVisitDateFormatted === encounterDateFormatted;
+        return conditionVisitDate === encounterDate;
       });
 
       return conditionVisit;
@@ -738,67 +735,6 @@ function createFilteredReportSection(
   `;
 }
 
-function buildEncounterSections(
-  encounterSections: EncounterSection,
-  diagnosticReports: DiagnosticReport[]
-): EncounterSection {
-  for (const report of diagnosticReports) {
-    const time = report.effectiveDateTime ?? report.effectivePeriod?.start;
-    const formattedDate = dayjs(time).format(ISO_DATE) ?? "";
-
-    if (formattedDate) {
-      if (!encounterSections[formattedDate]) {
-        encounterSections[formattedDate] = {};
-      }
-
-      let diagnosticReportsType: EncounterTypes | undefined = "documentation";
-
-      if (report.category) {
-        for (const iterator of report.category) {
-          if (iterator.text?.toLowerCase() === "lab") {
-            diagnosticReportsType = "labs";
-          }
-        }
-      }
-
-      if (diagnosticReportsType) {
-        const reportDate = dayjs(time).format(ISO_DATE) ?? "";
-        let isReportDuplicate = false;
-
-        if (encounterSections[formattedDate]?.[diagnosticReportsType]) {
-          const isDuplicate = encounterSections[formattedDate]?.[diagnosticReportsType]?.find(
-            reportInside => {
-              const reportInsideTime =
-                reportInside.effectiveDateTime ?? reportInside.effectivePeriod?.start;
-              const reportInsideDate = dayjs(reportInsideTime).format(ISO_DATE) ?? "";
-              const isDuplicateDate = reportInsideDate === reportDate;
-              const hasSamePresentedForm = report.presentedForm?.some(pf =>
-                reportInside.presentedForm?.some(ripf => pf.data === ripf.data)
-              );
-              return isDuplicateDate && hasSamePresentedForm;
-            }
-          );
-
-          isReportDuplicate = !!isDuplicate;
-        }
-
-        if (!encounterSections?.[formattedDate]?.[diagnosticReportsType]) {
-          encounterSections[formattedDate] = {
-            ...encounterSections[formattedDate],
-            [diagnosticReportsType]: [],
-          };
-        }
-
-        if (!isReportDuplicate) {
-          encounterSections[formattedDate]?.[diagnosticReportsType]?.push(report);
-        }
-      }
-    }
-  }
-
-  return encounterSections;
-}
-
 function buildReports(
   encounterSections: EncounterSection,
   mappedPractitioners: Record<string, Practitioner>,
@@ -813,19 +749,21 @@ function buildReports(
   const sortedAndFilteredNotes = Object.entries(docsWithNotes)
     // SORT BY ENCOUNTER DATE DESCENDING
     .sort(([keyA], [keyB]) => {
+      if (keyA === MISSING_DATE_KEY) return 1;
+      if (keyB === MISSING_DATE_KEY) return -1;
       return dayjs(keyA).isBefore(dayjs(keyB)) ? 1 : -1;
     })
     .slice(0, latest ? 1 : undefined)
     .filter(([key]) => {
       if (dateFilter) {
-        const encounterDateFormatted = dayjs(key).format(ISO_DATE);
-        return encounterDateFormatted > dateFilter;
+        if (key === MISSING_DATE_KEY) return false;
+        const encounterDate = key;
+        return encounterDate > dateFilter;
       }
 
       return true;
     })
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    .filter(([key, value]) => {
+    .filter(([, value]) => {
       const documentation = value.documentation;
       const validDocumentation = documentation?.filter(doc => {
         const containsB64InAnyPresentedForm = doc.presentedForm?.some(form => {
@@ -866,10 +804,10 @@ function buildReports(
           ? condition.onsetDateTime
           : conditionDateDict[conditionId]?.start;
 
-        const encounterDateFormatted = dayjs(key).format(ISO_DATE);
+        const encounterDate = key;
         const conditionVisitDateFormatted = dayjs(conditionVisitDate).format(ISO_DATE);
 
-        return conditionVisitDateFormatted === encounterDateFormatted;
+        return conditionVisitDateFormatted === encounterDate;
       });
 
       const codeName = getSpecificCode(condition?.code?.coding ?? [], [ICD_10_CODE]);
@@ -888,7 +826,7 @@ function buildReports(
         <div id="report">
           <div class="header">
             <h3 class="title">Encounter</h3>
-            <span>Date: ${formatDateForDisplay(key) ?? ""}</span>
+            <span>Date: ${key === MISSING_DATE_KEY ? MISSING_DATE_TEXT : key}</span>
           </div>
           <div>
             ${condition ? `<h4>Diagnosis</h4><p>${name} - ${codeName}</p>` : ""}
@@ -948,7 +886,7 @@ function getLatestDrPerSpecialty(
     const location = mappedLocations[locationRefId ?? ""];
 
     const time = diagnosticReport.effectiveDateTime ?? diagnosticReport.effectivePeriod?.start;
-    const formattedDate = dayjs(time).format(ISO_DATE) ?? "";
+    const formattedDate = formatDateForDisplay(time);
 
     diagnosticReportWithDate.push({
       diagnosticReportId,
@@ -964,9 +902,9 @@ function getLatestDrPerSpecialty(
       if (!specialtyExists || !curr.locationRefName) {
         acc.push(curr);
       } else {
-        const latestSpecialtyReportDate = dayjs(specialtyExists.date).format(ISO_DATE);
-        const isSameDate = dayjs(curr.date).isSame(dayjs(latestSpecialtyReportDate));
-        const isAfterDate = dayjs(curr.date).isAfter(dayjs(latestSpecialtyReportDate));
+        const latestSpecialtyReportDate = dayjs(specialtyExists.date);
+        const isSameDate = dayjs(curr.date).isSame(latestSpecialtyReportDate);
+        const isAfterDate = dayjs(curr.date).isAfter(latestSpecialtyReportDate);
 
         const planOfCareCode = "18776-5";
         const telephoneEncounterCode = "34748-4";
@@ -1096,7 +1034,7 @@ function createWhatWasDocumentedFromDiagnosticReports(
         field => field.trim().length > 0
       );
       return `
-      <div>
+      <div data-id="${doc.id}">
         ${fields.join("<br />")}
         ${
           notes.length > 0
@@ -1245,7 +1183,7 @@ function createSectionInMedications(
           });
 
           return `
-            <tr>
+            <tr data-id"${medicationStatement.id}">
               <td>${medication?.code?.text ?? ""}</td>
               <td>${blacklistedInstruction ? "" : medicationStatement.dosage?.[0]?.text ?? ""}</td>
               <td>${medicationStatement.dosage?.[0]?.doseAndRate?.[0]?.doseQuantity?.value ?? ""} ${

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
@@ -1205,10 +1205,11 @@ function createSectionInMedications(
 }
 
 type RenderCondition = {
+  id: string | undefined;
   code: string | null;
   name: string;
-  firstSeen: string;
-  lastSeen: string;
+  firstSeen: string | undefined;
+  lastSeen: string | undefined;
   clinicalStatus: string;
 };
 
@@ -1243,19 +1244,20 @@ function createConditionSection(conditions: Condition[], encounter: Encounter[])
         getValidCode(condition.code?.coding)[0]?.display ??
         condition.code?.text ??
         "";
-      const onsetDateTime = condition.onsetDateTime ?? "";
+      const onsetDateTime = condition.onsetDateTime;
       const clinicalStatus = getValidCode(condition.clinicalStatus?.coding)[0]?.display ?? "";
-      let onsetStartTime = condition.onsetPeriod?.start ?? "";
-      let onsetEndTime = condition.onsetPeriod?.end ?? "";
+      let onsetStartTime = condition.onsetPeriod?.start;
+      let onsetEndTime = condition.onsetPeriod?.end;
 
       if (!onsetStartTime && condition.id) {
-        onsetStartTime = conditionDateDict[condition.id]?.start ?? "";
+        onsetStartTime = conditionDateDict[condition.id]?.start;
       }
       if (!onsetEndTime && condition.id) {
-        onsetEndTime = conditionDateDict[condition.id]?.end ?? "";
+        onsetEndTime = conditionDateDict[condition.id]?.end;
       }
 
       const newCondition: RenderCondition = {
+        id: condition.id,
         code: codeName,
         name,
         firstSeen: onsetStartTime && onsetStartTime.length ? onsetStartTime : onsetDateTime,
@@ -1341,7 +1343,7 @@ function createConditionSection(conditions: Condition[], encounter: Encounter[])
       ${removeDuplicate
         .map(condition => {
           return `
-            <tr>
+            <tr data-id="${condition.id}">
               <td>${condition.name}</td>
               <td>${condition.code ?? ""}</td>
               <td>${formatDateForDisplay(condition.firstSeen)}</td>
@@ -1362,11 +1364,12 @@ function createConditionSection(conditions: Condition[], encounter: Encounter[])
 }
 
 type RenderAllergy = {
+  id: string | undefined;
   name: string;
   manifestation: string;
   code: string | null;
-  firstSeen: string;
-  lastSeen: string;
+  firstSeen: string | undefined;
+  lastSeen: string | undefined;
   clinicalStatus: string;
 };
 
@@ -1392,12 +1395,13 @@ function createAllergySection(allergies: AllergyIntolerance[]) {
         ? allergy.onsetDateTime
         : allergy.recordedDate
         ? allergy.recordedDate
-        : "";
+        : undefined;
       const clinicalStatus = allergy.clinicalStatus?.coding?.[0]?.code ?? "";
       const onsetStartTime = allergy.onsetPeriod?.start;
       const onsetEndTime = allergy.onsetPeriod?.end;
 
       const newAllergy: RenderAllergy = {
+        id: allergy.id,
         code,
         name,
         manifestation,
@@ -1461,7 +1465,7 @@ function createAllergySection(allergies: AllergyIntolerance[]) {
           });
 
           return `
-            <tr>
+            <tr data-id="${allergy.id}">
               <td>${allergy.name}</td>
               <td>${blacklistManifestation ? "" : allergy.manifestation}</td>
               <td>${allergy.code}</td>

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
@@ -1,0 +1,93 @@
+import { DiagnosticReport } from "@medplum/fhirtypes";
+import dayjs from "dayjs";
+
+export const ISO_DATE = "YYYY-MM-DD";
+export const MISSING_DATE_KEY = "N/A";
+export const MISSING_DATE_TEXT = "not available";
+
+type EncounterTypes =
+  | "labs"
+  | "progressNotes"
+  | "afterInstructions"
+  | "reasonForVisit"
+  | "documentation";
+
+/**
+ * EncounterSection is a map of strings to DiagnosticReport arrays.
+ * NOTE: don't assume key is a date, it might be MISSING_DATE_KEY, in case the date is not available.
+ */
+type EncounterSection = {
+  [key: string]: {
+    [k in EncounterTypes]?: DiagnosticReport[];
+  };
+};
+
+export function formatDateForDisplay(date: Date): string;
+export function formatDateForDisplay(date?: string | undefined): string;
+export function formatDateForDisplay(date?: Date | string | undefined): string {
+  const dateStr = typeof date === "string" ? date : date?.toISOString();
+  return dateStr ? dayjs(dateStr).format(ISO_DATE) : "";
+}
+
+/**
+ * @returns EncounterSection - NOTE: don't assume key is a date, it might be MISSING_DATE_KEY, in
+ * case the date is not available. See EncounterSection type for more details.
+ */
+export function buildEncounterSections(
+  encounterSections: EncounterSection,
+  diagnosticReports: DiagnosticReport[]
+): EncounterSection {
+  for (const report of diagnosticReports) {
+    const time = report.effectiveDateTime ?? report.effectivePeriod?.start;
+    const reportDate =
+      time && time !== MISSING_DATE_KEY ? formatDateForDisplay(time) : MISSING_DATE_KEY;
+
+    if (!encounterSections[reportDate]) {
+      encounterSections[reportDate] = {};
+    }
+
+    let diagnosticReportsType: EncounterTypes | undefined = "documentation";
+
+    if (report.category) {
+      for (const iterator of report.category) {
+        if (iterator.text?.toLowerCase() === "lab") {
+          diagnosticReportsType = "labs";
+        }
+      }
+    }
+
+    let isReportDuplicate = false;
+
+    if (encounterSections[reportDate]?.[diagnosticReportsType]) {
+      const isDuplicate = encounterSections[reportDate]?.[diagnosticReportsType]?.find(
+        reportInside => {
+          const reportInsideTime =
+            reportInside.effectiveDateTime ?? reportInside.effectivePeriod?.start;
+          const reportInsideDate = formatDateForDisplay(reportInsideTime);
+          const isDuplicateDate = reportInsideDate === reportDate;
+
+          const hasSamePresentedForm = report.presentedForm?.some(pf =>
+            reportInside.presentedForm?.some(ripf => pf.data === ripf.data)
+          );
+
+          return isDuplicateDate && hasSamePresentedForm;
+        }
+      );
+
+      isReportDuplicate = !!isDuplicate;
+    }
+
+    if (!encounterSections?.[reportDate]?.[diagnosticReportsType]) {
+      encounterSections[reportDate] = {
+        ...encounterSections[reportDate],
+        [diagnosticReportsType]: [],
+      };
+    }
+
+    if (!isReportDuplicate) {
+      encounterSections[reportDate]?.[diagnosticReportsType]?.push(report);
+    }
+  }
+
+  return encounterSections;
+}

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -1007,10 +1007,11 @@ function createSectionInMedications(
 }
 
 type RenderCondition = {
+  id: string | undefined;
   code: string | null;
   name: string;
-  firstSeen: string;
-  lastSeen: string;
+  firstSeen: string | undefined;
+  lastSeen: string | undefined;
   clinicalStatus: string;
 };
 
@@ -1053,19 +1054,20 @@ function createConditionSection(conditions: Condition[], encounter: Encounter[])
         getValidCode(condition.code?.coding)[0]?.display ??
         condition.code?.text ??
         "";
-      const onsetDateTime = condition.onsetDateTime ?? "";
+      const onsetDateTime = condition.onsetDateTime;
       const clinicalStatus = getValidCode(condition.clinicalStatus?.coding)[0]?.display ?? "";
-      let onsetStartTime = condition.onsetPeriod?.start ?? "";
-      let onsetEndTime = condition.onsetPeriod?.end ?? "";
+      let onsetStartTime = condition.onsetPeriod?.start;
+      let onsetEndTime = condition.onsetPeriod?.end;
 
       if (!onsetStartTime && condition.id) {
-        onsetStartTime = conditionDateDict[condition.id]?.start ?? "";
+        onsetStartTime = conditionDateDict[condition.id]?.start;
       }
       if (!onsetEndTime && condition.id) {
-        onsetEndTime = conditionDateDict[condition.id]?.end ?? "";
+        onsetEndTime = conditionDateDict[condition.id]?.end;
       }
 
       const newCondition: RenderCondition = {
+        id: condition.id,
         code: codeName,
         name,
         firstSeen: onsetStartTime && onsetStartTime.length ? onsetStartTime : onsetDateTime,
@@ -1174,11 +1176,12 @@ function createConditionSection(conditions: Condition[], encounter: Encounter[])
 }
 
 type RenderAllergy = {
+  id: string | undefined;
   name: string;
   manifestation: string;
   code: string | null;
-  firstSeen: string;
-  lastSeen: string;
+  firstSeen: string | undefined;
+  lastSeen: string | undefined;
   clinicalStatus: string;
 };
 
@@ -1204,12 +1207,13 @@ function createAllergySection(allergies: AllergyIntolerance[]) {
         ? allergy.onsetDateTime
         : allergy.recordedDate
         ? allergy.recordedDate
-        : "";
+        : undefined;
       const clinicalStatus = allergy.clinicalStatus?.coding?.[0]?.code ?? "";
       const onsetStartTime = allergy.onsetPeriod?.start;
       const onsetEndTime = allergy.onsetPeriod?.end;
 
       const newAllergy: RenderAllergy = {
+        id: allergy.id,
         code,
         name,
         manifestation,
@@ -1274,7 +1278,7 @@ function createAllergySection(allergies: AllergyIntolerance[]) {
           });
 
           return `
-            <tr>
+            <tr data-id="${allergy.id}">
               <td>${allergy.name}</td>
               <td>${blacklistManifestation ? "" : allergy.manifestation}</td>
               <td>${allergy.code}</td>

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -23,8 +23,13 @@ import {
 import dayjs from "dayjs";
 import { uniqWith } from "lodash";
 import { Brief } from "./bundle-to-brief";
-
-const ISO_DATE = "YYYY-MM-DD";
+import {
+  buildEncounterSections,
+  formatDateForDisplay,
+  ISO_DATE,
+  MISSING_DATE_KEY,
+  MISSING_DATE_TEXT,
+} from "./bundle-to-html-shared";
 
 const RX_NORM_CODE = "rxnorm";
 const NDC_CODE = "ndc";
@@ -287,10 +292,6 @@ export function bundleToHtml(fhirBundle: Bundle, brief?: Brief): string {
   return htmlPage;
 }
 
-function formatDateForDisplay(date?: string | undefined): string {
-  return date ? dayjs(date).format(ISO_DATE) : "";
-}
-
 // TODO: Use the version from "@metriport/core/external/fhir/shared/bundle.ts"
 function extractFhirTypesFromBundle(bundle: Bundle): {
   diagnosticReports: DiagnosticReport[];
@@ -427,7 +428,7 @@ function createMRHeader(patient: Patient) {
         <img src="https://raw.githubusercontent.com/metriport/metriport/develop/assets/logo-black.png" alt="Logo">
       </div>
       <h1 class="title">
-        Medical Record Summary (${dayjs().format(ISO_DATE)})
+        Medical Record Summary (${formatDateForDisplay(new Date())})
       </h1>
       <div class="header-tables">
         <div style="margin-right: 10px" class="header-table">
@@ -450,7 +451,7 @@ function createMRHeader(patient: Patient) {
             <table class="header-table-author">
               <tbody>
                 ${createHeaderTableRow("Name", "Metriport")}
-                ${createHeaderTableRow("Authored On", dayjs().format(ISO_DATE))}
+                ${createHeaderTableRow("Authored On", formatDateForDisplay(new Date()))}
               </tbody>
             </table>
           </div>
@@ -589,9 +590,9 @@ function createAWESection(
     return "";
   }
 
-  const encounterSections: EncounterSection = buildEncounterSections({}, diagnosticReports);
+  const encounterSections = buildEncounterSections({}, diagnosticReports);
 
-  const AWEreports = buildReports(
+  const aweReports = buildReports(
     encounterSections,
     mappedPractitioners,
     mappedOrganizations,
@@ -599,7 +600,7 @@ function createAWESection(
     true
   );
 
-  const hasAWEreports = AWEreports.length > 0;
+  const hasAweReports = aweReports.length > 0;
 
   return `
     <div id="awe" class="section">
@@ -609,8 +610,8 @@ function createAWESection(
       </div>
       <div class="section-content">
         ${
-          hasAWEreports
-            ? AWEreports
+          hasAweReports
+            ? aweReports
             : `<table><tbody><tr><td>No annual wellness exam info found</td></tr></tbody></table>`
         }
       </div>
@@ -631,7 +632,7 @@ function createDiagnosticReportsSection(
     return "";
   }
 
-  const encounterSections: EncounterSection = buildEncounterSections({}, diagnosticReports);
+  const encounterSections = buildEncounterSections({}, diagnosticReports);
 
   const nonAWEreports = buildReports(
     encounterSections,
@@ -659,68 +660,6 @@ function createDiagnosticReportsSection(
     </div>
   `;
 }
-function buildEncounterSections(
-  encounterSections: EncounterSection,
-  diagnosticReports: DiagnosticReport[]
-): EncounterSection {
-  for (const report of diagnosticReports) {
-    const time = report.effectiveDateTime ?? report.effectivePeriod?.start;
-    const formattedDate = dayjs(time).format(ISO_DATE) ?? "";
-
-    if (formattedDate) {
-      if (!encounterSections[formattedDate]) {
-        encounterSections[formattedDate] = {};
-      }
-
-      let diagnosticReportsType: EncounterTypes | undefined = "documentation";
-
-      if (report.category) {
-        for (const iterator of report.category) {
-          if (iterator.text?.toLowerCase() === "lab") {
-            diagnosticReportsType = "labs";
-          }
-        }
-      }
-
-      if (diagnosticReportsType) {
-        const reportDate = dayjs(time).format(ISO_DATE) ?? "";
-        let isReportDuplicate = false;
-
-        if (encounterSections[formattedDate]?.[diagnosticReportsType]) {
-          const isDuplicate = encounterSections[formattedDate]?.[diagnosticReportsType]?.find(
-            reportInside => {
-              const reportInsideTime =
-                reportInside.effectiveDateTime ?? reportInside.effectivePeriod?.start;
-              const reportInsideDate = dayjs(reportInsideTime).format(ISO_DATE) ?? "";
-              const isDuplicateDate = reportInsideDate === reportDate;
-
-              const hasSamePresentedForm = report.presentedForm?.some(pf =>
-                reportInside.presentedForm?.some(ripf => pf.data === ripf.data)
-              );
-
-              return isDuplicateDate && hasSamePresentedForm;
-            }
-          );
-
-          isReportDuplicate = !!isDuplicate;
-        }
-
-        if (!encounterSections?.[formattedDate]?.[diagnosticReportsType]) {
-          encounterSections[formattedDate] = {
-            ...encounterSections[formattedDate],
-            [diagnosticReportsType]: [],
-          };
-        }
-
-        if (!isReportDuplicate) {
-          encounterSections[formattedDate]?.[diagnosticReportsType]?.push(report);
-        }
-      }
-    }
-  }
-
-  return encounterSections;
-}
 
 function buildReports(
   encounterSections: EncounterSection,
@@ -735,22 +674,22 @@ function buildReports(
     Object.entries(docsWithNotes)
       // SORT BY ENCOUNTER DATE DESCENDING
       .sort(([keyA], [keyB]) => {
+        if (keyA === MISSING_DATE_KEY) return 1;
+        if (keyB === MISSING_DATE_KEY) return -1;
         return dayjs(keyA).isBefore(dayjs(keyB)) ? 1 : -1;
       })
       .filter(([key]) => {
         // FILTER FOR ENCOUNTERS WITH AWE DIAGNOSTIC REPORTS
-        const encounterDateFormatted = dayjs(key).format(ISO_DATE);
+        const encounterDateFormatted = key;
         const aweVisit = aweVisits.find(aweVisit => {
-          const aweVisitDate = aweVisit.onsetDateTime ?? "";
-          const aweVisitDateFormatted = dayjs(aweVisitDate).format(ISO_DATE);
-
+          const aweVisitDate = aweVisit.onsetDateTime;
+          const aweVisitDateFormatted = aweVisitDate;
           return aweVisitDateFormatted === encounterDateFormatted;
         });
 
         return onlyAWE ? aweVisit : !aweVisit;
       })
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      .filter(([key, value]) => {
+      .filter(([, value]) => {
         const documentation = value.documentation;
         const validDocumentation = documentation?.filter(doc => {
           const containsB64InAnyPresentedForm = doc.presentedForm?.some(form => {
@@ -779,7 +718,7 @@ function buildReports(
         <div id="report">
           <div class="header">
             <h3 class="title">Encounter</h3>
-            <span>Date: ${formatDateForDisplay(key) ?? ""}</span>
+            <span>Date: ${key === MISSING_DATE_KEY ? MISSING_DATE_TEXT : key}</span>
           </div>
           <div>
             ${
@@ -881,7 +820,7 @@ function createWhatWasDocumentedFromDiagnosticReports(
       );
 
       return `
-      <div>
+      <div data-id="${doc.id}">
         ${fields.join("<br />")}
         ${
           notes.length > 0
@@ -1045,7 +984,7 @@ function createSectionInMedications(
           });
 
           return `
-            <tr>
+            <tr data-id"${medicationStatement.id}">
               <td>${medication?.code?.text ?? ""}</td>
               <td>${blacklistedInstruction ? "" : medicationStatement.dosage?.[0]?.text ?? ""}</td>
               <td>${medicationStatement.dosage?.[0]?.doseAndRate?.[0]?.doseQuantity?.value ?? ""} ${


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

- Indicate missing date for DiagnosticReport - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1724276023306869?thread_ts=1724257837.838079&cid=C0616FCPAKZ)
- Move some shared code to a shared file
- Include the resource ID (hidden) on DiagnosticReport and MedicationStatement

Note: I intentionally kept changes to a minimum. There's a lot to fix/improve, but this needs more time and prioritization.

### Testing

- Local
  - [x] Generate regular MR
  - [x] Generate ADHD MR
- Staging
  - [ ] Generate regular MR
  - [ ] Generate ADHD MR
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
