### PR TITLE
feat(fhir-converter): default date for procedure and immunization

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Resources/Immunization.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/Immunization.hbs
@@ -46,6 +46,10 @@
         	"occurrenceDateTime":"{{formatAsDateTime imm.effectiveTime.low.value}}",
         {{else if imm.effectiveTime.value}}
         	"occurrenceDateTime":"{{formatAsDateTime imm.effectiveTime.value}}",
+        {{else if @encounterTimePeriod.low}}
+            "occurrenceDateTime": "{{formatAsDateTime @encounterTimePeriod.low.value}}",
+        {{else if @encounterTimePeriod.high}}
+            "occurrenceDateTime": "{{formatAsDateTime @encounterTimePeriod.high.value}}",
         {{else}}
           "occurrenceString":"unknown" 
         {{/if}}

--- a/packages/fhir-converter/src/templates/cda/Resources/Immunization.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/Immunization.hbs
@@ -46,10 +46,10 @@
         	"occurrenceDateTime":"{{formatAsDateTime imm.effectiveTime.low.value}}",
         {{else if imm.effectiveTime.value}}
         	"occurrenceDateTime":"{{formatAsDateTime imm.effectiveTime.value}}",
-        {{else if @encounterTimePeriod.low}}
-            "occurrenceDateTime": "{{formatAsDateTime @encounterTimePeriod.low.value}}",
         {{else if @encounterTimePeriod.high}}
             "occurrenceDateTime": "{{formatAsDateTime @encounterTimePeriod.high.value}}",
+        {{else if @encounterTimePeriod.low}}
+            "occurrenceDateTime": "{{formatAsDateTime @encounterTimePeriod.low.value}}",
         {{else}}
           "occurrenceString":"unknown" 
         {{/if}}

--- a/packages/fhir-converter/src/templates/cda/Resources/Procedure.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/Procedure.hbs
@@ -52,7 +52,7 @@
         {{#if procedureEntry.effectiveTime.value}}
             "performedDateTime":"{{formatAsDateTime procedureEntry.effectiveTime.value}}",
         {{else}}
-            "performedPeriod": {{>DataType/Period.hbs period=procedureEntry.effectiveTime}},
+            "performedPeriod": {{>Utils/PeriodOrDefaultPeriod.hbs period=procedureEntry.effectiveTime}},
         {{/if}}
         {{#if procedureEntry.text._}}
             "note": [


### PR DESCRIPTION
refs. metriport/metriport-internal#2149

### Description
- Default date for `Procedure` and `Immunization` resources

### Testing

- Local
  - [x] Conversion contains the date
  - [x] No issues with inserts

### Release Plan
- [ ] Merge this
