### PR TITLE
BUG FIX adding patient to FHIR on create command instead of route

### DIFF
--- a/packages/api/src/command/medical/patient/create-patient.ts
+++ b/packages/api/src/command/medical/patient/create-patient.ts
@@ -4,6 +4,8 @@ import {
   PatientData,
   PatientDemoData,
 } from "@metriport/core/domain/patient";
+import { toFHIR } from "@metriport/core/external/fhir/patient/index";
+import { upsertPatientToFHIRServer } from "../../../external/fhir/patient/upsert-patient";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { processAsyncError } from "@metriport/core/util/error/shared";
 import { PatientModel } from "../../../models/medical/patient";
@@ -73,6 +75,9 @@ export async function createPatient({
   if (addressWithCoordinates) patientCreate.data.address = addressWithCoordinates;
 
   const newPatient = await PatientModel.create(patientCreate);
+
+  const fhirPatient = toFHIR(newPatient);
+  await upsertPatientToFHIRServer(newPatient.cxId, fhirPatient);
 
   runInitialPatientDiscoveryAcrossHies({
     patient: newPatient.dataValues,

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -6,7 +6,6 @@ import {
 import { GetConsolidatedQueryProgressResponse } from "@metriport/api-sdk/medical/models/patient";
 import { mrFormat } from "@metriport/core/domain/conversion/fhir-to-medical-record";
 import { MAXIMUM_UPLOAD_FILE_SIZE } from "@metriport/core/external/aws/lambda-logic/document-uploader";
-import { toFHIR } from "@metriport/core/external/fhir/patient/index";
 import { getRequestId } from "@metriport/core/util/request";
 import { stringToBoolean } from "@metriport/shared";
 import { Request, Response } from "express";
@@ -39,7 +38,6 @@ import { getFacilityIdOrFail } from "../../domain/medical/patient-facility";
 import BadRequestError from "../../errors/bad-request";
 import NotFoundError from "../../errors/not-found";
 import { countResources } from "../../external/fhir/patient/count-resources";
-import { upsertPatientToFHIRServer } from "../../external/fhir/patient/upsert-patient";
 import { PatientModel as Patient } from "../../models/medical/patient";
 import { REQUEST_ID_HEADER_NAME } from "../../routes/header";
 import { Config } from "../../shared/config";
@@ -112,9 +110,6 @@ router.post(
       forceCarequality,
     });
 
-    // temp solution until we migrate to FHIR
-    const fhirPatient = toFHIR(patient);
-    await upsertPatientToFHIRServer(patient.cxId, fhirPatient);
     return res.status(status.CREATED).json(dtoFromModel(patient));
   })
 );


### PR DESCRIPTION
Ref: #1040

### Description

- moving FHIR patient create to create command

### Testing

- Local
  - [ ] make sure nothing breaks on patient create
- Staging
  - [ ] make sure nothing breaks on patient create
- Production
  - [ ] make sure nothing breaks
  - [ ] eventually run new CA and make sure no isssues

### Release Plan

- [ ] Merge this
