### PR TITLE
1040 E2E test w/ allergy ID on the HTML MR

### DIFF
--- a/packages/api/src/__tests__/e2e/mapi/parts/consolidated.test.part.ts
+++ b/packages/api/src/__tests__/e2e/mapi/parts/consolidated.test.part.ts
@@ -269,12 +269,15 @@ export function runConsolidatedTests(e2e: E2eContext) {
         const lastName = e2e.patient?.lastName;
         if (!lastName) throw new Error("Missing patient.lastName");
         if (!e2e.mrContentBuffer) throw new Error("Missing mrContentBuffer");
+        const allergyId = e2e.allergyIntolerance?.id;
+        if (!allergyId) throw new Error("Missing allergyIntolerance.id");
         const contents = e2e.mrContentBuffer.toString("utf-8");
         expect(contents).toBeTruthy();
         expect(
           checkConsolidatedHtml({
             contents,
             patientId: e2e.patient.id,
+            allergyId,
             lastName,
           })
         ).toBeTrue();

--- a/packages/api/src/__tests__/e2e/mapi/parts/consolidated/consolidated-template.html
+++ b/packages/api/src/__tests__/e2e/mapi/parts/consolidated/consolidated-template.html
@@ -409,7 +409,7 @@
     </thead>
     <tbody>
       
-            <tr>
+            <tr data-id="<%= allergyId %>">
               <td>Pollen</td>
               <td>Eruption of skin (disorder)</td>
               <td>SNOMED: 419199007</td>

--- a/packages/api/src/__tests__/e2e/mapi/parts/consolidated/consolidated.ts
+++ b/packages/api/src/__tests__/e2e/mapi/parts/consolidated/consolidated.ts
@@ -75,12 +75,14 @@ export function checkConsolidatedJson(
 export function checkConsolidatedHtml({
   patientId,
   lastName,
+  allergyId,
   ...params
 }: {
   patientId: string;
   lastName: string;
+  allergyId: string;
 } & Consolidated): boolean {
-  const templateParams = { patientId, lastName };
+  const templateParams = { patientId, lastName, allergyId };
   return checkConsolidated({ ...params, templateParams, extension: "html" });
 }
 

--- a/packages/api/src/__tests__/e2e/mapi/parts/consolidated/validate-received-html.ts
+++ b/packages/api/src/__tests__/e2e/mapi/parts/consolidated/validate-received-html.ts
@@ -17,6 +17,7 @@ dayjs.extend(utc);
 
 const patientId = "...";
 const lastName = "...";
+const allergyId = "...";
 const receivedFileName = "consolidated-received";
 const html = fs.readFileSync(`${__dirname}/${receivedFileName}.html`, "utf8");
 
@@ -24,6 +25,7 @@ const isMatch = checkConsolidatedHtml({
   contents: html,
   patientId,
   lastName,
+  allergyId,
   // send a diff name so we don't override the default received one that might exist on the filesystem
   outputReceivedFileName: `${receivedFileName}_validate`,
 });


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2642
- Downstream: none

### Description

E2E test w/ allergy ID on the HTML MR - [context](https://metriport.slack.com/archives/C04FZ9859FZ/p1724379010051399?thread_ts=1724371991.327449&cid=C04FZ9859FZ)

### Testing

- Local
  - [x] E2E runs successfully
- Staging
  - [ ] E2E runs successfully
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
