### PR TITLE
1040 date added to partition scheme

### DIFF
--- a/packages/core/src/domain/__tests__/filename.test.ts
+++ b/packages/core/src/domain/__tests__/filename.test.ts
@@ -20,11 +20,55 @@ describe("hive partition path", () => {
       patientId,
       keys,
       date,
+      dateGranularity: "second",
+    });
+    expect(result).toBe(targetPath);
+  });
+  it(`full - minute granularity`, async () => {
+    const targetPath = `date=2019-01-01/hour=12/minute=15/cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
+    const result = createHivePartitionFilePath({
+      cxId,
+      patientId,
+      keys,
+      date,
+      dateGranularity: "minute",
+    });
+    expect(result).toBe(targetPath);
+  });
+  it(`full - hour granularity`, async () => {
+    const targetPath = `date=2019-01-01/hour=12/cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
+    const result = createHivePartitionFilePath({
+      cxId,
+      patientId,
+      keys,
+      date,
+      dateGranularity: "hour",
+    });
+    expect(result).toBe(targetPath);
+  });
+  it(`full - day granularity (arg)`, async () => {
+    const targetPath = `date=2019-01-01/cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
+    const result = createHivePartitionFilePath({
+      cxId,
+      patientId,
+      keys,
+      date,
+      dateGranularity: "day",
+    });
+    expect(result).toBe(targetPath);
+  });
+  it(`full - day granularity (no arg)`, async () => {
+    const targetPath = `date=2019-01-01/cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
+    const result = createHivePartitionFilePath({
+      cxId,
+      patientId,
+      keys,
+      date,
     });
     expect(result).toBe(targetPath);
   });
   it(`full-uppercase`, async () => {
-    const targetPath = `date=2019-01-01/hour=12/minute=15/second=30/cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
+    const targetPath = `date=2019-01-01/cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
     const result = createHivePartitionFilePath({
       cxId,
       patientId,
@@ -43,7 +87,7 @@ describe("hive partition path", () => {
     expect(result).toBe(targetPath);
   });
   it(`no keys`, async () => {
-    const targetPath = `date=2019-01-01/hour=12/minute=15/second=30/cxid=${cxId}/patientid=${patientId}`;
+    const targetPath = `date=2019-01-01/cxid=${cxId}/patientid=${patientId}`;
     const result = createHivePartitionFilePath({
       cxId,
       patientId,

--- a/packages/core/src/domain/__tests__/filename.test.ts
+++ b/packages/core/src/domain/__tests__/filename.test.ts
@@ -14,7 +14,7 @@ const date = new Date(Date.parse("2019-01-01T12:15:30.000Z"));
 
 describe("hive partition path", () => {
   it(`full`, async () => {
-    const targetPath = `date=2019-01-01/hour=12/minute=15/second=30/cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
+    const targetPath = `date=2019-01-01/hour=12/minute=15/second=30/cx_id=${cxId}/patient_id=${patientId}/key1=value1/key2=value2`;
     const result = createHivePartitionFilePath({
       cxId,
       patientId,
@@ -25,7 +25,7 @@ describe("hive partition path", () => {
     expect(result).toBe(targetPath);
   });
   it(`full - minute granularity`, async () => {
-    const targetPath = `date=2019-01-01/hour=12/minute=15/cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
+    const targetPath = `date=2019-01-01/hour=12/minute=15/cx_id=${cxId}/patient_id=${patientId}/key1=value1/key2=value2`;
     const result = createHivePartitionFilePath({
       cxId,
       patientId,
@@ -36,7 +36,7 @@ describe("hive partition path", () => {
     expect(result).toBe(targetPath);
   });
   it(`full - hour granularity`, async () => {
-    const targetPath = `date=2019-01-01/hour=12/cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
+    const targetPath = `date=2019-01-01/hour=12/cx_id=${cxId}/patient_id=${patientId}/key1=value1/key2=value2`;
     const result = createHivePartitionFilePath({
       cxId,
       patientId,
@@ -47,7 +47,7 @@ describe("hive partition path", () => {
     expect(result).toBe(targetPath);
   });
   it(`full - day granularity (arg)`, async () => {
-    const targetPath = `date=2019-01-01/cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
+    const targetPath = `date=2019-01-01/cx_id=${cxId}/patient_id=${patientId}/key1=value1/key2=value2`;
     const result = createHivePartitionFilePath({
       cxId,
       patientId,
@@ -58,7 +58,7 @@ describe("hive partition path", () => {
     expect(result).toBe(targetPath);
   });
   it(`full - day granularity (no arg)`, async () => {
-    const targetPath = `date=2019-01-01/cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
+    const targetPath = `date=2019-01-01/cx_id=${cxId}/patient_id=${patientId}/key1=value1/key2=value2`;
     const result = createHivePartitionFilePath({
       cxId,
       patientId,
@@ -68,7 +68,7 @@ describe("hive partition path", () => {
     expect(result).toBe(targetPath);
   });
   it(`full-uppercase`, async () => {
-    const targetPath = `date=2019-01-01/cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
+    const targetPath = `date=2019-01-01/cx_id=${cxId}/patient_id=${patientId}/key1=value1/key2=value2`;
     const result = createHivePartitionFilePath({
       cxId,
       patientId,
@@ -78,7 +78,7 @@ describe("hive partition path", () => {
     expect(result).toBe(targetPath);
   });
   it(`no date`, async () => {
-    const targetPath = `cxid=${cxId}/patientid=${patientId}/key1=value1/key2=value2`;
+    const targetPath = `cx_id=${cxId}/patient_id=${patientId}/key1=value1/key2=value2`;
     const result = createHivePartitionFilePath({
       cxId,
       patientId,
@@ -87,7 +87,7 @@ describe("hive partition path", () => {
     expect(result).toBe(targetPath);
   });
   it(`no keys`, async () => {
-    const targetPath = `date=2019-01-01/cxid=${cxId}/patientid=${patientId}`;
+    const targetPath = `date=2019-01-01/cx_id=${cxId}/patient_id=${patientId}`;
     const result = createHivePartitionFilePath({
       cxId,
       patientId,
@@ -96,7 +96,7 @@ describe("hive partition path", () => {
     expect(result).toBe(targetPath);
   });
   it(`no date no keys`, async () => {
-    const targetPath = `cxid=${cxId}/patientid=${patientId}`;
+    const targetPath = `cx_id=${cxId}/patient_id=${patientId}`;
     const result = createHivePartitionFilePath({
       cxId,
       patientId,

--- a/packages/core/src/domain/filename.ts
+++ b/packages/core/src/domain/filename.ts
@@ -29,7 +29,6 @@ export function createHivePartitionFilePath({
     }
     if (["minute", "second"].includes(dateGranularity)) {
       datePath.push(`minute=${date.getUTCMinutes()}`);
-      x;
     }
     if (["second"].includes(dateGranularity)) {
       datePath.push(`second=${date.getUTCSeconds()}`);

--- a/packages/core/src/domain/filename.ts
+++ b/packages/core/src/domain/filename.ts
@@ -13,20 +13,26 @@ export function createHivePartitionFilePath({
   patientId,
   keys,
   date,
+  dateGranularity = "day",
 }: {
   cxId: string;
   patientId: string;
   keys?: { [key: string]: string };
   date?: Date;
+  dateGranularity?: "day" | "hour" | "minute" | "second";
 }): string {
-  let datePath: string[] = [];
+  const datePath: string[] = [];
   if (date) {
-    datePath = [
-      `date=${date.toISOString().slice(0, 10)}`,
-      `hour=${date.getUTCHours()}`,
-      `minute=${date.getUTCMinutes()}`,
-      `second=${date.getUTCSeconds()}`,
-    ];
+    datePath.push(`date=${date.toISOString().slice(0, 10)}`);
+    if (["hour", "minute", "second"].includes(dateGranularity)) {
+      datePath.push(`hour=${date.getUTCHours()}`);
+    }
+    if (["minute", "second"].includes(dateGranularity)) {
+      datePath.push(`minute=${date.getUTCMinutes()}`);
+    }
+    if (["second"].includes(dateGranularity)) {
+      datePath.push(`second=${date.getUTCSeconds()}`);
+    }
   }
   let keysPath: string[] = [];
   if (keys) {

--- a/packages/core/src/domain/filename.ts
+++ b/packages/core/src/domain/filename.ts
@@ -29,6 +29,7 @@ export function createHivePartitionFilePath({
     }
     if (["minute", "second"].includes(dateGranularity)) {
       datePath.push(`minute=${date.getUTCMinutes()}`);
+      x;
     }
     if (["second"].includes(dateGranularity)) {
       datePath.push(`second=${date.getUTCSeconds()}`);
@@ -38,7 +39,7 @@ export function createHivePartitionFilePath({
   if (keys) {
     keysPath = Object.entries(keys).map(([key, value]) => `${key.toLowerCase()}=${value}`);
   }
-  return [...datePath, `cxid=${cxId}`, `patientid=${patientId}`, ...keysPath].join("/");
+  return [...datePath, `cx_id=${cxId}`, `patient_id=${patientId}`, ...keysPath].join("/");
 }
 
 export type ParsedFileName = { cxId: string; patientId: string; fileId: string };

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/ihe-gateway-v2-logic.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/ihe-gateway-v2-logic.ts
@@ -188,12 +188,19 @@ export async function createSignSendProcessXCPDRequest({
             requestId: result.id,
             gatewayOid: result.gateway.oid,
           },
+          date: result.requestTimestamp ? new Date(result.requestTimestamp) : new Date(),
         });
         const key = `${filePath}/result.json`;
+        const extendedResult = {
+          ...result,
+          cxId,
+          patientId,
+          stage: "pd",
+        };
         await s3Utils.uploadFile({
           bucket: parsedResponsesBucket,
           key,
-          file: Buffer.from(JSON.stringify(result), "utf8"),
+          file: Buffer.from(JSON.stringify(extendedResult), "utf8"),
           contentType: "application/json",
         });
       } catch (error) {

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/ihe-gateway-v2-logic.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/ihe-gateway-v2-logic.ts
@@ -188,7 +188,9 @@ export async function createSignSendProcessXCPDRequest({
             requestId: result.id,
             gatewayOid: result.gateway.oid,
           },
-          date: result.requestTimestamp ? new Date(result.requestTimestamp) : new Date(),
+          date: result.requestTimestamp
+            ? new Date(Date.parse(result.requestTimestamp))
+            : new Date(),
         });
         const key = `${filePath}/result.json`;
         const extendedResult = {

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/ihe-gateway-v2-logic.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/ihe-gateway-v2-logic.ts
@@ -188,8 +188,8 @@ export async function createSignSendProcessXCPDRequest({
           patientId,
           keys: {
             stage: "pd",
-            requestId: result.id,
-            gatewayOid: result.gateway.oid,
+            request_id: result.id,
+            gateway_oid: result.gateway.oid,
           },
           date: partitionDate,
         });
@@ -197,8 +197,8 @@ export async function createSignSendProcessXCPDRequest({
         const extendedResult = {
           ...result,
           _date: partitionDate.toISOString().slice(0, 10),
-          _cxId: cxId,
-          _patientId: patientId,
+          cxid: cxId,
+          patientid: patientId,
           _stage: "pd",
         };
         await s3Utils.uploadFile({

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/ihe-gateway-v2-logic.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/ihe-gateway-v2-logic.ts
@@ -180,6 +180,9 @@ export async function createSignSendProcessXCPDRequest({
     }
     if (parsedResponsesBucket) {
       try {
+        const partitionDate = result.requestTimestamp
+          ? new Date(Date.parse(result.requestTimestamp))
+          : new Date();
         const filePath = createHivePartitionFilePath({
           cxId,
           patientId,
@@ -188,16 +191,15 @@ export async function createSignSendProcessXCPDRequest({
             requestId: result.id,
             gatewayOid: result.gateway.oid,
           },
-          date: result.requestTimestamp
-            ? new Date(Date.parse(result.requestTimestamp))
-            : new Date(),
+          date: partitionDate,
         });
         const key = `${filePath}/result.json`;
         const extendedResult = {
           ...result,
-          cxId,
-          patientId,
-          stage: "pd",
+          _date: partitionDate.toISOString().slice(0, 10),
+          _cxId: cxId,
+          _patientId: patientId,
+          _stage: "pd",
         };
         await s3Utils.uploadFile({
           bucket: parsedResponsesBucket,

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -86,6 +86,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
         storageDescriptor: {
           columns: [
             { name: "id", type: "string" },
+            { name: "date", type: "string" },
             { name: "cxId", type: "string" },
             { name: "patientId", type: "string" },
             { name: "stage", type: "string" },

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -86,6 +86,9 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
         storageDescriptor: {
           columns: [
             { name: "id", type: "string" },
+            { name: "cxId", type: "string" },
+            { name: "patientId", type: "string" },
+            { name: "stage", type: "string" },
             { name: "timestamp", type: "string" },
             { name: "requesttimestamp", type: "string" },
             { name: "responsetimestamp", type: "string" },

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -79,16 +79,16 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
         name: "ihe_parsed_responses_by_date",
         partitionKeys: [
           { name: "date", type: "string" },
-          { name: "cxid", type: "string" },
-          { name: "patientid", type: "string" },
+          { name: "cx_id", type: "string" },
+          { name: "patient_id", type: "string" },
           { name: "stage", type: "string" },
         ],
         storageDescriptor: {
           columns: [
             { name: "id", type: "string" },
             { name: "_date", type: "string" },
-            { name: "_cxId", type: "string" },
-            { name: "_patientId", type: "string" },
+            { name: "cxid", type: "string" },
+            { name: "patientid", type: "string" },
             { name: "_stage", type: "string" },
             { name: "timestamp", type: "string" },
             { name: "requesttimestamp", type: "string" },

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -86,10 +86,6 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
         storageDescriptor: {
           columns: [
             { name: "id", type: "string" },
-            { name: "_date", type: "string" },
-            { name: "cxid", type: "string" },
-            { name: "patientid", type: "string" },
-            { name: "_stage", type: "string" },
             { name: "timestamp", type: "string" },
             { name: "requesttimestamp", type: "string" },
             { name: "responsetimestamp", type: "string" },
@@ -100,6 +96,11 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
               name: "operationoutcome",
               type: "struct<resourcetype:string,id:string,issue:array<struct<severity:string,code:string,details:struct<text:string>>>>",
             },
+            // Partition columns flat in data - duplicate columns are prepended "_"
+            { name: "_date", type: "string" },
+            { name: "cxid", type: "string" },
+            { name: "patientid", type: "string" },
+            { name: "_stage", type: "string" },
           ],
           compressed: false,
           inputFormat: "org.apache.hadoop.mapred.TextInputFormat",

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -86,6 +86,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
         storageDescriptor: {
           columns: [
             { name: "id", type: "string" },
+            { name: "_date", type: "string" },
             { name: "_cxId", type: "string" },
             { name: "_patientId", type: "string" },
             { name: "_stage", type: "string" },

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -76,7 +76,7 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
       databaseName: "default",
       tableInput: {
         description: "Table used for debugging IHE parsed responses",
-        name: "ihe_parsed_respones_by_date",
+        name: "ihe_parsed_responses_by_date",
         partitionKeys: [
           { name: "date", type: "string" },
           { name: "cxid", type: "string" },
@@ -86,10 +86,9 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
         storageDescriptor: {
           columns: [
             { name: "id", type: "string" },
-            { name: "date", type: "string" },
-            { name: "cxId", type: "string" },
-            { name: "patientId", type: "string" },
-            { name: "stage", type: "string" },
+            { name: "_cxId", type: "string" },
+            { name: "_patientId", type: "string" },
+            { name: "_stage", type: "string" },
             { name: "timestamp", type: "string" },
             { name: "requesttimestamp", type: "string" },
             { name: "responsetimestamp", type: "string" },

--- a/packages/infra/lib/ihe-gateway-v2-stack.ts
+++ b/packages/infra/lib/ihe-gateway-v2-stack.ts
@@ -76,12 +76,12 @@ export class IHEGatewayV2LambdasNestedStack extends NestedStack {
       databaseName: "default",
       tableInput: {
         description: "Table used for debugging IHE parsed responses",
-        name: "ihe_parsed_respones_debug",
+        name: "ihe_parsed_respones_by_date",
         partitionKeys: [
+          { name: "date", type: "string" },
           { name: "cxid", type: "string" },
           { name: "patientid", type: "string" },
           { name: "stage", type: "string" },
-          { name: "requestid", type: "string" },
         ],
         storageDescriptor: {
           columns: [


### PR DESCRIPTION
Ticket: #1040

### Description

- add date level partitioning so that the stats query can run on a subset of dates within a month without timing out
- remove requsetId partitioning to make it a bit less heavy when running
- add new columns so that we can query data without the partitions if need be

### Testing

- Local
  - [x] test PD 
- Staging
  - [ ] test PD 
- Production
  - [ ] test PD 

### Release Plan

- [ ] Merge this
