### PR TITLE
PATCH RELEASE 799 Beef-up OpenSearch

### DIFF
--- a/packages/infra/lib/api-stack/ccda-search-connector.ts
+++ b/packages/infra/lib/api-stack/ccda-search-connector.ts
@@ -20,6 +20,7 @@ export function settings(): OpenSearchConnectorConfig & {
   connectorName: string;
   sqs: {
     maxReceiveCount: number;
+    retryAttempts: number;
     visibilityTimeout: Duration;
   };
 } {
@@ -29,7 +30,9 @@ export function settings(): OpenSearchConnectorConfig & {
     connectorName: "CCDAOpenSearch",
     sqs: {
       // Number of times we want to retry a message, this includes throttles!
-      maxReceiveCount: 2,
+      maxReceiveCount: 4,
+      // The maximum number of times to retry when the function returns an error.
+      retryAttempts: 2,
       // How long messages should be invisible for other consumers, based on the lambda timeout
       // We don't care if the message gets reprocessed, so no need to have a huge visibility timeout that makes it harder to move messages to the DLQ
       visibilityTimeout: Duration.seconds(config.openSearch.lambda.timeout.toSeconds() * 2 + 1),
@@ -66,7 +69,7 @@ export function setup({
     connectorName,
     openSearch: openSearchConfig,
     lambda: { memory, timeout, batchSize, maxConcurrency },
-    sqs: { maxReceiveCount, visibilityTimeout },
+    sqs: { maxReceiveCount, visibilityTimeout, retryAttempts },
   } = settings();
 
   const openSearch = new OpenSearchConstruct(stack, connectorName, {
@@ -112,6 +115,7 @@ export function setup({
       SEARCH_SECRET_NAME: openSearch.creds.secret.secretName,
       SEARCH_INDEX_NAME: openSearchConfig.indexName,
     },
+    retryAttempts,
     timeout,
     alarmSnsAction,
   });

--- a/packages/infra/lib/shared/lambda.ts
+++ b/packages/infra/lib/shared/lambda.ts
@@ -52,6 +52,7 @@ export interface LambdaProps extends StackProps {
   readonly timeout?: Duration;
   readonly memory?: number;
   readonly reservedConcurrentExecutions?: number;
+  /** The maximum number of times to retry when the function returns an error. */
   readonly retryAttempts?: number;
   readonly maxEventAge?: Duration;
   readonly alarmSnsAction?: SnsAction;


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/2156
- Downstream: none

### Description

Beef-up OpenSearch - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1724689492389159)

Also added retry attempts to the CCDASearch lambda so it can auto retry a couple of times before error and drive messages to DLQ.

### Testing

See upstream

### Release Plan

- :warning: Points to `master`
- See upstream
