### PR TITLE
PATCH RELEASE 2024_08_27 Fhir Dedup 

### DIFF
--- a/packages/core/src/fhir-deduplication/__tests__/examples/medication-related.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/examples/medication-related.ts
@@ -7,10 +7,12 @@ import {
 
 const DEFAULT_MEDICATION_REF = `Medication/${faker.string.uuid()}`;
 
-export function makeMedicationAdministration(params: Partial<MedicationAdministration>) {
+export function makeMedicationAdministration(
+  params?: Partial<MedicationAdministration>
+): MedicationAdministration {
   return {
     resourceType: "MedicationAdministration",
-    ...(params.id ? { id: params.id } : { id: faker.string.uuid() }),
+    ...(params?.id ? { id: params.id } : { id: faker.string.uuid() }),
     extension: [
       {
         url: "https://public.metriport.com/fhir/StructureDefinition/doc-id-extension.json",
@@ -37,10 +39,10 @@ export function makeMedicationAdministration(params: Partial<MedicationAdministr
   };
 }
 
-export function makeMedicationRequest(params: Partial<MedicationRequest>): MedicationRequest {
+export function makeMedicationRequest(params?: Partial<MedicationRequest>): MedicationRequest {
   return {
     resourceType: "MedicationRequest",
-    ...(params.id ? { id: params.id } : { id: faker.string.uuid() }),
+    ...(params?.id ? { id: params.id } : { id: faker.string.uuid() }),
     extension: [
       {
         url: "https://public.metriport.com/fhir/StructureDefinition/doc-id-extension.json",

--- a/packages/core/src/fhir-deduplication/__tests__/remove-dangling-link.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/remove-dangling-link.test.ts
@@ -1,0 +1,61 @@
+import { faker } from "@faker-js/faker";
+import {
+  BundleEntry,
+  Medication,
+  MedicationAdministration,
+  MedicationRequest,
+  MedicationStatement,
+  Reference,
+  Resource,
+} from "@medplum/fhirtypes";
+import { makeMedication } from "../../fhir-to-cda/cda-templates/components/__tests__/make-medication";
+import { removeResourcesWithDanglingLinks } from "../deduplicate-fhir";
+import {
+  makeMedicationAdministration,
+  makeMedicationRequest,
+  makeMedicationStatement,
+} from "./examples/medication-related";
+
+let medicationId: string;
+let medicationId2: string;
+let medication: Medication;
+let medStatement: MedicationStatement;
+let medRequest: MedicationRequest;
+let medAdmin: MedicationAdministration;
+let entries: BundleEntry<Resource>[];
+let medRef: Reference<Medication>;
+let medRef2: Reference<Medication>;
+
+beforeEach(() => {
+  medicationId = faker.string.uuid();
+  medicationId2 = faker.string.uuid();
+  medRef = { reference: `Medication/${medicationId}` };
+  medRef2 = { reference: `Medication/${medicationId2}` };
+  medication = makeMedication({ id: medicationId2 });
+  medStatement = makeMedicationStatement({ medicationReference: medRef });
+  medRequest = makeMedicationRequest({ medicationReference: medRef });
+  medAdmin = makeMedicationAdministration({ medicationReference: medRef });
+  entries = [medStatement, medRequest, medAdmin];
+});
+
+describe("removeResourcesWithDanglingLinks", () => {
+  it("correctly picks the more descriptive status", () => {
+    expect(entries.length).toBe(3);
+    const cleanedUpBundle = removeResourcesWithDanglingLinks(entries, [JSON.stringify(medRef)]);
+    expect(cleanedUpBundle.length).toBe(0);
+  });
+
+  it("does not remove a med-related resource that references another medication", () => {
+    const medStatementWithoutDeadLink = makeMedicationStatement({ medicationReference: medRef2 });
+    entries.push(...[medication, medStatementWithoutDeadLink]);
+    expect(entries.length).toBe(5);
+
+    const cleanedUpBundle = removeResourcesWithDanglingLinks(entries, [JSON.stringify(medRef)]);
+    expect(cleanedUpBundle.length).toBe(2);
+    const medStatement = cleanedUpBundle.find(r => r.id === medStatementWithoutDeadLink.id) as
+      | MedicationStatement
+      | undefined;
+    expect(medStatement?.id).toBe(medStatementWithoutDeadLink.id);
+    expect(medStatement?.medicationReference).toBe(medRef2);
+  });
+});


### PR DESCRIPTION
refs. metriport/metriport#2569

### Description
- Removing resources that are crucially dependent on the resources that had been eliminated in the deduplication step (i.e. if `Medication` that's referenced by a `MedicationStatement` was eliminated, then the whole `MedicationStatement` carries no meaning, and should therefore also be removed)

### Testing

- Local
  - [x] Unit tests

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
