### PR TITLE
2569 Dedup GO LIVE

### DIFF
--- a/.husky/check-signoff.sh
+++ b/.husky/check-signoff.sh
@@ -4,11 +4,15 @@ NPM_PUBLISH_MSG="chore(release): publish"
 grep -qs "${NPM_PUBLISH_MSG}" $1 # returns 0 if found, 1 if not found
 containsNpmPublishMessage=$?
 
+MERGE_MSG="Merge branch 'develop' into"
+grep -qs "${MERGE_MSG}" $1 # returns 0 if found, 1 if not found
+containsMergeMessage=$?
+
 SOB=$(git var GIT_AUTHOR_IDENT | sed -n -E 's/^(.+>).*$/Signed-off-by: \1/p')
 grep -qs "${SOB}" $1 # returns 0 if found, 1 if not found
 containsSignOffBy=$?
 
-if [ $containsNpmPublishMessage -ne 0 ] && [ $containsSignOffBy -ne 0 ]; then
+if [ $containsNpmPublishMessage -ne 0 ] && [ $containsMergeMessage -ne 0 ] && [ $containsSignOffBy -ne 0 ]; then
   commitMessage="$(cat $1)"
   echo ""
   echo "🚨 Missing commit sign-off!"

--- a/packages/core/src/command/consolidated/consolidated-connector-local.ts
+++ b/packages/core/src/command/consolidated/consolidated-connector-local.ts
@@ -26,6 +26,12 @@ export class ConsolidatedDataConnectorLocal implements ConsolidatedDataConnector
     let bundle = await getConsolidatedFhirBundle(params);
     const dedupEnabled = await isFhirDeduplicationEnabledForCx(params.patient.cxId);
     if (dedupEnabled) {
+      // store the original not deduplicated bundle on s3
+      await uploadConsolidatedBundleToS3({
+        ...params,
+        bundle,
+        s3BucketName: this.bucketName,
+      });
       const initialBundleLength = bundle.entry?.length;
       bundle = deduplicateSearchSetBundle(bundle);
       const startedAt = new Date();
@@ -48,6 +54,7 @@ export class ConsolidatedDataConnectorLocal implements ConsolidatedDataConnector
       ...params,
       bundle,
       s3BucketName: this.bucketName,
+      dedupEnabled,
     });
     const info = {
       bundleLocation: bucket,

--- a/packages/core/src/command/consolidated/consolidated-on-s3.ts
+++ b/packages/core/src/command/consolidated/consolidated-on-s3.ts
@@ -29,17 +29,17 @@ export async function uploadConsolidatedBundleToS3({
   dateTo,
   bundle,
   s3BucketName,
-  dedupEnabled,
+  isDeduped,
 }: Omit<ConsolidatedPatientDataRequest, "requestId" | "isAsync" | "conversionType"> & {
   requestId?: string;
   bundle: unknown;
   s3BucketName: string;
-  dedupEnabled?: boolean;
+  isDeduped?: boolean;
 }): Promise<{
   bucket: string;
   key: string;
 }> {
-  const key = createConsolidatedFileName(patient.cxId, patient.id, requestId, dedupEnabled);
+  const key = createConsolidatedFileName(patient.cxId, patient.id, requestId, isDeduped);
   const s3Utils = new S3Utils(Config.getAWSRegion());
   const uploadPayloadWithoutMeta = {
     bucket: s3BucketName,
@@ -76,12 +76,12 @@ function createConsolidatedFileName(
   cxId: string,
   patientId: string,
   requestId?: string,
-  dedupEnabled?: boolean
+  isDeduped?: boolean
 ): string {
   const date = new Date().toISOString();
   return createFilePath(
     cxId,
     patientId,
-    `consolidated_${date}_${requestId}${dedupEnabled ? "_deduped" : ""}.json`
+    `consolidated_${date}_${requestId}${isDeduped ? "_deduped" : ""}.json`
   );
 }


### PR DESCRIPTION
Refs: #[2569](https://github.com/metriport/metriport/issues/2569)

### Description

What's being done here - [context](https://metriport.slack.com/archives/C06CQC7GQG3/p1724813010647859):
- Move dedup logic to the "get consolidated lambda";
- Always generate the dedup bundle, just the FF to just indicates whether to use the non-deduped or the deduped version;
- Used the opportunity to fix the DCO checker when we merge from develop on local.

To help reviewing the PR:
- [this commit](https://github.com/metriport/metriport/pull/2673/files/458924f2d860298af6895b4c38ded0308d362f9e) shows the code being moved to the lambda;
- [this comparison](https://github.com/metriport/metriport/pull/2673/files/b22f81026d89dd12babb6b83b4d85c239675bcc6..f72939e0d3a103f019960bc968e3f0885daf7c9e) shows the update on the dedup logic to always dedup and use the FF just to choose which bundle to use.

### Testing

- Local
  - [x] both bundles are generated
  - [x] original, non-deduped version is returned for cxs not on the `cxsWithFhirDedupFeatureFlag` FF
  - [x] deduped version is returned for cxs on the `cxsWithFhirDedupFeatureFlag` FF
- Staging
  - [ ] both bundles are generated
  - [ ] original, non-deduped version is returned for cxs not on the `cxsWithFhirDedupFeatureFlag` FF
  - [ ] deduped version is returned for cxs on the `cxsWithFhirDedupFeatureFlag` FF
- Sandbox
  - none
- Production
  - [ ] both bundles are generated
  - [ ] original, non-deduped version is returned for cxs not on the `cxsWithFhirDedupFeatureFlag` FF
  - [ ] deduped version is returned for cxs on the `cxsWithFhirDedupFeatureFlag` FF

### Release Plan

- [ ] Remove cx `5af0...b418` (Ci) from the `cxsWithFhirDedupFeatureFlag` FF
- [ ] Add cx `23b2...d026` (Br) from the `cxsWithFhirDedupFeatureFlag` FF
- [ ] Merge this
- ~~ADD Br to fhir dedup FF~~
