### PR TITLE
PATCH RELEASE 2024-08-28 FHIR Dedup - unknown med resources

### DIFF
--- a/packages/core/src/fhir-deduplication/__tests__/group-same-medications.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-medications.test.ts
@@ -54,6 +54,15 @@ describe("groupSameMedications", () => {
     expect(snomedMap.size).toBe(1);
   });
 
+  it("removes no known medication resources based on the text tag", () => {
+    medication.code = { coding: [snomedCodeAm], text: "No known medication" };
+
+    const { rxnormMap, ndcMap, snomedMap } = groupSameMedications([medication]);
+    expect(rxnormMap.size).toBe(0);
+    expect(ndcMap.size).toBe(0);
+    expect(snomedMap.size).toBe(0);
+  });
+
   it("does not group duplicate medications that don't have overlapping codes", () => {
     medication.code = { coding: [rxnormCodeAm] };
     medication2.code = { coding: [ndcCodeAm] };

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-medications.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-medications.test.ts
@@ -55,7 +55,7 @@ describe("groupSameMedications", () => {
   });
 
   it("removes no known medication resources based on the text tag", () => {
-    medication.code = { coding: [snomedCodeAm], text: "No known medication" };
+    medication.code = { coding: [snomedCodeAm], text: "No known medications" };
 
     const { rxnormMap, ndcMap, snomedMap } = groupSameMedications([medication]);
     expect(rxnormMap.size).toBe(0);

--- a/packages/core/src/fhir-deduplication/resources/medication.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication.ts
@@ -61,6 +61,11 @@ export function groupSameMedications(medications: Medication[]): {
   }
 
   for (const medication of medications) {
+    if (medication.id && medication.code?.text?.toLowerCase().includes("no known")) {
+      danglingReferences.add(createMedicationRef(medication.id));
+      continue;
+    }
+
     // TODO: Deal with medications that contain >1 rxnorm / ndc code
     const { rxnormCode, ndcCode, snomedCode } = extractCodes(medication.code);
 
@@ -71,7 +76,7 @@ export function groupSameMedications(medications: Medication[]): {
     } else if (snomedCode) {
       fillMaps(snomedMap, snomedCode, medication, refReplacementMap, false, removeOtherCodes);
     } else {
-      if (medication.id) danglingReferences.add(`Medication/${medication.id}`);
+      if (medication.id) danglingReferences.add(createMedicationRef(medication.id));
     }
   }
 
@@ -110,4 +115,8 @@ function extractCodes(concept: CodeableConcept | undefined): {
     }
   }
   return { rxnormCode, ndcCode, snomedCode };
+}
+
+function createMedicationRef(medId: string): string {
+  return `Medication/${medId}`;
 }

--- a/packages/core/src/fhir-deduplication/resources/medication.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication.ts
@@ -7,7 +7,7 @@ import {
   SNOMED_CODE,
   SNOMED_OID,
 } from "../../util/constants";
-import { combineResources, fillMaps } from "../shared";
+import { combineResources, fillMaps, isBlacklistedText } from "../shared";
 
 export function deduplicateMedications(medications: Medication[]): {
   combinedMedications: Medication[];
@@ -61,7 +61,7 @@ export function groupSameMedications(medications: Medication[]): {
   }
 
   for (const medication of medications) {
-    if (medication.id && medication.code?.text?.toLowerCase().includes("no known")) {
+    if (medication.id && isBlacklistedText(medication.code)) {
       danglingReferences.add(createMedicationRef(medication.id));
       continue;
     }

--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -1,4 +1,4 @@
-import { Resource } from "@medplum/fhirtypes";
+import { CodeableConcept, Resource } from "@medplum/fhirtypes";
 import dayjs from "dayjs";
 import { cloneDeep } from "lodash";
 
@@ -233,4 +233,8 @@ export function pickMostDescriptiveStatus<T extends string>(
     return lowestRanking;
   }
   return status;
+}
+
+export function isBlacklistedText(concept: CodeableConcept | undefined): boolean {
+  return concept?.text?.toLowerCase().includes("no known") ?? false;
 }


### PR DESCRIPTION
refs. metriport/metriport#2569

### Description
- Removing `Medication` resources that have `No known medication` for code, as well as the Medication-related resources that refer to them. 

### Testing

- Local
  - [x] Unit tests

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
