### PR TITLE
2569 Allow get consolidated lambda to access FFs

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -46,6 +46,7 @@ import { createAppConfigStack } from "./app-config-stack";
 import { EnvType } from "./env-type";
 import { IHEGatewayV2LambdasNestedStack } from "./ihe-gateway-v2-stack";
 import { CDA_TO_VIS_TIMEOUT, LambdasNestedStack } from "./lambdas-nested-stack";
+import * as AppConfigUtils from "./shared/app-config";
 import { DailyBackup } from "./shared/backup";
 import { addErrorAlarmToLambdaFunc, createLambda, MAXIMUM_LAMBDA_TIMEOUT } from "./shared/lambda";
 import { LambdaLayers } from "./shared/lambda-layers";
@@ -1320,20 +1321,12 @@ export class APIStack extends Stack {
       alarmSnsAction: alarmAction,
     });
 
-    fhirToMedicalRecordLambda.role?.attachInlinePolicy(
-      new iam.Policy(this, "FhirLambdaPermissionsForAppConfig", {
-        statements: [
-          new iam.PolicyStatement({
-            actions: [
-              "appconfig:StartConfigurationSession",
-              "appconfig:GetLatestConfiguration",
-              "appconfig:GetConfiguration",
-            ],
-            resources: ["*"],
-          }),
-        ],
-      })
-    );
+    AppConfigUtils.allowReadConfig({
+      scope: this,
+      resourceName: "FhirToMrLambda",
+      resourceRole: fhirToMedicalRecordLambda.role,
+      appConfigResources: ["*"],
+    });
 
     medicalDocumentsBucket.grantReadWrite(fhirToMedicalRecordLambda);
 

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -9,6 +9,7 @@ import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 import { EnvConfig } from "../config/env-config";
 import { EnvType } from "./env-type";
+import * as AppConfigUtils from "./shared/app-config";
 import { createLambda, MAXIMUM_LAMBDA_TIMEOUT } from "./shared/lambda";
 import { LambdaLayers, setupLambdasLayers } from "./shared/lambda-layers";
 import { Secrets } from "./shared/secrets";
@@ -405,6 +406,7 @@ export class LambdasNestedStack extends NestedStack {
     return outboundDocumentRetrievalLambda;
   }
 
+  /** AKA, get consolidated lambda */
   private setupFhirBundleLambda({
     lambdaLayers,
     vpc,
@@ -451,6 +453,13 @@ export class LambdasNestedStack extends NestedStack {
     });
 
     bucket.grantReadWrite(fhirToBundleLambda);
+
+    AppConfigUtils.allowReadConfig({
+      scope: this,
+      resourceName: "FhirToBundleLambda",
+      resourceRole: fhirToBundleLambda.role,
+      appConfigResources: ["*"],
+    });
 
     return fhirToBundleLambda;
   }

--- a/packages/infra/lib/shared/app-config.ts
+++ b/packages/infra/lib/shared/app-config.ts
@@ -1,0 +1,29 @@
+import * as iam from "aws-cdk-lib/aws-iam";
+import { Construct } from "constructs";
+
+export function allowReadConfig({
+  scope,
+  resourceRole,
+  appConfigResources,
+  resourceName,
+}: {
+  scope: Construct;
+  resourceRole: iam.IRole | undefined;
+  appConfigResources: string[];
+  resourceName: string;
+}) {
+  resourceRole?.attachInlinePolicy(
+    new iam.Policy(scope, `${resourceName}PermissionsForAppConfig`, {
+      statements: [
+        new iam.PolicyStatement({
+          actions: [
+            "appconfig:StartConfigurationSession",
+            "appconfig:GetLatestConfiguration",
+            "appconfig:GetConfiguration",
+          ],
+          resources: appConfigResources,
+        }),
+      ],
+    })
+  );
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#2569

### Dependencies

- upstream: https://github.com/metriport/metriport/pull/2673

### Description

Allow get consolidated lambda to access FFs - [context](https://metriport.slack.com/archives/C04T5Q9JHFX/p1724852868602349)

### Testing

See upstream

### Release Plan

- [ ] Merge this
