### PR TITLE
PATCH RELEASE: return cq link if no patient

### DIFF
--- a/packages/api/src/command/medical/patient/get-patient-facility-matches.ts
+++ b/packages/api/src/command/medical/patient/get-patient-facility-matches.ts
@@ -42,10 +42,6 @@ async function getCqFacilityMatches(cqLinks: CQLink[]): Promise<PatientFacilityM
   const patientFacilityMatches: PatientFacilityMatch[] = [];
 
   for (const cqLink of cqLinks) {
-    if (!cqLink.patientResource) {
-      continue;
-    }
-
     const cqFacility = await CQDirectoryEntryModel.findOne({
       where: { id: cqLink.oid },
     });
@@ -54,7 +50,9 @@ async function getCqFacilityMatches(cqLinks: CQLink[]): Promise<PatientFacilityM
       continue;
     }
 
-    const patientMatchDemo = cqPatientResourceToNormalizedLinkDemographics(cqLink.patientResource);
+    const patientMatchDemo = cqLink.patientResource
+      ? cqPatientResourceToNormalizedLinkDemographics(cqLink.patientResource)
+      : undefined;
 
     patientFacilityMatches.push({
       name: cqFacility.name ?? undefined,


### PR DESCRIPTION
Ref. metriport/metriport#2064

### Dependencies

- Upstream: none
- Downstream: none

### Description

Return CQ links that dont have patient resource - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1723307734296789)

### Testing

_[Regular PRs:]_

- Local
  - [x] Returns the patient match
- Production
  - [ ] Returns the patient match

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
