### PR TITLE
feat(fhir-to-cda): split up mental status tables

### DIFF
--- a/packages/core/src/fhir-to-cda/cda-templates/components/observations.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/components/observations.ts
@@ -159,9 +159,9 @@ export function createEntriesFromObservation(
     socHistNumber,
     date
   );
-  observationEntry.observation.entryRelationship = [];
 
   if (observation.resource.component && observation.resource.component.length > 0) {
+    observationEntry.observation.entryRelationship = [];
     observation.resource.component.map(pair => {
       pairNumber++;
       const entryRelationshipObservation = createEntryFromObservation(
@@ -171,7 +171,10 @@ export function createEntriesFromObservation(
         date
       );
       const entryRelationship = createEntryRelationship(entryRelationshipObservation);
-      if (observationEntry.observation.entryRelationship) {
+      if (
+        observationEntry.observation.entryRelationship &&
+        Array.isArray(observationEntry.observation.entryRelationship)
+      ) {
         observationEntry.observation.entryRelationship.push(entryRelationship);
       }
     });

--- a/packages/core/src/fhir-to-cda/cda-templates/constants.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/constants.ts
@@ -16,6 +16,7 @@ export const vaccineAdministeredCodeSet = "2.16.840.1.113883.12.292";
 export const icd10SystemCode = "2.16.840.1.113883.6.90";
 export const extensionValue2014 = "2014-06-09";
 export const extensionValue2015 = "2015-08-01";
+export const extensionValue2019 = "2019-06-20";
 export const loincCodeSystem = "2.16.840.1.113883.6.1";
 export const loincSystemName = "LOINC";
 export const snomedCodeSystem = "2.16.840.1.113883.6.96";
@@ -60,6 +61,7 @@ export const oids = {
   vitalSignsOrganizer: "2.16.840.1.113883.10.20.22.4.26",
   noteActivity: "2.16.840.1.113883.10.20.22.4.202",
   procedureActivity: "2.16.840.1.113883.10.20.22.4.14",
+  problemStatus: "2.16.840.1.113883.10.20.22.4.6",
 };
 
 export const mentalHealthSurveyCodes = ["44249-1"];

--- a/packages/core/src/fhir-to-cda/cda-templates/create-table-rows-and-entries.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/create-table-rows-and-entries.ts
@@ -10,7 +10,8 @@ import { AugmentedResource } from "./components/augmented-resources";
 export function createTableRowsAndEntries<R extends Resource, T extends AugmentedResource<R>, X>(
   augObs: T[],
   tableRowsCallback: CreateTableRowsCallback<T>,
-  entriesCallback: CreateEntriesCallback<T, X>
+  entriesCallback: CreateEntriesCallback<T, X>,
+  tableIndex?: number
 ): TableRowsAndEntriesResult<X> {
   const result: TableRowsAndEntriesResult<X> = {
     trs: [],
@@ -18,7 +19,7 @@ export function createTableRowsAndEntries<R extends Resource, T extends Augmente
   };
 
   augObs.map((aug, index) => {
-    const sectionPrefix = `${aug.sectionName}${index + 1}`;
+    const sectionPrefix = `${aug.sectionName}${(tableIndex ?? index) + 1}`;
     const trs = tableRowsCallback(aug, sectionPrefix);
     const trsEntries = toArray(trs);
     const entries = entriesCallback(aug, sectionPrefix);

--- a/packages/core/src/fhir-to-cda/cda-templates/table.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/table.ts
@@ -2,7 +2,10 @@ import { ObservationTableRow } from "../cda-types/shared-types";
 
 type TableHeader = {
   tr: {
-    th: string[];
+    th: {
+      "#text": string;
+      _colspan?: number;
+    }[];
   }[];
 };
 
@@ -15,11 +18,28 @@ type TableRowWithId = {
   td: TableCell[];
 };
 
-export function createTableHeader(tableHeaders: string[]): TableHeader {
+export function createTableHeader(
+  tableHeaders: string[],
+  specialHeader?: string | undefined
+): TableHeader {
   return {
     tr: [
+      ...(specialHeader
+        ? [
+            {
+              th: [
+                {
+                  "#text": specialHeader,
+                  _colspan: tableHeaders.length,
+                },
+              ],
+            },
+          ]
+        : []),
       {
-        th: tableHeaders,
+        th: tableHeaders.map(header => ({
+          "#text": header,
+        })),
       },
     ],
   };
@@ -45,12 +65,13 @@ function mapTableRows(tableRows: ObservationTableRow[]): TableRowWithId[] {
 export function initiateSectionTable(
   sectionName: string,
   tableHeaders: string[],
-  tableRows: ObservationTableRow[]
+  tableRows: ObservationTableRow[],
+  specialHeader?: string
 ): CdaTable {
   return {
     table: {
       _ID: sectionName,
-      thead: createTableHeader(tableHeaders),
+      thead: createTableHeader(tableHeaders, specialHeader),
       tbody: {
         tr: mapTableRows(tableRows),
       },

--- a/packages/core/src/fhir-to-cda/cda-types/sections.ts
+++ b/packages/core/src/fhir-to-cda/cda-types/sections.ts
@@ -18,7 +18,7 @@ type CdaSection<T> =
       templateId?: CdaInstanceIdentifier | CdaInstanceIdentifier[];
       code: CdaCodeCe;
       title: string;
-      text: CdaTable | TextParagraph | TextUnstructured | string;
+      text: CdaTable | CdaTable[] | TextParagraph | TextUnstructured | string;
       entry?: T | T[];
     }
   | undefined;

--- a/packages/core/src/fhir-to-cda/cda-types/shared-types.ts
+++ b/packages/core/src/fhir-to-cda/cda-types/shared-types.ts
@@ -158,6 +158,7 @@ export type CdaValueCd = {
   _codeSystem?: string | undefined;
   _codeSystemName?: string | undefined;
   originalText?: CdaOriginalText;
+  [_xmlnsXsiAttribute]?: string;
 };
 
 export type CdaValuePq = {
@@ -262,7 +263,7 @@ export type ObservationEntry = {
       | CdaValueSt[]
       | undefined;
     participant?: Participant | undefined;
-    entryRelationship?: ObservationEntryRelationship[] | undefined;
+    entryRelationship?: ObservationEntryRelationship | ObservationEntryRelationship[] | undefined;
     interpretationCode?: CdaCodeCe | CdaCodeCe[] | undefined;
   };
 };


### PR DESCRIPTION
refs. metriport/metriport-internal#2174

### Description
- Split up different mental status tables and added headers to each. Previously, there was just one big table with all the questions and results
- Added support for Problems' Provider status and Clinical status

### Testing

- Local
  - [x] FHIR->CDA->HTML conversions locally to make sure all looks good

### Screenshot
<img width="1494" alt="Screenshot 2024-08-29 at 7 21 03 PM" src="https://github.com/user-attachments/assets/a8d7332b-a01e-4e0e-9bae-62e903221fdd">

### Release Plan
- [ ] Merge this
