### PR TITLE
PATCH RELESE Don't fail when gets a non-string value

### DIFF
--- a/packages/fhir-converter/src/lib/handlebars-converter/__tests__/handlebars-helpers.test.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/__tests__/handlebars-helpers.test.js
@@ -268,9 +268,24 @@ describe("getDateTime", function () {
     expect(date).toEqual("2023-06-26 19:08:46.000Z");
   });
 
-  it("should render nothing when invalid dateTimeString", function () {
+  it("should render date when valid date on invalid dateTimeString", function () {
     var date = functions.getDateTime("20240714040785-0400");
     expect(date).toEqual("2024-07-14T00:00:00.000Z");
+  });
+
+  it("should render nothing when invalid dateTimeString", function () {
+    var date = functions.getDateTime("a202407140407f");
+    expect(date).toEqual("");
+  });
+
+  it("should render date when gets a Date object", function () {
+    var date = functions.getDateTime(new Date("2023-06-26T19:08:46.000Z"));
+    expect(date).toEqual("2023-06-26T19:08:46.000Z");
+  });
+
+  it("should render nothing when gets a non-Date object", function () {
+    var date = functions.getDateTime({ a: "123" });
+    expect(date).toEqual("");
   });
 });
 

--- a/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
@@ -185,6 +185,11 @@ var isValidYear = function (year) {
 
 // handling the datetime format here
 var getDateTime = function (dateTimeStringRaw) {
+  if (typeof dateTimeStringRaw !== "string") {
+    // TODO remove this once we learn what the value is and fix it
+    console.log(`[getDateTime] Invalid datetime value: ${JSON.stringify(dateTimeStringRaw)}`);
+    return "";
+  }
   var dateTimeString = dateTimeStringRaw?.trim();
 
   if (alreadyValidDateTime(dateTimeString)) {

--- a/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
@@ -149,6 +149,22 @@ var alreadyValidDateTime = function (dateTimeString) {
 
 // handling the date format here
 var getDate = function (dateStringRaw) {
+  if (dateStringRaw instanceof Date) {
+    console.log(
+      `[getDateTime] Date was a Date (converted it to string): ${JSON.stringify(dateStringRaw)}`
+    );
+    dateStringRaw = dateStringRaw.toISOString();
+  }
+  if (typeof dateStringRaw === "object") {
+    console.log(
+      `[getDate] Date was an object (converted it to string): ${JSON.stringify(dateStringRaw)}`
+    );
+    dateStringRaw = dateStringRaw.toString();
+  }
+  if (typeof dateStringRaw !== "string") {
+    console.log(`[getDate] Invalid date value (returning empty): ${JSON.stringify(dateStringRaw)}`);
+    return "";
+  }
   var dateString = dateStringRaw?.trim();
   if (alreadyValidDateTime(dateString)) {
     return dateString;
@@ -185,9 +201,26 @@ var isValidYear = function (year) {
 
 // handling the datetime format here
 var getDateTime = function (dateTimeStringRaw) {
+  if (dateTimeStringRaw instanceof Date) {
+    console.log(
+      `[getDateTime] Datetime was a Date (converted it to string): ${JSON.stringify(
+        dateTimeStringRaw
+      )}`
+    );
+    dateTimeStringRaw = dateTimeStringRaw.toISOString();
+  }
+  if (typeof dateTimeStringRaw === "object") {
+    console.log(
+      `[getDateTime] Datetime was an object (converted it to string): ${JSON.stringify(
+        dateTimeStringRaw
+      )}`
+    );
+    dateTimeStringRaw = dateTimeStringRaw.toString();
+  }
   if (typeof dateTimeStringRaw !== "string") {
-    // TODO remove this once we learn what the value is and fix it
-    console.log(`[getDateTime] Invalid datetime value: ${JSON.stringify(dateTimeStringRaw)}`);
+    console.log(
+      `[getDateTime] Invalid datetime value (returning empty): ${JSON.stringify(dateTimeStringRaw)}`
+    );
     return "";
   }
   var dateTimeString = dateTimeStringRaw?.trim();


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Description

Don't fail when gets a non-string value - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1724885917317999?thread_ts=1724827486.314079&cid=C04T256DQPQ)

Original PR: https://github.com/metriport/metriport/pull/2685

### Testing

- Local
  - [x] Unit tests
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
