### PR TITLE
PATCH RELEASE 2024_08_29 FHIR Dedup Obs

### DIFF
--- a/packages/core/src/fhir-deduplication/__tests__/group-same-observations.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-observations.test.ts
@@ -181,15 +181,6 @@ describe("groupSameObservations", () => {
     const { observationsMap } = groupSameObservations([observation, observation2]);
     expect(observationsMap.size).toBe(0);
   });
-  it("removes observations without codes", () => {
-    observation.effectiveDateTime = dateTime.start;
-    observation2.effectiveDateTime = dateTime.start;
-    observation.valueCodeableConcept = valueConceptTobacco;
-    observation2.valueCodeableConcept = valueConceptTobacco;
-
-    const { observationsMap } = groupSameObservations([observation, observation2]);
-    expect(observationsMap.size).toBe(0);
-  });
 
   it("does not group observations with different dates", () => {
     observation.effectiveDateTime = dateTime.start;

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-observations.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-observations.test.ts
@@ -162,6 +162,16 @@ describe("groupSameObservations", () => {
     expect(observationsMap.size).toBe(1);
   });
 
+  it("correctly groups observations without codes", () => {
+    observation.effectiveDateTime = dateTime.start;
+    observation2.effectiveDateTime = dateTime.start;
+    observation.valueCodeableConcept = valueConceptTobacco;
+    observation2.valueCodeableConcept = valueConceptTobacco;
+
+    const { observationsMap } = groupSameObservations([observation, observation2]);
+    expect(observationsMap.size).toBe(1);
+  });
+
   it("removes observations without dates", () => {
     observation.code = loincCodeTobacco;
     observation2.code = loincCodeTobacco;

--- a/packages/core/src/fhir-deduplication/resources/observation.ts
+++ b/packages/core/src/fhir-deduplication/resources/observation.ts
@@ -5,13 +5,7 @@ import {
   getDateFromResource,
   pickMostDescriptiveStatus,
 } from "../shared";
-import {
-  extractCodes,
-  extractValueFromObservation,
-  retrieveCode,
-  statusRanking,
-  unknownCoding,
-} from "./observation-shared";
+import { extractValueFromObservation, statusRanking, unknownCoding } from "./observation-shared";
 
 export function deduplicateObservations(observations: Observation[]): {
   combinedObservations: Observation[];
@@ -62,16 +56,12 @@ export function groupSameObservations(observations: Observation[]): {
   }
 
   for (const observation of observations) {
-    const keyCodes = extractCodes(observation.code);
-    const keyCode = retrieveCode(keyCodes);
     const date = getDateFromResource(observation);
     const value = extractValueFromObservation(observation);
 
-    if (date && value && keyCode) {
-      const key = keyCode ? JSON.stringify({ date, value, keyCode }) : undefined;
-      if (key) {
-        fillMaps(observationsMap, key, observation, refReplacementMap, undefined, postProcess);
-      }
+    if (date && value) {
+      const key = JSON.stringify({ date, value });
+      fillMaps(observationsMap, key, observation, refReplacementMap, undefined, postProcess);
     }
   }
 


### PR DESCRIPTION
refs. metriport/metriport-internal#2148

### Description
- Removing the `code` from the key for Observation dedup

### Testing
- Local
  - [x] Unit tests

### Release Plan
- :warning: Points to `master`
- [ ] Merge this
