### PR TITLE
feat(core): handling dangling links

### DIFF
--- a/packages/core/src/fhir-deduplication/__tests__/combine-two-resources.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/combine-two-resources.test.ts
@@ -16,7 +16,7 @@ beforeAll(() => {
   condition2 = makeCondition({ id: conditionId2, onsetPeriod: dateTime2 });
 });
 
-describe("groupSameConditions", () => {
+describe("combineTwoResources", () => {
   it("keeps the id of the first condition", () => {
     const combinedCondition = combineTwoResources(condition, condition2);
     expect(combinedCondition.id).toBe(conditionId);

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-observations.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-observations.test.ts
@@ -1,15 +1,15 @@
 import { faker } from "@faker-js/faker";
 import { Observation } from "@medplum/fhirtypes";
 import { makeObservation } from "../../fhir-to-cda/cda-templates/components/__tests__/make-observation";
-import { unknownCoding, unknownCode } from "../resources/observation-shared";
+import { groupSameObservations } from "../resources/observation";
 import { groupSameObservationsSocial } from "../resources/observation-social";
+import { unknownCode, unknownCoding } from "../shared";
 import { dateTime, dateTime2 } from "./examples/condition-examples";
 import {
   loincCodeTobacco,
   snomedCodeTobacco,
   valueConceptTobacco,
 } from "./examples/observation-examples";
-import { groupSameObservations } from "../resources/observation";
 
 let observationId: string;
 let observationId2: string;

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-organizations.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-organizations.test.ts
@@ -39,13 +39,13 @@ describe("groupSameOrganizations", () => {
     expect(organizationsMap.size).toBe(2);
   });
 
-  it("removes organizations without names", () => {
+  it("keeps organizations without names", () => {
     organization.address = [exampleAddress];
     organization2.address = [exampleAddress];
     delete organization2.name;
 
     const { organizationsMap } = groupSameOrganizations([organization, organization2]);
-    expect(organizationsMap.size).toBe(1);
+    expect(organizationsMap.size).toBe(2);
   });
 
   it("removes organizations without addresses", () => {

--- a/packages/core/src/fhir-deduplication/__tests__/is-unknown-coding.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/is-unknown-coding.test.ts
@@ -1,0 +1,34 @@
+import { Coding } from "@medplum/fhirtypes";
+import { isUnknownCoding, unknownCoding } from "../shared";
+
+describe("isUnknownCoding", () => {
+  it("correctly identifies unknown coding", () => {
+    const coding: Coding = unknownCoding;
+    const res = isUnknownCoding(coding);
+    expect(res).toBe(true);
+  });
+
+  it("correctly identifies a known code as such", () => {
+    const coding = { code: "A1B2C3" };
+    const res = isUnknownCoding(coding);
+    expect(res).toBe(false);
+  });
+
+  it("correctly identifies unknown display as unknown", () => {
+    const coding = { display: "unknown" };
+    const res = isUnknownCoding(coding);
+    expect(res).toBe(true);
+  });
+
+  it("correctly identifies a known display as such", () => {
+    const coding = { display: "SomethingImportant" };
+    const res = isUnknownCoding(coding);
+    expect(res).toBe(false);
+  });
+
+  it("correctly identifies a known text as such", () => {
+    const coding = {};
+    const res = isUnknownCoding(coding, "SomethingImportant");
+    expect(res).toBe(false);
+  });
+});

--- a/packages/core/src/fhir-deduplication/__tests__/remove-dangling-link.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/remove-dangling-link.test.ts
@@ -39,10 +39,13 @@ beforeEach(() => {
 });
 
 describe("removeResourcesWithDanglingLinks", () => {
-  it("correctly picks the more descriptive status", () => {
+  it("correctly removes med-related resources if the medication reference is a dangling link", () => {
     expect(entries.length).toBe(3);
-    const cleanedUpBundle = removeResourcesWithDanglingLinks(entries, [JSON.stringify(medRef)]);
-    expect(cleanedUpBundle.length).toBe(0);
+    if (medRef.reference) {
+      const danglingLinks = [medRef.reference];
+      const cleanedUpBundle = removeResourcesWithDanglingLinks(entries, danglingLinks);
+      expect(cleanedUpBundle.length).toBe(0);
+    }
   });
 
   it("does not remove a med-related resource that references another medication", () => {
@@ -50,12 +53,15 @@ describe("removeResourcesWithDanglingLinks", () => {
     entries.push(...[medication, medStatementWithoutDeadLink]);
     expect(entries.length).toBe(5);
 
-    const cleanedUpBundle = removeResourcesWithDanglingLinks(entries, [JSON.stringify(medRef)]);
-    expect(cleanedUpBundle.length).toBe(2);
-    const medStatement = cleanedUpBundle.find(r => r.id === medStatementWithoutDeadLink.id) as
-      | MedicationStatement
-      | undefined;
-    expect(medStatement?.id).toBe(medStatementWithoutDeadLink.id);
-    expect(medStatement?.medicationReference).toBe(medRef2);
+    if (medRef.reference) {
+      const danglingLinks = [medRef.reference];
+      const cleanedUpBundle = removeResourcesWithDanglingLinks(entries, danglingLinks);
+      expect(cleanedUpBundle.length).toBe(2);
+      const medStatement = cleanedUpBundle.find(r => r.id === medStatementWithoutDeadLink.id) as
+        | MedicationStatement
+        | undefined;
+      expect(medStatement?.id).toBe(medStatementWithoutDeadLink.id);
+      expect(medStatement?.medicationReference).toBe(medRef2);
+    }
   });
 });

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -1,4 +1,12 @@
-import { Bundle, BundleEntry, Resource } from "@medplum/fhirtypes";
+import {
+  Bundle,
+  BundleEntry,
+  EncounterDiagnosis,
+  Organization,
+  Practitioner,
+  Reference,
+  Resource,
+} from "@medplum/fhirtypes";
 import { cloneDeep } from "lodash";
 import { ExtractedFhirTypes, extractFhirTypesFromBundle } from "../external/fhir/shared/bundle";
 import { deduplicateAllergyIntolerances } from "./resources/allergy-intolerance";
@@ -27,61 +35,69 @@ export function deduplicateFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> 
   // TODO: Add unit tests for the ID replacements
 
   const processedArrays: string[] = [];
-  const danglingCrucialLinks: string[] = [];
+  const danglingLinks: string[] = [];
 
   // Practitioner deduplication
   const practitionersResult = deduplicatePractitioners(resourceArrays.practitioners);
   resourceArrays = replaceResourceReferences(resourceArrays, practitionersResult.refReplacementMap);
   processedArrays.push("practitioners");
+  danglingLinks.push(...practitionersResult.danglingReferences);
   deduplicatedEntries.push(...practitionersResult.combinedPractitioners);
 
   // Conditions deduplication
   const conditionsResult = deduplicateConditions(resourceArrays.conditions);
   resourceArrays = replaceResourceReferences(resourceArrays, conditionsResult.refReplacementMap);
   processedArrays.push("conditions");
+  danglingLinks.push(...conditionsResult.danglingReferences);
   deduplicatedEntries.push(...conditionsResult.combinedConditions);
 
   // Allergies deduplication
   const allergiesResult = deduplicateAllergyIntolerances(resourceArrays.allergies);
   resourceArrays = replaceResourceReferences(resourceArrays, allergiesResult.refReplacementMap);
   processedArrays.push("allergies");
+  danglingLinks.push(...allergiesResult.danglingReferences);
   deduplicatedEntries.push(...allergiesResult.combinedAllergies);
 
   // Medication deduplication
   const medicationsResult = deduplicateMedications(resourceArrays.medications);
   resourceArrays = replaceResourceReferences(resourceArrays, medicationsResult.refReplacementMap);
   processedArrays.push("medications");
-  danglingCrucialLinks.push(...medicationsResult.danglingReferences);
+  danglingLinks.push(...medicationsResult.danglingReferences);
   deduplicatedEntries.push(...medicationsResult.combinedMedications);
 
   // MedicationAdministration deduplication
   const medAdminsResult = deduplicateMedAdmins(resourceArrays.medicationAdministrations);
   resourceArrays = replaceResourceReferences(resourceArrays, medAdminsResult.refReplacementMap);
   processedArrays.push("medicationAdministrations");
+  danglingLinks.push(...medAdminsResult.danglingReferences);
   deduplicatedEntries.push(...medAdminsResult.combinedMedAdmins);
 
   // MedicationRequest deduplication
   const medRequestResult = deduplicateMedRequests(resourceArrays.medicationRequests);
   resourceArrays = replaceResourceReferences(resourceArrays, medRequestResult.refReplacementMap);
   processedArrays.push("medicationRequests");
+  danglingLinks.push(...medRequestResult.danglingReferences);
   deduplicatedEntries.push(...medRequestResult.combinedMedRequests);
 
   // MedicationStatement deduplication
   const medStatementResult = deduplicateMedStatements(resourceArrays.medicationStatements);
   resourceArrays = replaceResourceReferences(resourceArrays, medStatementResult.refReplacementMap);
   processedArrays.push("medicationStatements");
+  danglingLinks.push(...medStatementResult.danglingReferences);
   deduplicatedEntries.push(...medStatementResult.combinedMedStatements);
 
   // Encounter deduplication
   const encountersResult = deduplicateEncounters(resourceArrays.encounters);
   resourceArrays = replaceResourceReferences(resourceArrays, encountersResult.refReplacementMap);
   processedArrays.push("encounters");
+  danglingLinks.push(...encountersResult.danglingReferences);
   deduplicatedEntries.push(...encountersResult.combinedEncounters);
 
   // DiagnosticReport deduplication
   const diagReportsResult = deduplicateDiagReports(resourceArrays.diagnosticReports);
   resourceArrays = replaceResourceReferences(resourceArrays, diagReportsResult.refReplacementMap);
   processedArrays.push("diagnosticReports");
+  danglingLinks.push(...diagReportsResult.danglingReferences);
   deduplicatedEntries.push(...diagReportsResult.combinedDiagnosticReports);
 
   // Immunization deduplication
@@ -100,24 +116,28 @@ export function deduplicateFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> 
   const obsSocialResult = deduplicateObservationsSocial(resourceArrays.observationSocialHistory);
   resourceArrays = replaceResourceReferences(resourceArrays, obsSocialResult.refReplacementMap);
   processedArrays.push("observationSocialHistory");
+  danglingLinks.push(...obsSocialResult.danglingReferences);
   deduplicatedEntries.push(...obsSocialResult.combinedObservations);
 
   // Observation (labs) deduplication
   const obsLabsResult = deduplicateObservations(resourceArrays.observationLaboratory);
   resourceArrays = replaceResourceReferences(resourceArrays, obsLabsResult.refReplacementMap);
   processedArrays.push("observationLaboratory");
+  danglingLinks.push(...obsLabsResult.danglingReferences);
   deduplicatedEntries.push(...obsLabsResult.combinedObservations);
 
   // Observation (vitals) deduplication
   const obsVitalsResult = deduplicateObservations(resourceArrays.observationVitals);
   resourceArrays = replaceResourceReferences(resourceArrays, obsVitalsResult.refReplacementMap);
   processedArrays.push("observationVitals");
+  danglingLinks.push(...obsVitalsResult.danglingReferences);
   deduplicatedEntries.push(...obsVitalsResult.combinedObservations);
 
   // Observation (other) deduplication
   const obsOthersResult = deduplicateObservations(resourceArrays.observationOther);
   resourceArrays = replaceResourceReferences(resourceArrays, obsOthersResult.refReplacementMap);
   processedArrays.push("observationOther");
+  danglingLinks.push(...obsOthersResult.danglingReferences);
   deduplicatedEntries.push(...obsOthersResult.combinedObservations);
 
   // Location deduplication
@@ -172,8 +192,9 @@ export function deduplicateFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> 
 
   const deduplicatedNoDangling = removeResourcesWithDanglingLinks(
     deduplicatedEntries,
-    danglingCrucialLinks
+    danglingLinks
   );
+
   const deduplicatedBundle: Bundle = cloneDeep(fhirBundle);
   deduplicatedBundle.entry = deduplicatedNoDangling.map(
     r => ({ resource: r } as BundleEntry<Resource>)
@@ -201,19 +222,108 @@ function replaceResourceReferences(
   return JSON.parse(updatedArrays);
 }
 
+type ResourceFilter = (entry: Resource, link: string) => Resource | undefined;
+
+const compositionFiltersMap = new Map<
+  string,
+  typeof removeResource | typeof removeDanglingReferences
+>([["all", removeDanglingReferences]]);
+
+const medicationRelatedFiltersMap = new Map<string, ResourceFilter>([
+  ["Medication", removeResource],
+]);
+
+const encounterFiltersMap = new Map<string, ResourceFilter>([
+  ["Condition", removeDanglingReferences],
+]);
+
+const diagReportFiltersMap = new Map<string, ResourceFilter>([
+  ["Observation", removeDanglingReferences],
+  ["Encounter", removeDanglingReferences],
+]);
+
+const resourceFiltersMap = new Map<string, Map<string, ResourceFilter>>([
+  ["DiagnosticReport", diagReportFiltersMap],
+  ["Encounter", encounterFiltersMap],
+  ["MedicationStatement", medicationRelatedFiltersMap],
+  ["MedicationRequest", medicationRelatedFiltersMap],
+  ["MedicationAdministration", medicationRelatedFiltersMap],
+  ["Composition", compositionFiltersMap],
+]);
+
 export function removeResourcesWithDanglingLinks(
   entries: BundleEntry<Resource>[],
-  danglingLinks: string[]
+  links: string[]
 ) {
-  return entries.flatMap(entry => {
-    if (!hasDanglingLink(JSON.stringify(entry), danglingLinks)) return entry;
-    return [];
-  });
+  return entries.flatMap(entry => handleDanglingLinks(entry as Resource, links));
 }
 
-function hasDanglingLink(resourceString: string, refs: string[]): boolean {
-  for (const ref of refs) {
-    if (resourceString.includes(ref)) return true;
+function handleDanglingLinks(res: Resource, danglingLinks: string[]): Resource | [] {
+  if (res) {
+    let entry = res;
+    const filtersMap =
+      res.resourceType === "Composition"
+        ? resourceFiltersMap.get("all")
+        : resourceFiltersMap.get(res.resourceType);
+
+    if (filtersMap) {
+      for (const danglingLink of danglingLinks) {
+        const linkResourceType = danglingLink.split("/")[0];
+        if (linkResourceType) {
+          const callbackFn = filtersMap.get(linkResourceType);
+          if (callbackFn) {
+            const result = callbackFn(entry, danglingLink);
+            if (result) entry = result;
+            else return [];
+          }
+        }
+      }
+    }
+    return entry;
   }
-  return false;
+  return [];
+}
+
+function removeResource<T extends Resource>(entry: T, link: string): T | undefined {
+  if (JSON.stringify(entry).includes(link)) return undefined;
+  return entry;
+}
+
+function removeDanglingReferences<T extends Resource>(entry: T, link: string): T {
+  if (!entry) return entry;
+  if ("result" in entry) {
+    const results = entry.result;
+    if (Array.isArray(results)) {
+      entry.result = results.filter(entry => entry.reference !== link);
+      if (!entry.result.length) delete entry.result;
+    }
+  }
+  if ("encounter" in entry) {
+    const encounterRef = entry.encounter;
+    if (encounterRef.reference === link) delete entry.encounter;
+  }
+  if ("diagnosis" in entry) {
+    if (entry.resourceType === "Encounter") {
+      const diagnoses = entry.diagnosis as EncounterDiagnosis[];
+      entry.diagnosis = diagnoses.filter(diagnosis => diagnosis.condition?.reference !== link);
+      if (!entry.diagnosis.length) delete entry.diagnosis;
+    }
+  }
+  if ("author" in entry) {
+    const authors = entry.author as Reference<Practitioner | Organization>[];
+    if (Array.isArray(authors)) {
+      entry.author = authors.filter(author => author.reference !== link);
+    }
+  }
+  if ("custodian" in entry) {
+    if (entry.custodian.reference === link) delete entry.custodian;
+  }
+  if ("section" in entry) {
+    entry.section = entry.section.map(section => {
+      if (section.entry) section.entry = section.entry.filter(entry => entry.reference !== link);
+      return section;
+    });
+  }
+
+  return entry;
 }

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -252,6 +252,10 @@ const conditionsFiltersMap = new Map<string, ResourceFilter>([
   ["Practitioner", removeDanglingReferences],
 ]);
 
+const coveragesFiltersMap = new Map<string, ResourceFilter>([
+  ["Organization", removeDanglingReferences],
+]);
+
 const diagReportFiltersMap = new Map<string, ResourceFilter>([
   ["Observation", removeDanglingReferences],
   ["Encounter", removeDanglingReferences],
@@ -272,6 +276,7 @@ const procedureFiltersMap = new Map<string, ResourceFilter>([
 const resourceFiltersMap = new Map<string, Map<string, ResourceFilter>>([
   ["AllergyIntolerance", allergiesFiltersMap],
   ["Condition", conditionsFiltersMap],
+  ["Coverage", coveragesFiltersMap],
   ["DiagnosticReport", diagReportFiltersMap],
   ["Encounter", encounterFiltersMap],
   ["MedicationStatement", medicationRelatedFiltersMap],
@@ -383,6 +388,10 @@ function removeDanglingReferences<T extends Resource>(entry: T, link: string): T
   }
   if ("serviceProvider" in entry) {
     if (entry.serviceProvider.reference === link) delete entry.serviceProvider;
+  }
+  if ("payor" in entry) {
+    entry.payor = entry.payor?.filter(payor => payor.reference !== link);
+    if (!entry.payor.length) delete entry.payor;
   }
 
   return entry;

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -201,7 +201,7 @@ export function deduplicateFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> 
 
   const deduplicatedBundle: Bundle = cloneDeep(fhirBundle);
   deduplicatedBundle.entry = [...deduplicatedNoDangling, ...compositionsNoDangling].map(
-    r => ({ resource: r } as BundleEntry<Resource>)
+    r => ({ fullUrl: `urn:uuid:${r.id}`, resource: r } as BundleEntry<Resource>)
   );
 
   deduplicatedBundle.total = deduplicatedNoDangling.length;

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -266,7 +266,7 @@ const observationFiltersMap = new Map<string, ResourceFilter>([
 
 const procedureFiltersMap = new Map<string, ResourceFilter>([
   ["Practitioner", removeDanglingReferences],
-  // ["Organization", removeDanglingReferences],
+  ["Organization", removeDanglingReferences],
 ]);
 
 const resourceFiltersMap = new Map<string, Map<string, ResourceFilter>>([
@@ -380,6 +380,9 @@ function removeDanglingReferences<T extends Resource>(entry: T, link: string): T
   }
   if ("recorder" in entry) {
     if (entry.recorder.reference === link) delete entry.recorder;
+  }
+  if ("serviceProvider" in entry) {
+    if (entry.serviceProvider.reference === link) delete entry.serviceProvider;
   }
 
   return entry;

--- a/packages/core/src/fhir-deduplication/resources/allergy-intolerance.ts
+++ b/packages/core/src/fhir-deduplication/resources/allergy-intolerance.ts
@@ -6,7 +6,7 @@ import {
 } from "@medplum/fhirtypes";
 import _, { cloneDeep } from "lodash";
 import { combineResources, createRef, fillMaps, hasBlacklistedText } from "../shared";
-import { isUnknownCoding, unknownCode } from "./observation-shared";
+import { isUnknownCoding, unknownCode } from "../shared";
 
 export function deduplicateAllergyIntolerances(allergies: AllergyIntolerance[]) {
   const { allergiesMap, refReplacementMap, danglingReferences } = groupSameAllergies(allergies);

--- a/packages/core/src/fhir-deduplication/resources/condition.ts
+++ b/packages/core/src/fhir-deduplication/resources/condition.ts
@@ -2,7 +2,6 @@ import { CodeableConcept, Condition } from "@medplum/fhirtypes";
 import { ICD_10_CODE, ICD_10_OID, SNOMED_CODE, SNOMED_OID } from "../../util/constants";
 import {
   combineResources,
-  createCompositeKey,
   createRef,
   fillMaps,
   getDateFromResource,
@@ -70,10 +69,10 @@ export function groupSameConditions(conditions: Condition[]): {
     const { snomedCode, icd10Code } = extractCodes(condition.code);
 
     if (icd10Code && date) {
-      const compKey = JSON.stringify(createCompositeKey(icd10Code, date));
+      const compKey = JSON.stringify({ icd10Code, date });
       fillMaps(icd10Map, compKey, condition, refReplacementMap, undefined, removeOtherCodes);
     } else if (snomedCode && date) {
-      const compKey = JSON.stringify(createCompositeKey(snomedCode, date));
+      const compKey = JSON.stringify({ snomedCode, date });
       fillMaps(snomedMap, compKey, condition, refReplacementMap, undefined, removeOtherCodes);
     } else {
       danglingReferencesSet.add(createRef(condition));

--- a/packages/core/src/fhir-deduplication/resources/condition.ts
+++ b/packages/core/src/fhir-deduplication/resources/condition.ts
@@ -86,6 +86,8 @@ export function groupSameConditions(conditions: Condition[]): {
       if (display) {
         const compKey = JSON.stringify({ display, date });
         fillMaps(dispayMap, compKey, condition, refReplacementMap, undefined, removeOtherCodes);
+      } else {
+        danglingReferencesSet.add(createRef(condition));
       }
     }
   }

--- a/packages/core/src/fhir-deduplication/resources/coverage.ts
+++ b/packages/core/src/fhir-deduplication/resources/coverage.ts
@@ -1,16 +1,18 @@
 import { Coverage } from "@medplum/fhirtypes";
-import { combineResources, fillMaps } from "../shared";
+import { combineResources, createRef, fillMaps } from "../shared";
 
 export function deduplicateCoverages(medications: Coverage[]): {
   combinedCoverages: Coverage[];
   refReplacementMap: Map<string, string[]>;
+  danglingReferences: string[];
 } {
-  const { coveragesMap, refReplacementMap } = groupSameCoverages(medications);
+  const { coveragesMap, refReplacementMap, danglingReferences } = groupSameCoverages(medications);
   return {
     combinedCoverages: combineResources({
       combinedMaps: [coveragesMap],
     }),
     refReplacementMap,
+    danglingReferences,
   };
 }
 
@@ -24,9 +26,11 @@ export function deduplicateCoverages(medications: Coverage[]): {
 export function groupSameCoverages(coverages: Coverage[]): {
   coveragesMap: Map<string, Coverage>;
   refReplacementMap: Map<string, string[]>;
+  danglingReferences: string[];
 } {
   const coveragesMap = new Map<string, Coverage>();
   const refReplacementMap = new Map<string, string[]>();
+  const danglingReferencesSet = new Set<string>();
 
   for (const coverage of coverages) {
     const payor = coverage.payor?.find(ref => ref.reference?.startsWith("Organization"));
@@ -36,11 +40,14 @@ export function groupSameCoverages(coverages: Coverage[]): {
     if (payor) {
       const key = JSON.stringify({ payor, status, period });
       fillMaps(coveragesMap, key, coverage, refReplacementMap);
+    } else {
+      danglingReferencesSet.add(createRef(coverage));
     }
   }
 
   return {
     coveragesMap,
     refReplacementMap: refReplacementMap,
+    danglingReferences: [...danglingReferencesSet],
   };
 }

--- a/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
+++ b/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
@@ -2,6 +2,7 @@ import { DiagnosticReport } from "@medplum/fhirtypes";
 import { LOINC_CODE, LOINC_OID } from "../../util/constants";
 import {
   combineResources,
+  createRef,
   fillMaps,
   getDateFromResource,
   pickMostDescriptiveStatus,
@@ -37,13 +38,16 @@ const statusRanking: Record<DiagnosticReportStatus, number> = {
 export function deduplicateDiagReports(medications: DiagnosticReport[]): {
   combinedDiagnosticReports: DiagnosticReport[];
   refReplacementMap: Map<string, string[]>;
+  danglingReferences: string[];
 } {
-  const { diagReportsMap, refReplacementMap } = groupSameDiagnosticReports(medications);
+  const { diagReportsMap, refReplacementMap, danglingReferences } =
+    groupSameDiagnosticReports(medications);
   return {
     combinedDiagnosticReports: combineResources({
       combinedMaps: [diagReportsMap],
     }),
     refReplacementMap,
+    danglingReferences,
   };
 }
 
@@ -56,12 +60,12 @@ export function deduplicateDiagReports(medications: DiagnosticReport[]): {
  */
 export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
   diagReportsMap: Map<string, DiagnosticReport>;
-  remainingDiagReports: DiagnosticReport[];
   refReplacementMap: Map<string, string[]>;
+  danglingReferences: string[];
 } {
   const diagReportsMap = new Map<string, DiagnosticReport>();
   const refReplacementMap = new Map<string, string[]>();
-  const remainingDiagReports: DiagnosticReport[] = [];
+  const danglingReferencesSet = new Set<string>();
 
   function removeCodesAndAssignStatus(
     master: DiagnosticReport,
@@ -99,13 +103,13 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
         removeCodesAndAssignStatus
       );
     } else {
-      remainingDiagReports.push(diagReport);
+      danglingReferencesSet.add(createRef(diagReport));
     }
   }
 
   return {
     diagReportsMap,
-    remainingDiagReports,
     refReplacementMap,
+    danglingReferences: [...danglingReferencesSet],
   };
 }

--- a/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
+++ b/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
@@ -89,11 +89,11 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
   }
 
   for (const diagReport of diagReports) {
-    const date = getDateFromResource(diagReport, "datetime");
+    const datetime = getDateFromResource(diagReport, "datetime");
     const isPresentedFormPresent = diagReport.presentedForm?.length;
     const isResultPresent = diagReport.result?.length;
-    if (date && (isPresentedFormPresent || isResultPresent)) {
-      const key = JSON.stringify({ date });
+    if (datetime && (isPresentedFormPresent || isResultPresent)) {
+      const key = JSON.stringify({ datetime });
       fillMaps(
         diagReportsMap,
         key,

--- a/packages/core/src/fhir-deduplication/resources/encounter.ts
+++ b/packages/core/src/fhir-deduplication/resources/encounter.ts
@@ -1,6 +1,7 @@
 import { Encounter } from "@medplum/fhirtypes";
 import {
   combineResources,
+  createRef,
   fillMaps,
   getDateFromResource,
   pickMostDescriptiveStatus,
@@ -35,13 +36,15 @@ export const statusRanking: Record<EncounterStatus, number> = {
 export function deduplicateEncounters(encounters: Encounter[]): {
   combinedEncounters: Encounter[];
   refReplacementMap: Map<string, string[]>;
+  danglingReferences: string[];
 } {
-  const { encountersMap, refReplacementMap } = groupSameEncounters(encounters);
+  const { encountersMap, refReplacementMap, danglingReferences } = groupSameEncounters(encounters);
   return {
     combinedEncounters: combineResources({
       combinedMaps: [encountersMap],
     }),
     refReplacementMap,
+    danglingReferences,
   };
 }
 
@@ -54,9 +57,11 @@ export function deduplicateEncounters(encounters: Encounter[]): {
 export function groupSameEncounters(encounters: Encounter[]): {
   encountersMap: Map<string, Encounter>;
   refReplacementMap: Map<string, string[]>;
+  danglingReferences: string[];
 } {
   const encountersMap = new Map<string, Encounter>();
   const refReplacementMap = new Map<string, string[]>();
+  const danglingReferencesSet = new Set<string>();
 
   function assignMostDescriptiveStatus(
     master: Encounter,
@@ -69,6 +74,7 @@ export function groupSameEncounters(encounters: Encounter[]): {
 
   for (const encounter of encounters) {
     const date = getDateFromResource(encounter, "datetime");
+    // TODO: Improve the key. Just date is not sufficient.
     if (date) {
       const key = JSON.stringify({ date });
       fillMaps(
@@ -79,11 +85,14 @@ export function groupSameEncounters(encounters: Encounter[]): {
         undefined,
         assignMostDescriptiveStatus
       );
+    } else {
+      danglingReferencesSet.add(createRef(encounter));
     }
   }
 
   return {
     encountersMap,
     refReplacementMap,
+    danglingReferences: [...danglingReferencesSet],
   };
 }

--- a/packages/core/src/fhir-deduplication/resources/encounter.ts
+++ b/packages/core/src/fhir-deduplication/resources/encounter.ts
@@ -73,10 +73,10 @@ export function groupSameEncounters(encounters: Encounter[]): {
   }
 
   for (const encounter of encounters) {
-    const date = getDateFromResource(encounter, "datetime");
+    const datetime = getDateFromResource(encounter, "datetime");
     // TODO: Improve the key. Just date is not sufficient.
-    if (date) {
-      const key = JSON.stringify({ date });
+    if (datetime) {
+      const key = JSON.stringify({ datetime });
       fillMaps(
         encountersMap,
         key,

--- a/packages/core/src/fhir-deduplication/resources/medication-administration.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication-administration.ts
@@ -1,6 +1,7 @@
 import { MedicationAdministration } from "@medplum/fhirtypes";
 import {
   combineResources,
+  createRef,
   fillMaps,
   getDateFromResource,
   pickMostDescriptiveStatus,
@@ -30,13 +31,15 @@ const statusRanking: Record<MedicationAdministrationStatus, number> = {
 export function deduplicateMedAdmins(medications: MedicationAdministration[]): {
   combinedMedAdmins: MedicationAdministration[];
   refReplacementMap: Map<string, string[]>;
+  danglingReferences: string[];
 } {
-  const { medAdminsMap, refReplacementMap } = groupSameMedAdmins(medications);
+  const { medAdminsMap, refReplacementMap, danglingReferences } = groupSameMedAdmins(medications);
   return {
     combinedMedAdmins: combineResources({
       combinedMaps: [medAdminsMap],
     }),
     refReplacementMap,
+    danglingReferences,
   };
 }
 
@@ -50,9 +53,11 @@ export function deduplicateMedAdmins(medications: MedicationAdministration[]): {
 export function groupSameMedAdmins(medAdmins: MedicationAdministration[]): {
   medAdminsMap: Map<string, MedicationAdministration>;
   refReplacementMap: Map<string, string[]>;
+  danglingReferences: string[];
 } {
   const medAdminsMap = new Map<string, MedicationAdministration>();
   const refReplacementMap = new Map<string, string[]>();
+  const danglingReferencesSet = new Set<string>();
 
   function assignMostDescriptiveStatus(
     master: MedicationAdministration,
@@ -78,11 +83,14 @@ export function groupSameMedAdmins(medAdmins: MedicationAdministration[]): {
         undefined,
         assignMostDescriptiveStatus
       );
+    } else {
+      danglingReferencesSet.add(createRef(medAdmin));
     }
   }
 
   return {
     medAdminsMap,
     refReplacementMap: refReplacementMap,
+    danglingReferences: [...danglingReferencesSet],
   };
 }

--- a/packages/core/src/fhir-deduplication/resources/medication-administration.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication-administration.ts
@@ -70,11 +70,11 @@ export function groupSameMedAdmins(medAdmins: MedicationAdministration[]): {
 
   for (const medAdmin of medAdmins) {
     const medRef = medAdmin.medicationReference?.reference;
-    const date = getDateFromResource(medAdmin, "datetime");
+    const datetime = getDateFromResource(medAdmin, "datetime");
     const dosage = medAdmin.dosage;
 
-    if (medRef && date && dosage) {
-      const key = JSON.stringify({ medRef, date, dosage });
+    if (medRef && datetime && dosage) {
+      const key = JSON.stringify({ medRef, datetime, dosage });
       fillMaps(
         medAdminsMap,
         key,

--- a/packages/core/src/fhir-deduplication/resources/medication-request.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication-request.ts
@@ -1,5 +1,11 @@
 import { MedicationRequest } from "@medplum/fhirtypes";
-import { combineResources, createRef, fillMaps, pickMostDescriptiveStatus } from "../shared";
+import {
+  combineResources,
+  createRef,
+  fillMaps,
+  getDateFromString,
+  pickMostDescriptiveStatus,
+} from "../shared";
 
 const medicationRequestStatus = [
   "active",
@@ -67,11 +73,11 @@ export function groupSameMedRequests(medRequests: MedicationRequest[]): {
   for (const medRequest of medRequests) {
     const medRef = medRequest.medicationReference?.reference;
     const date = medRequest.authoredOn;
-    // TODO: Deduplicate Practitioners prior to MedicationRequests, so the reference to requester can also be used for key?
 
     if (medRef && date) {
+      const datetime = getDateFromString(date, "datetime");
       // TODO: Include medRequest.dosage into the key when we start mapping it on the FHIR converter
-      const key = JSON.stringify({ medRef, date });
+      const key = JSON.stringify({ medRef, datetime });
       fillMaps(
         medRequestsMap,
         key,

--- a/packages/core/src/fhir-deduplication/resources/medication-statement.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication-statement.ts
@@ -72,11 +72,11 @@ export function groupSameMedStatements(medStatements: MedicationStatement[]): {
   }
 
   for (const medStatement of medStatements) {
-    const date = getDateFromResource(medStatement, "datetime");
+    const datetime = getDateFromResource(medStatement, "datetime");
     const medRef = medStatement.medicationReference?.reference;
     const dosage = medStatement.dosage;
-    if (medRef && date && dosage) {
-      const key = JSON.stringify({ medRef, date, dosage });
+    if (medRef && datetime && dosage) {
+      const key = JSON.stringify({ medRef, datetime, dosage });
       fillMaps(
         medStatementsMap,
         key,

--- a/packages/core/src/fhir-deduplication/resources/medication.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication.ts
@@ -7,7 +7,7 @@ import {
   SNOMED_CODE,
   SNOMED_OID,
 } from "../../util/constants";
-import { combineResources, fillMaps, isBlacklistedText } from "../shared";
+import { combineResources, createRef, fillMaps, hasBlacklistedText } from "../shared";
 
 export function deduplicateMedications(medications: Medication[]): {
   combinedMedications: Medication[];
@@ -61,8 +61,8 @@ export function groupSameMedications(medications: Medication[]): {
   }
 
   for (const medication of medications) {
-    if (medication.id && isBlacklistedText(medication.code)) {
-      danglingReferences.add(createMedicationRef(medication.id));
+    if (hasBlacklistedText(medication.code)) {
+      danglingReferences.add(createRef(medication));
       continue;
     }
 
@@ -76,7 +76,7 @@ export function groupSameMedications(medications: Medication[]): {
     } else if (snomedCode) {
       fillMaps(snomedMap, snomedCode, medication, refReplacementMap, false, removeOtherCodes);
     } else {
-      if (medication.id) danglingReferences.add(createMedicationRef(medication.id));
+      danglingReferences.add(createRef(medication));
     }
   }
 
@@ -115,8 +115,4 @@ function extractCodes(concept: CodeableConcept | undefined): {
     }
   }
   return { rxnormCode, ndcCode, snomedCode };
-}
-
-function createMedicationRef(medId: string): string {
-  return `Medication/${medId}`;
 }

--- a/packages/core/src/fhir-deduplication/resources/observation-shared.ts
+++ b/packages/core/src/fhir-deduplication/resources/observation-shared.ts
@@ -1,6 +1,5 @@
 import {
   CodeableConcept,
-  Coding,
   Observation,
   Period,
   Quantity,
@@ -8,7 +7,7 @@ import {
   SampledData,
 } from "@medplum/fhirtypes";
 import { LOINC_CODE, LOINC_OID, SNOMED_CODE, SNOMED_OID } from "../../util/constants";
-import _ from "lodash";
+import { isUnknownCoding } from "../shared";
 
 export const observationStatus = [
   "entered-in-error",
@@ -119,31 +118,4 @@ export function extractValueFromObservation(
     return observation.valuePeriod;
   }
   return undefined;
-}
-
-export const unknownCoding = {
-  system: "http://terminology.hl7.org/ValueSet/v3-Unknown",
-  code: "UNK",
-  display: "unknown",
-};
-
-export const unknownCode = {
-  coding: [unknownCoding],
-  text: "unknown",
-};
-
-export function isUnknownCoding(coding: Coding, text?: string | undefined): boolean {
-  if (_.isEqual(coding, unknownCoding)) return true;
-  const system = coding.system?.toLowerCase();
-  const code = coding.code?.trim().toLowerCase();
-  const display = coding.display?.trim().toLowerCase();
-  if (
-    system?.includes("unknown") &&
-    code?.includes(unknownCoding.code.toLowerCase()) &&
-    display === unknownCoding.display.toLowerCase() &&
-    (!text || text === unknownCode.text.toLowerCase())
-  ) {
-    return true;
-  }
-  return false;
 }

--- a/packages/core/src/fhir-deduplication/resources/observation-shared.ts
+++ b/packages/core/src/fhir-deduplication/resources/observation-shared.ts
@@ -56,7 +56,6 @@ export function extractCodes(concept: CodeableConcept | undefined): {
         } else {
           const text = concept.text?.trim().toLowerCase();
           if (isUnknownCoding(coding, text)) {
-            // This identifies and ignores unknown codes
             continue;
           } else {
             otherCode = system + code;

--- a/packages/core/src/fhir-deduplication/resources/observation-social.ts
+++ b/packages/core/src/fhir-deduplication/resources/observation-social.ts
@@ -90,6 +90,7 @@ export function groupSameObservationsSocial(observations: Observation[]): {
       }
     }
     if (key) fillMaps(observationsMap, key, observation, refReplacementMap, undefined, postProcess);
+    else danglingReferencesSet.add(createRef(observation));
   }
 
   return {

--- a/packages/core/src/fhir-deduplication/resources/observation-social.ts
+++ b/packages/core/src/fhir-deduplication/resources/observation-social.ts
@@ -6,12 +6,12 @@ import {
   createRef,
   extractDisplayFromConcept,
   fillMaps,
+  isUnknownCoding,
   pickMostDescriptiveStatus,
 } from "../shared";
 import {
   extractCodes,
   extractValueFromObservation,
-  isUnknownCoding,
   retrieveCode,
   statusRanking,
 } from "./observation-shared";

--- a/packages/core/src/fhir-deduplication/resources/observation.ts
+++ b/packages/core/src/fhir-deduplication/resources/observation.ts
@@ -7,13 +7,13 @@ import {
   getDateFromResource,
   hasBlacklistedText,
   pickMostDescriptiveStatus,
+  unknownCoding,
 } from "../shared";
 import {
   extractCodes,
   extractValueFromObservation,
   retrieveCode,
   statusRanking,
-  unknownCoding,
 } from "./observation-shared";
 
 export function deduplicateObservations(observations: Observation[]): {

--- a/packages/core/src/fhir-deduplication/resources/organization.ts
+++ b/packages/core/src/fhir-deduplication/resources/organization.ts
@@ -1,6 +1,6 @@
 import { Organization } from "@medplum/fhirtypes";
 import { normalizeAddress } from "../../mpi/normalize-address";
-import { combineResources, createRef, fillMaps } from "../shared";
+import { combineResources, createRef, extractNpi, fillMaps } from "../shared";
 
 export function deduplicateOrganizations(organizations: Organization[]): {
   combinedOrganizations: Organization[];
@@ -34,10 +34,14 @@ export function groupSameOrganizations(organizations: Organization[]): {
   const danglingReferencesSet = new Set<string>();
 
   for (const organization of organizations) {
+    const npi = extractNpi(organization.identifier);
     const name = organization.name;
     const addresses = organization.address;
 
-    if (name && addresses) {
+    if (npi) {
+      const key = JSON.stringify({ npi });
+      fillMaps(organizationsMap, key, organization, refReplacementMap);
+    } else if (name && addresses) {
       const normalizedAddresses = addresses.map(address => normalizeAddress(address));
       const key = JSON.stringify({ name, address: normalizedAddresses[0] });
       fillMaps(organizationsMap, key, organization, refReplacementMap);

--- a/packages/core/src/fhir-deduplication/resources/organization.ts
+++ b/packages/core/src/fhir-deduplication/resources/organization.ts
@@ -45,6 +45,9 @@ export function groupSameOrganizations(organizations: Organization[]): {
       const normalizedAddresses = addresses.map(address => normalizeAddress(address));
       const key = JSON.stringify({ name, address: normalizedAddresses[0] });
       fillMaps(organizationsMap, key, organization, refReplacementMap);
+    } else if (name) {
+      const key = JSON.stringify({ name });
+      fillMaps(organizationsMap, key, organization, refReplacementMap);
     } else {
       danglingReferencesSet.add(createRef(organization));
     }

--- a/packages/core/src/fhir-deduplication/resources/organization.ts
+++ b/packages/core/src/fhir-deduplication/resources/organization.ts
@@ -1,17 +1,20 @@
 import { Organization } from "@medplum/fhirtypes";
 import { normalizeAddress } from "../../mpi/normalize-address";
-import { combineResources, fillMaps } from "../shared";
+import { combineResources, createRef, fillMaps } from "../shared";
 
 export function deduplicateOrganizations(organizations: Organization[]): {
   combinedOrganizations: Organization[];
   refReplacementMap: Map<string, string[]>;
+  danglingReferences: string[];
 } {
-  const { organizationsMap, refReplacementMap } = groupSameOrganizations(organizations);
+  const { organizationsMap, refReplacementMap, danglingReferences } =
+    groupSameOrganizations(organizations);
   return {
     combinedOrganizations: combineResources({
       combinedMaps: [organizationsMap],
     }),
     refReplacementMap,
+    danglingReferences,
   };
 }
 
@@ -24,9 +27,11 @@ export function deduplicateOrganizations(organizations: Organization[]): {
 export function groupSameOrganizations(organizations: Organization[]): {
   organizationsMap: Map<string, Organization>;
   refReplacementMap: Map<string, string[]>;
+  danglingReferences: string[];
 } {
   const organizationsMap = new Map<string, Organization>();
   const refReplacementMap = new Map<string, string[]>();
+  const danglingReferencesSet = new Set<string>();
 
   for (const organization of organizations) {
     const name = organization.name;
@@ -36,11 +41,14 @@ export function groupSameOrganizations(organizations: Organization[]): {
       const normalizedAddresses = addresses.map(address => normalizeAddress(address));
       const key = JSON.stringify({ name, address: normalizedAddresses[0] });
       fillMaps(organizationsMap, key, organization, refReplacementMap);
+    } else {
+      danglingReferencesSet.add(createRef(organization));
     }
   }
 
   return {
     organizationsMap,
     refReplacementMap,
+    danglingReferences: [...danglingReferencesSet],
   };
 }

--- a/packages/core/src/fhir-deduplication/resources/practitioner.ts
+++ b/packages/core/src/fhir-deduplication/resources/practitioner.ts
@@ -1,6 +1,6 @@
 import { Practitioner } from "@medplum/fhirtypes";
 import { normalizeAddress } from "../../mpi/normalize-address";
-import { combineResources, createRef, fillMaps } from "../shared";
+import { combineResources, createRef, extractNpi, fillMaps } from "../shared";
 
 export function deduplicatePractitioners(practitioners: Practitioner[]): {
   combinedPractitioners: Practitioner[];
@@ -34,10 +34,14 @@ export function groupSamePractitioners(practitioners: Practitioner[]): {
   const danglingReferencesSet = new Set<string>();
 
   for (const practitioner of practitioners) {
+    const npi = extractNpi(practitioner.identifier);
     const name = practitioner.name;
     const addresseses = practitioner.address;
 
-    if (name && addresseses) {
+    if (npi) {
+      const key = JSON.stringify({ npi });
+      fillMaps(practitionersMap, key, practitioner, refReplacementMap);
+    } else if (name && addresseses) {
       const normalizedAddresses = addresseses.map(address => normalizeAddress(address));
       const key = JSON.stringify({ name, address: normalizedAddresses[0] });
       fillMaps(practitionersMap, key, practitioner, refReplacementMap);

--- a/packages/core/src/fhir-deduplication/resources/procedure.ts
+++ b/packages/core/src/fhir-deduplication/resources/procedure.ts
@@ -115,8 +115,8 @@ export function groupSameProcedures(procedures: Procedure[]): {
 
     let key;
     if (cptCode) key = JSON.stringify({ datetime, cptCode });
-    else if (loincCode) JSON.stringify({ datetime, loincCode });
-    else if (snomedCode) JSON.stringify({ datetime, snomedCode });
+    else if (loincCode) key = JSON.stringify({ datetime, loincCode });
+    else if (snomedCode) key = JSON.stringify({ datetime, snomedCode });
 
     if (key) {
       fillMaps(

--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -237,9 +237,7 @@ export function pickMostDescriptiveStatus<T extends string>(
 export function hasBlacklistedText(concept: CodeableConcept | undefined): boolean {
   const knownCodings = concept?.coding?.filter(c => !isUnknownCoding(c));
   return (
-    concept?.text?.toLowerCase().includes(NO_KNOWN_SUBSTRING) ??
-    Boolean(knownCodings?.length) ??
-    false
+    concept?.text?.toLowerCase().includes(NO_KNOWN_SUBSTRING) ?? !knownCodings?.length ?? false
   );
 }
 

--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -2,6 +2,8 @@ import { CodeableConcept, Resource } from "@medplum/fhirtypes";
 import dayjs from "dayjs";
 import { cloneDeep } from "lodash";
 
+const NO_KNOWN_SUBSTRING = "no known";
+
 const dateFormats = ["datetime", "date"] as const;
 export type DateFormats = (typeof dateFormats)[number];
 
@@ -235,6 +237,15 @@ export function pickMostDescriptiveStatus<T extends string>(
   return status;
 }
 
-export function isBlacklistedText(concept: CodeableConcept | undefined): boolean {
-  return concept?.text?.toLowerCase().includes("no known") ?? false;
+export function hasBlacklistedText(concept: CodeableConcept | undefined): boolean {
+  return (
+    concept?.text?.toLowerCase().includes(NO_KNOWN_SUBSTRING) ??
+    concept?.coding?.some(c => c.display?.toLowerCase().includes(NO_KNOWN_SUBSTRING)) ??
+    false
+  );
+}
+
+export function createRef<T extends Resource>(res: T): string {
+  if (!res.id) throw new Error("FHIR Resource has no ID");
+  return `${res.resourceType}/${res.id}`;
 }

--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -14,13 +14,6 @@ export type CompositeKey = {
   date: string | undefined;
 };
 
-export function createCompositeKey(code: string, date: string | undefined): CompositeKey {
-  return {
-    code,
-    date,
-  };
-}
-
 export function getDateFromString(dateString: string, dateFormat?: "date" | "datetime"): string {
   const date = dayjs(dateString);
 

--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -1,6 +1,7 @@
 import { CodeableConcept, Identifier, Resource } from "@medplum/fhirtypes";
 import dayjs from "dayjs";
 import { cloneDeep } from "lodash";
+import { isUnknownCoding } from "./resources/observation-shared";
 
 const NO_KNOWN_SUBSTRING = "no known";
 
@@ -234,9 +235,10 @@ export function pickMostDescriptiveStatus<T extends string>(
 }
 
 export function hasBlacklistedText(concept: CodeableConcept | undefined): boolean {
+  const knownCodings = concept?.coding?.filter(c => !isUnknownCoding(c));
   return (
     concept?.text?.toLowerCase().includes(NO_KNOWN_SUBSTRING) ??
-    concept?.coding?.some(c => c.display?.toLowerCase().includes(NO_KNOWN_SUBSTRING)) ??
+    Boolean(knownCodings?.length) ??
     false
   );
 }

--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -1,7 +1,6 @@
-import { CodeableConcept, Identifier, Resource } from "@medplum/fhirtypes";
+import { CodeableConcept, Coding, Identifier, Resource } from "@medplum/fhirtypes";
 import dayjs from "dayjs";
-import { cloneDeep } from "lodash";
-import { isUnknownCoding } from "./resources/observation-shared";
+import _, { cloneDeep } from "lodash";
 
 const NO_KNOWN_SUBSTRING = "no known";
 
@@ -266,4 +265,34 @@ export function extractNpi(identifiers: Identifier[] | undefined): string | unde
 
   const npiIdentifier = identifiers.find(i => i.system?.includes("us-npi") && i.value);
   return npiIdentifier?.value;
+}
+
+export const unknownCoding = {
+  system: "http://terminology.hl7.org/ValueSet/v3-Unknown",
+  code: "UNK",
+  display: "unknown",
+};
+
+export const unknownCode = {
+  coding: [unknownCoding],
+  text: "unknown",
+};
+
+export function isUnknownCoding(coding: Coding, text?: string | undefined): boolean {
+  if (_.isEqual(coding, unknownCoding)) return true;
+  const code = coding.code?.trim().toLowerCase();
+  const display = coding.display?.trim().toLowerCase();
+
+  if (code) {
+    return (
+      code?.includes(unknownCoding.code.toLowerCase()) &&
+      (!display || display === unknownCoding.display.toLowerCase()) &&
+      (!text || text === unknownCode.text.toLowerCase())
+    );
+  } else {
+    return (
+      (!display || display === unknownCoding.display.toLowerCase()) &&
+      (!text || text === unknownCode.text.toLowerCase())
+    );
+  }
 }

--- a/packages/core/src/fhir-to-cda/cda-templates/components/__tests__/encompassing-enc.test.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/components/__tests__/encompassing-enc.test.ts
@@ -52,7 +52,7 @@ beforeAll(() => {
   );
   practitioner = makePractitioner({ ...practitioner1, id: practitionerId });
   location = makeLocation({ ...location1, id: locationId });
-  composition = makeComposition({ enc: encounterId, pract: practitionerId });
+  composition = makeComposition({ encId: encounterId, practId: practitionerId });
 });
 
 beforeEach(() => {

--- a/packages/core/src/fhir-to-cda/cda-templates/components/__tests__/make-composition.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/components/__tests__/make-composition.ts
@@ -1,7 +1,13 @@
+import { faker } from "@faker-js/faker";
 import { Composition } from "@medplum/fhirtypes";
 import { makeBaseDomain, makeSubjectReference } from "./shared";
 
-export function makeComposition(ids: { enc: string; pract: string }): Composition {
+export function makeComposition(
+  ids?: { encId: string; practId: string },
+  params: Partial<Composition> = {}
+): Composition {
+  const encounterId = ids?.encId ?? faker.string.uuid();
+
   return {
     ...makeBaseDomain(),
     ...makeSubjectReference(),
@@ -28,13 +34,14 @@ export function makeComposition(ids: { enc: string; pract: string }): Compositio
         mode: "snapshot",
         entry: [
           {
-            reference: `Encounter/${ids.enc}`,
+            reference: `Encounter/${encounterId}`,
             display: "Encounter 1",
           },
         ],
       },
     ],
-    encounter: { reference: `Encounter/${ids.enc}` },
-    author: [{ reference: `Practitioner/${ids.pract}` }],
+    encounter: { reference: `Encounter/${encounterId}` },
+    author: [{ reference: `Practitioner/${ids?.practId ?? faker.string.uuid()}` }],
+    ...params,
   };
 }


### PR DESCRIPTION
refs. metriport/metriport#2569

### Dependencies
- Downstream: https://github.com/metriport/metriport/pull/2699

### Description
- Handling dangling links
- Added backup keys as per [this discussion](https://metriport.slack.com/archives/C06CQC7GQG3/p1725060614148579) on Slack
- The blacklisted values checks were added to the following resources with the logic as discussed [here](https://metriport.slack.com/archives/C06CQC7GQG3/p1725063802398999?thread_ts=1725062079.255369&cid=C06CQC7GQG3):
    - Condition - condition.code
    - Immunization - immunization.vaccineCode
    - Medication - medication.code
    - Observation - observation.code
    - Procedure - procedure.code

### Testing
- Local
  - [x] Some unit tests
  - [x] More thorough testing

### Release Plan
- [ ] Merge this
