### PR TITLE
2064 dedup from dash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28514,7 +28514,7 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "12.1.1-alpha.0",
+      "version": "12.1.1-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28430,7 +28430,7 @@
       }
     },
     "packages/api": {
-      "version": "1.22.0",
+      "version": "1.22.1-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -28514,12 +28514,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "12.1.0",
+      "version": "12.1.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.1.0",
-        "@metriport/shared": "^0.13.0",
+        "@metriport/commonwell-sdk": "^5.1.1-alpha.0",
+        "@metriport/shared": "^0.13.1-alpha.0",
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28575,10 +28575,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.11.0",
+      "version": "1.11.1-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.12.0",
+        "@metriport/ihe-gateway-sdk": "^0.12.1-alpha.0",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -28592,7 +28592,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.13.0",
+      "version": "0.13.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -28602,10 +28602,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.19.0",
+      "version": "1.19.1-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.1.0",
+        "@metriport/commonwell-sdk": "^5.1.1-alpha.0",
         "axios": "^1.4.0",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -28644,10 +28644,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.17.0",
+      "version": "1.17.1-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.1.0",
+        "@metriport/commonwell-sdk": "^5.1.1-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -28679,10 +28679,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.1.0",
+      "version": "5.1.1-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.13.0",
+        "@metriport/shared": "^0.13.1-alpha.0",
         "axios": "^1.4.0",
         "http-status": "^1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -28730,7 +28730,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.17.0",
+      "version": "1.17.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.616.0",
@@ -28813,17 +28813,17 @@
     "packages/core/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.12.0",
+      "version": "0.12.1-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.13.0",
+        "@metriport/shared": "^0.13.1-alpha.0",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.15.0",
+      "version": "1.15.1-alpha.0",
       "dependencies": {
         "aws-cdk-lib": "^2.122.0",
         "constructs": "^10.2.69",
@@ -28871,7 +28871,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.14.0",
+      "version": "1.14.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -29898,14 +29898,14 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.13.0",
+      "version": "0.13.1-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^8.0.2"
       }
     },
     "packages/utils": {
-      "version": "1.18.0",
+      "version": "1.18.1-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-bedrock-agent-runtime": "^3.616.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "12.1.0",
+  "version": "12.1.1-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -57,8 +57,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.1.0",
-    "@metriport/shared": "^0.13.0",
+    "@metriport/commonwell-sdk": "^5.1.1-alpha.0",
+    "@metriport/shared": "^0.13.1-alpha.0",
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "12.1.1-alpha.0",
+  "version": "12.1.1-alpha.1",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -369,7 +369,7 @@ export class MetriportMedicalApi {
    * @param resources Optional array of resources to be returned.
    * @param dateFrom Optional start date that resources will be filtered by (inclusive). Format is YYYY-MM-DD.
    * @param dateTo Optional end date that resources will be filtered by (inclusive). Format is YYYY-MM-DD.
-   * @param dashboard Optional parameter to indicate that the request is coming from the dashboard.
+   * @param fromDashboard Optional parameter to indicate that the request is coming from the dashboard.
    * @return Patient's consolidated data.
    */
   async getPatientConsolidated(
@@ -377,10 +377,10 @@ export class MetriportMedicalApi {
     resources?: string[],
     dateFrom?: string,
     dateTo?: string,
-    dashboard?: boolean
+    fromDashboard?: boolean
   ): Promise<Bundle<Resource>> {
     const resp = await this.api.get(`${PATIENT_URL}/${patientId}/consolidated`, {
-      params: { resources: resources && resources.join(","), dateFrom, dateTo, dashboard },
+      params: { resources: resources && resources.join(","), dateFrom, dateTo, fromDashboard },
     });
     return resp.data;
   }

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -369,16 +369,18 @@ export class MetriportMedicalApi {
    * @param resources Optional array of resources to be returned.
    * @param dateFrom Optional start date that resources will be filtered by (inclusive). Format is YYYY-MM-DD.
    * @param dateTo Optional end date that resources will be filtered by (inclusive). Format is YYYY-MM-DD.
+   * @param dashboard Optional parameter to indicate that the request is coming from the dashboard.
    * @return Patient's consolidated data.
    */
   async getPatientConsolidated(
     patientId: string,
     resources?: string[],
     dateFrom?: string,
-    dateTo?: string
+    dateTo?: string,
+    dashboard?: boolean
   ): Promise<Bundle<Resource>> {
     const resp = await this.api.get(`${PATIENT_URL}/${patientId}/consolidated`, {
-      params: { resources: resources && resources.join(","), dateFrom, dateTo },
+      params: { resources: resources && resources.join(","), dateFrom, dateTo, dashboard },
     });
     return resp.data;
   }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.22.0",
+  "version": "1.22.1-alpha.0",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/src/command/medical/patient/consolidated-get.ts
+++ b/packages/api/src/command/medical/patient/consolidated-get.ts
@@ -54,6 +54,7 @@ type GetConsolidatedPatientData = {
   dateFrom?: string;
   dateTo?: string;
   generateAiBrief?: boolean;
+  fromDashboard?: boolean;
 };
 
 export type GetConsolidatedSendToCxParams = GetConsolidatedParams & {
@@ -417,6 +418,7 @@ export async function getConsolidatedPatientData({
   dateFrom,
   dateTo,
   generateAiBrief,
+  fromDashboard = false,
 }: GetConsolidatedPatientData): Promise<SearchSetBundle<Resource>> {
   const payload: ConsolidatedDataRequestSync = {
     patient,
@@ -426,6 +428,7 @@ export async function getConsolidatedPatientData({
     dateTo,
     generateAiBrief,
     isAsync: false,
+    fromDashboard,
   };
   const connector = buildConsolidatedDataConnector();
   const { bundleLocation, bundleFilename } = await connector.execute(payload);

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -247,7 +247,7 @@ router.get(
  * @param req.query.resources Optional comma-separated list of resources to be returned.
  * @param req.query.dateFrom Optional start date that resources will be filtered by (inclusive).
  * @param req.query.dateTo Optional end date that resources will be filtered by (inclusive).
- * @param req.query.dashboard Optional parameter to indicate that the request is coming from the dashboard.
+ * @param req.query.fromDashboard Optional parameter to indicate that the request is coming from the dashboard.
  * @return Patient's consolidated data.
  */
 router.get(
@@ -259,7 +259,7 @@ router.get(
     const resources = getResourcesQueryParam(req);
     const dateFrom = parseISODate(getFrom("query").optional("dateFrom", req));
     const dateTo = parseISODate(getFrom("query").optional("dateTo", req));
-    const fromDashboard = getFromQueryAsBoolean("dashboard", req);
+    const fromDashboard = getFromQueryAsBoolean("fromDashboard", req);
     const patient = await getPatientOrFail({ id: patientId, cxId });
 
     const data = await getConsolidatedPatientData({

--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -247,6 +247,7 @@ router.get(
  * @param req.query.resources Optional comma-separated list of resources to be returned.
  * @param req.query.dateFrom Optional start date that resources will be filtered by (inclusive).
  * @param req.query.dateTo Optional end date that resources will be filtered by (inclusive).
+ * @param req.query.dashboard Optional parameter to indicate that the request is coming from the dashboard.
  * @return Patient's consolidated data.
  */
 router.get(
@@ -258,6 +259,7 @@ router.get(
     const resources = getResourcesQueryParam(req);
     const dateFrom = parseISODate(getFrom("query").optional("dateFrom", req));
     const dateTo = parseISODate(getFrom("query").optional("dateTo", req));
+    const fromDashboard = getFromQueryAsBoolean("dashboard", req);
     const patient = await getPatientOrFail({ id: patientId, cxId });
 
     const data = await getConsolidatedPatientData({
@@ -265,6 +267,7 @@ router.get(
       resources,
       dateFrom,
       dateTo,
+      fromDashboard,
     });
 
     return res.json(data);

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.11.0",
+  "version": "1.11.1-alpha.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.12.0",
+    "@metriport/ihe-gateway-sdk": "^0.12.1-alpha.0",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.13.0",
+  "version": "0.13.1-alpha.0",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.19.0",
+  "version": "1.19.1-alpha.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.1.0",
+    "@metriport/commonwell-sdk": "^5.1.1-alpha.0",
     "axios": "^1.4.0",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.17.0",
+  "version": "1.17.1-alpha.0",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.1.0",
+    "@metriport/commonwell-sdk": "^5.1.1-alpha.0",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.1.0",
+  "version": "5.1.1-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -59,7 +59,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.13.0",
+    "@metriport/shared": "^0.13.1-alpha.0",
     "axios": "^1.4.0",
     "http-status": "^1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.17.0",
+  "version": "1.17.1-alpha.0",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/core/src/command/consolidated/consolidated-connector-local.ts
+++ b/packages/core/src/command/consolidated/consolidated-connector-local.ts
@@ -30,7 +30,7 @@ export class ConsolidatedDataConnectorLocal implements ConsolidatedDataConnector
       isFhirDeduplicationEnabledForCx(params.patient.cxId),
     ]);
 
-    const dedupEnabled = ffDedupEnabled ?? params.fromDashboard;
+    const dedupEnabled = ffDedupEnabled || params.fromDashboard;
 
     const dedupedBundle = deduplicate({ cxId, patientId, bundle: originalBundle });
 

--- a/packages/core/src/command/consolidated/consolidated-connector-local.ts
+++ b/packages/core/src/command/consolidated/consolidated-connector-local.ts
@@ -25,10 +25,12 @@ export class ConsolidatedDataConnectorLocal implements ConsolidatedDataConnector
   ): Promise<ConsolidatedDataResponse> {
     const { cxId, id: patientId } = params.patient;
 
-    const [originalBundle, dedupEnabled] = await Promise.all([
+    const [originalBundle, ffDedupEnabled] = await Promise.all([
       getConsolidatedFhirBundle(params),
       isFhirDeduplicationEnabledForCx(params.patient.cxId),
     ]);
+
+    const dedupEnabled = ffDedupEnabled ?? params.fromDashboard;
 
     const dedupedBundle = deduplicate({ cxId, patientId, bundle: originalBundle });
 

--- a/packages/core/src/command/consolidated/consolidated-connector.ts
+++ b/packages/core/src/command/consolidated/consolidated-connector.ts
@@ -9,11 +9,13 @@ export type ConsolidatedDataRequestAsync = ConsolidatedPatientDataRequest & {
   isAsync: true;
   requestId: string;
   conversionType?: ConsolidationConversionType | undefined;
+  fromDashboard?: boolean | undefined;
 };
 
 export type ConsolidatedDataRequestSync = ConsolidatedPatientDataRequest & {
   isAsync: false;
   requestId?: string | undefined;
+  fromDashboard?: boolean | undefined;
 };
 
 export type ConsolidatedDataResponse = {

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.12.0",
+  "version": "0.12.1-alpha.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -52,7 +52,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.13.0",
+    "@metriport/shared": "^0.13.1-alpha.0",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.15.0",
+  "version": "1.15.1-alpha.0",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.14.0",
+  "version": "1.14.1-alpha.0",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.13.0",
+  "version": "0.13.1-alpha.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.18.0",
+  "version": "1.18.1-alpha.0",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ticket: #2064

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/2097

### Description

Dedup available for dash

### Testing

_[Regular PRs:]_

- Local
  - [x] dedups
- Staging
  - [ ] dedups
- Production
  - [ ] dedups

_[Release PRs:]_

Check each PR.

### Release Plan

- [ ] Release NPM packages
- [ ] Merge this
