### PR TITLE
feat(core): adding npi validation

### DIFF
--- a/packages/core/src/fhir-deduplication/resources/organization.ts
+++ b/packages/core/src/fhir-deduplication/resources/organization.ts
@@ -1,4 +1,5 @@
 import { Organization } from "@medplum/fhirtypes";
+import { validateNPI } from "@metriport/shared";
 import { normalizeAddress } from "../../mpi/normalize-address";
 import { combineResources, createRef, extractNpi, fillMaps } from "../shared";
 
@@ -38,7 +39,7 @@ export function groupSameOrganizations(organizations: Organization[]): {
     const name = organization.name;
     const addresses = organization.address;
 
-    if (npi) {
+    if (npi && validateNPI(npi)) {
       const key = JSON.stringify({ npi });
       fillMaps(organizationsMap, key, organization, refReplacementMap);
     } else if (name && addresses) {

--- a/packages/core/src/fhir-deduplication/resources/practitioner.ts
+++ b/packages/core/src/fhir-deduplication/resources/practitioner.ts
@@ -1,4 +1,5 @@
 import { Practitioner } from "@medplum/fhirtypes";
+import { validateNPI } from "@metriport/shared";
 import { normalizeAddress } from "../../mpi/normalize-address";
 import { combineResources, createRef, extractNpi, fillMaps } from "../shared";
 
@@ -38,7 +39,7 @@ export function groupSamePractitioners(practitioners: Practitioner[]): {
     const name = practitioner.name;
     const addresseses = practitioner.address;
 
-    if (npi) {
+    if (npi && validateNPI(npi)) {
       const key = JSON.stringify({ npi });
       fillMaps(practitionersMap, key, practitioner, refReplacementMap);
     } else if (name && addresseses) {


### PR DESCRIPTION
refs. metriport/metriport#2569

### Description
- adding `validateNpi` for the `Organization` and `Practitioner` deduplication to avoid using fake NPIs as the dedup key

### Testing
- Local
  - [x] Unit tests 

### Release Plan
- [ ] Merge this
