### PR TITLE
2179 Fix missing refs report on dedup script to account for all refs

### DIFF
--- a/packages/utils/src/fhir-dedup/condition.ts
+++ b/packages/utils/src/fhir-dedup/condition.ts
@@ -7,41 +7,42 @@ import { isSibling } from "./shared";
 
 // Lots of fields were not mapped, see https://www.hl7.org/fhir/R4/condition.html if you want to add them
 const columns = [
-  "id_o",
+  "id",
   "date",
-  "cliStat_code0_o",
-  "cliStat_code0_d",
-  "cliStat_display0_o",
-  "cliStat_display0_d",
-  "cliStat_code1_o",
-  "cliStat_code1_d",
-  "cliStat_display1_o",
-  "cliStat_display1_d",
-  "cliStat_text_o",
-  "cliStat_text_d",
-  "cat_code0_o",
-  "cat_code0_d",
-  "cat_disp0_o",
-  "cat_disp0_d",
-  "cat_code1_o",
-  "cat_code1_d",
-  "cat_disp1_o",
-  "cat_disp1_d",
-  "cat_text_o",
-  "cat_text_d",
+  "links",
+  "cliStat_code0",
+  "cliStat_code0_s",
+  "cliStat_disp0",
+  "cliStat_disp0_s",
+  "cliStat_code1",
+  "cliStat_code1_s",
+  "cliStat_disp1",
+  "cliStat_disp1_s",
+  "cliStat_text",
+  "cliStat_text_s",
+  "cat_code0",
+  "cat_code0_s",
+  "cat_disp0",
+  "cat_disp0_s",
+  "cat_code1",
+  "cat_code1_s",
+  "cat_disp1",
+  "cat_disp1_s",
+  "cat_text",
+  "cat_text_s",
   ...codeColumns,
   ...bodySiteColumns,
-  "subjRef_o",
-  "subjRef_d",
-  "encounterRef_o",
-  "encounterRef_d",
-  "onsetPeriod_start_o",
-  "onsetPeriod_start_d",
-  "onsetPeriod_end_o",
-  "onsetPeriod_end_d",
-  "recorderRef_o",
-  "recorderRef_d",
-  "id_d",
+  "subjRef",
+  "subjRef_s",
+  "encounterRef",
+  "encounterRef_s",
+  "onsetPeriod_start",
+  "onsetPeriod_start_s",
+  "onsetPeriod_end",
+  "onsetPeriod_end_s",
+  "recorderRef",
+  "recorderRef_s",
+  "ids_siblings",
 ] as const;
 type Columns = (typeof columns)[number];
 
@@ -82,85 +83,88 @@ function sort(a: Condition, b: Condition): number {
   return 0;
 }
 
-function toCsv(resource: Condition, siblings: Condition[]): string {
-  const sibling = siblings.find(isSibling(resource));
+function toCsv(resource: Condition, others: Condition[]): string {
+  const siblings = others.filter(isSibling(resource));
+  const firstSibling = siblings[0];
   const date = resource.meta?.lastUpdated ? new Date(resource.meta?.lastUpdated).toISOString() : "";
+  const links = siblings.length;
 
-  // set all fields necessary to populate the "res" object below, using resource and sibling, using the processMedicationStatement function as reference. Start with the properties that need "resource", then populate the ones that rely on "sibling".
-  const cliStat_code0_o = resource.clinicalStatus?.coding?.[0]?.code ?? "";
-  const cliStat_display0_o = resource.clinicalStatus?.coding?.[0]?.display ?? "";
-  const cliStat_code1_o = resource.clinicalStatus?.coding?.[1]?.code ?? "";
-  const cliStat_display1_o = resource.clinicalStatus?.coding?.[1]?.display ?? "";
-  const cliStat_text_o = resource.clinicalStatus?.text ?? "";
-  const cat_code0_o = resource.category?.[0]?.coding?.[0]?.code ?? "";
-  const cat_disp0_o = resource.category?.[0]?.coding?.[0]?.display ?? "";
-  const cat_code1_o = resource.category?.[0]?.coding?.[1]?.code ?? "";
-  const cat_disp1_o = resource.category?.[0]?.coding?.[1]?.display ?? "";
-  const cat_text_o = resource.category?.[0]?.text ?? "";
-  const subjRef_o = resource.subject?.reference ?? "";
-  const encounterRef_o = resource.encounter?.reference ?? "";
-  const onsetPeriod_start_o = resource.onsetPeriod?.start ?? "";
-  const onsetPeriod_end_o = resource.onsetPeriod?.end ?? "";
-  const recorderRef_o = resource.recordedDate ?? "";
+  // set all fields necessary to populate the "res" object below, using resource and firstSibling, using the processMedicationStatement function as reference. Start with the properties that need "resource", then populate the ones that rely on "firstSibling".
+  const cliStat_code0 = resource.clinicalStatus?.coding?.[0]?.code ?? "";
+  const cliStat_disp0 = resource.clinicalStatus?.coding?.[0]?.display ?? "";
+  const cliStat_code1 = resource.clinicalStatus?.coding?.[1]?.code ?? "";
+  const cliStat_disp1 = resource.clinicalStatus?.coding?.[1]?.display ?? "";
+  const cliStat_text = resource.clinicalStatus?.text ?? "";
+  const cat_code0 = resource.category?.[0]?.coding?.[0]?.code ?? "";
+  const cat_disp0 = resource.category?.[0]?.coding?.[0]?.display ?? "";
+  const cat_code1 = resource.category?.[0]?.coding?.[1]?.code ?? "";
+  const cat_disp1 = resource.category?.[0]?.coding?.[1]?.display ?? "";
+  const cat_text = resource.category?.[0]?.text ?? "";
+  const subjRef = resource.subject?.reference ?? "";
+  const encounterRef = resource.encounter?.reference ?? "";
+  const onsetPeriod_start = resource.onsetPeriod?.start ?? "";
+  const onsetPeriod_end = resource.onsetPeriod?.end ?? "";
+  const recorderRef = resource.recordedDate ?? "";
 
-  const cliStat_code0_d = sibling?.clinicalStatus?.coding?.[0]?.code ?? "";
-  const cliStat_display0_d = sibling?.clinicalStatus?.coding?.[0]?.display ?? "";
-  const cliStat_code1_d = sibling?.clinicalStatus?.coding?.[1]?.code ?? "";
-  const cliStat_display1_d = sibling?.clinicalStatus?.coding?.[1]?.display ?? "";
-  const cliStat_text_d = sibling?.clinicalStatus?.text ?? "";
-  const cat_code0_d = sibling?.category?.[0]?.coding?.[0]?.code ?? "";
-  const cat_disp0_d = sibling?.category?.[0]?.coding?.[0]?.display ?? "";
-  const cat_code1_d = sibling?.category?.[0]?.coding?.[1]?.code ?? "";
-  const cat_disp1_d = sibling?.category?.[0]?.coding?.[1]?.display ?? "";
-  const cat_text_d = sibling?.category?.[0]?.text ?? "";
-  const subjRef_d = sibling?.subject?.reference ?? "";
-  const encounterRef_d = sibling?.encounter?.reference ?? "";
-  const onsetPeriod_start_d = sibling?.onsetPeriod?.start ?? "";
-  const onsetPeriod_end_d = sibling?.onsetPeriod?.end ?? "";
-  const recorderRef_d = sibling?.recordedDate ?? "";
+  const cliStat_code0_s = firstSibling?.clinicalStatus?.coding?.[0]?.code ?? "";
+  const cliStat_disp0_s = firstSibling?.clinicalStatus?.coding?.[0]?.display ?? "";
+  const cliStat_code1_s = firstSibling?.clinicalStatus?.coding?.[1]?.code ?? "";
+  const cliStat_disp1_s = firstSibling?.clinicalStatus?.coding?.[1]?.display ?? "";
+  const cliStat_text_s = firstSibling?.clinicalStatus?.text ?? "";
+  const cat_code0_s = firstSibling?.category?.[0]?.coding?.[0]?.code ?? "";
+  const cat_disp0_s = firstSibling?.category?.[0]?.coding?.[0]?.display ?? "";
+  const cat_code1_s = firstSibling?.category?.[0]?.coding?.[1]?.code ?? "";
+  const cat_disp1_s = firstSibling?.category?.[0]?.coding?.[1]?.display ?? "";
+  const cat_text_s = firstSibling?.category?.[0]?.text ?? "";
+  const subjRef_s = firstSibling?.subject?.reference ?? "";
+  const encounterRef_s = firstSibling?.encounter?.reference ?? "";
+  const onsetPeriod_start_s = firstSibling?.onsetPeriod?.start ?? "";
+  const onsetPeriod_end_s = firstSibling?.onsetPeriod?.end ?? "";
+  const recorderRef_s = firstSibling?.recordedDate ?? "";
 
-  const code = getCode(resource, sibling);
+  const code = getCode(resource, firstSibling);
   const bodySite = getBodySite(
     { bodySite: resource.bodySite?.[0] },
-    { bodySite: sibling?.bodySite?.[0] }
+    { bodySite: firstSibling?.bodySite?.[0] }
   );
 
   const res: Record<Columns, string | number | boolean> = {
-    id_o: resource.id ?? "",
+    id: resource.id ?? "",
     date,
-    cliStat_code0_o,
-    cliStat_code0_d,
-    cliStat_display0_o,
-    cliStat_display0_d,
-    cliStat_code1_o,
-    cliStat_code1_d,
-    cliStat_display1_o,
-    cliStat_display1_d,
-    cliStat_text_o,
-    cliStat_text_d,
-    cat_code0_o,
-    cat_code0_d,
-    cat_disp0_o,
-    cat_disp0_d,
-    cat_code1_o,
-    cat_code1_d,
-    cat_disp1_o,
-    cat_disp1_d,
-    cat_text_o,
-    cat_text_d,
-    onsetPeriod_start_o,
-    onsetPeriod_start_d,
-    onsetPeriod_end_o,
-    onsetPeriod_end_d,
+    links,
+    cliStat_code0,
+    cliStat_code0_s,
+    cliStat_disp0,
+    cliStat_disp0_s,
+    cliStat_code1,
+    cliStat_code1_s,
+    cliStat_disp1,
+    cliStat_disp1_s,
+    cliStat_text,
+    cliStat_text_s,
+    cat_code0,
+    cat_code0_s,
+    cat_disp0,
+    cat_disp0_s,
+    cat_code1,
+    cat_code1_s,
+    cat_disp1,
+    cat_disp1_s,
+    cat_text,
+    cat_text_s,
+    onsetPeriod_start,
+    onsetPeriod_start_s,
+    onsetPeriod_end,
+    onsetPeriod_end_s,
     ...code,
     ...bodySite,
-    subjRef_o,
-    subjRef_d,
-    encounterRef_o,
-    encounterRef_d,
-    recorderRef_o,
-    recorderRef_d,
-    id_d: sibling?.id ?? "",
+    subjRef,
+    subjRef_s,
+    encounterRef,
+    encounterRef_s,
+    recorderRef,
+    recorderRef_s,
+    ids_siblings: siblings.map(s => s.id).join(","),
   };
   return Object.values(res).map(safeCsv).join(csvSeparator);
 }

--- a/packages/utils/src/fhir-dedup/medication-administration.ts
+++ b/packages/utils/src/fhir-dedup/medication-administration.ts
@@ -20,45 +20,46 @@ import { isSibling } from "./shared";
 
 // Lots of fields were not mapped, see https://www.hl7.org/fhir/R4/medicationadministration.html if you want to add them
 const columns = [
-  "id_o",
+  "id",
   "date",
-  "status_o",
-  "status_d",
-  "medRef_o",
-  "medRef_d",
-  "subjRef_o",
-  "subjRef_d",
-  "reqRef_o",
-  "reqRef_d",
-  "ctxtRef_o",
-  "ctxtRef_d",
-  "perfActorRef0_o",
-  "perfActorRef0_d",
-  "perfActorRef1_o",
-  "perfActorRef1_d",
+  "links",
+  "status",
+  "status_s",
+  "medRef",
+  "medRef_s",
+  "subjRef",
+  "subjRef_s",
+  "reqRef",
+  "reqRef_s",
+  "ctxtRef",
+  "ctxtRef_s",
+  "perfActorRef0",
+  "perfActorRef0_s",
+  "perfActorRef1",
+  "perfActorRef1_s",
   ...effectiveDateTimeColumns,
   ...effectivePeriodColumns,
-  "dosage_text_o",
-  "dosage_text_d",
-  "dosage_route_code0_o",
-  "dosage_route_code0_d",
-  "dosage_route_disp0_o",
-  "dosage_route_disp0_d",
-  "dosage_route_code1_o",
-  "dosage_route_code1_d",
-  "dosage_route_disp1_o",
-  "dosage_route_disp1_d",
-  "dosage_route_text_o",
-  "dosage_route_text_d",
-  "dosage_dose_value_o",
-  "dosage_dose_value_d",
-  "dosage_dose_unit_o",
-  "dosage_dose_unit_d",
+  "dosage_text",
+  "dosage_text_s",
+  "dosage_route_code0",
+  "dosage_route_code0_s",
+  "dosage_route_disp0",
+  "dosage_route_disp0_s",
+  "dosage_route_code1",
+  "dosage_route_code1_s",
+  "dosage_route_disp1",
+  "dosage_route_disp1_s",
+  "dosage_route_text",
+  "dosage_route_text_s",
+  "dosage_dose_value",
+  "dosage_dose_value_s",
+  "dosage_dose_unit",
+  "dosage_dose_unit_s",
   ...category0Columns,
   ...reasonCodeColumns,
   ...reasonReferenceColumns,
   ...notesColumns,
-  "id_d",
+  "ids_siblings",
 ] as const;
 type Columns = (typeof columns)[number];
 
@@ -103,91 +104,94 @@ function sort(a: MedicationAdministration, b: MedicationAdministration): number 
   return 0;
 }
 
-function toCsv(resource: MedicationAdministration, siblings: MedicationAdministration[]): string {
-  const sibling = siblings.find(isSibling(resource));
+function toCsv(resource: MedicationAdministration, others: MedicationAdministration[]): string {
+  const siblings = others.filter(isSibling(resource));
+  const firstSibling = siblings[0];
   const date = resource.meta?.lastUpdated ? new Date(resource.meta?.lastUpdated).toISOString() : "";
+  const links = siblings.length;
 
-  const status_o = resource.status ?? "";
-  const medRef_o = resource.medicationReference?.reference ?? "";
-  const subjRef_o = resource.subject?.reference ?? "";
-  const reqRef_o = resource.request?.reference ?? "";
-  const perfActorRef0_o = resource.performer?.[0]?.actor?.reference ?? "";
-  const perfActorRef1_o = resource.performer?.[1]?.actor?.reference ?? "";
-  const ctxtRef_o = resource.context?.reference ?? "";
+  const status = resource.status ?? "";
+  const medRef = resource.medicationReference?.reference ?? "";
+  const subjRef = resource.subject?.reference ?? "";
+  const reqRef = resource.request?.reference ?? "";
+  const perfActorRef0 = resource.performer?.[0]?.actor?.reference ?? "";
+  const perfActorRef1 = resource.performer?.[1]?.actor?.reference ?? "";
+  const ctxtRef = resource.context?.reference ?? "";
   const dosage = resource.dosage;
-  const dosage_text_o = dosage?.text ?? "";
-  const dosage_route_code0_o = dosage?.route?.coding?.[0]?.code ?? "";
-  const dosage_route_disp0_o = dosage?.route?.coding?.[0]?.display ?? "";
-  const dosage_route_code1_o = dosage?.route?.coding?.[1]?.code ?? "";
-  const dosage_route_disp1_o = dosage?.route?.coding?.[1]?.display ?? "";
-  const dosage_route_text_o = dosage?.route?.text ?? "";
-  const dosage_dose_value_o = dosage?.dose?.value ?? "";
-  const dosage_dose_unit_o = dosage?.dose?.unit ?? "";
+  const dosage_text = dosage?.text ?? "";
+  const dosage_route_code0 = dosage?.route?.coding?.[0]?.code ?? "";
+  const dosage_route_disp0 = dosage?.route?.coding?.[0]?.display ?? "";
+  const dosage_route_code1 = dosage?.route?.coding?.[1]?.code ?? "";
+  const dosage_route_disp1 = dosage?.route?.coding?.[1]?.display ?? "";
+  const dosage_route_text = dosage?.route?.text ?? "";
+  const dosage_dose_value = dosage?.dose?.value ?? "";
+  const dosage_dose_unit = dosage?.dose?.unit ?? "";
 
-  const status_d = sibling?.status ?? "";
-  const medRef_d = sibling?.medicationReference?.reference ?? "";
-  const subjRef_d = sibling?.subject?.reference ?? "";
-  const reqRef_d = sibling?.request?.reference ?? "";
-  const perfActorRef0_d = sibling?.performer?.[0]?.actor?.reference ?? "";
-  const perfActorRef1_d = sibling?.performer?.[1]?.actor?.reference ?? "";
-  const ctxtRef_d = sibling?.context?.reference ?? "";
-  const dosage_d = sibling?.dosage;
-  const dosage_text_d = dosage_d?.text ?? "";
-  const dosage_route_code0_d = dosage_d?.route?.coding?.[0]?.code ?? "";
-  const dosage_route_disp0_d = dosage_d?.route?.coding?.[0]?.display ?? "";
-  const dosage_route_code1_d = dosage_d?.route?.coding?.[1]?.code ?? "";
-  const dosage_route_disp1_d = dosage_d?.route?.coding?.[1]?.display ?? "";
-  const dosage_route_text_d = dosage_d?.route?.text ?? "";
-  const dosage_dose_value_d = dosage_d?.dose?.value ?? "";
-  const dosage_dose_unit_d = dosage_d?.dose?.unit ?? "";
+  const status_s = firstSibling?.status ?? "";
+  const medRef_s = firstSibling?.medicationReference?.reference ?? "";
+  const subjRef_s = firstSibling?.subject?.reference ?? "";
+  const reqRef_s = firstSibling?.request?.reference ?? "";
+  const perfActorRef0_s = firstSibling?.performer?.[0]?.actor?.reference ?? "";
+  const perfActorRef1_s = firstSibling?.performer?.[1]?.actor?.reference ?? "";
+  const ctxtRef_s = firstSibling?.context?.reference ?? "";
+  const dosage_s = firstSibling?.dosage;
+  const dosage_text_s = dosage_s?.text ?? "";
+  const dosage_route_code0_s = dosage_s?.route?.coding?.[0]?.code ?? "";
+  const dosage_route_disp0_s = dosage_s?.route?.coding?.[0]?.display ?? "";
+  const dosage_route_code1_s = dosage_s?.route?.coding?.[1]?.code ?? "";
+  const dosage_route_disp1_s = dosage_s?.route?.coding?.[1]?.display ?? "";
+  const dosage_route_text_s = dosage_s?.route?.text ?? "";
+  const dosage_dose_value_s = dosage_s?.dose?.value ?? "";
+  const dosage_dose_unit_s = dosage_s?.dose?.unit ?? "";
 
-  const category = getCategory(resource, sibling);
-  const effectiveDateTime = getEffectiveDateTime(resource, sibling);
-  const effectivePeriod = getEffectivePeriod(resource, sibling);
-  const reasonCodes = getReasonCode(resource, sibling);
-  const reasonReferences = getReasonReference(resource, sibling);
-  const notes = getNotes(resource, sibling);
+  const category = getCategory(resource, firstSibling);
+  const effectiveDateTime = getEffectiveDateTime(resource, firstSibling);
+  const effectivePeriod = getEffectivePeriod(resource, firstSibling);
+  const reasonCodes = getReasonCode(resource, firstSibling);
+  const reasonReferences = getReasonReference(resource, firstSibling);
+  const notes = getNotes(resource, firstSibling);
 
   const res: Record<Columns, string | number | boolean> = {
-    id_o: resource.id ?? "",
+    id: resource.id ?? "",
     date,
-    status_o,
-    status_d,
-    medRef_o,
-    medRef_d,
-    subjRef_o,
-    subjRef_d,
-    reqRef_o,
-    reqRef_d,
-    ctxtRef_o,
-    ctxtRef_d,
-    perfActorRef0_o,
-    perfActorRef0_d,
-    perfActorRef1_o,
-    perfActorRef1_d,
+    links,
+    status,
+    status_s,
+    medRef,
+    medRef_s,
+    subjRef,
+    subjRef_s,
+    reqRef,
+    reqRef_s,
+    ctxtRef,
+    ctxtRef_s,
+    perfActorRef0,
+    perfActorRef0_s,
+    perfActorRef1,
+    perfActorRef1_s,
     ...effectiveDateTime,
     ...effectivePeriod,
-    dosage_text_o,
-    dosage_text_d,
-    dosage_route_code0_o,
-    dosage_route_code0_d,
-    dosage_route_disp0_o,
-    dosage_route_disp0_d,
-    dosage_route_code1_o,
-    dosage_route_code1_d,
-    dosage_route_disp1_o,
-    dosage_route_disp1_d,
-    dosage_route_text_o,
-    dosage_route_text_d,
-    dosage_dose_value_o,
-    dosage_dose_value_d,
-    dosage_dose_unit_o,
-    dosage_dose_unit_d,
+    dosage_text,
+    dosage_text_s,
+    dosage_route_code0,
+    dosage_route_code0_s,
+    dosage_route_disp0,
+    dosage_route_disp0_s,
+    dosage_route_code1,
+    dosage_route_code1_s,
+    dosage_route_disp1,
+    dosage_route_disp1_s,
+    dosage_route_text,
+    dosage_route_text_s,
+    dosage_dose_value,
+    dosage_dose_value_s,
+    dosage_dose_unit,
+    dosage_dose_unit_s,
     ...category,
     ...reasonCodes,
     ...reasonReferences,
     ...notes,
-    id_d: sibling?.id ?? "",
+    ids_siblings: siblings.map(s => s.id).join(","),
   };
   return Object.values(res).map(safeCsv).join(csvSeparator);
 }

--- a/packages/utils/src/fhir-dedup/medication-requests.ts
+++ b/packages/utils/src/fhir-dedup/medication-requests.ts
@@ -6,83 +6,84 @@ import { isSibling } from "./shared";
 
 // Lots of fields were not mapped, see https://www.hl7.org/fhir/R4/medicationrequest.html if you want to add them
 const columns = [
-  "id_o",
+  "id",
   "date",
-  "status_o",
-  "status_d",
-  "intent_o",
-  "intent_d",
-  "medRef_o",
-  "medRef_d",
-  "subjRef_o",
-  "subjRef_d",
-  "reqRef_o",
-  "reqRef_d",
-  "perfRef_o",
-  "perfRef_d",
-  "encounterRef_o",
-  "encounterRef_d",
-  "recRef_o",
-  "recRef_d",
-  "authdOn_o",
-  "authdOn_d",
-  "prio_o",
-  "prio_d",
-  "doNotPerf_o",
-  "doNotPerf_d",
-  "cat0_code0_o",
-  "cat0_code0_d",
-  "cat0_disp0_o",
-  "cat0_disp0_d",
-  "cat0_code1_o",
-  "cat0_code1_d",
-  "cat0_disp1_o",
-  "cat0_disp1_d",
-  "cat0_text_o",
-  "cat0_text_d",
-  "cat1_code0_o",
-  "cat1_code0_d",
-  "cat1_disp0_o",
-  "cat1_disp0_d",
-  "cat1_code1_o",
-  "cat1_code1_d",
-  "cat1_disp1_o",
-  "cat1_disp1_d",
-  "cat1_text_o",
-  "cat1_text_d",
-  "reason0_code0_o",
-  "reason0_code0_d",
-  "reason0_disp0_o",
-  "reason0_disp0_d",
-  "reason0_code1_o",
-  "reason0_code1_d",
-  "reason0_disp1_o",
-  "reason0_disp1_d",
-  "reason0_text_o",
-  "reason0_text_d",
-  "reason1_code0_o",
-  "reason1_code0_d",
-  "reason1_disp0_o",
-  "reason1_disp0_d",
-  "reason1_code1_o",
-  "reason1_code1_d",
-  "reason1_disp1_o",
-  "reason1_disp1_d",
-  "reason1_text_o",
-  "reason1_text_d",
-  "reasonRef0_o",
-  "reasonRef0_d",
-  "reasonRef1_o",
-  "reasonRef1_d",
-  "basedOnRef0_o",
-  "basedOnRef0_d",
-  "basedOnRef1_o",
-  "basedOnRef1_d",
-  "note0_txt_o",
-  "note0_txt_d",
-  "note1_txt_o",
-  "note1_txt_d",
-  "id_d",
+  "links",
+  "status",
+  "status_s",
+  "intent",
+  "intent_s",
+  "medRef",
+  "medRef_s",
+  "subjRef",
+  "subjRef_s",
+  "reqRef",
+  "reqRef_s",
+  "perfRef",
+  "perfRef_s",
+  "encounterRef",
+  "encounterRef_s",
+  "recRef",
+  "recRef_s",
+  "authdOn",
+  "authdOn_s",
+  "prio",
+  "prio_s",
+  "doNotPerf",
+  "doNotPerf_s",
+  "cat0_code0",
+  "cat0_code0_s",
+  "cat0_disp0",
+  "cat0_disp0_s",
+  "cat0_code1",
+  "cat0_code1_s",
+  "cat0_disp1",
+  "cat0_disp1_s",
+  "cat0_text",
+  "cat0_text_s",
+  "cat1_code0",
+  "cat1_code0_s",
+  "cat1_disp0",
+  "cat1_disp0_s",
+  "cat1_code1",
+  "cat1_code1_s",
+  "cat1_disp1",
+  "cat1_disp1_s",
+  "cat1_text",
+  "cat1_text_s",
+  "reason0_code0",
+  "reason0_code0_s",
+  "reason0_disp0",
+  "reason0_disp0_s",
+  "reason0_code1",
+  "reason0_code1_s",
+  "reason0_disp1",
+  "reason0_disp1_s",
+  "reason0_text",
+  "reason0_text_s",
+  "reason1_code0",
+  "reason1_code0_s",
+  "reason1_disp0",
+  "reason1_disp0_s",
+  "reason1_code1",
+  "reason1_code1_s",
+  "reason1_disp1",
+  "reason1_disp1_s",
+  "reason1_text",
+  "reason1_text_s",
+  "reasonRef0",
+  "reasonRef0_s",
+  "reasonRef1",
+  "reasonRef1_s",
+  "basedOnRef0",
+  "basedOnRef0_s",
+  "basedOnRef1",
+  "basedOnRef1_s",
+  "note0_txt",
+  "note0_txt_s",
+  "note1_txt",
+  "note1_txt_s",
+  "ids_siblings",
 ] as const;
 type Columns = (typeof columns)[number];
 
@@ -127,168 +128,171 @@ function sort(a: MedicationRequest, b: MedicationRequest): number {
   return 0;
 }
 
-function toCsv(resource: MedicationRequest, siblings: MedicationRequest[]): string {
-  const sibling = siblings.find(isSibling(resource));
+function toCsv(resource: MedicationRequest, others: MedicationRequest[]): string {
+  const siblings = others.filter(isSibling(resource));
+  const firstSibling = siblings[0];
   const date = resource.meta?.lastUpdated ? new Date(resource.meta?.lastUpdated).toISOString() : "";
+  const links = siblings.length;
 
-  const status_o = resource.status ?? "";
-  const intent_o = resource.intent ?? "";
-  const medRef_o = resource.medicationReference?.reference ?? "";
-  const subjRef_o = resource.subject?.reference ?? "";
-  const reqRef_o = resource.requester?.reference ?? "";
-  const perfRef_o = resource.performer?.reference ?? "";
-  const encounterRef_o = resource.encounter?.reference ?? "";
-  const recRef_o = resource.recorder?.reference ?? "";
-  const authdOn_o = resource.authoredOn ?? "";
-  const prio_o = resource.priority ?? "";
-  const doNotPerf_o = resource.doNotPerform ?? "";
+  const status = resource.status ?? "";
+  const intent = resource.intent ?? "";
+  const medRef = resource.medicationReference?.reference ?? "";
+  const subjRef = resource.subject?.reference ?? "";
+  const reqRef = resource.requester?.reference ?? "";
+  const perfRef = resource.performer?.reference ?? "";
+  const encounterRef = resource.encounter?.reference ?? "";
+  const recRef = resource.recorder?.reference ?? "";
+  const authdOn = resource.authoredOn ?? "";
+  const prio = resource.priority ?? "";
+  const doNotPerf = resource.doNotPerform ?? "";
   const cat0 = resource.category?.[0];
-  const cat0_code0_o = cat0?.coding?.[0]?.code ?? "";
-  const cat0_disp0_o = cat0?.coding?.[0]?.display ?? "";
-  const cat0_code1_o = cat0?.coding?.[1]?.code ?? "";
-  const cat0_disp1_o = cat0?.coding?.[1]?.display ?? "";
-  const cat0_text_o = cat0?.text ?? "";
+  const cat0_code0 = cat0?.coding?.[0]?.code ?? "";
+  const cat0_disp0 = cat0?.coding?.[0]?.display ?? "";
+  const cat0_code1 = cat0?.coding?.[1]?.code ?? "";
+  const cat0_disp1 = cat0?.coding?.[1]?.display ?? "";
+  const cat0_text = cat0?.text ?? "";
   const cat1 = resource.category?.[0];
-  const cat1_code0_o = cat1?.coding?.[0]?.code ?? "";
-  const cat1_disp0_o = cat1?.coding?.[0]?.display ?? "";
-  const cat1_code1_o = cat1?.coding?.[1]?.code ?? "";
-  const cat1_disp1_o = cat1?.coding?.[1]?.display ?? "";
-  const cat1_text_o = cat1?.text ?? "";
+  const cat1_code0 = cat1?.coding?.[0]?.code ?? "";
+  const cat1_disp0 = cat1?.coding?.[0]?.display ?? "";
+  const cat1_code1 = cat1?.coding?.[1]?.code ?? "";
+  const cat1_disp1 = cat1?.coding?.[1]?.display ?? "";
+  const cat1_text = cat1?.text ?? "";
   const reason0 = resource.reasonCode?.[0];
-  const reason0_code0_o = reason0?.coding?.[0]?.code ?? "";
-  const reason0_disp0_o = reason0?.coding?.[0]?.display ?? "";
-  const reason0_code1_o = reason0?.coding?.[1]?.code ?? "";
-  const reason0_disp1_o = reason0?.coding?.[1]?.display ?? "";
-  const reason0_text_o = reason0?.text ?? "";
+  const reason0_code0 = reason0?.coding?.[0]?.code ?? "";
+  const reason0_disp0 = reason0?.coding?.[0]?.display ?? "";
+  const reason0_code1 = reason0?.coding?.[1]?.code ?? "";
+  const reason0_disp1 = reason0?.coding?.[1]?.display ?? "";
+  const reason0_text = reason0?.text ?? "";
   const reason1 = resource.reasonCode?.[1];
-  const reason1_code0_o = reason1?.coding?.[0]?.code ?? "";
-  const reason1_disp0_o = reason1?.coding?.[0]?.display ?? "";
-  const reason1_code1_o = reason1?.coding?.[1]?.code ?? "";
-  const reason1_disp1_o = reason1?.coding?.[1]?.display ?? "";
-  const reason1_text_o = reason1?.text ?? "";
-  const reasonRef0_o = resource.reasonReference?.[0]?.reference ?? "";
-  const reasonRef1_o = resource.reasonReference?.[1]?.reference ?? "";
-  const basedOnRef0_o = resource.basedOn?.[0]?.reference ?? "";
-  const basedOnRef1_o = resource.basedOn?.[1]?.reference ?? "";
-  const note0_txt_o = resource.note?.[0]?.text ?? "";
-  const note1_txt_o = resource.note?.[1]?.text ?? "";
+  const reason1_code0 = reason1?.coding?.[0]?.code ?? "";
+  const reason1_disp0 = reason1?.coding?.[0]?.display ?? "";
+  const reason1_code1 = reason1?.coding?.[1]?.code ?? "";
+  const reason1_disp1 = reason1?.coding?.[1]?.display ?? "";
+  const reason1_text = reason1?.text ?? "";
+  const reasonRef0 = resource.reasonReference?.[0]?.reference ?? "";
+  const reasonRef1 = resource.reasonReference?.[1]?.reference ?? "";
+  const basedOnRef0 = resource.basedOn?.[0]?.reference ?? "";
+  const basedOnRef1 = resource.basedOn?.[1]?.reference ?? "";
+  const note0_txt = resource.note?.[0]?.text ?? "";
+  const note1_txt = resource.note?.[1]?.text ?? "";
 
-  const status_d = sibling?.status ?? "";
-  const intent_d = sibling?.intent ?? "";
-  const medRef_d = sibling?.medicationReference?.reference ?? "";
-  const subjRef_d = sibling?.subject?.reference ?? "";
-  const reqRef_d = sibling?.requester?.reference ?? "";
-  const perfRef_d = sibling?.performer?.reference ?? "";
-  const encounterRef_d = sibling?.encounter?.reference ?? "";
-  const recRef_d = sibling?.recorder?.reference ?? "";
-  const authdOn_d = sibling?.authoredOn ?? "";
-  const prio_d = sibling?.priority ?? "";
-  const doNotPerf_d = sibling?.doNotPerform ?? "";
-  const cat0_code0_d = sibling?.category?.[0]?.coding?.[0]?.code ?? "";
-  const cat0_disp0_d = sibling?.category?.[0]?.coding?.[0]?.display ?? "";
-  const cat0_code1_d = sibling?.category?.[0]?.coding?.[1]?.code ?? "";
-  const cat0_disp1_d = sibling?.category?.[0]?.coding?.[1]?.display ?? "";
-  const cat0_text_d = sibling?.category?.[0]?.text ?? "";
-  const cat1_code0_d = sibling?.category?.[1]?.coding?.[0]?.code ?? "";
-  const cat1_disp0_d = sibling?.category?.[1]?.coding?.[0]?.display ?? "";
-  const cat1_code1_d = sibling?.category?.[1]?.coding?.[1]?.code ?? "";
-  const cat1_disp1_d = sibling?.category?.[1]?.coding?.[1]?.display ?? "";
-  const cat1_text_d = sibling?.category?.[1]?.text ?? "";
-  const reason0_code0_d = sibling?.reasonCode?.[0]?.coding?.[0]?.code ?? "";
-  const reason0_disp0_d = sibling?.reasonCode?.[0]?.coding?.[0]?.display ?? "";
-  const reason0_code1_d = sibling?.reasonCode?.[0]?.coding?.[1]?.code ?? "";
-  const reason0_disp1_d = sibling?.reasonCode?.[0]?.coding?.[1]?.display ?? "";
-  const reason0_text_d = sibling?.reasonCode?.[0]?.text ?? "";
-  const reason1_code0_d = sibling?.reasonCode?.[1]?.coding?.[0]?.code ?? "";
-  const reason1_disp0_d = sibling?.reasonCode?.[1]?.coding?.[0]?.display ?? "";
-  const reason1_code1_d = sibling?.reasonCode?.[1]?.coding?.[1]?.code ?? "";
-  const reason1_disp1_d = sibling?.reasonCode?.[1]?.coding?.[1]?.display ?? "";
-  const reason1_text_d = sibling?.reasonCode?.[1]?.text ?? "";
-  const reasonRef0_d = sibling?.reasonReference?.[0]?.reference ?? "";
-  const reasonRef1_d = sibling?.reasonReference?.[1]?.reference ?? "";
-  const basedOnRef0_d = sibling?.basedOn?.[0]?.reference ?? "";
-  const basedOnRef1_d = sibling?.basedOn?.[1]?.reference ?? "";
-  const note0_txt_d = sibling?.note?.[0]?.text ?? "";
-  const note1_txt_d = sibling?.note?.[1]?.text ?? "";
+  const status_s = firstSibling?.status ?? "";
+  const intent_s = firstSibling?.intent ?? "";
+  const medRef_s = firstSibling?.medicationReference?.reference ?? "";
+  const subjRef_s = firstSibling?.subject?.reference ?? "";
+  const reqRef_s = firstSibling?.requester?.reference ?? "";
+  const perfRef_s = firstSibling?.performer?.reference ?? "";
+  const encounterRef_s = firstSibling?.encounter?.reference ?? "";
+  const recRef_s = firstSibling?.recorder?.reference ?? "";
+  const authdOn_s = firstSibling?.authoredOn ?? "";
+  const prio_s = firstSibling?.priority ?? "";
+  const doNotPerf_s = firstSibling?.doNotPerform ?? "";
+  const cat0_code0_s = firstSibling?.category?.[0]?.coding?.[0]?.code ?? "";
+  const cat0_disp0_s = firstSibling?.category?.[0]?.coding?.[0]?.display ?? "";
+  const cat0_code1_s = firstSibling?.category?.[0]?.coding?.[1]?.code ?? "";
+  const cat0_disp1_s = firstSibling?.category?.[0]?.coding?.[1]?.display ?? "";
+  const cat0_text_s = firstSibling?.category?.[0]?.text ?? "";
+  const cat1_code0_s = firstSibling?.category?.[1]?.coding?.[0]?.code ?? "";
+  const cat1_disp0_s = firstSibling?.category?.[1]?.coding?.[0]?.display ?? "";
+  const cat1_code1_s = firstSibling?.category?.[1]?.coding?.[1]?.code ?? "";
+  const cat1_disp1_s = firstSibling?.category?.[1]?.coding?.[1]?.display ?? "";
+  const cat1_text_s = firstSibling?.category?.[1]?.text ?? "";
+  const reason0_code0_s = firstSibling?.reasonCode?.[0]?.coding?.[0]?.code ?? "";
+  const reason0_disp0_s = firstSibling?.reasonCode?.[0]?.coding?.[0]?.display ?? "";
+  const reason0_code1_s = firstSibling?.reasonCode?.[0]?.coding?.[1]?.code ?? "";
+  const reason0_disp1_s = firstSibling?.reasonCode?.[0]?.coding?.[1]?.display ?? "";
+  const reason0_text_s = firstSibling?.reasonCode?.[0]?.text ?? "";
+  const reason1_code0_s = firstSibling?.reasonCode?.[1]?.coding?.[0]?.code ?? "";
+  const reason1_disp0_s = firstSibling?.reasonCode?.[1]?.coding?.[0]?.display ?? "";
+  const reason1_code1_s = firstSibling?.reasonCode?.[1]?.coding?.[1]?.code ?? "";
+  const reason1_disp1_s = firstSibling?.reasonCode?.[1]?.coding?.[1]?.display ?? "";
+  const reason1_text_s = firstSibling?.reasonCode?.[1]?.text ?? "";
+  const reasonRef0_s = firstSibling?.reasonReference?.[0]?.reference ?? "";
+  const reasonRef1_s = firstSibling?.reasonReference?.[1]?.reference ?? "";
+  const basedOnRef0_s = firstSibling?.basedOn?.[0]?.reference ?? "";
+  const basedOnRef1_s = firstSibling?.basedOn?.[1]?.reference ?? "";
+  const note0_txt_s = firstSibling?.note?.[0]?.text ?? "";
+  const note1_txt_s = firstSibling?.note?.[1]?.text ?? "";
 
   const res: Record<Columns, string | number | boolean> = {
-    id_o: resource.id ?? "",
+    id: resource.id ?? "",
     date,
-    status_o,
-    status_d,
-    intent_o,
-    intent_d,
-    medRef_o,
-    medRef_d,
-    subjRef_o,
-    subjRef_d,
-    reqRef_o,
-    reqRef_d,
-    perfRef_o,
-    perfRef_d,
-    encounterRef_o,
-    encounterRef_d,
-    recRef_o,
-    recRef_d,
-    authdOn_o,
-    authdOn_d,
-    prio_o,
-    prio_d,
-    doNotPerf_o,
-    doNotPerf_d,
-    cat0_code0_o,
-    cat0_code0_d,
-    cat1_code0_o,
-    cat1_code0_d,
-    cat0_disp0_o,
-    cat0_disp0_d,
-    cat1_disp0_o,
-    cat1_disp0_d,
-    cat0_code1_o,
-    cat0_code1_d,
-    cat1_code1_o,
-    cat1_code1_d,
-    cat0_disp1_o,
-    cat0_disp1_d,
-    cat1_disp1_o,
-    cat1_disp1_d,
-    cat0_text_o,
-    cat0_text_d,
-    cat1_text_o,
-    cat1_text_d,
-    reason0_code0_o,
-    reason0_code0_d,
-    reason1_code0_o,
-    reason1_code0_d,
-    reason0_disp0_o,
-    reason0_disp0_d,
-    reason1_disp0_o,
-    reason1_disp0_d,
-    reason0_code1_o,
-    reason0_code1_d,
-    reason1_code1_o,
-    reason1_code1_d,
-    reason0_disp1_o,
-    reason0_disp1_d,
-    reason1_disp1_o,
-    reason1_disp1_d,
-    reason0_text_o,
-    reason0_text_d,
-    reason1_text_o,
-    reason1_text_d,
-    reasonRef0_o,
-    reasonRef0_d,
-    reasonRef1_o,
-    reasonRef1_d,
-    basedOnRef0_o,
-    basedOnRef0_d,
-    basedOnRef1_o,
-    basedOnRef1_d,
-    note0_txt_o,
-    note0_txt_d,
-    note1_txt_o,
-    note1_txt_d,
-    id_d: sibling?.id ?? "",
+    links,
+    status,
+    status_s,
+    intent,
+    intent_s,
+    medRef,
+    medRef_s,
+    subjRef,
+    subjRef_s,
+    reqRef,
+    reqRef_s,
+    perfRef,
+    perfRef_s,
+    encounterRef,
+    encounterRef_s,
+    recRef,
+    recRef_s,
+    authdOn,
+    authdOn_s,
+    prio,
+    prio_s,
+    doNotPerf,
+    doNotPerf_s,
+    cat0_code0,
+    cat0_code0_s,
+    cat1_code0,
+    cat1_code0_s,
+    cat0_disp0,
+    cat0_disp0_s,
+    cat1_disp0,
+    cat1_disp0_s,
+    cat0_code1,
+    cat0_code1_s,
+    cat1_code1,
+    cat1_code1_s,
+    cat0_disp1,
+    cat0_disp1_s,
+    cat1_disp1,
+    cat1_disp1_s,
+    cat0_text,
+    cat0_text_s,
+    cat1_text,
+    cat1_text_s,
+    reason0_code0,
+    reason0_code0_s,
+    reason1_code0,
+    reason1_code0_s,
+    reason0_disp0,
+    reason0_disp0_s,
+    reason1_disp0,
+    reason1_disp0_s,
+    reason0_code1,
+    reason0_code1_s,
+    reason1_code1,
+    reason1_code1_s,
+    reason0_disp1,
+    reason0_disp1_s,
+    reason1_disp1,
+    reason1_disp1_s,
+    reason0_text,
+    reason0_text_s,
+    reason1_text,
+    reason1_text_s,
+    reasonRef0,
+    reasonRef0_s,
+    reasonRef1,
+    reasonRef1_s,
+    basedOnRef0,
+    basedOnRef0_s,
+    basedOnRef1,
+    basedOnRef1_s,
+    note0_txt,
+    note0_txt_s,
+    note1_txt,
+    note1_txt_s,
+    ids_siblings: siblings.map(s => s.id).join(","),
   };
   return Object.values(res).map(safeCsv).join(csvSeparator);
 }

--- a/packages/utils/src/fhir-dedup/medication-statement.ts
+++ b/packages/utils/src/fhir-dedup/medication-statement.ts
@@ -4,93 +4,65 @@ import { Dictionary } from "lodash";
 import { csvSeparator, safeCsv } from "./csv";
 import { isSibling } from "./shared";
 
-// TODO add these when we're ready to compare/analyze them
-// dosage0_doseRate0_doseRange_low_value_o,
-// dosage0_doseRate0_doseRange_low_unit_o,
-// dosage0_doseRate0_doseRange_high_value_o,
-// dosage0_doseRate0_doseRange_high_unit_o,
-// dosage0_doseRate0_rateRatio_num_val_o,
-// dosage0_doseRate0_rateRatio_num_un_o,
-// dosage0_doseRate0_rateRatio_den_val_o,
-// dosage0_doseRate0_rateRatio_den_un_o,
-// dosage0_doseRate0_rateRange_low_val_o,
-// dosage0_doseRate0_rateRange_low_un_o,
-// dosage0_doseRate0_rateRange_high_val_o,
-// dosage0_doseRate0_rateRange_high_un_o,
-// dosage0_doseRate0_rateQtty_val_o,
-// dosage0_doseRate0_rateQtty_un_o,
-// dosage0_maxPeriod_num_val_o,
-// dosage0_maxPeriod_num_un_o,
-// dosage0_maxPeriod_den_val_o,
-// dosage0_maxPeriod_den_un_o,
-// dosage0_maxAdmin_val_o,
-// dosage0_maxAdmin_un_o,
-// dosage0_maxLife_val_o,
-// dosage0_maxLife_un_o,
-// reason_code0_o,
-// reason_display0_o,
-// reason_code1_o,
-// reason_display1_o,
-// reason_text_o,
-
 const columns = [
-  "id_o",
+  "id",
   "date",
-  "status_o",
-  "status_d",
-  "medRef_o",
-  "medRef_d",
-  "subjRef_o",
-  "subjRef_d",
-  "eDateTime_o",
-  "eDateTime_d",
-  "ePeriod_start_o",
-  "ePeriod_start_d",
-  "ePeriod_end_o",
-  "ePeriod_end_d",
-  "dateAsserted_o",
-  "dateAsserted_d",
-  "dosage0_text_o",
-  "dosage0_text_d",
-  "dosage0_route_code0_o",
-  "dosage0_route_code0_d",
-  "dosage0_route_disp0_o",
-  "dosage0_route_disp0_d",
-  "dosage0_route_code1_o",
-  "dosage0_route_code1_d",
-  "dosage0_route_disp1_o",
-  "dosage0_route_disp1_d",
-  "dosage0_route_text_o",
-  "dosage0_route_text_d",
-  "dosage0_doseRate0_doseQtty_value_o",
-  "dosage0_doseRate0_doseQtty_value_d",
-  "dosage0_doseRate0_doseQtty_unit_o",
-  "dosage0_doseRate0_doseQtty_unit_d",
-  "dosage0_doseRate1_doseQtty_value_o",
-  "dosage0_doseRate1_doseQtty_value_d",
-  "dosage0_doseRate1_doseQtty_unit_o",
-  "dosage0_doseRate1_doseQtty_unit_d",
-  "dosage1_text_o",
-  "dosage1_text_d",
-  "dosage1_route_code0_o",
-  "dosage1_route_code0_d",
-  "dosage1_route_disp0_o",
-  "dosage1_route_disp0_d",
-  "dosage1_route_code1_o",
-  "dosage1_route_code1_d",
-  "dosage1_route_disp1_o",
-  "dosage1_route_disp1_d",
-  "dosage1_route_text_o",
-  "dosage1_route_text_d",
-  "dosage1_doseRate0_doseQtty_value_o",
-  "dosage1_doseRate0_doseQtty_value_d",
-  "dosage1_doseRate0_doseQtty_unit_o",
-  "dosage1_doseRate0_doseQtty_unit_d",
-  "dosage1_doseRate1_doseQtty_value_o",
-  "dosage1_doseRate1_doseQtty_value_d",
-  "dosage1_doseRate1_doseQtty_unit_o",
-  "dosage1_doseRate1_doseQtty_unit_d",
-  "id_d",
+  "links",
+  "status",
+  "status_s",
+  "medRef",
+  "medRef_s",
+  "subjRef",
+  "subjRef_s",
+  "eDateTime",
+  "eDateTime_s",
+  "ePeriod_dtart",
+  "ePeriod_dtart_s",
+  "ePeriod_end",
+  "ePeriod_end_s",
+  "dateAsserted",
+  "dateAsserted_s",
+  "dosage0_text",
+  "dosage0_text_s",
+  "dosage0_route_code0",
+  "dosage0_route_code0_s",
+  "dosage0_route_disp0",
+  "dosage0_route_disp0_s",
+  "dosage0_route_code1",
+  "dosage0_route_code1_s",
+  "dosage0_route_disp1",
+  "dosage0_route_disp1_s",
+  "dosage0_route_text",
+  "dosage0_route_text_s",
+  "dosage0_doseRate0_doseQtty_value",
+  "dosage0_doseRate0_doseQtty_value_s",
+  "dosage0_doseRate0_doseQtty_unit",
+  "dosage0_doseRate0_doseQtty_unit_s",
+  "dosage0_doseRate1_doseQtty_value",
+  "dosage0_doseRate1_doseQtty_value_s",
+  "dosage0_doseRate1_doseQtty_unit",
+  "dosage0_doseRate1_doseQtty_unit_s",
+  "dosage1_text",
+  "dosage1_text_s",
+  "dosage1_route_code0",
+  "dosage1_route_code0_s",
+  "dosage1_route_disp0",
+  "dosage1_route_disp0_s",
+  "dosage1_route_code1",
+  "dosage1_route_code1_s",
+  "dosage1_route_disp1",
+  "dosage1_route_disp1_s",
+  "dosage1_route_text",
+  "dosage1_route_text_s",
+  "dosage1_doseRate0_doseQtty_value",
+  "dosage1_doseRate0_doseQtty_value_s",
+  "dosage1_doseRate0_doseQtty_unit",
+  "dosage1_doseRate0_doseQtty_unit_s",
+  "dosage1_doseRate1_doseQtty_value",
+  "dosage1_doseRate1_doseQtty_value_s",
+  "dosage1_doseRate1_doseQtty_unit",
+  "dosage1_doseRate1_doseQtty_unit_s",
+  "ids_siblings",
 ] as const;
 type Columns = (typeof columns)[number];
 
@@ -135,127 +107,131 @@ function sort(a: MedicationStatement, b: MedicationStatement): number {
   return 0;
 }
 
-function toCsv(resource: MedicationStatement, siblings: MedicationStatement[]): string {
-  const sibling = siblings.find(isSibling(resource));
+function toCsv(resource: MedicationStatement, others: MedicationStatement[]): string {
+  const siblings = others.filter(isSibling(resource));
+  const firstSibling = siblings[0];
   const date = resource.meta?.lastUpdated ? new Date(resource.meta?.lastUpdated).toISOString() : "";
-  const status_o = resource.status ?? "";
-  const medRef_o = resource.medicationReference?.reference ?? "";
-  const subjRef_o = resource.subject?.reference ?? "";
-  const eDateTime_o = resource.effectiveDateTime ?? "";
-  const ePeriod_start_o = resource.effectivePeriod?.start ?? "";
-  const ePeriod_end_o = resource.effectivePeriod?.end ?? "";
-  const dateAsserted_o = resource.dateAsserted ?? "";
-  const dosage0 = resource.dosage?.[0];
-  const dosage0_text_o = dosage0?.text ?? "";
-  const dosage0_route_code0_o = dosage0?.route?.coding?.[0]?.code ?? "";
-  const dosage0_route_disp0_o = dosage0?.route?.coding?.[0]?.display ?? "";
-  const dosage0_route_code1_o = dosage0?.route?.coding?.[1]?.code ?? "";
-  const dosage0_route_disp1_o = dosage0?.route?.coding?.[1]?.display ?? "";
-  const dosage0_route_text_o = dosage0?.route?.text ?? "";
-  const dosage0_doseRate0_doseQtty_value_o = dosage0?.doseAndRate?.[0]?.doseQuantity?.value ?? "";
-  const dosage0_doseRate0_doseQtty_unit_o = dosage0?.doseAndRate?.[0]?.doseQuantity?.unit ?? "";
-  const dosage0_doseRate1_doseQtty_value_o = dosage0?.doseAndRate?.[1]?.doseQuantity?.value ?? "";
-  const dosage0_doseRate1_doseQtty_unit_o = dosage0?.doseAndRate?.[1]?.doseQuantity?.unit ?? "";
-  const dosage1 = resource.dosage?.[1];
-  const dosage1_text_o = dosage1?.text ?? "";
-  const dosage1_route_code0_o = dosage1?.route?.coding?.[0]?.code ?? "";
-  const dosage1_route_disp0_o = dosage1?.route?.coding?.[0]?.display ?? "";
-  const dosage1_route_code1_o = dosage1?.route?.coding?.[1]?.code ?? "";
-  const dosage1_route_disp1_o = dosage1?.route?.coding?.[1]?.display ?? "";
-  const dosage1_route_text_o = dosage1?.route?.text ?? "";
-  const dosage1_doseRate0_doseQtty_value_o = dosage1?.doseAndRate?.[0]?.doseQuantity?.value ?? "";
-  const dosage1_doseRate0_doseQtty_unit_o = dosage1?.doseAndRate?.[0]?.doseQuantity?.unit ?? "";
-  const dosage1_doseRate1_doseQtty_value_o = dosage1?.doseAndRate?.[1]?.doseQuantity?.value ?? "";
-  const dosage1_doseRate1_doseQtty_unit_o = dosage1?.doseAndRate?.[1]?.doseQuantity?.unit ?? "";
+  const links = siblings.length;
 
-  const status_d = sibling?.status ?? "";
-  const medRef_d = sibling?.medicationReference?.reference ?? "";
-  const subjRef_d = sibling?.subject?.reference ?? "";
-  const eDateTime_d = sibling?.effectiveDateTime ?? "";
-  const ePeriod_start_d = sibling?.effectivePeriod?.start ?? "";
-  const ePeriod_end_d = sibling?.effectivePeriod?.end ?? "";
-  const dateAsserted_d = sibling?.dateAsserted ?? "";
-  const dosage0_d = sibling?.dosage?.[0];
-  const dosage0_text_d = dosage0_d?.text ?? "";
-  const dosage0_route_code0_d = dosage0_d?.route?.coding?.[0]?.code ?? "";
-  const dosage0_route_disp0_d = dosage0_d?.route?.coding?.[0]?.display ?? "";
-  const dosage0_route_code1_d = dosage0_d?.route?.coding?.[1]?.code ?? "";
-  const dosage0_route_disp1_d = dosage0_d?.route?.coding?.[1]?.display ?? "";
-  const dosage0_route_text_d = dosage0_d?.route?.text ?? "";
-  const dosage0_doseRate0_doseQtty_value_d = dosage0_d?.doseAndRate?.[0]?.doseQuantity?.value ?? "";
-  const dosage0_doseRate0_doseQtty_unit_d = dosage0_d?.doseAndRate?.[0]?.doseQuantity?.unit ?? "";
-  const dosage0_doseRate1_doseQtty_value_d = dosage0_d?.doseAndRate?.[1]?.doseQuantity?.value ?? "";
-  const dosage0_doseRate1_doseQtty_unit_d = dosage0_d?.doseAndRate?.[1]?.doseQuantity?.unit ?? "";
-  const dosage1_d = sibling?.dosage?.[1];
-  const dosage1_text_d = dosage1_d?.text ?? "";
-  const dosage1_route_code0_d = dosage1_d?.route?.coding?.[0]?.code ?? "";
-  const dosage1_route_disp0_d = dosage1_d?.route?.coding?.[0]?.display ?? "";
-  const dosage1_route_code1_d = dosage1_d?.route?.coding?.[1]?.code ?? "";
-  const dosage1_route_disp1_d = dosage1_d?.route?.coding?.[1]?.display ?? "";
-  const dosage1_route_text_d = dosage1_d?.route?.text ?? "";
-  const dosage1_doseRate0_doseQtty_value_d = dosage1_d?.doseAndRate?.[0]?.doseQuantity?.value ?? "";
-  const dosage1_doseRate0_doseQtty_unit_d = dosage1_d?.doseAndRate?.[0]?.doseQuantity?.unit ?? "";
-  const dosage1_doseRate1_doseQtty_value_d = dosage1_d?.doseAndRate?.[1]?.doseQuantity?.value ?? "";
-  const dosage1_doseRate1_doseQtty_unit_d = dosage1_d?.doseAndRate?.[1]?.doseQuantity?.unit ?? "";
+  const status = resource.status ?? "";
+  const medRef = resource.medicationReference?.reference ?? "";
+  const subjRef = resource.subject?.reference ?? "";
+  const eDateTime = resource.effectiveDateTime ?? "";
+  const ePeriod_dtart = resource.effectivePeriod?.start ?? "";
+  const ePeriod_end = resource.effectivePeriod?.end ?? "";
+  const dateAsserted = resource.dateAsserted ?? "";
+  const dosage0 = resource.dosage?.[0];
+  const dosage0_text = dosage0?.text ?? "";
+  const dosage0_route_code0 = dosage0?.route?.coding?.[0]?.code ?? "";
+  const dosage0_route_disp0 = dosage0?.route?.coding?.[0]?.display ?? "";
+  const dosage0_route_code1 = dosage0?.route?.coding?.[1]?.code ?? "";
+  const dosage0_route_disp1 = dosage0?.route?.coding?.[1]?.display ?? "";
+  const dosage0_route_text = dosage0?.route?.text ?? "";
+  const dosage0_doseRate0_doseQtty_value = dosage0?.doseAndRate?.[0]?.doseQuantity?.value ?? "";
+  const dosage0_doseRate0_doseQtty_unit = dosage0?.doseAndRate?.[0]?.doseQuantity?.unit ?? "";
+  const dosage0_doseRate1_doseQtty_value = dosage0?.doseAndRate?.[1]?.doseQuantity?.value ?? "";
+  const dosage0_doseRate1_doseQtty_unit = dosage0?.doseAndRate?.[1]?.doseQuantity?.unit ?? "";
+  const dosage1 = resource.dosage?.[1];
+  const dosage1_text = dosage1?.text ?? "";
+  const dosage1_route_code0 = dosage1?.route?.coding?.[0]?.code ?? "";
+  const dosage1_route_disp0 = dosage1?.route?.coding?.[0]?.display ?? "";
+  const dosage1_route_code1 = dosage1?.route?.coding?.[1]?.code ?? "";
+  const dosage1_route_disp1 = dosage1?.route?.coding?.[1]?.display ?? "";
+  const dosage1_route_text = dosage1?.route?.text ?? "";
+  const dosage1_doseRate0_doseQtty_value = dosage1?.doseAndRate?.[0]?.doseQuantity?.value ?? "";
+  const dosage1_doseRate0_doseQtty_unit = dosage1?.doseAndRate?.[0]?.doseQuantity?.unit ?? "";
+  const dosage1_doseRate1_doseQtty_value = dosage1?.doseAndRate?.[1]?.doseQuantity?.value ?? "";
+  const dosage1_doseRate1_doseQtty_unit = dosage1?.doseAndRate?.[1]?.doseQuantity?.unit ?? "";
+
+  const status_s = firstSibling?.status ?? "";
+  const medRef_s = firstSibling?.medicationReference?.reference ?? "";
+  const subjRef_s = firstSibling?.subject?.reference ?? "";
+  const eDateTime_s = firstSibling?.effectiveDateTime ?? "";
+  const ePeriod_dtart_s = firstSibling?.effectivePeriod?.start ?? "";
+  const ePeriod_end_s = firstSibling?.effectivePeriod?.end ?? "";
+  const dateAsserted_s = firstSibling?.dateAsserted ?? "";
+  const dosage0_s = firstSibling?.dosage?.[0];
+  const dosage0_text_s = dosage0_s?.text ?? "";
+  const dosage0_route_code0_s = dosage0_s?.route?.coding?.[0]?.code ?? "";
+  const dosage0_route_disp0_s = dosage0_s?.route?.coding?.[0]?.display ?? "";
+  const dosage0_route_code1_s = dosage0_s?.route?.coding?.[1]?.code ?? "";
+  const dosage0_route_disp1_s = dosage0_s?.route?.coding?.[1]?.display ?? "";
+  const dosage0_route_text_s = dosage0_s?.route?.text ?? "";
+  const dosage0_doseRate0_doseQtty_value_s = dosage0_s?.doseAndRate?.[0]?.doseQuantity?.value ?? "";
+  const dosage0_doseRate0_doseQtty_unit_s = dosage0_s?.doseAndRate?.[0]?.doseQuantity?.unit ?? "";
+  const dosage0_doseRate1_doseQtty_value_s = dosage0_s?.doseAndRate?.[1]?.doseQuantity?.value ?? "";
+  const dosage0_doseRate1_doseQtty_unit_s = dosage0_s?.doseAndRate?.[1]?.doseQuantity?.unit ?? "";
+  const dosage1_s = firstSibling?.dosage?.[1];
+  const dosage1_text_s = dosage1_s?.text ?? "";
+  const dosage1_route_code0_s = dosage1_s?.route?.coding?.[0]?.code ?? "";
+  const dosage1_route_disp0_s = dosage1_s?.route?.coding?.[0]?.display ?? "";
+  const dosage1_route_code1_s = dosage1_s?.route?.coding?.[1]?.code ?? "";
+  const dosage1_route_disp1_s = dosage1_s?.route?.coding?.[1]?.display ?? "";
+  const dosage1_route_text_s = dosage1_s?.route?.text ?? "";
+  const dosage1_doseRate0_doseQtty_value_s = dosage1_s?.doseAndRate?.[0]?.doseQuantity?.value ?? "";
+  const dosage1_doseRate0_doseQtty_unit_s = dosage1_s?.doseAndRate?.[0]?.doseQuantity?.unit ?? "";
+  const dosage1_doseRate1_doseQtty_value_s = dosage1_s?.doseAndRate?.[1]?.doseQuantity?.value ?? "";
+  const dosage1_doseRate1_doseQtty_unit_s = dosage1_s?.doseAndRate?.[1]?.doseQuantity?.unit ?? "";
 
   const res: Record<Columns, string | number> = {
-    id_o: resource.id ?? "",
+    id: resource.id ?? "",
     date,
-    status_o,
-    status_d,
-    medRef_o,
-    medRef_d,
-    subjRef_o,
-    subjRef_d,
-    eDateTime_o,
-    eDateTime_d,
-    ePeriod_start_o,
-    ePeriod_start_d,
-    ePeriod_end_o,
-    ePeriod_end_d,
-    dateAsserted_o,
-    dateAsserted_d,
-    dosage0_text_o,
-    dosage0_text_d,
-    dosage0_route_code0_o,
-    dosage0_route_code0_d,
-    dosage0_route_disp0_o,
-    dosage0_route_disp0_d,
-    dosage0_route_code1_o,
-    dosage0_route_code1_d,
-    dosage0_route_disp1_o,
-    dosage0_route_disp1_d,
-    dosage0_route_text_o,
-    dosage0_route_text_d,
-    dosage0_doseRate0_doseQtty_value_o,
-    dosage0_doseRate0_doseQtty_value_d,
-    dosage0_doseRate0_doseQtty_unit_o,
-    dosage0_doseRate0_doseQtty_unit_d,
-    dosage0_doseRate1_doseQtty_value_o,
-    dosage0_doseRate1_doseQtty_value_d,
-    dosage0_doseRate1_doseQtty_unit_o,
-    dosage0_doseRate1_doseQtty_unit_d,
-    dosage1_text_o,
-    dosage1_text_d,
-    dosage1_route_code0_o,
-    dosage1_route_code0_d,
-    dosage1_route_disp0_o,
-    dosage1_route_disp0_d,
-    dosage1_route_code1_o,
-    dosage1_route_code1_d,
-    dosage1_route_disp1_o,
-    dosage1_route_disp1_d,
-    dosage1_route_text_o,
-    dosage1_route_text_d,
-    dosage1_doseRate0_doseQtty_value_o,
-    dosage1_doseRate0_doseQtty_value_d,
-    dosage1_doseRate0_doseQtty_unit_o,
-    dosage1_doseRate0_doseQtty_unit_d,
-    dosage1_doseRate1_doseQtty_value_o,
-    dosage1_doseRate1_doseQtty_value_d,
-    dosage1_doseRate1_doseQtty_unit_o,
-    dosage1_doseRate1_doseQtty_unit_d,
-    id_d: sibling?.id ?? "",
+    links,
+    status,
+    status_s,
+    medRef,
+    medRef_s,
+    subjRef,
+    subjRef_s,
+    eDateTime,
+    eDateTime_s,
+    ePeriod_dtart,
+    ePeriod_dtart_s,
+    ePeriod_end,
+    ePeriod_end_s,
+    dateAsserted,
+    dateAsserted_s,
+    dosage0_text,
+    dosage0_text_s,
+    dosage0_route_code0,
+    dosage0_route_code0_s,
+    dosage0_route_disp0,
+    dosage0_route_disp0_s,
+    dosage0_route_code1,
+    dosage0_route_code1_s,
+    dosage0_route_disp1,
+    dosage0_route_disp1_s,
+    dosage0_route_text,
+    dosage0_route_text_s,
+    dosage0_doseRate0_doseQtty_value,
+    dosage0_doseRate0_doseQtty_value_s,
+    dosage0_doseRate0_doseQtty_unit,
+    dosage0_doseRate0_doseQtty_unit_s,
+    dosage0_doseRate1_doseQtty_value,
+    dosage0_doseRate1_doseQtty_value_s,
+    dosage0_doseRate1_doseQtty_unit,
+    dosage0_doseRate1_doseQtty_unit_s,
+    dosage1_text,
+    dosage1_text_s,
+    dosage1_route_code0,
+    dosage1_route_code0_s,
+    dosage1_route_disp0,
+    dosage1_route_disp0_s,
+    dosage1_route_code1,
+    dosage1_route_code1_s,
+    dosage1_route_disp1,
+    dosage1_route_disp1_s,
+    dosage1_route_text,
+    dosage1_route_text_s,
+    dosage1_doseRate0_doseQtty_value,
+    dosage1_doseRate0_doseQtty_value_s,
+    dosage1_doseRate0_doseQtty_unit,
+    dosage1_doseRate0_doseQtty_unit_s,
+    dosage1_doseRate1_doseQtty_value,
+    dosage1_doseRate1_doseQtty_value_s,
+    dosage1_doseRate1_doseQtty_unit,
+    dosage1_doseRate1_doseQtty_unit_s,
+    ids_siblings: siblings.map(s => s.id).join(","),
   };
   return Object.values(res).map(safeCsv).join(csvSeparator);
 }

--- a/packages/utils/src/fhir-dedup/medication.ts
+++ b/packages/utils/src/fhir-dedup/medication.ts
@@ -5,19 +5,42 @@ import { csvSeparator, safeCsv } from "./csv";
 import { isSibling } from "./shared";
 
 const columns = [
-  "id_o",
+  "id",
   "date",
-  "code0_o",
-  "code0_d",
-  "display0_o",
-  "display0_d",
-  "code1_o",
-  "code1_d",
-  "display1_o",
-  "display1_d",
-  "text_o",
-  "text_d",
-  "id_d",
+  "links",
+  "status",
+  "status_s",
+  "code0",
+  "code0_s",
+  "disp0",
+  "disp0_s",
+  "code1",
+  "code1_s",
+  "disp1",
+  "disp1_s",
+  "text",
+  "text_s",
+  "amount_num_val",
+  "amount_num_val_s",
+  "amount_num_unit",
+  "amount_num_unit_s",
+  "amount_denom_val",
+  "amount_denom_val_s",
+  "amount_denom_unit",
+  "amount_denom_unit_s",
+  "manufRef",
+  "manufRef_s",
+  "form_code0",
+  "form_code0_s",
+  "form_disp0",
+  "form_disp0_s",
+  "form_code1",
+  "form_code1_s",
+  "form_disp1",
+  "form_disp1_s",
+  "form_text",
+  "form_text_s",
+  "ids_siblings",
 ] as const;
 type Columns = (typeof columns)[number];
 
@@ -60,37 +83,83 @@ function sortMedication(a: Medication, b: Medication): number {
   return 0;
 }
 
-function medicationToCsv(medication: Medication, siblings: Medication[]): string {
-  const sibling = siblings.find(isSibling(medication));
-  const date = medication.meta?.lastUpdated
-    ? new Date(medication.meta?.lastUpdated).toISOString()
-    : "";
-  const code0_o = medication.code?.coding?.[0]?.code ?? "";
-  const display0_o = medication.code?.coding?.[0]?.display ?? "";
-  const code1_o = medication.code?.coding?.[1]?.code ?? "";
-  const display1_o = medication.code?.coding?.[1]?.display ?? "";
-  const text_o = medication.code?.text ?? "";
+function medicationToCsv(resource: Medication, others: Medication[]): string {
+  const siblings = others.filter(isSibling(resource));
+  const firstSibling = siblings[0];
+  const date = resource.meta?.lastUpdated ? new Date(resource.meta?.lastUpdated).toISOString() : "";
+  const links = siblings.length;
 
-  const code0_d = sibling?.code?.coding?.[0]?.code ?? "";
-  const display0_d = sibling?.code?.coding?.[0]?.display ?? "";
-  const code1_d = sibling?.code?.coding?.[1]?.code ?? "";
-  const display1_d = sibling?.code?.coding?.[1]?.display ?? "";
-  const text_d = sibling?.code?.text ?? "";
+  const status = resource.status ?? "";
+  const code0 = resource.code?.coding?.[0]?.code ?? "";
+  const disp0 = resource.code?.coding?.[0]?.display ?? "";
+  const code1 = resource.code?.coding?.[1]?.code ?? "";
+  const disp1 = resource.code?.coding?.[1]?.display ?? "";
+  const text = resource.code?.text ?? "";
+  const amount_num_val = resource.amount?.numerator?.value ?? "";
+  const amount_num_unit = resource.amount?.numerator?.unit ?? "";
+  const amount_denom_val = resource.amount?.denominator?.value ?? "";
+  const amount_denom_unit = resource.amount?.denominator?.unit ?? "";
+  const manufRef = resource.manufacturer?.reference ?? "";
+  const form_code0 = resource.form?.coding?.[0]?.code ?? "";
+  const form_disp0 = resource.form?.coding?.[0]?.display ?? "";
+  const form_code1 = resource.form?.coding?.[1]?.code ?? "";
+  const form_disp1 = resource.form?.coding?.[1]?.display ?? "";
+  const form_text = resource.form?.text ?? "";
 
-  const res: Record<Columns, string> = {
-    id_o: medication.id ?? "",
+  const status_s = firstSibling?.status ?? "";
+  const code0_s = firstSibling?.code?.coding?.[0]?.code ?? "";
+  const disp0_s = firstSibling?.code?.coding?.[0]?.display ?? "";
+  const code1_s = firstSibling?.code?.coding?.[1]?.code ?? "";
+  const disp1_s = firstSibling?.code?.coding?.[1]?.display ?? "";
+  const text_s = firstSibling?.code?.text ?? "";
+  const amount_num_val_s = firstSibling?.amount?.numerator?.value ?? "";
+  const amount_num_unit_s = firstSibling?.amount?.numerator?.unit ?? "";
+  const amount_denom_val_s = firstSibling?.amount?.denominator?.value ?? "";
+  const amount_denom_unit_s = firstSibling?.amount?.denominator?.unit ?? "";
+  const manufRef_s = firstSibling?.manufacturer?.reference ?? "";
+  const form_code0_s = firstSibling?.form?.coding?.[0]?.code ?? "";
+  const form_disp0_s = firstSibling?.form?.coding?.[0]?.display ?? "";
+  const form_code1_s = firstSibling?.form?.coding?.[1]?.code ?? "";
+  const form_disp1_s = firstSibling?.form?.coding?.[1]?.display ?? "";
+  const form_text_s = firstSibling?.form?.text ?? "";
+
+  const res: Record<Columns, string | number> = {
+    id: resource.id ?? "",
     date,
-    code0_o,
-    code0_d,
-    display0_o,
-    display0_d,
-    code1_o,
-    code1_d,
-    display1_o,
-    display1_d,
-    text_o,
-    text_d,
-    id_d: sibling?.id ?? "",
+    links,
+    status,
+    status_s,
+    code0,
+    code0_s,
+    disp0,
+    disp0_s,
+    code1,
+    code1_s,
+    disp1,
+    disp1_s,
+    text,
+    text_s,
+    amount_num_val,
+    amount_num_val_s,
+    amount_num_unit,
+    amount_num_unit_s,
+    amount_denom_val,
+    amount_denom_val_s,
+    amount_denom_unit,
+    amount_denom_unit_s,
+    manufRef,
+    manufRef_s,
+    form_code0,
+    form_code0_s,
+    form_disp0,
+    form_disp0_s,
+    form_code1,
+    form_code1_s,
+    form_disp1,
+    form_disp1_s,
+    form_text,
+    form_text_s,
+    ids_siblings: siblings.map(s => s.id).join(","),
   };
   return Object.values(res).map(safeCsv).join(csvSeparator);
 }

--- a/packages/utils/src/fhir-dedup/report-dedup.ts
+++ b/packages/utils/src/fhir-dedup/report-dedup.ts
@@ -1,11 +1,9 @@
 import * as dotenv from "dotenv";
 dotenv.config();
 // keep that ^ on top
-import { BundleEntry, EncounterDiagnosis, Reference, Resource } from "@medplum/fhirtypes";
+import { BundleEntry, Resource } from "@medplum/fhirtypes";
 import { getEnvVarOrFail } from "@metriport/core/util/env-var";
 import { out } from "@metriport/core/util/log";
-import dayjs from "dayjs";
-import duration from "dayjs/plugin/duration";
 import fs from "fs";
 import { groupBy } from "lodash";
 import { ellapsedTimeAsStr } from "../shared/duration";
@@ -13,7 +11,6 @@ import { initRunsFolder } from "../shared/folder";
 import { processAllergyIntolerance } from "./allergy-intolerance";
 import { processCondition } from "./condition";
 import { processCoverage } from "./coverage";
-import { csvSeparator } from "./csv";
 import { processDiagnosticReport } from "./diagnostic-report";
 import { processEncounter } from "./encounter";
 import { processFamilyMemberHistory } from "./family-member-history";
@@ -33,8 +30,7 @@ import { processOrganization } from "./organization";
 import { processPractitioner } from "./practitioner";
 import { processProcedure } from "./procedure";
 import { processRelatedPerson } from "./related-person";
-
-dayjs.extend(duration);
+import { validateReferences } from "./validate-references";
 
 /**
  * Utility to report differences between two FHIR bundles.
@@ -67,7 +63,6 @@ const bucketName = getEnvVarOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
 
 const startedAt = Date.now();
 const dirName = buildGetDirPathInside(`dedup-reports`, startedAt);
-const missingRefsFileName = "missing-refs.csv";
 
 async function main() {
   initRunsFolder();
@@ -163,114 +158,6 @@ async function main() {
   console.log(``);
 
   console.log(`>>> Done in ${ellapsedTimeAsStr(startedAt)}`);
-}
-
-/**
- * Go through each resource, find other resources it references, and check if they are present in the bundle.
- */
-function validateReferences(resources: Resource[], dirName: string): boolean {
-  const resourceMap = new Map<string, Resource>();
-  resources.forEach(r => resourceMap.set(r.id ?? "", r));
-
-  const missingRefs: { resource: Resource; missingRefs: string[] }[] = [];
-  resources.forEach(r => {
-    const localMissingRefs = findMissingRefs(r, resourceMap);
-    if (localMissingRefs.length) missingRefs.push({ resource: r, missingRefs: localMissingRefs });
-  });
-
-  if (missingRefs.length) {
-    const outputFileName = dirName + "/" + missingRefsFileName;
-    const header = ["resource", "missing-refs..."].join(csvSeparator);
-    fs.writeFileSync(outputFileName, header + "\n");
-    console.log(
-      `>>> Found ${missingRefs.length} missing references! Check the file ${outputFileName} for details.`
-    );
-    const lines = missingRefs
-      .map(entry => {
-        const resource = `${entry.resource.resourceType}/${entry.resource.id}`;
-        const missingRefs = entry.missingRefs.join(csvSeparator);
-        return resource + csvSeparator + missingRefs;
-      })
-      .join("\n");
-    fs.writeFileSync(outputFileName, lines, { flag: "a+" });
-    return false;
-  }
-  return true;
-}
-
-function findMissingRefs(resource: Resource, resourceMap: Map<string, Resource>): string[] {
-  const missingRefs: string[] = [];
-  const refs = findRefs(resource);
-  refs.forEach(ref => {
-    if (!resourceMap.has(ref.split("/")[1] ?? "")) {
-      missingRefs.push(ref);
-    }
-  });
-  return missingRefs;
-}
-
-function findRefs<T extends Resource>(resource: T): string[] {
-  if ("result" in resource && resource.result) {
-    const results = resource.result;
-    if (Array.isArray(results)) {
-      return results.flatMap(item => item.reference ?? []);
-    }
-  }
-
-  if ("diagnosis" in resource && resource.diagnosis) {
-    if (resource.resourceType === "Encounter") {
-      const diagnoses = resource.diagnosis as EncounterDiagnosis[];
-      return diagnoses.flatMap(d => d.condition?.reference ?? []);
-    }
-  }
-
-  if ("author" in resource && resource.author) {
-    if (resource.resourceType === "Composition") {
-      return resource.author.flatMap(a => a.reference ?? []);
-    }
-  }
-
-  if ("section" in resource && resource.section) {
-    return resource.section.flatMap(s => s.entry?.flatMap(e => e.reference ?? []) ?? []);
-  }
-
-  if ("location" in resource && resource.location) {
-    if (Array.isArray(resource.location)) {
-      if (resource.location.length < 1) return [];
-      //eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const withRefs = (resource.location as any[]).filter(
-        //eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (l: any) => "reference" in l
-      ) as Reference<Resource>[];
-      return withRefs.flatMap(l => l.reference ?? []);
-    }
-    if ("reference" in resource.location) {
-      return [resource.location.reference ?? ""];
-    }
-  }
-
-  if ("participant" in resource && resource.participant) {
-    if (resource.resourceType === "Encounter") {
-      return resource.participant.flatMap(p => p.individual?.reference ?? []);
-    }
-  }
-
-  if ("performer" in resource && resource.performer) {
-    if (Array.isArray(resource.performer)) {
-      return resource.performer.flatMap(p => {
-        if ("reference" in p) return p.reference ?? [];
-        if ("actor" in p) return p.actor?.reference ?? [];
-        return [];
-      });
-    }
-    return [resource.performer.reference ?? []].flat();
-  }
-
-  if ("payor" in resource && resource.payor) {
-    return resource.payor.flatMap(p => p.reference ?? []);
-  }
-
-  return [];
 }
 
 main();

--- a/packages/utils/src/fhir-dedup/resource-props.ts
+++ b/packages/utils/src/fhir-dedup/resource-props.ts
@@ -453,24 +453,24 @@ export function getReasonCode(
   const reason1_text_s = sib1?.text ?? "";
   return {
     reason0_code0,
-    reason0_disp0,
-    reason0_code1,
-    reason0_disp1,
-    reason0_text,
-    reason1_code0,
-    reason1_disp0,
-    reason1_code1,
-    reason1_disp1,
-    reason1_text,
     reason0_code0_s,
+    reason0_disp0,
     reason0_disp0_s,
+    reason0_code1,
     reason0_code1_s,
+    reason0_disp1,
     reason0_disp1_s,
+    reason0_text,
     reason0_text_s,
+    reason1_code0,
     reason1_code0_s,
+    reason1_disp0,
     reason1_disp0_s,
+    reason1_code1,
     reason1_code1_s,
+    reason1_disp1,
     reason1_disp1_s,
+    reason1_text,
     reason1_text_s,
   };
 }
@@ -492,8 +492,8 @@ export function getReasonReference(
   const reasonRef1_s = sibling?.reasonReference?.[1]?.reference ?? "";
   return {
     reasonRef0,
-    reasonRef1,
     reasonRef0_s,
+    reasonRef1,
     reasonRef1_s,
   };
 }

--- a/packages/utils/src/fhir-dedup/validate-references.ts
+++ b/packages/utils/src/fhir-dedup/validate-references.ts
@@ -1,0 +1,292 @@
+import { Reference, Resource } from "@medplum/fhirtypes";
+import fs from "fs";
+import { csvSeparator } from "./csv";
+
+const missingRefsFileName = "missing-refs.csv";
+
+/**
+ * Go through each resource, find other resources it references, and check if they are present in the bundle.
+ */
+export function validateReferences(resources: Resource[], dirName: string): boolean {
+  const resourceMap = new Map<string, Resource>();
+  resources.forEach(r => resourceMap.set(r.id ?? "", r));
+
+  const missingRefs: { resource: Resource; missingRefs: string[] }[] = [];
+  resources.forEach(r => {
+    const localMissingRefs = findMissingRefs(r, resourceMap);
+    if (localMissingRefs.length) missingRefs.push({ resource: r, missingRefs: localMissingRefs });
+  });
+
+  if (missingRefs.length) {
+    const outputFileName = dirName + "/" + missingRefsFileName;
+    const header = ["resource", "missing-refs..."].join(csvSeparator);
+    fs.writeFileSync(outputFileName, header + "\n");
+    console.log(
+      `>>> Found ${missingRefs.length} missing references! Check the file ${outputFileName} for details.`
+    );
+    const lines = missingRefs
+      .map(entry => {
+        const resource = `${entry.resource.resourceType}/${entry.resource.id}`;
+        const missingRefs = entry.missingRefs.join(csvSeparator);
+        return resource + csvSeparator + missingRefs;
+      })
+      .join("\n");
+    fs.writeFileSync(outputFileName, lines, { flag: "a+" });
+    return false;
+  }
+  return true;
+}
+
+function findMissingRefs(resource: Resource, resourceMap: Map<string, Resource>): string[] {
+  const missingRefs: string[] = [];
+  const refs = findRefs(resource);
+  refs.forEach(ref => {
+    if (!resourceMap.has(ref.split("/")[1] ?? "")) {
+      missingRefs.push(ref);
+    }
+  });
+  return missingRefs;
+}
+
+function findRefs<T extends Resource>(resource: T): string[] {
+  const refs: string[] = [];
+
+  if ("result" in resource && resource.result) {
+    if (Array.isArray(resource.result)) {
+      refs.push(...resource.result.flatMap(referenceToArray));
+    } else if (typeof resource.result === "object") {
+      refs.push(...referenceToArray(resource.result));
+    }
+  }
+
+  if ("location" in resource && resource.location) {
+    if (Array.isArray(resource.location)) {
+      if (
+        resource.resourceType === "Device" ||
+        resource.resourceType === "Immunization" ||
+        resource.resourceType === "MedicationDispense" ||
+        resource.resourceType === "Procedure" ||
+        resource.resourceType === "Provenance" ||
+        resource.resourceType === "Task"
+      ) {
+        refs.push(...referenceToArray(resource.location));
+      } else if (resource.resourceType === "Encounter") {
+        refs.push(...resource.location.flatMap(l => referenceToArray(l.location)));
+      } else if (resource.resourceType === "PractitionerRole") {
+        refs.push(...resource.location.flatMap(referenceToArray));
+      }
+    } else if ("reference" in resource.location) {
+      refs.push(...referenceToArray(resource.location));
+    }
+  }
+
+  if (resource.resourceType === "Medication") {
+    refs.push(...(resource.ingredient?.flatMap(i => referenceToArray(i.itemReference)) ?? []));
+  }
+  if ("diagnosis" in resource && resource.diagnosis) {
+    if (resource.resourceType === "Encounter") {
+      refs.push(...resource.diagnosis.flatMap(referenceToArray));
+    }
+  }
+  if ("participant" in resource && resource.participant) {
+    if (resource.resourceType === "Encounter") {
+      refs.push(...resource.participant.flatMap(p => referenceToArray(p.individual)));
+    }
+  }
+  if ("protocolApplied" in resource && resource.protocolApplied) {
+    refs.push(...resource.protocolApplied.flatMap(i => referenceToArray(i.authority)));
+  }
+  if ("qualification" in resource && resource.qualification) {
+    refs.push(...resource.qualification.flatMap(i => referenceToArray(i.issuer)));
+  }
+
+  if ("reaction" in resource && resource.reaction) {
+    refs.push(
+      ...resource.reaction.flatMap(p => {
+        if ("detail" in p) return p.detail?.reference ?? [];
+        return [];
+      })
+    );
+  }
+
+  if ("section" in resource && resource.section) {
+    refs.push(...resource.section.flatMap(s => s.entry?.flatMap(referenceToArray) ?? []));
+  }
+  if ("stage" in resource && resource.stage) {
+    refs.push(...resource.stage.flatMap(p => p.assessment?.flatMap(referenceToArray) ?? []));
+  }
+  if ("evidence" in resource && resource.evidence) {
+    refs.push(...resource.evidence.flatMap(p => p.detail?.flatMap(referenceToArray) ?? []));
+  }
+
+  if ("partOf" in resource && resource.partOf) {
+    refs.push(...stringReferenceOrArrayToStringArr(resource.partOf));
+  }
+  if ("performer" in resource && resource.performer) {
+    if (Array.isArray(resource.performer)) {
+      refs.push(
+        ...resource.performer.flatMap(p => {
+          if ("reference" in p) return p.reference ?? [];
+          if ("actor" in p) return p.actor?.reference ?? [];
+          if ("onBehalfOf" in p) return p.onBehalfOf?.reference ?? [];
+          return [];
+        })
+      );
+    } else {
+      refs.push(...referenceToArray(resource.performer));
+    }
+  }
+  if ("focus" in resource && resource.focus) {
+    if (Array.isArray(resource.focus)) {
+      refs.push(
+        ...resource.focus.flatMap(f => {
+          if ("reference" in f) return f.reference ?? [];
+          return [];
+        })
+      );
+    } else {
+      refs.push(...referenceToArray(resource.focus));
+    }
+  }
+
+  if ("recorder" in resource && resource.recorder) {
+    if (Array.isArray(resource.recorder)) {
+      refs.push(...resource.recorder.flatMap(referenceToArray));
+    } else {
+      refs.push(...referenceToArray(resource.recorder));
+    }
+  }
+
+  if ("context" in resource && resource.context) {
+    if (!Array.isArray(resource.context)) {
+      refs.push(...referenceToArray(resource.context));
+    }
+  }
+
+  if ("specimen" in resource && resource.specimen) {
+    refs.push(...stringReferenceOrArrayToStringArr(resource.specimen));
+  }
+  if ("appointment" in resource && resource.appointment) {
+    refs.push(...stringReferenceOrArrayToStringArr(resource.appointment));
+  }
+  if ("subject" in resource && resource.subject) {
+    refs.push(...stringReferenceOrArrayToStringArr(resource.subject));
+  }
+  if ("author" in resource && resource.author) {
+    refs.push(...stringReferenceOrArrayToStringArr(resource.author));
+  }
+  if ("basedOn" in resource && resource.basedOn) {
+    refs.push(...stringReferenceOrArrayToStringArr(resource.basedOn));
+  }
+  if ("device" in resource && resource.device) {
+    refs.push(...stringReferenceOrArrayToStringArr(resource.device));
+  }
+  if ("reasonReference" in resource && resource.reasonReference) {
+    refs.push(...stringReferenceOrArrayToStringArr(resource.reasonReference));
+  }
+  if ("manufacturer" in resource && resource.manufacturer) {
+    refs.push(...stringReferenceOrArrayToStringArr(resource.manufacturer));
+  }
+
+  if ("request" in resource && resource.request) {
+    refs.push(...stringReferenceOrArrayToStringArr(resource.request));
+  }
+  if ("derivedFrom" in resource && resource.derivedFrom) {
+    refs.push(...stringReferenceOrArrayToStringArr(resource.derivedFrom));
+  }
+  if ("managingOrganization" in resource && resource.managingOrganization) {
+    refs.push(...stringReferenceOrArrayToStringArr(resource.managingOrganization));
+  }
+
+  if ("patient" in resource && resource.patient) {
+    refs.push(...referenceToArray(resource.patient));
+  }
+  if ("encounter" in resource && resource.encounter) {
+    refs.push(...referenceToArray(resource.encounter));
+  }
+  if ("informationSource" in resource && resource.informationSource) {
+    refs.push(...referenceToArray(resource.informationSource));
+  }
+  if ("medicationReference" in resource && resource.medicationReference) {
+    refs.push(...referenceToArray(resource.medicationReference));
+  }
+  if ("priorPrescription" in resource && resource.priorPrescription) {
+    refs.push(...referenceToArray(resource.priorPrescription));
+  }
+  if ("asserter" in resource && resource.asserter) {
+    refs.push(...referenceToArray(resource.asserter));
+  }
+  if ("hospitalization" in resource && resource.hospitalization) {
+    refs.push(...referenceToArray(resource.hospitalization.destination));
+  }
+  if ("serviceProvider" in resource && resource.serviceProvider) {
+    refs.push(...referenceToArray(resource.serviceProvider));
+  }
+  if ("policyHolder" in resource && resource.policyHolder) {
+    refs.push(...referenceToArray(resource.policyHolder));
+  }
+  if ("beneficiary" in resource && resource.beneficiary) {
+    refs.push(...referenceToArray(resource.beneficiary));
+  }
+
+  if ("episodeOfCare" in resource && resource.episodeOfCare) {
+    refs.push(...resource.episodeOfCare.flatMap(referenceToArray));
+  }
+  if ("supportingInformation" in resource && resource.supportingInformation) {
+    refs.push(...resource.supportingInformation.flatMap(referenceToArray));
+  }
+  if ("payor" in resource && resource.payor) {
+    refs.push(...resource.payor.flatMap(referenceToArray));
+  }
+  if ("insurance" in resource && resource.insurance) {
+    refs.push(...resource.insurance.flatMap(referenceToArray));
+  }
+  if ("detectedIssue" in resource && resource.detectedIssue) {
+    refs.push(...resource.detectedIssue.flatMap(referenceToArray));
+  }
+  if ("eventHistory" in resource && resource.eventHistory) {
+    refs.push(...resource.eventHistory.flatMap(referenceToArray));
+  }
+  if ("hasMember" in resource && resource.hasMember) {
+    refs.push(...resource.hasMember.flatMap(referenceToArray));
+  }
+  if ("resultsInterpreter" in resource && resource.resultsInterpreter) {
+    refs.push(...resource.resultsInterpreter.flatMap(referenceToArray));
+  }
+  if ("report" in resource && resource.report) {
+    refs.push(...resource.report.flatMap(referenceToArray));
+  }
+  if ("complicationDetail" in resource && resource.complicationDetail) {
+    refs.push(...resource.complicationDetail.flatMap(referenceToArray));
+  }
+  if ("usedReference" in resource && resource.usedReference) {
+    refs.push(...resource.usedReference.flatMap(referenceToArray));
+  }
+  if ("payor" in resource && resource.payor) {
+    refs.push(...resource.payor.flatMap(referenceToArray));
+  }
+  if ("contract" in resource && resource.contract) {
+    refs.push(...resource.contract.flatMap(referenceToArray));
+  }
+  if ("endpoint" in resource && resource.endpoint) {
+    refs.push(...resource.endpoint.flatMap(referenceToArray));
+  }
+
+  return refs;
+}
+
+function referenceToArray(ref?: Reference): string[] {
+  return [ref?.reference ?? []].flat();
+}
+
+function stringReferenceOrArrayToStringArr(
+  obj?: string | string[] | Reference | Reference[]
+): string[] {
+  if (typeof obj === "string") {
+    return [obj];
+  } else if (Array.isArray(obj)) {
+    return obj.flatMap(stringReferenceOrArrayToStringArr);
+  } else {
+    return referenceToArray(obj);
+  }
+}

--- a/packages/utils/src/fhir-dedup/validate-references.ts
+++ b/packages/utils/src/fhir-dedup/validate-references.ts
@@ -272,6 +272,15 @@ function findRefs<T extends Resource>(resource: T): string[] {
     refs.push(...resource.endpoint.flatMap(referenceToArray));
   }
 
+  // Check references that point to "contained" and remove them from the list
+  if ("contained" in resource && resource.contained) {
+    const containedRefs = refs.filter(ref => ref.startsWith("#"));
+    if (containedRefs.length) {
+      const containedIds = resource.contained.map(c => c.id) ?? [];
+      return refs.filter(ref => !containedIds.includes(ref.slice(1)));
+    }
+  }
+
   return refs;
 }
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#2179

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2712
- Downstream: none

### Description

Fix missing refs report on dedup script to account for all refs - [context](https://www.notion.so/metriport/Data-Quality-v2-28a69479807a4f9b897921fd77e54d8f?pvs=4#66e201ddd7424d96b58312caad7b2702)

Replicate improvements done from 5th resource onwards to the first resources as well.

### Testing

- Local
  - [x] Finds additional missing refs
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge upstream
- [ ] Merge this
