### PR TITLE
2064 Set CORS on medical buckets

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -256,6 +256,12 @@ export class APIStack extends Stack {
       publicReadAccess: false,
       encryption: s3.BucketEncryption.S3_MANAGED,
       versioned: true,
+      cors: [
+        {
+          allowedOrigins: ["*"],
+          allowedMethods: [s3.HttpMethods.GET],
+        },
+      ],
     });
 
     const medicalDocumentsUploadBucket = new s3.Bucket(this, "APIMedicalDocumentsUploadBucket", {
@@ -263,6 +269,12 @@ export class APIStack extends Stack {
       publicReadAccess: false,
       encryption: s3.BucketEncryption.S3_MANAGED,
       versioned: true,
+      cors: [
+        {
+          allowedOrigins: ["*"],
+          allowedMethods: [s3.HttpMethods.PUT, s3.HttpMethods.POST],
+        },
+      ],
     });
 
     let ehrResponsesBucket: s3.Bucket | undefined;


### PR DESCRIPTION
Ref. metriport/metriport-internal#2064

### Dependencies

- Upstream: none
- Downstream: TBD

### Description

Set CORS on medical buckets - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1725649603411619?thread_ts=1725636736.574229&cid=C04DMKE9DME)

### Testing

- Local
  - [x] Manually set it on staging
- Staging
  - [ ] download file from browser
- Sandbox
  - [ ] none
- Production
  - [ ] download file from browser

### Release Plan

- [ ] Merge this
