### PR TITLE
fix(api): add validation for patient dob

### DIFF
--- a/packages/api/src/command/medical/patient/__tests__/validate.test.ts
+++ b/packages/api/src/command/medical/patient/__tests__/validate.test.ts
@@ -41,20 +41,22 @@ describe("validate", () => {
 
   describe("dob", () => {
     it("throws an error if dob is in the future", async () => {
-      const futureDate = dayjs().add(7, 'day').format('YYYY-MM-DD');
+      const futureDate = dayjs().add(1, 'day').format('YYYY-MM-DD');
       const patient = makePatientCreate({ dob: futureDate });
       expect(() => validate(patient)).toThrow(`Date must be in the past: ${futureDate}`);
     });
 
-    it("returns true when dob is valid", async () => {
+    it("returns true when dob is the current date", async () => {
       const currentDate = dayjs().format('YYYY-MM-DD');
-      let patient = makePatientCreate({ dob: currentDate });
-      let resp = validate(patient);
+      const patient = makePatientCreate({ dob: currentDate });
+      const resp = validate(patient);
       expect(resp).toBeTruthy();
+    })
 
-      const pastDate = dayjs().subtract(7, 'day').format('YYYY-MM-DD');
-      patient = makePatientCreate({ dob: pastDate });
-      resp = validate(patient);
+    it("returns true when dob is in the past", async () => {
+      const pastDate = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
+      const patient = makePatientCreate({ dob: pastDate });
+      const resp = validate(patient);
       expect(resp).toBeTruthy();
     })
   })

--- a/packages/api/src/command/medical/patient/__tests__/validate.test.ts
+++ b/packages/api/src/command/medical/patient/__tests__/validate.test.ts
@@ -1,6 +1,7 @@
 import { makeAddressStrict } from "../../../../domain/medical/__tests__/location-address";
 import { makePatientCreate } from "../../../../domain/medical/__tests__/patient";
 import { validate } from "../shared";
+import dayjs from "dayjs";
 
 describe("validate", () => {
   it("returns true when patient is valid", async () => {
@@ -37,4 +38,24 @@ describe("validate", () => {
       expect(resp).toBeTruthy();
     });
   });
+
+  describe("dob", () => {
+    it("throws an error if dob is in the future", async () => {
+      const futureDate = dayjs().add(7, 'day').format('YYYY-MM-DD');
+      const patient = makePatientCreate({ dob: futureDate });
+      expect(() => validate(patient)).toThrow(`Date must be in the past: ${futureDate}`);
+    });
+
+    it("returns true when dob is valid", async () => {
+      const currentDate = dayjs().format('YYYY-MM-DD');
+      let patient = makePatientCreate({ dob: currentDate });
+      let resp = validate(patient);
+      expect(resp).toBeTruthy();
+
+      const pastDate = dayjs().subtract(7, 'day').format('YYYY-MM-DD');
+      patient = makePatientCreate({ dob: pastDate });
+      resp = validate(patient);
+      expect(resp).toBeTruthy();
+    })
+  })
 });

--- a/packages/api/src/command/medical/patient/shared.ts
+++ b/packages/api/src/command/medical/patient/shared.ts
@@ -19,6 +19,7 @@ export function validate<T extends PatientCreateCmd | PatientUpdateCmd | Patient
 ): boolean {
   if (!patient.address || patient.address.length < 1) return false;
   patient.personalIdentifiers?.forEach(pid => pid.period && validatePeriod(pid.period));
+  validateIsPast(patient.dob);
   return true;
 }
 


### PR DESCRIPTION
Ref: #2453

Ticket: https://github.com/metriport/metriport/issues/2453

### Dependencies

N/A

### Description

Add validation for the `dob` field in the request payload of the Create/Update/Match Patient endpoints. The API will return an error when the `dob` is a future date.

### Testing

Tested locally with unit tests.

### Release Plan

_[How does the changes on this PR impact/interact with the existing environment (database, configs, secrets, FFs, api contracts, etc.)?_

This could be considered a breaking change because a new validation rule is added. I'm not sure if there's any API versioning approach that we can use.

_[This is the release plan for production]_

_[Add and remove items below accordingly]_

- [ ] Merge this
