### PR TITLE
2569 medication statements without dates

### DIFF
--- a/packages/core/src/fhir-deduplication/__tests__/group-same-med-statements.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-med-statements.test.ts
@@ -27,4 +27,14 @@ describe("groupSameMedStatements", () => {
     const result = groupSameMedStatements([medStatement, medStatement2]);
     expect(result.medStatementsMap.values().next().value.status).toBe("intended");
   });
+  it("correctly groups medStatements with no dates based on medRef", () => {
+    const medStatementNoDate1 = makeMedicationStatement({ id: faker.string.uuid() });
+    const medStatementNoDate2 = makeMedicationStatement({ id: faker.string.uuid() });
+
+    delete medStatementNoDate1.effectiveDateTime;
+    delete medStatementNoDate2.effectiveDateTime;
+
+    const { medStatementsMap } = groupSameMedStatements([medStatementNoDate1, medStatementNoDate2]);
+    expect(medStatementsMap.size).toBe(1);
+  });
 });

--- a/packages/core/src/fhir-deduplication/resources/medication-statement.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication-statement.ts
@@ -94,6 +94,16 @@ export function groupSameMedStatements(medStatements: MedicationStatement[]): {
         undefined,
         assignMostDescriptiveStatus
       );
+    } else if (medRef) {
+      const key = JSON.stringify({ medRef });
+      fillMaps(
+        medStatementsMap,
+        key,
+        medStatement,
+        refReplacementMap,
+        undefined,
+        assignMostDescriptiveStatus
+      );
     } else {
       danglingReferencesSet.add(createRef(medStatement));
     }


### PR DESCRIPTION
Ticket: #[2569](https://github.com/metriport/metriport/issues/2569)

### Description
- allow medication statements to not have dates 

### Testing
- refactoring unit tests

### Release Plan
- [ ] Merge this
