### PR TITLE
Kno2 and Ehex Zod Schema Issues

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/error.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/error.ts
@@ -28,6 +28,7 @@ export function processRegistryErrorList(
   };
 
   try {
+    if (typeof registryErrorList !== "object") return undefined;
     const registryErrors = toArray(registryErrorList?.RegistryError);
     registryErrors.forEach((entry: RegistryError) => {
       const issue = {

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/schema.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/schema.ts
@@ -5,6 +5,7 @@ import {
   schemaOrArrayOrEmpty,
   slot,
   stringOrNumberSchema,
+  schemaOrString,
 } from "../../../schema";
 
 const name = z.object({
@@ -19,22 +20,18 @@ const classification = z.object({
   Slot: schemaOrArray(slot).optional(),
   Name: name.optional(),
   _classificationScheme: z.string(),
-  _classifiedObject: z.string(),
-  _id: z.string(),
-  _nodeRepresentation: z.string(),
-  _objectType: z
-    .literal("urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:Classification")
-    .optional(),
+  _classifiedObject: z.string().optional(),
+  _id: z.string().optional(),
+  _nodeRepresentation: z.string().optional(),
+  _objectType: z.string().optional(),
 });
 export type Classification = z.infer<typeof classification>;
 
 const externalIdentifier = z.object({
   Name: name.optional(),
-  _id: z.string(),
+  _id: z.string().optional(),
   _identificationScheme: z.string(),
-  _objectType: z
-    .literal("urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier")
-    .optional(),
+  _objectType: z.string().optional(),
   _registryObject: z.string().optional(),
   _value: z.string().optional(),
 });
@@ -57,10 +54,12 @@ export const registryError = z.object({
 });
 export type RegistryError = z.infer<typeof registryError>;
 
-const registryErrorList = z.object({
-  RegistryError: schemaOrArray(registryError),
-  _highestSeverity: z.string().optional(),
-});
+const registryErrorList = schemaOrString(
+  z.object({
+    RegistryError: schemaOrArray(registryError),
+    _highestSeverity: z.string().optional(),
+  })
+);
 export type RegistryErrorList = z.infer<typeof registryErrorList>;
 
 export const iti38Body = z.object({

--- a/packages/core/src/external/carequality/ihe-gateway-v2/schema.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/schema.ts
@@ -8,6 +8,9 @@ export const schemaOrArray = <T extends z.ZodTypeAny>(schema: T) =>
   z.union([schema, z.array(schema)]);
 export const schemaOrArrayOrEmpty = <T extends z.ZodTypeAny>(schema: T) =>
   z.union([schema, z.array(schema), z.literal("")]);
+
+export const schemaOrString = <T extends z.ZodTypeAny>(schema: T) => z.union([schema, z.string()]);
+
 export const textSchema = z.union([
   stringOrNumberSchema,
   z.object({


### PR DESCRIPTION
Ticket: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- removing unnessecary fields in zod response schema that cause us to throw zod errors that we dont use anyway for processing

### Testing

- Local
  - [x] unit tests

### Release Plan

- [ ] Merge this
