### PR TITLE
feat(dedup): composition references bug fix

### DIFF
--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -401,7 +401,10 @@ function removeDanglingReferences<T extends Resource>(entry: T, link: string): T
     entry.payor = entry.payor?.filter(payor => payor.reference !== link);
     if (!entry.payor.length) delete entry.payor;
   }
-
+  if ("attester" in entry) {
+    entry.attester = entry.attester?.filter(attester => attester.party?.reference !== link);
+    if (!entry.attester.length) delete entry.attester;
+  }
   return entry;
 }
 


### PR DESCRIPTION
Ticket: #[2569](https://github.com/metriport/metriport/issues/2569)

### Description
- fix for removed Practitioners, Organizations, RelatedPersons lingering as dangling references in Compositions

### Testing
- [ ] NOT DONE YET. WOULD BE GOOD TO - locally ran validate references scripts to confirm that all deduplicated files have no dangling references 

### Release Plan
- [ ] Merge this
