### PR TITLE
feat(dedup): condition useless code filter

### DIFF
--- a/packages/core/src/fhir-deduplication/__tests__/group-same-conditions.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-conditions.test.ts
@@ -95,6 +95,39 @@ describe("groupSameConditions", () => {
     expect(snomedMap.size).toBe(2);
   });
 
+  it("removes conditions that only have one coding that just says 'Problem'", () => {
+    condition.code = {
+      coding: [
+        {
+          system: "http://snomed.info/sct",
+          code: "55607006",
+          display: "Problem",
+        },
+      ],
+    };
+    condition.onsetPeriod = dateTime;
+
+    const { snomedMap } = groupSameConditions([condition]);
+    expect(snomedMap.size).toBe(0);
+  });
+
+  it("keeps the conditions that only have more than one coding, where one just says 'Problem'", () => {
+    condition.code = {
+      coding: [
+        {
+          system: "http://snomed.info/sct",
+          code: "55607006",
+          display: "Problem",
+        },
+        snomedCodeMd,
+      ],
+    };
+    condition.onsetPeriod = dateTime;
+
+    const { snomedMap } = groupSameConditions([condition]);
+    expect(snomedMap.size).toBe(1);
+  });
+
   it("strips away codes that aren't SNOMED or ICD-10", () => {
     condition.code = { coding: [icd10CodeMd] };
     condition2.code = { coding: [icd10CodeMd, snomedCodeMd, otherCodeSystemMd] };

--- a/packages/core/src/fhir-deduplication/resources/condition.ts
+++ b/packages/core/src/fhir-deduplication/resources/condition.ts
@@ -113,7 +113,6 @@ function isKnownCondition(concept: CodeableConcept | undefined) {
       (coding.code !== "55607006" || coding.display?.toLowerCase().trim() !== "problem")
   );
 
-  console.log(knownCodings);
   return knownCodings?.length && knownCodings?.length > 0;
 }
 

--- a/packages/core/src/fhir-deduplication/resources/condition.ts
+++ b/packages/core/src/fhir-deduplication/resources/condition.ts
@@ -8,6 +8,7 @@ import {
   fillMaps,
   getDateFromResource,
   hasBlacklistedText,
+  isUnknownCoding,
 } from "../shared";
 
 /**
@@ -67,7 +68,7 @@ export function groupSameConditions(conditions: Condition[]): {
   }
 
   for (const condition of conditions) {
-    if (hasBlacklistedText(condition.code)) {
+    if (hasBlacklistedText(condition.code) || !isKnownCondition(condition.code)) {
       danglingReferencesSet.add(createRef(condition));
       continue;
     }
@@ -103,6 +104,17 @@ export function groupSameConditions(conditions: Condition[]): {
     refReplacementMap,
     danglingReferences: [...danglingReferencesSet],
   };
+}
+
+function isKnownCondition(concept: CodeableConcept | undefined) {
+  const knownCodings = concept?.coding?.filter(
+    coding =>
+      !isUnknownCoding(coding) &&
+      (coding.code !== "55607006" || coding.display?.toLowerCase().trim() !== "problem")
+  );
+
+  console.log(knownCodings);
+  return knownCodings?.length && knownCodings?.length > 0;
 }
 
 export function extractCodes(concept: CodeableConcept | undefined): {


### PR DESCRIPTION
refs. metriport/metriport-internal#2569

### Description
- Sometimes conditions have this useless code that just says "Problem". We shouldn't use those as a key for dedup. 

### Testing

- Local
  - [x] Unit tests

### Release Plan
- [ ] Merge this
