### PR TITLE
2569 healthlake valid fhir v0

### DIFF
--- a/packages/core/src/fhir-deduplication/__tests__/group-same-conditions.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-conditions.test.ts
@@ -158,7 +158,7 @@ describe("groupSameConditions", () => {
       ])
     );
   });
-  it("proper behavior when only one code of unrecognized system", () => {
+  it("do not remove code and preserve original coding when there is only one code of unrecognized system", () => {
     condition.code = { coding: [otherCodeSystemMd] };
     condition2.code = { coding: [otherCodeSystemMd] };
     condition.onsetPeriod = dateTime;
@@ -166,5 +166,7 @@ describe("groupSameConditions", () => {
 
     const { displayMap } = groupSameConditions([condition, condition2]);
     expect(displayMap.size).toBe(1);
+    const groupedCondition = displayMap.values().next().value;
+    expect(groupedCondition.code?.coding).toEqual([otherCodeSystemMd]);
   });
 });

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-conditions.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-conditions.test.ts
@@ -158,4 +158,13 @@ describe("groupSameConditions", () => {
       ])
     );
   });
+  it("proper behavior when only one code of unrecognized system", () => {
+    condition.code = { coding: [otherCodeSystemMd] };
+    condition2.code = { coding: [otherCodeSystemMd] };
+    condition.onsetPeriod = dateTime;
+    condition2.onsetPeriod = dateTime;
+
+    const { displayMap } = groupSameConditions([condition, condition2]);
+    expect(displayMap.size).toBe(1);
+  });
 });

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-medications.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-medications.test.ts
@@ -148,3 +148,19 @@ describe("groupSameMedications", () => {
     expect(combinedMedication?.extension).toBe(undefined);
   });
 });
+it("doesnt remove code and preserves original coding when there is only one unknown code", () => {
+  const originalCoding = [{ system: "some other system", code: "123", display: "some display" }];
+  medication.code = { coding: originalCoding };
+  medication2.code = { coding: originalCoding };
+
+  const { rxnormMap, ndcMap, snomedMap, displayMap } = groupSameMedications([
+    medication,
+    medication2,
+  ]);
+  expect(rxnormMap.size).toBe(0);
+  expect(ndcMap.size).toBe(0);
+  expect(snomedMap.size).toBe(0);
+  expect(displayMap.size).toBe(1);
+  const groupedMedication = displayMap.values().next().value;
+  expect(groupedMedication.code?.coding).toEqual(originalCoding);
+});

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-observations.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-observations.test.ts
@@ -306,4 +306,20 @@ describe("groupSameObservations", () => {
     const { observationsMap } = groupSameObservations([observation, observation2]);
     expect(observationsMap.size).toBe(2);
   });
+
+  it("does not remove code and preserve original coding when there is only one code of unrecognized system", () => {
+    observation.effectiveDateTime = dateTime.start;
+    observation2.effectiveDateTime = dateTime.start;
+    const originalCoding = [{ system: "some other system", code: "123", display: "some display" }];
+
+    observation.code = { coding: originalCoding };
+    observation2.code = { coding: originalCoding };
+    observation.valueCodeableConcept = valueConceptTobacco;
+    observation2.valueCodeableConcept = valueConceptTobacco;
+
+    const { observationsMap } = groupSameObservations([observation, observation2]);
+    expect(observationsMap.size).toBe(1);
+    const groupedObservation = observationsMap.values().next().value;
+    expect(groupedObservation.code?.coding).toEqual(originalCoding);
+  });
 });

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-procedures.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-procedures.test.ts
@@ -72,4 +72,23 @@ describe("groupSameProcedures", () => {
     expect(coding?.length).toEqual(2);
     expect(coding).toEqual(expect.arrayContaining([...cptCodeAb.coding, ...loincCodeAb.coding]));
   });
+  it("doesnt remove code and preserves original coding when there is only one unknown code", () => {
+    procedure.performedDateTime = dateTime.start;
+    procedure2.performedDateTime = dateTime.start;
+    const originalCoding = [
+      {
+        system: "some system",
+        code: "some code",
+        display: "some display",
+      },
+    ];
+    procedure.code = { coding: originalCoding };
+    procedure2.code = { coding: originalCoding };
+
+    const { proceduresMap } = groupSameProcedures([procedure, procedure2]);
+    expect(proceduresMap.size).toBe(1);
+
+    const masterProcedure = proceduresMap.values().next().value as Procedure;
+    expect(masterProcedure.code?.coding).toEqual(originalCoding);
+  });
 });

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -337,7 +337,9 @@ function removeDanglingReferences<T extends Resource>(entry: T, link: string): T
   if ("author" in entry) {
     if (entry.resourceType === "Composition") {
       entry.author = entry.author?.filter(author => author.reference !== link);
-      if (!entry.author.length) delete entry.author;
+      if (!entry.author.length) {
+        entry.author = [{ display: "No Known Author" }];
+      }
     }
   }
   if ("custodian" in entry) {

--- a/packages/core/src/fhir-deduplication/resources/condition.ts
+++ b/packages/core/src/fhir-deduplication/resources/condition.ts
@@ -48,14 +48,16 @@ export function groupSameConditions(conditions: Condition[]): {
 
   function removeOtherCodes(master: Condition): Condition {
     const code = master.code;
-    const filtered = code?.coding?.filter(
-      coding =>
-        coding.system?.includes(SNOMED_CODE) ||
-        coding.system?.includes(SNOMED_OID) ||
-        coding.system?.includes(ICD_10_CODE) ||
-        coding.system?.includes(ICD_10_OID) ||
-        coding.system?.includes(ICD_9_CODE)
-    );
+    const filtered = code?.coding?.filter(coding => {
+      const system = coding.system?.toLowerCase();
+      return (
+        system?.includes(SNOMED_CODE) ||
+        system?.includes(SNOMED_OID) ||
+        system?.includes(ICD_10_CODE) ||
+        system?.includes(ICD_10_OID) ||
+        system?.includes(ICD_9_CODE)
+      );
+    });
     if (filtered && filtered.length > 0) {
       master.code = {
         ...code,

--- a/packages/core/src/fhir-deduplication/resources/condition.ts
+++ b/packages/core/src/fhir-deduplication/resources/condition.ts
@@ -91,7 +91,7 @@ export function groupSameConditions(conditions: Condition[]): {
       const display = extractDisplayFromConcept(condition.code);
       if (display) {
         const compKey = JSON.stringify({ display, date });
-        fillMaps(displayMap, compKey, condition, refReplacementMap, undefined, c => c);
+        fillMaps(displayMap, compKey, condition, refReplacementMap, undefined);
       } else {
         danglingReferencesSet.add(createRef(condition));
       }

--- a/packages/core/src/fhir-deduplication/resources/medication.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication.ts
@@ -84,7 +84,7 @@ export function groupSameMedications(medications: Medication[]): {
       const display = extractDisplayFromConcept(medication.code);
       if (display) {
         const compKey = JSON.stringify({ display });
-        fillMaps(displayMap, compKey, medication, refReplacementMap, undefined, removeOtherCodes);
+        fillMaps(displayMap, compKey, medication, refReplacementMap, undefined, m => m);
       } else {
         danglingReferences.add(createRef(medication));
       }

--- a/packages/core/src/fhir-deduplication/resources/medication.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication.ts
@@ -84,7 +84,7 @@ export function groupSameMedications(medications: Medication[]): {
       const display = extractDisplayFromConcept(medication.code);
       if (display) {
         const compKey = JSON.stringify({ display });
-        fillMaps(displayMap, compKey, medication, refReplacementMap, undefined, m => m);
+        fillMaps(displayMap, compKey, medication, refReplacementMap, undefined);
       } else {
         danglingReferences.add(createRef(medication));
       }

--- a/packages/core/src/fhir-deduplication/resources/procedure.ts
+++ b/packages/core/src/fhir-deduplication/resources/procedure.ts
@@ -99,6 +99,15 @@ export function groupSameProcedures(procedures: Procedure[]): {
     return master;
   }
 
+  function postProcessOnlyStatus(
+    master: Procedure,
+    existing: Procedure,
+    target: Procedure
+  ): Procedure {
+    master.status = pickMostDescriptiveStatus(statusRanking, existing.status, target.status);
+    return master;
+  }
+
   for (const procedure of procedures) {
     if (hasBlacklistedText(procedure.code)) {
       danglingReferencesSet.add(createRef(procedure));
@@ -137,7 +146,7 @@ export function groupSameProcedures(procedures: Procedure[]): {
           procedure,
           refReplacementMap,
           undefined,
-          removeCodesAndAssignStatus
+          postProcessOnlyStatus
         );
       } else {
         danglingReferencesSet.add(createRef(procedure));

--- a/packages/core/src/util/constants.ts
+++ b/packages/core/src/util/constants.ts
@@ -9,7 +9,7 @@ export const LOINC_OID = "2.16.840.1.113883.6.1";
 export const ICD_10_CODE = "icd-10";
 export const ICD_10_OID = "2.16.840.1.113883.6.90";
 
-export const ICD_9_CODE = "ICD-9";
+export const ICD_9_CODE = "icd-9";
 
 export const RXNORM_CODE = "rxnorm";
 export const RXNORM_OID = "2.16.840.1.113883.6.88";

--- a/packages/core/src/util/constants.ts
+++ b/packages/core/src/util/constants.ts
@@ -9,6 +9,8 @@ export const LOINC_OID = "2.16.840.1.113883.6.1";
 export const ICD_10_CODE = "icd-10";
 export const ICD_10_OID = "2.16.840.1.113883.6.90";
 
+export const ICD_9_CODE = "ICD-9";
+
 export const RXNORM_CODE = "rxnorm";
 export const RXNORM_OID = "2.16.840.1.113883.6.88";
 


### PR DESCRIPTION
Ticket: #[2569](https://github.com/metriport/metriport/issues/2569)

### Description
- `Object must have some content`. Remove post-processing of codes when all we have is a code without a valid display. Basically, when we use the display as a key, we are removing the code in post processing (the reason we used the display in the first place was because we didnt have a good code) leaving us with no code in the resource. So we need a different post processing function for a few different resources to stop this from happening. 
- `Composition.author: minimum required = 1, but only found 0`. An issue where compositions had no author even though author is a required field 

### Testing
- more unit tests

### Release Plan
- [ ] Merge this
