### PR TITLE
feat(dedup): no data text field

### DIFF
--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -373,8 +373,10 @@ export function isUnknownCoding(coding: Coding, text?: string | undefined): bool
     );
   } else {
     return (
-      (!display || display === unknownCoding.display.toLowerCase()) &&
-      (!text || text === unknownCode.text.toLowerCase())
+      (!display ||
+        display === unknownCoding.display.toLowerCase() ||
+        display.includes("no data available")) &&
+      (!text || text === unknownCode.text.toLowerCase() || text.includes("no data"))
     );
   }
 }


### PR DESCRIPTION
refs. metriport/metriport-internal#2569

### Description
- Blacklisting `no data` in `text` field of codeable concepts

### Testing

- Local
  - [ ] 

### Release Plan

- [ ] Merge this
