### PR TITLE
fix(ihe): address line 2 not used by cq

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/create/iti55-envelope.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/create/iti55-envelope.ts
@@ -190,7 +190,9 @@ function createSoapBodyContent({
               ? {
                   [`${prefix}patientAddress`]: {
                     [`${prefix}value`]: patientAddresses.map(address => ({
-                      [`${prefix}streetAddressLine`]: address.line?.join(", "),
+                      ...address.line?.map(line => ({
+                        [`${prefix}streetAddressLine`]: line,
+                      })),
                       [`${prefix}city`]: address.city,
                       [`${prefix}state`]: address.state,
                       [`${prefix}postalCode`]: address.postalCode,

--- a/packages/core/src/external/fhir/patient/index.ts
+++ b/packages/core/src/external/fhir/patient/index.ts
@@ -79,8 +79,11 @@ export function mapPatientDataToResource(patient: PatientIdAndData) {
     birthDate: patient.data.dob,
     address:
       patient.data.address.map((addr: Address) => {
+        const lines = [addr.addressLine1];
+        if (addr.addressLine2) lines.push(addr.addressLine2);
+
         return {
-          line: addr.addressLine1 ? [addr.addressLine1] : [],
+          line: lines,
           city: addr.city,
           state: addr.state,
           postalCode: addr.zip,


### PR DESCRIPTION
Ticket: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- address line 2 is not being used in CQ flow

### Testing

- Local
  - [x] unit tests

### Release Plan

- [x] Merge this
