### PR TITLE
feat(inbound): use epic similarity algo for inbound patient matching

### DIFF
--- a/packages/core/src/mpi/__tests__/inbound-epic-match.test.ts
+++ b/packages/core/src/mpi/__tests__/inbound-epic-match.test.ts
@@ -1,0 +1,71 @@
+import { USState } from "@metriport/shared";
+import { epicMatchingAlgorithm } from "../match-patients";
+import { PatientData, GenderAtBirth } from "../../domain/patient";
+
+describe("epicMatchingAlgorithm", () => {
+  const basePatient: PatientData = {
+    firstName: "John",
+    lastName: "Doe",
+    dob: "1990-01-01",
+    genderAtBirth: "M",
+    address: [{ addressLine1: "123 Main St", city: "Anytown", state: USState.CA, zip: "12345" }],
+    contact: [{ phone: "1234567890", email: "john.doe@example.com" }],
+    personalIdentifiers: [{ type: "ssn", value: "123-45-6789" }],
+  };
+
+  it("should match identical patients", () => {
+    const patient1 = { ...basePatient };
+    const patient2 = { ...basePatient };
+    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(true);
+  });
+
+  it("should match patients with slight name and dob difference", () => {
+    const patient1 = { ...basePatient };
+    const patient2 = { ...basePatient, dob: "1995-01-01" };
+    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(true);
+  });
+
+  it("should not match patients with different names and dob", () => {
+    const patient1 = { ...basePatient };
+    const patient2 = { ...basePatient, lastName: "Smith", dob: "1995-01-01" };
+    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(false);
+  });
+
+  it("should not match patients with matching SSN when all other fields differ", () => {
+    const patient1 = { ...basePatient };
+    const patient2 = {
+      ...basePatient,
+      firstName: "Jane",
+      lastName: "Smith",
+      dob: "1995-01-01",
+      genderAtBirth: "F" as GenderAtBirth,
+    };
+    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(false);
+  });
+
+  it("should match patient with different SSN if other fields are identical", () => {
+    const patient1 = { ...basePatient };
+    const patient2 = {
+      ...basePatient,
+      personalIdentifiers: [{ type: "ssn" as const, value: "987-65-4320" }],
+    };
+    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(true);
+  });
+
+  it("should match patients with partial DOB match", () => {
+    const patient1 = { ...basePatient };
+    const patient2 = { ...basePatient, dob: "1990-01-02" };
+    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(true);
+  });
+
+  it("should not match patients with different names and DOB", () => {
+    const patient1 = { ...basePatient };
+    const patient2 = {
+      ...basePatient,
+      firstName: "Jane",
+      lastName: "Smith",
+      dob: "1995-01-01",
+    };
+    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(false);
+  });
+});

--- a/packages/core/src/mpi/inbound-patient-mpi-metriport-api.ts
+++ b/packages/core/src/mpi/inbound-patient-mpi-metriport-api.ts
@@ -6,7 +6,7 @@ import { MPI } from "./mpi";
 import { normalizePatient } from "./normalize-patient";
 import { PatientMPI, patientToPatientMPI } from "./shared";
 
-export class InboundMPIMetriportAPI implements MPI {
+export class InboundMpiMetriportApi implements MPI {
   protected readonly SIMILARITY_THRESHOLD = 20;
   protected readonly patientLoader = new PatientLoaderMetriportAPI(this.apiUrl);
 

--- a/packages/core/src/mpi/inbound-patient-mpi-metriport-api.ts
+++ b/packages/core/src/mpi/inbound-patient-mpi-metriport-api.ts
@@ -1,0 +1,34 @@
+import { PatientLoaderMetriportAPI } from "../command/patient-loader-metriport-api";
+import { PatientData } from "../domain/patient";
+import { epicMatchingAlgorithm, matchPatients } from "./match-patients";
+import { useFirstMatchingPatient } from "./merge-patients";
+import { MPI } from "./mpi";
+import { normalizePatient } from "./normalize-patient";
+import { PatientMPI, patientToPatientMPI } from "./shared";
+
+export class InboundMPIMetriportAPI implements MPI {
+  protected readonly SIMILARITY_THRESHOLD = 20;
+  protected readonly patientLoader = new PatientLoaderMetriportAPI(this.apiUrl);
+
+  constructor(protected apiUrl: string) {}
+
+  public async findMatchingPatient(patient: PatientData): Promise<PatientMPI | undefined> {
+    const normalizedPatientDemo = normalizePatient(patient);
+    if (!normalizedPatientDemo) throw new Error("Invalid Patient Data");
+
+    const foundPatients = await this.patientLoader.findBySimilarityAcrossAllCxs({
+      data: {
+        dob: normalizedPatientDemo.dob,
+        genderAtBirth: normalizedPatientDemo.genderAtBirth,
+      },
+    });
+    const matchingPatients = matchPatients(
+      epicMatchingAlgorithm,
+      [],
+      foundPatients.map(patientToPatientMPI),
+      normalizedPatientDemo,
+      this.SIMILARITY_THRESHOLD
+    );
+    return useFirstMatchingPatient(matchingPatients);
+  }
+}

--- a/packages/core/src/mpi/match-patients.ts
+++ b/packages/core/src/mpi/match-patients.ts
@@ -4,6 +4,9 @@ import { Contact } from "../domain/contact";
 import { PatientData, PersonalIdentifier } from "../domain/patient";
 import { normalizePatient } from "./normalize-patient";
 import { PatientMPI } from "./shared";
+import { out } from "../util/log";
+
+const { log } = out(`Patient Matching`);
 
 // Define a type for the similarity function
 type SimilarityFunction = (
@@ -174,4 +177,124 @@ function isSameIdentifierById(a?: PersonalIdentifier, b?: PersonalIdentifier): b
     a.type === b.type &&
     (a.type === "driversLicense" && b.type === "driversLicense" ? a.state === b.state : true)
   );
+}
+
+export function epicMatchingAlgorithm(
+  patient1: PatientData,
+  patient2: PatientData,
+  threshold: number
+): boolean {
+  const scores = {
+    dob: 0,
+    gender: 0,
+    names: 0,
+    address: 0,
+    phone: 0,
+    email: 0,
+    ssn: 0,
+  };
+
+  // DOB comparison
+  if (patient1.dob && patient2.dob) {
+    if (patient1.dob === patient2.dob) {
+      scores.dob = 8;
+    } else {
+      const dob1Split = splitDob(patient1.dob);
+      const dob2Split = splitDob(patient2.dob);
+      const overlappingDateParts = dob2Split.filter(dp => dob1Split.includes(dp));
+      if (overlappingDateParts.length >= 2) {
+        scores.dob = 2;
+      }
+    }
+  }
+
+  // Gender comparison
+  if (patient1.genderAtBirth && patient2.genderAtBirth) {
+    if (patient1.genderAtBirth === patient2.genderAtBirth) {
+      scores.gender = 1;
+    }
+  }
+
+  // Names comparison
+  const names1 = [patient1.firstName, patient1.lastName].filter(Boolean);
+  const names2 = [patient2.firstName, patient2.lastName].filter(Boolean);
+  const overlapNames = names2.filter(name => names1.includes(name));
+  if (overlapNames.length === 2) {
+    scores.names = 10;
+  } else if (overlapNames.length === 1) {
+    scores.names = 5;
+  }
+
+  // Address comparison
+  const addressMatch = patient1.address.some(addr1 =>
+    patient2.address.some(addr2 => JSON.stringify(addr1) === JSON.stringify(addr2))
+  );
+  if (addressMatch) {
+    scores.address = 2;
+  } else {
+    const cityMatch = patient1.address.some(addr1 =>
+      patient2.address.some(addr2 => addr1.city === addr2.city)
+    );
+    const zipMatch = patient1.address.some(addr1 =>
+      patient2.address.some(addr2 => addr1.zip === addr2.zip)
+    );
+    if (cityMatch) scores.address += 0.5;
+    if (zipMatch) scores.address += 0.5;
+  }
+
+  // Telephone comparison
+  const phoneMatch = patient1.contact?.some(c1 =>
+    patient2.contact?.some(c2 => c1.phone && c2.phone && c1.phone === c2.phone)
+  );
+  if (phoneMatch) {
+    scores.phone = 2;
+  }
+
+  // Email comparison
+  const emailMatch = patient1.contact?.some(c1 =>
+    patient2.contact?.some(c2 => c1.email && c2.email && c1.email === c2.email)
+  );
+  if (emailMatch) {
+    scores.email = 2;
+  }
+
+  // SSN comparison
+  const ssn1 = patient1.personalIdentifiers?.filter(id => id.type === "ssn").map(id => id.value);
+  const ssn2 = patient2.personalIdentifiers?.filter(id => id.type === "ssn").map(id => id.value);
+  if (ssn1?.length || ssn2?.length) {
+    const ssnMatch = ssn1?.some(s1 => ssn2?.includes(s1));
+    if (ssnMatch) {
+      scores.ssn = 5;
+    }
+  }
+
+  const totalScore = Object.values(scores).reduce((sum, score) => sum + score, 0);
+
+  if (ssn1?.length || ssn2?.length) {
+    const newThreshold = threshold + 1;
+    const match = totalScore >= newThreshold;
+    if (match) {
+      log(
+        `Match: ${match}, Score: ${totalScore}, Threshold: ${newThreshold}, Patient1: ${JSON.stringify(
+          patient1
+        )}, Patient2: ${JSON.stringify(patient2)}`
+      );
+    }
+    return match;
+  }
+
+  const match = totalScore >= threshold;
+  if (match) {
+    log(
+      `Match: ${match}, Score: ${totalScore}, Threshold: ${threshold}, Patient1: ${JSON.stringify(
+        patient1
+      )}, Patient2: ${JSON.stringify(patient2)}`
+    );
+  }
+  return match;
+}
+
+// Helper function to split DOB string into parts
+function splitDob(dob: string): string[] {
+  return dob.split(/[-/]/);
 }

--- a/packages/core/src/mpi/match-patients.ts
+++ b/packages/core/src/mpi/match-patients.ts
@@ -178,6 +178,11 @@ function isSameIdentifierById(a?: PersonalIdentifier, b?: PersonalIdentifier): b
     (a.type === "driversLicense" && b.type === "driversLicense" ? a.state === b.state : true)
   );
 }
+/**
+ * Implements the EPIC matching algorithm for patient data comparison.
+ * For detailed algorithm description and scoring logic, refer to:
+ * https://docs.google.com/document/d/1XgY-4AbBDpnQdiEcOuBe9It_i7oNuPYgIJM44FUSI3E/edit
+ */
 
 export function epicMatchingAlgorithm(
   patient1: PatientData,
@@ -194,16 +199,14 @@ export function epicMatchingAlgorithm(
     ssn: 0,
   };
 
-  if (patient1.dob && patient2.dob) {
-    if (patient1.dob === patient2.dob) {
-      scores.dob = 8;
-    } else {
-      const dob1Split = splitDob(patient1.dob);
-      const dob2Split = splitDob(patient2.dob);
-      const overlappingDateParts = dob2Split.filter(dp => dob1Split.includes(dp));
-      if (overlappingDateParts.length >= 2) {
-        scores.dob = 2;
-      }
+  if (patient1.dob && patient2.dob && patient1.dob === patient2.dob) {
+    scores.dob = 8;
+  } else if (patient1.dob && patient2.dob) {
+    const dob1Split = splitDob(patient1.dob);
+    const dob2Split = splitDob(patient2.dob);
+    const overlappingDateParts = dob2Split.filter(dp => dob1Split.includes(dp));
+    if (overlappingDateParts.length >= 2) {
+      scores.dob = 2;
     }
   }
 
@@ -254,8 +257,8 @@ export function epicMatchingAlgorithm(
 
   const ssn1 = patient1.personalIdentifiers?.filter(id => id.type === "ssn").map(id => id.value);
   const ssn2 = patient2.personalIdentifiers?.filter(id => id.type === "ssn").map(id => id.value);
-  if (ssn1?.length || ssn2?.length) {
-    const ssnMatch = ssn1?.some(s1 => ssn2?.includes(s1));
+  if (ssn1?.length && ssn2?.length) {
+    const ssnMatch = ssn1.some(s1 => ssn2.includes(s1));
     if (ssnMatch) {
       scores.ssn = 5;
     }

--- a/packages/core/src/mpi/match-patients.ts
+++ b/packages/core/src/mpi/match-patients.ts
@@ -194,7 +194,6 @@ export function epicMatchingAlgorithm(
     ssn: 0,
   };
 
-  // DOB comparison
   if (patient1.dob && patient2.dob) {
     if (patient1.dob === patient2.dob) {
       scores.dob = 8;
@@ -208,14 +207,12 @@ export function epicMatchingAlgorithm(
     }
   }
 
-  // Gender comparison
   if (patient1.genderAtBirth && patient2.genderAtBirth) {
     if (patient1.genderAtBirth === patient2.genderAtBirth) {
       scores.gender = 1;
     }
   }
 
-  // Names comparison
   const names1 = [patient1.firstName, patient1.lastName].filter(Boolean);
   const names2 = [patient2.firstName, patient2.lastName].filter(Boolean);
   const overlapNames = names2.filter(name => names1.includes(name));
@@ -225,7 +222,6 @@ export function epicMatchingAlgorithm(
     scores.names = 5;
   }
 
-  // Address comparison
   const addressMatch = patient1.address.some(addr1 =>
     patient2.address.some(addr2 => JSON.stringify(addr1) === JSON.stringify(addr2))
   );
@@ -242,7 +238,6 @@ export function epicMatchingAlgorithm(
     if (zipMatch) scores.address += 0.5;
   }
 
-  // Telephone comparison
   const phoneMatch = patient1.contact?.some(c1 =>
     patient2.contact?.some(c2 => c1.phone && c2.phone && c1.phone === c2.phone)
   );
@@ -250,7 +245,6 @@ export function epicMatchingAlgorithm(
     scores.phone = 2;
   }
 
-  // Email comparison
   const emailMatch = patient1.contact?.some(c1 =>
     patient2.contact?.some(c2 => c1.email && c2.email && c1.email === c2.email)
   );
@@ -258,7 +252,6 @@ export function epicMatchingAlgorithm(
     scores.email = 2;
   }
 
-  // SSN comparison
   const ssn1 = patient1.personalIdentifiers?.filter(id => id.type === "ssn").map(id => id.value);
   const ssn2 = patient2.personalIdentifiers?.filter(id => id.type === "ssn").map(id => id.value);
   if (ssn1?.length || ssn2?.length) {
@@ -294,7 +287,6 @@ export function epicMatchingAlgorithm(
   return match;
 }
 
-// Helper function to split DOB string into parts
 function splitDob(dob: string): string[] {
   return dob.split(/[-/]/);
 }

--- a/packages/lambdas/src/ihe-gateway-v2-inbound-patient-discovery.ts
+++ b/packages/lambdas/src/ihe-gateway-v2-inbound-patient-discovery.ts
@@ -7,7 +7,7 @@ import { errorToString } from "@metriport/shared";
 import { processInboundXcpdRequest } from "@metriport/core/external/carequality/ihe-gateway-v2/inbound/xcpd/process/xcpd-request";
 import { processInboundXcpd } from "@metriport/core/external/carequality/pd/process-inbound-pd";
 import { createInboundXcpdResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/inbound/xcpd/create/xcpd-response";
-import { InboundMPIMetriportAPI } from "@metriport/core/mpi/inbound-patient-mpi-metriport-api";
+import { InboundMpiMetriportApi } from "@metriport/core/mpi/inbound-patient-mpi-metriport-api";
 import { getEnvVarOrFail, getEnvVar } from "@metriport/core/util/env-var";
 import { getSecretValue } from "@metriport/core/external/aws/secret-manager";
 import { analyticsAsync, EventTypes } from "@metriport/core/external/analytics/posthog";
@@ -21,7 +21,7 @@ const region = getEnvVarOrFail("AWS_REGION");
 const engineeringCxId = getEnvVar("ENGINEERING_CX_ID");
 const postHogSecretName = getEnvVar("POST_HOG_API_KEY_SECRET");
 const lambdaName = getEnvOrFail("AWS_LAMBDA_FUNCTION_NAME");
-const mpi = new InboundMPIMetriportAPI(apiUrl);
+const mpi = new InboundMpiMetriportApi(apiUrl);
 const { log } = out(`ihe-gateway-v2-inbound-patient-discovery`);
 
 export async function handler(event: APIGatewayProxyEventV2) {

--- a/packages/lambdas/src/ihe-gateway-v2-inbound-patient-discovery.ts
+++ b/packages/lambdas/src/ihe-gateway-v2-inbound-patient-discovery.ts
@@ -7,7 +7,7 @@ import { errorToString } from "@metriport/shared";
 import { processInboundXcpdRequest } from "@metriport/core/external/carequality/ihe-gateway-v2/inbound/xcpd/process/xcpd-request";
 import { processInboundXcpd } from "@metriport/core/external/carequality/pd/process-inbound-pd";
 import { createInboundXcpdResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/inbound/xcpd/create/xcpd-response";
-import { MPIMetriportAPI } from "@metriport/core/mpi/patient-mpi-metriport-api";
+import { InboundMPIMetriportAPI } from "@metriport/core/mpi/inbound-patient-mpi-metriport-api";
 import { getEnvVarOrFail, getEnvVar } from "@metriport/core/util/env-var";
 import { getSecretValue } from "@metriport/core/external/aws/secret-manager";
 import { analyticsAsync, EventTypes } from "@metriport/core/external/analytics/posthog";
@@ -21,7 +21,7 @@ const region = getEnvVarOrFail("AWS_REGION");
 const engineeringCxId = getEnvVar("ENGINEERING_CX_ID");
 const postHogSecretName = getEnvVar("POST_HOG_API_KEY_SECRET");
 const lambdaName = getEnvOrFail("AWS_LAMBDA_FUNCTION_NAME");
-const mpi = new MPIMetriportAPI(apiUrl);
+const mpi = new InboundMPIMetriportAPI(apiUrl);
 const { log } = out(`ihe-gateway-v2-inbound-patient-discovery`);
 
 export async function handler(event: APIGatewayProxyEventV2) {


### PR DESCRIPTION
Refs: #[1766](https://github.com/metriport/metriport-internal/issues/1766)

### Description
- use epic similarity algo for patient matching on inbound which is more lenient than exact string matching, which is our current algorithm

### Testing

- Local
  - [x] unit tests
- Staging
  - [ ] Test

Check each PR.

### Release Plan

- [ ] Merge this
- [ ] Communicate with Surescripts
