### PR TITLE
feat(core): dont fail dq on missing repository id

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
@@ -116,8 +116,8 @@ export function parseDocumentReference({
   const repositoryUniqueId = findSlotValue("repositoryUniqueId");
   const docUniqueId = findExternalIdentifierValue(XDSDocumentEntryUniqueId);
 
-  if (!repositoryUniqueId || !docUniqueId) {
-    const msg = "Document Reference is missing repositoryUniqueId or docUniqueId";
+  if (!docUniqueId) {
+    const msg = "Document Reference is missing docUniqueId";
     capture.error(msg, {
       extra: {
         extrinsicObject,
@@ -131,9 +131,11 @@ export function parseDocumentReference({
   const serviceStartTimeValue = findSlotValue("serviceStartTime");
   const serviceStopTimeValue = findSlotValue("serviceStopTime");
 
+  const homeCommunityId = getHomeCommunityIdForDr(extrinsicObject);
+
   const documentReference: DocumentReference = {
-    homeCommunityId: getHomeCommunityIdForDr(extrinsicObject),
-    repositoryUniqueId,
+    homeCommunityId,
+    repositoryUniqueId: repositoryUniqueId ?? homeCommunityId,
     docUniqueId: stripUrnPrefix(docUniqueId),
     contentType: extrinsicObject?._mimeType,
     language: findSlotValue("languageCode"),


### PR DESCRIPTION
refs. metriport/metriport-internal#2222

### Description
- Dont fail DQ on missing `repositoryUniqueId`

### Testing

- Local
  - [x] Setup a local saml-server and sent a DQ to the erroring facility
  - [x] Compared the responses to other successful DQs

### Release Plan
- [ ] Merge this
