### PR TITLE
PATCH RELEASE 2024_09_13 FHIR Converter datetime

### DIFF
--- a/packages/fhir-converter/src/lib/handlebars-converter/__tests__/handlebars-helpers.test.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/__tests__/handlebars-helpers.test.js
@@ -263,9 +263,14 @@ describe("getDateTime", function () {
     expect(date).toEqual("2023-06-26T19:08:46.000-0300");
   });
 
+  it("should render date when incomplete ISO YYYY-MM-DD HH:MM:SS", function () {
+    var date = functions.getDateTime("2023-06-26 19:08:46");
+    expect(date).toEqual("2023-06-26T19:08:46.000Z");
+  });
+
   it("should render date when ISO YYYY-MM-DD HH:MM:SS.MMMZ", function () {
     var date = functions.getDateTime("2023-06-26 19:08:46.000Z");
-    expect(date).toEqual("2023-06-26 19:08:46.000Z");
+    expect(date).toEqual("2023-06-26T19:08:46.000Z");
   });
 
   it("should render date when valid date on invalid dateTimeString", function () {

--- a/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
@@ -150,16 +150,16 @@ var alreadyValidDateTime = function (dateTimeString) {
 const incompeteIso8601Regex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
 const iso8601RegexWithMissingT = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{3}Z)$/;
 
-var incompleteIso8601 = function (dateTimeString) {
-  if (!dateTimeString || dateTimeString.toString() === "") return false;
+function incompleteIso8601(dateTimeString) {
+  if (isEmptyString(dateTimeString)) return false;
   if (incompeteIso8601Regex.test(dateTimeString) || iso8601RegexWithMissingT.test(dateTimeString)) {
     return true;
   }
   return false;
-};
+}
 
-var correctIsoFormat = function (dateTimeString) {
-  if (!dateTimeString || dateTimeString.toString() === "") "";
+function correctIsoFormat(dateTimeString) {
+  if (isEmptyString(dateTimeString)) return "";
   if (iso8601RegexWithMissingT.test(dateTimeString)) {
     const newDate = dateTimeString.trim().replace(" ", "T");
     if (alreadyValidDateTime(newDate)) return newDate;
@@ -171,7 +171,11 @@ var correctIsoFormat = function (dateTimeString) {
     console.log(`Poorly reformatted the dateTime string: ${JSON.stringify(dateTimeString)}`);
   }
   return dateTimeString;
-};
+}
+
+function isEmptyString(str) {
+  return !str || str.trim().length < 1;
+}
 
 // handling the date format here
 var getDate = function (dateStringRaw) {

--- a/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
@@ -147,6 +147,30 @@ var alreadyValidDateTime = function (dateTimeString) {
   );
 };
 
+const incompeteIso8601Regex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+const Iso8601RegexWithMissingT = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{3}Z)$/;
+
+var incompleteIso8601 = function (dateTimeString) {
+  if (incompeteIso8601Regex.test(dateTimeString) || Iso8601RegexWithMissingT.test(dateTimeString)) {
+    return true;
+  }
+  return false;
+};
+
+var correctIsoFormat = function (dateTimeString) {
+  if (Iso8601RegexWithMissingT.test(dateTimeString)) {
+    const newDate = dateTimeString.replace(" ", "T");
+    if (alreadyValidDateTime(newDate)) return newDate;
+    console.log(`Poorly reformatted the dateTime.000Z string: ${JSON.stringify(dateTimeString)}`);
+  }
+  if (incompeteIso8601Regex.test(dateTimeString)) {
+    const newDate = dateTimeString.replace(" ", "T") + ".000Z";
+    if (alreadyValidDateTime(newDate)) return newDate;
+    console.log(`Poorly reformatted the dateTime string: ${JSON.stringify(dateTimeString)}`);
+  }
+  return dateTimeString;
+};
+
 // handling the date format here
 var getDate = function (dateStringRaw) {
   if (dateStringRaw === null || dateStringRaw === undefined) {
@@ -239,11 +263,17 @@ var getDateTime = function (dateTimeStringRaw) {
   }
   var dateTimeString = dateTimeStringRaw?.trim();
 
+  if (incompleteIso8601(dateTimeString)) {
+    return correctIsoFormat(dateTimeString);
+  }
+
   if (alreadyValidDateTime(dateTimeString)) {
     return dateTimeString;
   }
 
-  if (!validDatetimeString(dateTimeString)) return "";
+  if (!validDatetimeString(dateTimeString)) {
+    return "";
+  }
 
   // handle the datetime format with time zone
   var ds = dateTimeString.toString();

--- a/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
@@ -148,23 +148,25 @@ var alreadyValidDateTime = function (dateTimeString) {
 };
 
 const incompeteIso8601Regex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
-const Iso8601RegexWithMissingT = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{3}Z)$/;
+const iso8601RegexWithMissingT = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{3}Z)$/;
 
 var incompleteIso8601 = function (dateTimeString) {
-  if (incompeteIso8601Regex.test(dateTimeString) || Iso8601RegexWithMissingT.test(dateTimeString)) {
+  if (!dateTimeString || dateTimeString.toString() === "") return false;
+  if (incompeteIso8601Regex.test(dateTimeString) || iso8601RegexWithMissingT.test(dateTimeString)) {
     return true;
   }
   return false;
 };
 
 var correctIsoFormat = function (dateTimeString) {
-  if (Iso8601RegexWithMissingT.test(dateTimeString)) {
-    const newDate = dateTimeString.replace(" ", "T");
+  if (!dateTimeString || dateTimeString.toString() === "") "";
+  if (iso8601RegexWithMissingT.test(dateTimeString)) {
+    const newDate = dateTimeString.trim().replace(" ", "T");
     if (alreadyValidDateTime(newDate)) return newDate;
     console.log(`Poorly reformatted the dateTime.000Z string: ${JSON.stringify(dateTimeString)}`);
   }
   if (incompeteIso8601Regex.test(dateTimeString)) {
-    const newDate = dateTimeString.replace(" ", "T") + ".000Z";
+    const newDate = dateTimeString.trim().replace(" ", "T") + ".000Z";
     if (alreadyValidDateTime(newDate)) return newDate;
     console.log(`Poorly reformatted the dateTime string: ${JSON.stringify(dateTimeString)}`);
   }

--- a/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
@@ -142,7 +142,7 @@ var convertDate = function (dateString) {
 var alreadyValidDateTime = function (dateTimeString) {
   if (!dateTimeString || dateTimeString.toString() === "") return false;
   var ds = dateTimeString.toString();
-  return /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,7}))?(Z|[-+]\d{2}:?\d{2})?)?$/.test(
+  return /^(\d{4})-(\d{2})-(\d{2})(?:[T](\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,7}))?(Z|[-+]\d{2}:?\d{2})?)?$/.test(
     ds
   );
 };


### PR DESCRIPTION
refs. metriport/metriport-internal#2107

### Description
- Datetimes that are missing `T` and/or `.000Z` get these appended

### Testing

- Local
  - [x] E2E test suite with insert

### Release Plan
- :warning: Points to master
- [ ] Merge this
- [ ] Rerun FHIR Server DLQ
