### PR TITLE
feat(pd): update pd status in sweeper lambda

### DIFF
--- a/packages/api/src/command/medical/document/check-doc-queries-shared.ts
+++ b/packages/api/src/command/medical/document/check-doc-queries-shared.ts
@@ -7,5 +7,6 @@ export type GroupedValidationResult = {
   cxId: string; // needed downstream
   convert?: SingleValidationResult;
   download?: SingleValidationResult;
+  carequalityPatientDiscoveryStatus?: boolean;
 };
 export type PatientsWithValidationResult = Record<string, GroupedValidationResult>;


### PR DESCRIPTION
Refs: #[1832](https://github.com/metriport/metriport-internal/issues/1832)

### Description

- updating sweeper lambda to update cq patient discovery status 

### Testing

- Staging
  - [ ] update a test patient to have a processing status and then see if the sweeper lambda updates it

### Release Plan

- [ ] Merge this
