### PR TITLE
PATCH RELEASE 2215 Message dedup uses rightmost chars of s3 key

### DIFF
--- a/packages/lambdas/src/shared/__tests__/sqs.test.ts
+++ b/packages/lambdas/src/shared/__tests__/sqs.test.ts
@@ -46,7 +46,13 @@ describe("sqs", () => {
     it("prioritizes right part of value when asked to", async () => {
       const value = faker.string.alpha({ length: { min: 130, max: 130 } });
       const res = toMessageGroupId(value, "right-to-left");
-      expect(res).toEqual(value.slice(0, -128));
+      expect(res).toEqual(value.slice(-128));
+    });
+
+    it("prioritizes right part of value with fixed input", async () => {
+      const value = "1234567890";
+      const res = toMessageGroupId(value, "right-to-left", 4);
+      expect(res).toEqual("7890");
     });
   });
 });

--- a/packages/lambdas/src/shared/sqs.ts
+++ b/packages/lambdas/src/shared/sqs.ts
@@ -47,8 +47,12 @@ export class SQSUtils {
  */
 export function toMessageGroupId(
   value: string,
-  order: "left-to-right" | "right-to-left" = "left-to-right"
+  order: "left-to-right" | "right-to-left" = "left-to-right",
+  maxChars = 128
 ): string {
-  const limitChars = order === "left-to-right" ? 128 : -128;
-  return value.replace(/[^a-zA-Z0-9.]/g, "").slice(0, limitChars);
+  const replaced = value.replace(/[^a-zA-Z0-9.]/g, "");
+  if (order === "left-to-right") {
+    return replaced.slice(0, maxChars);
+  }
+  return replaced.slice(-maxChars);
 }


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/2215

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2767
- Downstream: none

### Description

Message dedup uses rightmost chars of s3 key.

### Testing

- Local
  - [x] unit test
- Staging
  - none
- Sandbox
  - none
- Production
  - [ ] monitor next runs

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
