### PR TITLE
2215 Consolidated from S3 FF from boolean to per cx

### DIFF
--- a/packages/core/src/command/consolidated/get-snapshot-local.ts
+++ b/packages/core/src/command/consolidated/get-snapshot-local.ts
@@ -68,7 +68,7 @@ async function getBundle(
   params: ConsolidatedSnapshotRequestSync | ConsolidatedSnapshotRequestAsync
 ): Promise<Bundle<Resource>> {
   const { cxId, id: patientId } = params.patient;
-  const isGetFromS3 = await isConsolidatedFromS3Enabled();
+  const isGetFromS3 = await isConsolidatedFromS3Enabled(cxId);
   const { log } = out(`getBundle - fromS3: ${isGetFromS3}`);
   if (isGetFromS3) {
     const startedAt = new Date();

--- a/packages/core/src/external/aws/app-config.ts
+++ b/packages/core/src/external/aws/app-config.ts
@@ -29,7 +29,6 @@ export type BooleanFF = z.infer<typeof ffBooleanSchema>;
 export const booleanFFsSchema = z.object({
   commonwellFeatureFlag: ffBooleanSchema,
   carequalityFeatureFlag: ffBooleanSchema,
-  consolidatedFromS3: ffBooleanSchema.optional(),
 });
 export type BooleanFeatureFlags = z.infer<typeof booleanFFsSchema>;
 
@@ -44,6 +43,7 @@ export const cxBasedFFsSchema = z.object({
   cxsWithIncreasedSandboxLimitFeatureFlag: ffStringValuesSchema,
   cxsWithEpicEnabled: ffStringValuesSchema,
   cxsWithDemoAugEnabled: ffStringValuesSchema,
+  cxsWithConsolidatedFromS3: ffStringValuesSchema.optional(),
 });
 export type CxBasedFFsSchema = z.infer<typeof cxBasedFFsSchema>;
 
@@ -250,6 +250,7 @@ export async function isAiBriefFeatureFlagEnabledForCx(cxId: string): Promise<bo
   return cxsWithADHDFeatureFlagValue.includes(cxId);
 }
 
-export async function isConsolidatedFromS3Enabled(): Promise<boolean> {
-  return isFeatureFlagEnabled("consolidatedFromS3");
+export async function isConsolidatedFromS3Enabled(cxId: string): Promise<boolean> {
+  const customerIds = await getCxsWithFeatureFlagEnabled("cxsWithConsolidatedFromS3");
+  return customerIds.includes(cxId);
 }

--- a/packages/infra/lib/lambdas-nested-stack/consolidate-patient-data-connector.ts
+++ b/packages/infra/lib/lambdas-nested-stack/consolidate-patient-data-connector.ts
@@ -30,7 +30,7 @@ function settings() {
     visibilityTimeout: Duration.seconds(lambdaTimeout.toSeconds() * 2 + 1),
     retryAttempts: 2,
     maxMessageCountAlarmThreshold: 1_000,
-    maxAgeOfOldestMessage: lambdaTimeout,
+    maxAgeOfOldestMessage: Duration.minutes(lambdaTimeout.toMinutes() * 2),
     maxAgeOfOldestMessageDlq: Duration.minutes(30),
   };
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#2215

### Dependencies

none

### Description

Consolidated from S3 FF from boolean to per cx - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1726687148822529?thread_ts=1726522010.103949&cid=C04DMKE9DME).

Also adjust the threshold for the alert about max age on consolidator SQS - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1726679666129669?thread_ts=1726660494.128789&cid=C04T256DQPQ).

### Testing

- Local
  - none
- Staging
  - [ ] enable consolidated from S3 per cx
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
- [ ] Set FF `cxsWithConsolidatedFromS3`
   ```
   "cxsWithConsolidatedFromS3": {
     "enabled": false,
     "values": [
       "abc123"
     ]
   },
   ``` 
