### PR TITLE
fix(core): dont notify us on bad request errors

### DIFF
--- a/packages/core/src/fhir-to-cda/cda-templates/components/medications.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/components/medications.ts
@@ -1,10 +1,10 @@
 import { Bundle, Dosage, DosageDoseAndRate, MedicationStatement } from "@medplum/fhirtypes";
+import { BadRequestError } from "@metriport/shared";
 import {
   findResourceInBundle,
   isMedication,
   isMedicationStatement,
 } from "../../../external/fhir/shared";
-import BadRequestError from "../../../util/error/bad-request";
 import { MedicationSection } from "../../cda-types/sections";
 import {
   CdaValuePq,

--- a/packages/lambdas/src/fhir-to-cda-converter.ts
+++ b/packages/lambdas/src/fhir-to-cda-converter.ts
@@ -1,4 +1,5 @@
 import { Input } from "@metriport/core/domain/conversion/fhir-to-cda";
+import { BadRequestError } from "@metriport/shared";
 import { splitBundleByCompositions } from "@metriport/core/fhir-to-cda/composition-splitter";
 import { convertFhirBundleToCda } from "@metriport/core/fhir-to-cda/fhir-to-cda";
 import { out } from "@metriport/core/util/log";
@@ -26,14 +27,16 @@ export const handler = Sentry.AWSLambda.wrapHandler(
     } catch (error: any) {
       const msg = `Error converting FHIR bundle to CDA`;
       log(`${msg} - error: ${error.message}`);
-      capture.error(msg, {
-        extra: {
-          error,
-          cxId,
-          context: lambdaName,
-          orgOid,
-        },
-      });
+      if (!(error instanceof BadRequestError)) {
+        capture.error(msg, {
+          extra: {
+            error,
+            cxId,
+            context: lambdaName,
+            orgOid,
+          },
+        });
+      }
       throw error;
     }
   }


### PR DESCRIPTION
refs. metriport/metriport-internal#799

### Description
- FHIR to CDA has some scenarios where it errors with `BadRequestError`. We don't want to be notified of those on Sentry. This PR handles that.

### Testing

- Local
  - [x] Trigger the issue on local API and make sure the check passes as expected 
### Release Plan
- [ ] Merge this
