### PR TITLE
1040 Add some FHIR and S3 utils

### DIFF
--- a/packages/utils/src/fhir-deduplication/check-references.ts
+++ b/packages/utils/src/fhir-deduplication/check-references.ts
@@ -1,0 +1,51 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import { BundleEntry, Resource } from "@medplum/fhirtypes";
+import { out } from "@metriport/core/util/log";
+import fs from "fs";
+import { elapsedTimeAsStr } from "../shared/duration";
+import { initRunsFolder } from "../shared/folder";
+import { getMissingReferences } from "./report/validate-references";
+
+/**
+ * Utility to validate references on a FHIR bundle.
+ *
+ * Usage:
+ * - set the path to the file on `filePath`
+ * - run `ts-node src/fhir-deduplication/validate-references.ts`
+ */
+const filePath = "";
+
+async function main() {
+  const startedAt = Date.now();
+  initRunsFolder();
+  const { log } = out(``);
+
+  const bundleFile = fs.readFileSync(filePath, "utf8");
+
+  const resources: Resource[] =
+    JSON.parse(bundleFile).entry?.map((entry: BundleEntry) => entry.resource) ?? [];
+
+  log(`Validating references on bundle (${resources.length} resources)...`);
+  const res = getMissingReferences(resources);
+
+  const resourcesWithMissingRefs = res.filter(r => r.missingRefs.length > 0);
+
+  if (resourcesWithMissingRefs.length) {
+    console.log(`Found ${resourcesWithMissingRefs.length} resources with missing references:`);
+    resourcesWithMissingRefs.forEach(r => {
+      const resource = r.resource;
+      console.log(`- resource: ${resource.resourceType}/${resource.id} - missing refs:`);
+      r.missingRefs.forEach(missingRef => {
+        console.log(`   - ${missingRef}`);
+      });
+    });
+  } else {
+    console.log(`No resources with missing references, yay!`);
+  }
+
+  console.log(`>>> Done in ${elapsedTimeAsStr(startedAt)}`);
+}
+
+main();

--- a/packages/utils/src/fhir-deduplication/report/validate-references.ts
+++ b/packages/utils/src/fhir-deduplication/report/validate-references.ts
@@ -7,7 +7,9 @@ const missingRefsFileName = "missing-refs.csv";
 /**
  * Go through each resource, find other resources it references, and check if they are present in the bundle.
  */
-export function validateReferences(resources: Resource[], dirName: string): boolean {
+export function getMissingReferences(
+  resources: Resource[]
+): { resource: Resource; missingRefs: string[] }[] {
   const resourceMap = new Map<string, Resource>();
   resources.forEach(r => resourceMap.set(r.id ?? "", r));
 
@@ -17,6 +19,15 @@ export function validateReferences(resources: Resource[], dirName: string): bool
     if (localMissingRefs.length) missingRefs.push({ resource: r, missingRefs: localMissingRefs });
   });
 
+  return missingRefs;
+}
+
+/**
+ * Find missing references, store them on 'dirName' if any, return a boolean indicating if
+ * there references are valid.
+ */
+export function validateReferences(resources: Resource[], dirName: string): boolean {
+  const missingRefs = getMissingReferences(resources);
   if (missingRefs.length) {
     const outputFileName = dirName + "/" + missingRefsFileName;
     const header = ["resource", "missing-refs..."].join(csvSeparator);
@@ -292,7 +303,8 @@ function stringReferenceOrArrayToStringArr(
   obj?: string | string[] | Reference | Reference[]
 ): string[] {
   if (typeof obj === "string") {
-    return [obj];
+    if (obj.startsWith("#") || obj.includes("/")) return [obj];
+    return [];
   } else if (Array.isArray(obj)) {
     return obj.flatMap(stringReferenceOrArrayToStringArr);
   } else {

--- a/packages/utils/src/s3/load-patient-objects.ts
+++ b/packages/utils/src/s3/load-patient-objects.ts
@@ -1,0 +1,56 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import { createFolderName } from "@metriport/core/domain/filename";
+import { S3Utils } from "@metriport/core/external/aws/s3";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
+import { out } from "@metriport/core/util/log";
+import { getEnvVarOrFail } from "@metriport/shared";
+import { formatNumber } from "@metriport/shared/common/numbers";
+import { elapsedTimeAsStr } from "../shared/duration";
+
+/**
+ * Utility download files from a patient from S3 and log duration and size.
+ *
+ * Usage:
+ * - set the constants below
+ */
+const cxId = "";
+const patientId = "";
+const bucketName = "";
+const suffixToInclude = ".xml.json";
+const region = getEnvVarOrFail("AWS_REGION");
+
+async function main() {
+  const startedAt = Date.now();
+  const { log } = out(``);
+  const s3 = new S3Utils(region);
+
+  log(`Processing patient...`);
+  const patientPrefix = createFolderName(cxId, patientId);
+  const objects = await s3.listObjects(bucketName, patientPrefix);
+  const filteredObjects = objects?.filter(obj => obj.Key?.includes(suffixToInclude)) ?? [];
+  const timeToList = elapsedTimeAsStr(startedAt);
+  log(`Found ${filteredObjects.length} files in ${timeToList}`);
+
+  let totalSize = 0;
+  const startedAtDownload = Date.now();
+  await executeAsynchronously(
+    filteredObjects,
+    async obj => {
+      if (!obj.Key) return;
+      log(`Downloading file ${obj.Key}...`);
+      const contents = Buffer.from(await s3.getFileContentsAsString(bucketName, obj.Key));
+      totalSize += contents.length;
+    },
+    { numberOfParallelExecutions: 10 }
+  );
+  log(`Found ${filteredObjects.length} files in ${timeToList}`);
+  log(
+    `Downloaded them in ${elapsedTimeAsStr(startedAtDownload)} - ${totalSize} B / ${formatNumber(
+      totalSize / 1024
+    )} MB`
+  );
+}
+
+main();


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Add some FHIR and S3 utils:
- fhir: check-references
- fhir: validate-references
- s3: load objects from a patient's "folder" on s3 and log duration and total size

### Testing

- Local
  - [x] run the scripts
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
