### PR TITLE
fix(fhir-converter): default 400 status

### DIFF
--- a/packages/fhir-converter/src/routes.js
+++ b/packages/fhir-converter/src/routes.js
@@ -228,7 +228,7 @@ module.exports = function (app) {
         console.log(
           `[patient ${patientId}] Took ${duration}ms / status ${status} to process file ${fileName}`
         );
-        res.status(status ?? 400);
+        res.status(status);
         res.json(resultMessage);
         return;
       });

--- a/packages/fhir-converter/src/routes.js
+++ b/packages/fhir-converter/src/routes.js
@@ -227,7 +227,7 @@ module.exports = function (app) {
         console.log(
           `[patient ${patientId}] Took ${duration}ms / status ${result.status} to process file ${fileName}`
         );
-        res.status(result.status);
+        res.status(result.status ?? 400);
         res.json(resultMessage);
         return;
       });

--- a/packages/fhir-converter/src/routes.js
+++ b/packages/fhir-converter/src/routes.js
@@ -217,6 +217,7 @@ module.exports = function (app) {
       })
       .then(result => {
         const duration = new Date().getTime() - startTime;
+        const status = result.status ?? 400;
         const resultMessage = result.resultMsg;
         if (!retUnusedSegments) {
           delete resultMessage["unusedSegments"];
@@ -225,9 +226,9 @@ module.exports = function (app) {
           delete resultMessage["invalidAccess"];
         }
         console.log(
-          `[patient ${patientId}] Took ${duration}ms / status ${result.status} to process file ${fileName}`
+          `[patient ${patientId}] Took ${duration}ms / status ${status} to process file ${fileName}`
         );
-        res.status(result.status ?? 400);
+        res.status(status ?? 400);
         res.json(resultMessage);
         return;
       });


### PR DESCRIPTION
refs. metriport/metriport-internal#2107

### Description
- When conversion status is `undefined`, we wait until timeout. This fix defaults to 400, so we instantly return if there are errors in the conversion. 

### Testing
- Local
  - [x] Used a malformed XML to replicate timeout behavior. The fix works. 

### Release Plan
- [ ] Merge this
