### PR TITLE
feat(api): always return CCD to CW

### DIFF
--- a/packages/api/src/external/commonwell/proxy/cw-process-request.ts
+++ b/packages/api/src/external/commonwell/proxy/cw-process-request.ts
@@ -1,5 +1,4 @@
 import { Bundle, BundleEntry, DocumentReference, Resource, ResourceType } from "@medplum/fhirtypes";
-import { getDocumentContents } from "@metriport/core/external/carequality/dq/process-inbound-dq";
 import {
   docContributionFileParam,
   getDocContributionURL,
@@ -7,6 +6,7 @@ import {
 import { isDocumentReference } from "@metriport/core/external/fhir/document/document-reference";
 import { toFHIR as patientToFHIR } from "@metriport/core/external/fhir/patient/index";
 import { buildBundle } from "@metriport/core/external/fhir/shared/bundle";
+import { getMetadataDocumentContents } from "@metriport/core/shareback/metadata/get-metadata-xml";
 import { parseExtrinsicObjectXmlToDocumentReference } from "@metriport/core/shareback/metadata/parse-metadata-xml";
 import BadRequestError from "@metriport/core/util/error/bad-request";
 import { out } from "@metriport/core/util/log";
@@ -62,7 +62,7 @@ export async function processRequest(req: Request): Promise<Bundle<Resource>> {
     },
   ];
 
-  const metadataFiles = await getDocumentContents(cxId, patientId);
+  const metadataFiles = await getMetadataDocumentContents(cxId, patientId);
   const docRefs: DocumentReference[] = [];
   for (const file of metadataFiles) {
     const additionalDocRef = await parseExtrinsicObjectXmlToDocumentReference(file, patientId);

--- a/packages/api/src/external/commonwell/proxy/cw-process-request.ts
+++ b/packages/api/src/external/commonwell/proxy/cw-process-request.ts
@@ -6,6 +6,7 @@ import {
 import { isDocumentReference } from "@metriport/core/external/fhir/document/document-reference";
 import { toFHIR as patientToFHIR } from "@metriport/core/external/fhir/patient/index";
 import { buildBundle } from "@metriport/core/external/fhir/shared/bundle";
+import { ensureCcdExists } from "@metriport/core/shareback/ensure-ccd-exists";
 import { getMetadataDocumentContents } from "@metriport/core/shareback/metadata/get-metadata-xml";
 import { parseExtrinsicObjectXmlToDocumentReference } from "@metriport/core/shareback/metadata/parse-metadata-xml";
 import BadRequestError from "@metriport/core/util/error/bad-request";
@@ -62,6 +63,7 @@ export async function processRequest(req: Request): Promise<Bundle<Resource>> {
     },
   ];
 
+  await ensureCcdExists({ cxId, patientId, log });
   const metadataFiles = await getMetadataDocumentContents(cxId, patientId);
   const docRefs: DocumentReference[] = [];
   for (const file of metadataFiles) {

--- a/packages/core/src/external/carequality/dq/process-inbound-dq.ts
+++ b/packages/core/src/external/carequality/dq/process-inbound-dq.ts
@@ -56,7 +56,7 @@ export async function processInboundDq(
       log("CCD generated. Fetching the document contents");
     }
 
-    const documentContents = await getDocumentContents(cxId, patientId);
+    const documentContents = await getDocumentContents(cxId, patientId, false);
     const response: InboundDocumentQueryResp = {
       id: payload.id,
       patientId: payload.patientId,
@@ -78,10 +78,14 @@ export async function processInboundDq(
   }
 }
 
-export async function getDocumentContents(cxId: string, patientId: string): Promise<string[]> {
+export async function getDocumentContents(
+  cxId: string,
+  patientId: string,
+  failGracefully = true
+): Promise<string[]> {
   const documentContents = await retrieveXmlContentsFromMetadataFilesOnS3(cxId, patientId, bucket);
 
-  if (!documentContents.length) {
+  if (!documentContents.length && !failGracefully) {
     const msg = `Error getting document contents`;
     capture.error(msg, { extra: { cxId, patientId } });
     throw new XDSRegistryError("Internal Server Error");

--- a/packages/core/src/external/carequality/dq/process-inbound-dq.ts
+++ b/packages/core/src/external/carequality/dq/process-inbound-dq.ts
@@ -2,7 +2,7 @@ import { InboundDocumentQueryReq, InboundDocumentQueryResp } from "@metriport/ih
 import { executeWithNetworkRetries } from "@metriport/shared";
 import axios from "axios";
 import { CCD_SUFFIX, createUploadFilePath } from "../../../domain/document/upload";
-import { getMetadataDocumentContents } from "../../../shareback/metadata/retrieve-metadata-xml";
+import { getMetadataDocumentContents } from "../../../shareback/metadata/get-metadata-xml";
 import { Config } from "../../../util/config";
 import { out } from "../../../util/log";
 import { S3Utils } from "../../aws/s3";

--- a/packages/core/src/shareback/ensure-ccd-exists.ts
+++ b/packages/core/src/shareback/ensure-ccd-exists.ts
@@ -30,13 +30,14 @@ export async function ensureCcdExists({
   };
   const params = new URLSearchParams(queryParams).toString();
 
-  executeWithNetworkRetries(async () => api.post(`${apiUrl}/internal/docs/ccd?${params}`), {
-    log,
-  });
   await executeWithNetworkRetries(
     async () => await api.post(`${apiUrl}/internal/docs/empty-ccd?${params}`),
     { log }
   );
+
+  executeWithNetworkRetries(async () => api.post(`${apiUrl}/internal/docs/ccd?${params}`), {
+    log,
+  });
 
   log("CCD generated. Fetching the document contents");
   return;

--- a/packages/core/src/shareback/ensure-ccd-exists.ts
+++ b/packages/core/src/shareback/ensure-ccd-exists.ts
@@ -1,0 +1,43 @@
+import { executeWithNetworkRetries } from "@metriport/shared";
+import axios from "axios";
+import { S3Utils } from "../external/aws/s3";
+import { Config } from "../util/config";
+import { CCD_SUFFIX, createUploadFilePath } from "../domain/document/upload";
+
+const apiUrl = Config.getApiUrl();
+const region = Config.getAWSRegion();
+const s3Utils = new S3Utils(region);
+const api = axios.create();
+const bucket = Config.getMedicalDocumentsBucketName();
+
+export async function ensureCcdExists({
+  cxId,
+  patientId,
+  log,
+}: {
+  cxId: string;
+  patientId: string;
+  log: typeof console.log;
+}): Promise<void> {
+  const destinationKey = createUploadFilePath(cxId, patientId, `${CCD_SUFFIX}.xml`);
+  const ccdExists = await s3Utils.fileExists(bucket, destinationKey);
+  if (ccdExists) return;
+
+  log("No CCD found. Let's trigger generating one.");
+  const queryParams = {
+    cxId,
+    patientId,
+  };
+  const params = new URLSearchParams(queryParams).toString();
+
+  executeWithNetworkRetries(async () => api.post(`${apiUrl}/internal/docs/ccd?${params}`), {
+    log,
+  });
+  await executeWithNetworkRetries(
+    async () => await api.post(`${apiUrl}/internal/docs/empty-ccd?${params}`),
+    { log }
+  );
+
+  log("CCD generated. Fetching the document contents");
+  return;
+}

--- a/packages/core/src/shareback/metadata/get-metadata-xml.ts
+++ b/packages/core/src/shareback/metadata/get-metadata-xml.ts
@@ -11,12 +11,11 @@ const bucket = Config.getMedicalDocumentsBucketName();
 
 export async function getMetadataDocumentContents(
   cxId: string,
-  patientId: string,
-  failGracefully = true
+  patientId: string
 ): Promise<string[]> {
   const documentContents = await retrieveXmlContentsFromMetadataFilesOnS3(cxId, patientId, bucket);
 
-  if (!documentContents.length && !failGracefully) {
+  if (!documentContents.length) {
     const msg = `Error getting document contents`;
     capture.error(msg, { extra: { cxId, patientId } });
     throw new XDSRegistryError("Internal Server Error");

--- a/packages/core/src/shareback/metadata/get-metadata-xml.ts
+++ b/packages/core/src/shareback/metadata/get-metadata-xml.ts
@@ -1,0 +1,61 @@
+import { UPLOADS_FOLDER } from "../../domain/document/upload";
+import { createFolderName } from "../../domain/filename";
+import { S3Utils, executeWithRetriesS3 } from "../../external/aws/s3";
+import { XDSRegistryError } from "../../external/carequality/error";
+import { Config } from "../../util/config";
+import { capture } from "../../util/notifications";
+
+const region = Config.getAWSRegion();
+const s3Utils = new S3Utils(region);
+const bucket = Config.getMedicalDocumentsBucketName();
+
+export async function getMetadataDocumentContents(
+  cxId: string,
+  patientId: string,
+  failGracefully = true
+): Promise<string[]> {
+  const documentContents = await retrieveXmlContentsFromMetadataFilesOnS3(cxId, patientId, bucket);
+
+  if (!documentContents.length && !failGracefully) {
+    const msg = `Error getting document contents`;
+    capture.error(msg, { extra: { cxId, patientId } });
+    throw new XDSRegistryError("Internal Server Error");
+  }
+  return documentContents;
+}
+
+async function retrieveXmlContentsFromMetadataFilesOnS3(
+  cxId: string,
+  patientId: string,
+  bucketName: string
+): Promise<string[]> {
+  const folderName = createFolderName(cxId, patientId);
+  const Prefix = `${folderName}/${UPLOADS_FOLDER}/`;
+
+  const params = {
+    Bucket: bucketName,
+    Prefix,
+  };
+
+  const data = await executeWithRetriesS3(() => s3Utils._s3.listObjectsV2(params).promise());
+  const documentContents = (
+    await Promise.all(
+      data.Contents?.filter(item => item.Key && item.Key.endsWith("_metadata.xml")).map(
+        async item => {
+          if (item.Key) {
+            const params = {
+              Bucket: bucketName,
+              Key: item.Key,
+            };
+
+            const data = await executeWithRetriesS3(() => s3Utils._s3.getObject(params).promise());
+            return data.Body?.toString();
+          }
+          return undefined;
+        }
+      ) || []
+    )
+  ).filter((item): item is string => Boolean(item));
+
+  return documentContents;
+}

--- a/packages/infra/lib/ihe-stack.ts
+++ b/packages/infra/lib/ihe-stack.ts
@@ -260,7 +260,6 @@ export class IHEStack extends Stack {
       envVars: {
         MEDICAL_DOCUMENTS_BUCKET_NAME: props.config.medicalDocumentsBucketName,
         IHE_REQUESTS_BUCKET_NAME: iheRequestsBucket.bucketName,
-        API_URL: props.config.loadBalancerDnsName,
         ...(props.config.engineeringCxId
           ? { ENGINEERING_CX_ID: props.config.engineeringCxId }
           : {}),

--- a/packages/lambdas/src/ihe-gateway-v2-inbound-document-query.ts
+++ b/packages/lambdas/src/ihe-gateway-v2-inbound-document-query.ts
@@ -10,7 +10,6 @@ import { getEnvVarOrFail, getEnvVar } from "@metriport/core/util/env-var";
 import { out } from "@metriport/core/util/log";
 import { getEnvOrFail } from "./shared/env";
 
-const apiUrl = getEnvVarOrFail("API_URL");
 const region = getEnvVarOrFail("AWS_REGION");
 const engineeringCxId = getEnvVar("ENGINEERING_CX_ID");
 const postHogSecretName = getEnvVar("POST_HOG_API_KEY_SECRET");
@@ -25,7 +24,7 @@ export async function handler(event: APIGatewayProxyEventV2) {
         ? Buffer.from(event.body, "base64").toString()
         : event.body;
       const dqRequest: InboundDocumentQueryReq = await processInboundDqRequest(body);
-      const result: InboundDocumentQueryResp = await processInboundDq(dqRequest, apiUrl);
+      const result: InboundDocumentQueryResp = await processInboundDq(dqRequest);
       const xmlResponse = createInboundDqResponse(result);
 
       if (


### PR DESCRIPTION
refs. metriport/metriport-internal#2240

### Description
- Before responding to CW DQ requests, we now ensure that a CCD exists (by checking for an existing one, or creating a new one)

### Testing
- Staging: 
  - [ ] Make sure that between two CW Orgs, a CCD for matching patients is returned

### Release Plan
- [ ] Merge this
