### PR TITLE
feat(cq): adding operation outcomes

### DIFF
--- a/packages/api/src/external/hie/carequality-analytics.ts
+++ b/packages/api/src/external/hie/carequality-analytics.ts
@@ -2,12 +2,16 @@ import {
   OutboundPatientDiscoveryResp,
   OutboundDocumentQueryResp,
   OutboundDocumentRetrievalResp,
-  isSuccessfulOutboundDocRetrievalResponse,
   isNonErroringOutboundPatientDiscoveryResponse,
   isSuccessfulOutboundPatientDiscoveryResponse,
 } from "@metriport/ihe-gateway-sdk";
 
-import { httpErrorCode, schemaErrorCode } from "@metriport/core/external/carequality/error";
+import {
+  httpErrorCode,
+  schemaErrorCode,
+  registryErrorCode,
+  documentNotFoundErrorCode,
+} from "@metriport/core/external/carequality/error";
 
 export type GatewayCounts = {
   ehealthexchange: number;
@@ -178,16 +182,54 @@ export function getOutboundDocQuerySuccessFailureCount(response: OutboundDocumen
 
 export function getOutboundDocRetrievalSuccessFailureCount(
   response: OutboundDocumentRetrievalResp[]
-): { successCount: number; failureCount: number } {
+): {
+  totalCount: number;
+  successCount: number;
+  failureCount: number;
+  noDocumentFoundCount: number;
+  schemaErrorCount: number;
+  httpErrorCount: number;
+  registryErrorCount: number;
+} {
   let successCount = 0;
   let failureCount = 0;
+  let totalCount = 0;
+  let noDocumentFoundCount = 0;
+  let schemaErrorCount = 0;
+  let httpErrorCount = 0;
+  let registryErrorCount = 0;
   for (const result of response) {
-    if (isSuccessfulOutboundDocRetrievalResponse(result)) {
-      successCount++;
-    } else if (result.operationOutcome?.issue) {
-      failureCount++;
+    if (result.documentReference) {
+      totalCount += result.documentReference.length;
+      successCount += result.documentReference.length;
+    }
+    if (result.operationOutcome?.issue) {
+      totalCount += result.operationOutcome.issue.length;
+      failureCount += result.operationOutcome.issue.filter(
+        issue => issue.severity === "error"
+      ).length;
+      noDocumentFoundCount += result.operationOutcome.issue.filter(
+        issue => issue.code === documentNotFoundErrorCode
+      ).length;
+      schemaErrorCount += result.operationOutcome.issue.filter(
+        issue => issue.code === schemaErrorCode
+      ).length;
+      httpErrorCount += result.operationOutcome.issue.filter(
+        issue => issue.code === httpErrorCode
+      ).length;
+      registryErrorCount += result.operationOutcome.issue.filter(
+        issue => issue.code === registryErrorCode
+      ).length;
     }
   }
 
-  return { successCount, failureCount };
+  return {
+    totalCount,
+    successCount,
+    failureCount,
+    noDocumentFoundCount,
+    schemaErrorCount,
+    httpErrorCount,
+    registryErrorCount,
+  };
 }

--- a/packages/core/src/external/carequality/error.ts
+++ b/packages/core/src/external/carequality/error.ts
@@ -140,3 +140,5 @@ export function constructPDErrorResponse(
 
 export const httpErrorCode = "http-error";
 export const schemaErrorCode = "schema-error";
+export const registryErrorCode = "registry-error";
+export const documentNotFoundErrorCode = "document-not-found";

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/dr-partial-success.xml
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/dr-partial-success.xml
@@ -35,23 +35,20 @@
                 </rim:RegistryErrorList>
 
             </rs:RegistryResponse>
-
-            <!-- Documents available now -->
             <DocumentResponse>
-                <homeCommunityId>urn:oid:1.2.3.4</homeCommunityId>
-                <RepositoryUniqueId>1.3.6.1.4...1000</RepositoryUniqueId>
-                <DocumentUniqueId>1.3.6.1.4...2300</DocumentUniqueId>
-                <mimeType>text/xml</mimeType>
-
-                <Document>UjBsR09EbGhjZ0dTQUxNQUFBUUNBRU1tQ1p0dU1GUXhEUzhi</Document>
+                <HomeCommunityId>urn:oid:2.16.840.1.113883.3.9621</HomeCommunityId>
+                <RepositoryUniqueId>urn:oid:2.16.840.1.113883.3.9621</RepositoryUniqueId>
+                <DocumentUniqueId>123456789</DocumentUniqueId>
+                <mimeType>application/pdf</mimeType>
+                <Document>Metriport Rocks!</Document>
             </DocumentResponse>
             <DocumentResponse>
-                <homeCommunityId>urn:oid:1.2.3.4</homeCommunityId>
-                <RepositoryUniqueId>1.3.6.1.4...1000</RepositoryUniqueId>
-                <DocumentUniqueId>1.3.6.1.4...2300</DocumentUniqueId>
-                <mimeType>text/xml</mimeType>
-
-                <Document>UjBsR09EbGhjZ0dTQUxNQUFBUUNBRU1tQ1p0dU1GUXhEUzhi</Document>
+                <HomeCommunityId>urn:oid:2.16.840.1.113883.3.9621</HomeCommunityId>
+                <RepositoryUniqueId>urn:oid:2.16.840.1.113883.3.9621</RepositoryUniqueId>
+                <DocumentUniqueId>987654321</DocumentUniqueId>
+                <mimeType>application/xml</mimeType>
+                <Document>Metriport is the best!</Document>
+                <CreationTime>2024-04-04T22:15:35.094Z</CreationTime>
             </DocumentResponse>
         </RetrieveDocumentSetResponse>
     </S:Body>

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
@@ -13,7 +13,6 @@ import {
   XDSDocumentEntryClassCode,
   XDSDocumentEntryUniqueId,
 } from "../../../../../../shareback/metadata/constants";
-import { errorToString } from "../../../../../../util/error/shared";
 import { out } from "../../../../../../util/log";
 import { capture } from "../../../../../../util/notifications";
 import { stripUrnPrefix } from "../../../../../../util/urn";
@@ -21,10 +20,10 @@ import { Slot } from "../../../schema";
 import { DQSamlClientResponse } from "../send/dq-requests";
 import { partialSuccessStatus, successStatus } from "./constants";
 import {
-  handleEmptyResponse,
-  handleHttpErrorResponse,
-  handleRegistryErrorResponse,
-  handleSchemaErrorResponse,
+  handleEmptyResponseDq,
+  handleHttpErrorResponseDq,
+  handleRegistryErrorResponseDq,
+  handleSchemaErrorResponseDq,
 } from "./error";
 import { Classification, ExternalIdentifier, ExtrinsicObject, iti38Schema } from "./schema";
 
@@ -180,7 +179,7 @@ export function processDqResponse({
   response: DQSamlClientResponse;
 }): OutboundDocumentQueryResp {
   if (success === false) {
-    return handleHttpErrorResponse({
+    return handleHttpErrorResponseDq({
       httpError: response,
       outboundRequest,
       gateway: gateway,
@@ -210,23 +209,22 @@ export function processDqResponse({
         gateway,
       });
     } else if (registryErrorList) {
-      return handleRegistryErrorResponse({
+      return handleRegistryErrorResponseDq({
         registryErrorList,
         outboundRequest,
         gateway,
       });
     } else {
-      return handleEmptyResponse({
+      return handleEmptyResponseDq({
         outboundRequest,
         gateway,
       });
     }
   } catch (error) {
     log(`Error processing DQ response ${JSON.stringify(jsonObj)}`);
-    return handleSchemaErrorResponse({
+    return handleSchemaErrorResponseDq({
       outboundRequest,
       gateway,
-      text: errorToString(error),
     });
   }
 }

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
@@ -7,10 +7,11 @@ import {
   DocumentReference,
 } from "@metriport/ihe-gateway-sdk";
 import {
-  handleRegistryErrorResponse,
-  handleHttpErrorResponse,
-  handleEmptyResponse,
-  handleSchemaErrorResponse,
+  handleRegistryErrorResponseDr,
+  handleHttpErrorResponseDr,
+  handleEmptyResponseDr,
+  handleSchemaErrorResponseDr,
+  generateOperationOutcomesForMissingDocuments,
 } from "./error";
 import { parseFileFromString, parseFileFromBuffer } from "./parse-file-from-string";
 import { stripUrnPrefix } from "../../../../../../util/urn";
@@ -23,7 +24,7 @@ import { createDocumentFilePath } from "../../../../../../domain/document/filena
 import { MetriportError } from "../../../../../../util/error/metriport-error";
 import { getCidReference } from "../mtom/cid";
 import { out } from "../../../../../../util/log";
-import { errorToString, toArray } from "@metriport/shared";
+import { toArray } from "@metriport/shared";
 import { iti39Schema, DocumentResponse } from "./schema";
 import { capture } from "../../../../../../util/notifications";
 
@@ -116,7 +117,7 @@ async function processDocumentReference({
     }
 
     log(
-      `Downloaded a document with mime type: ${mimeType} for patient: ${outboundRequest.patientId} and request: ${outboundRequest.id}`
+      `Downloaded a document with mime type: ${mimeType} and docUniqueId: ${documentResponse.DocumentUniqueId} for patient: ${outboundRequest.patientId} and request: ${outboundRequest.id}`
     );
 
     return {
@@ -189,6 +190,15 @@ async function handleSuccessResponse({
       )
       .map(result => result.value);
 
+    const processedIds = new Set(
+      documentReferences.map(doc => doc.metriportId).filter((id): id is string => id != null)
+    );
+    const operationOutcome = generateOperationOutcomesForMissingDocuments(
+      idMapping,
+      processedIds,
+      outboundRequest.id
+    );
+
     const response: OutboundDocumentRetrievalResp = {
       id: outboundRequest.id,
       requestChunkId: outboundRequest.requestChunkId,
@@ -198,6 +208,7 @@ async function handleSuccessResponse({
       responseTimestamp: dayjs().toISOString(),
       gateway,
       documentReference: documentReferences,
+      operationOutcome: operationOutcome.issue.length > 0 ? operationOutcome : undefined,
       iheGatewayV2: true,
     };
     return response;
@@ -213,7 +224,7 @@ export async function processDrResponse({
 }): Promise<OutboundDocumentRetrievalResp> {
   if (!gateway || !outboundRequest) throw new Error("Missing gateway or outboundRequest");
   if (errorResponse) {
-    return handleHttpErrorResponse({
+    return handleHttpErrorResponseDr({
       httpError: errorResponse,
       outboundRequest,
       gateway,
@@ -251,23 +262,22 @@ export async function processDrResponse({
         mtomResponse,
       });
     } else if (registryErrorList) {
-      return handleRegistryErrorResponse({
+      return handleRegistryErrorResponseDr({
         registryErrorList,
         outboundRequest,
         gateway,
       });
     } else {
-      return handleEmptyResponse({
+      return handleEmptyResponseDr({
         outboundRequest,
         gateway,
       });
     }
   } catch (error) {
     log(`Error processing DR response ${JSON.stringify(error)}`);
-    return handleSchemaErrorResponse({
+    return handleSchemaErrorResponseDr({
       outboundRequest,
       gateway,
-      text: errorToString(error),
     });
   }
 }

--- a/packages/ihe-gateway-sdk/src/models/shared.ts
+++ b/packages/ihe-gateway-sdk/src/models/shared.ts
@@ -49,6 +49,7 @@ export const codeSchema = z.object({
 export type Code = z.infer<typeof codeSchema>;
 
 export const detailsSchema = z.object({
+  id: z.string().optional(),
   coding: z.array(codeSchema).optional(),
   text: z.string().optional(),
 });
@@ -56,6 +57,7 @@ export const detailsSchema = z.object({
 export type Details = z.infer<typeof detailsSchema>;
 
 export const issueSchema = z.object({
+  id: z.string().nullish(),
   severity: z.string(),
   code: z.string(),
   details: detailsSchema,


### PR DESCRIPTION
Ticket: #[2223](https://github.com/metriport/metriport-internal/issues/2223), [1877](https://github.com/metriport/metriport-internal/issues/1877)

### Description

- operation outcomes for erroring drs and for missing dr responses
- updated analytics to track errors more granularly
- updating document reference processing to update erroring documents references from preliminary to entered-in-error
- de duplicate document reference between cw and cq and then update document reference status appropriately 

### Testing

- Local
  - [x] unit tests
- Staging
  - [ ] testing on staging

Check each PR.

### Release Plan

- [ ] Merge this
- [ ] update analytics with new granular error data 
