### PR TITLE
PATCH RELEASE 2240 Add missing env var

### DIFF
--- a/packages/infra/lib/ihe-stack.ts
+++ b/packages/infra/lib/ihe-stack.ts
@@ -260,6 +260,7 @@ export class IHEStack extends Stack {
       envVars: {
         MEDICAL_DOCUMENTS_BUCKET_NAME: props.config.medicalDocumentsBucketName,
         IHE_REQUESTS_BUCKET_NAME: iheRequestsBucket.bucketName,
+        API_LB_ADDRESS: props.config.loadBalancerDnsName,
         ...(props.config.engineeringCxId
           ? { ENGINEERING_CX_ID: props.config.engineeringCxId }
           : {}),


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/2240

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2787
- Downstream: none

### Description

Add missing env var - [context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1726869465900829)

### Testing

None

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
- [ ] Backmerge into develop