### PR TITLE
2215 Move "conversion done" notification to the converter lambda

### DIFF
--- a/packages/infra/lib/api-stack/fhir-server-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-server-connector.ts
@@ -57,11 +57,6 @@ export function createConnector({
     console.log("No FHIR Server URL provided, skipping connector creation");
     return undefined;
   }
-  const apiURL = config.loadBalancerDnsName;
-  if (!apiURL) {
-    console.log("No API URL provided, skipping connector creation");
-    return undefined;
-  }
   const {
     connectorName,
     lambdaMemory,
@@ -104,7 +99,6 @@ export function createConnector({
       METRICS_NAMESPACE,
       ...(config.lambdasSentryDSN ? { SENTRY_DSN: config.lambdasSentryDSN } : {}),
       FHIR_SERVER_URL: fhirServerUrl,
-      API_URL: apiURL,
     },
     timeout: lambdaTimeout,
     alarmSnsAction,

--- a/packages/lambdas/src/shared/oss-api.ts
+++ b/packages/lambdas/src/shared/oss-api.ts
@@ -10,8 +10,8 @@ export type NotificationParams = {
   cxId: string;
   patientId: string;
   status: "success" | "failed";
-  details?: string;
-  jobId?: string;
+  details?: string | undefined;
+  jobId: string | undefined;
   /** The MedicalDataSource, or HIE name */
   source?: string;
 };

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -402,11 +402,10 @@ async function sendConversionResult(
     })
     .promise();
 
-  // TODO 2215 Reenable this when we're ready to move the notification from the FHIR server here
-  // await ossApi.internal.notifyApi(
-  //   { cxId, patientId, status: "success", source: medicalDataSource },
-  //   log
-  // );
+  await ossApi.internal.notifyApi(
+    { cxId, patientId, status: "success", source: medicalDataSource },
+    log
+  );
 }
 
 async function storePreProcessedConversionResult({

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -403,7 +403,7 @@ async function sendConversionResult(
     .promise();
 
   await ossApi.internal.notifyApi(
-    { cxId, patientId, status: "success", source: medicalDataSource },
+    { cxId, patientId, jobId, source: medicalDataSource, status: "success" },
     log
   );
 }


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/2215

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2786
- Downstream: none

### Description

Moves the notification about completed CDA>FHIR conversion from the FHIR server lambda to the Converter lambda.

⚠️ We can only merge this PR when we're ready to move all customers to use consolidated from S3 _permanently_. If we need something temporary and/or that can be toggled, we'll need to tweak this PR so the notification can be moved back/forth between converter and server lambdas.

### Testing

- Local
  - none
- Staging
  - [ ] Throttle the FHIR Server lambda and trigger a DQ, the `/conversion-status` gets called from the converter lambda
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
- [ ] Throttle the FHIRConverter lambda, so there won't be "in flight" conversions
   - This is important b/c we moved the notification of completed conversion from the FHIR server lambda to the converter lambda;
   - If we don't throttle the converter lambda, we could get to a state where the messages for a given jobId have all been converted and are waiting to be inserted into the FHIR server... then we update both lambdas' code... now the server lambda won't notify the OSS API of completed work, so that job ID will never finishes (only through the sweeper job).
- [ ] Wait for this to finish shipping
- [ ] Confirm FHIRConverter lambda is not throttled, otherwise un-throttle it!