### PR TITLE
2261 fhir meta fix

### DIFF
--- a/docs/medical-api/api-reference/document/get-document.mdx
+++ b/docs/medical-api/api-reference/document/get-document.mdx
@@ -4,7 +4,7 @@ description: "Gets a downloadable URL for downloading the specified document."
 api: "GET /medical/v1/document/download-url"
 ---
 
-This endpoint returns a URL which you can use to download the specified document and/or convert using the file name provided from the [List Documents endpoint](/medical-api/api-reference/document/list-documents).
+This endpoint returns a URL which you can use to download the specified document and/or convert using the file name provided from the [List Documents endpoint](/medical-api/api-reference/document/list-documents), or from the `meta.source` field of the FHIR resource you are interested in.
 
 <Info>The URL will only be valid for 60 seconds before you need to request a new one.</Info>
 

--- a/packages/core/src/external/fhir/consolidated/consolidated.ts
+++ b/packages/core/src/external/fhir/consolidated/consolidated.ts
@@ -126,6 +126,15 @@ export async function getConsolidatedFhirBundle({
         };
       }
     }
+    if (entry.resourceType === "DocumentReference") {
+      const attachment = entry.content?.[0]?.attachment;
+      if (attachment) {
+        entry.meta = {
+          ...entry.meta,
+          source: attachment.title ?? entry.meta?.source ?? "",
+        };
+      }
+    }
     return { resource: entry };
   });
   return buildBundle(entry);

--- a/packages/core/src/external/fhir/parse-bundle.ts
+++ b/packages/core/src/external/fhir/parse-bundle.ts
@@ -1,8 +1,8 @@
-import { Bundle } from "@medplum/fhirtypes";
+import { Bundle, Extension } from "@medplum/fhirtypes";
 import { Config } from "../../util/config";
 import { uuidv4 } from "../../util/uuid-v7";
+import { DOC_ID_EXTENSION_URL } from "./shared/extensions/doc-id-extension";
 
-const sourceUrl = "https://api.metriport.com/cda/to/fhir";
 const placeholderReplaceRegex = new RegExp("66666666-6666-6666-6666-666666666666", "g");
 const metriportPrefixRegex = new RegExp("Metriport/identifiers/Metriport/", "g");
 
@@ -37,12 +37,15 @@ function replaceIds(payload: string) {
     // validate resource id
     const idToUse = bundleEntry.resource.id;
     const newId = uuidv4();
+    const docIdExtension = bundleEntry.resource.extension?.find(
+      (ext: { url: string }) => ext.url === DOC_ID_EXTENSION_URL
+    ) as Extension | undefined;
     bundleEntry.resource.id = newId;
     stringsToReplace.push({ old: idToUse, new: newId });
     // replace meta's source and profile
     bundleEntry.resource.meta = {
       lastUpdated: bundleEntry.resource.meta?.lastUpdated ?? new Date().toISOString(),
-      source: sourceUrl,
+      source: docIdExtension?.valueString ?? "",
     };
   }
   let fhirBundleStr = JSON.stringify(fhirBundle);

--- a/packages/core/src/external/fhir/shared/extensions/doc-id-extension.ts
+++ b/packages/core/src/external/fhir/shared/extensions/doc-id-extension.ts
@@ -12,3 +12,11 @@ export function buildDocIdFhirExtension(docId: string): DocIdExtension {
     valueString: docId,
   };
 }
+
+export function findDocIdExtension(extensions: Extension[]): Extension | undefined {
+  return extensions.find(isDocIdExtension);
+}
+
+export function isDocIdExtension(e: Extension): e is DocIdExtension {
+  return e.url === DOC_ID_EXTENSION_URL;
+}

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -1,5 +1,6 @@
 import { executeWithRetriesS3, S3Utils } from "@metriport/core/external/aws/s3";
 import { removeBase64PdfEntries } from "@metriport/core/external/cda/remove-b64";
+import { DOC_ID_EXTENSION_URL } from "@metriport/core/external/fhir/shared/extensions/doc-id-extension";
 import { FHIR_APP_MIME_TYPE, TXT_MIME_TYPE, XML_APP_MIME_TYPE } from "@metriport/core/util/mime";
 import { errorToString, executeWithNetworkRetries, MetriportError } from "@metriport/shared";
 import { SQSEvent, SQSRecord } from "aws-lambda";
@@ -27,7 +28,6 @@ const axiosTimeoutSeconds = Number(getEnvOrFail("AXIOS_TIMEOUT_SECONDS"));
 const fhirServerQueueURL = getEnvOrFail("FHIR_SERVER_QUEUE_URL");
 const conversionResultBucketName = getEnvOrFail("CONVERSION_RESULT_BUCKET_NAME");
 
-const sourceUrl = "https://api.metriport.com/cda/to/fhir";
 const defaultS3RetriesConfig = {
   maxAttempts: 3,
   initialDelay: 500,
@@ -52,6 +52,10 @@ function replaceIDs(fhirBundle: FHIRBundle, patientId: string): FHIRBundle {
     if (!bundleEntry.resource) throw new Error(`Missing resource`);
     if (!bundleEntry.resource.id) throw new Error(`Missing resource id`);
     if (bundleEntry.resource.id === patientId) continue;
+
+    const docIdExtension = bundleEntry.resource.extension?.find(
+      ext => ext.url === DOC_ID_EXTENSION_URL
+    );
     const idToUse = bundleEntry.resource.id;
     const newId = uuid.v4();
     bundleEntry.resource.id = newId;
@@ -59,7 +63,7 @@ function replaceIDs(fhirBundle: FHIRBundle, patientId: string): FHIRBundle {
     // replace meta's source and profile
     bundleEntry.resource.meta = {
       lastUpdated: bundleEntry.resource.meta?.lastUpdated ?? new Date().toISOString(),
-      source: sourceUrl,
+      source: docIdExtension?.valueString ?? "",
     };
   }
   let fhirBundleStr = JSON.stringify(fhirBundle);


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/2261

### Description
- The `meta` attribute of the FHIR resources is now populated with the title of the document that was used to generate this resource. This allows for an easier way to download the source document for our customers

### Testing

- Staging
  - [x] Using 2 orgs and CW DQ, created some FHIR data and checked for the contents using GET /consolidated

### Release Plan

- [ ] Merge this
