### PR TITLE
2215 FF for consolidated on s3 for all customers

### DIFF
--- a/packages/core/src/command/consolidated/get-snapshot-local.ts
+++ b/packages/core/src/command/consolidated/get-snapshot-local.ts
@@ -74,7 +74,7 @@ async function getBundle(
   params: ConsolidatedSnapshotRequestSync | ConsolidatedSnapshotRequestAsync
 ): Promise<Bundle<Resource>> {
   const { cxId, id: patientId } = params.patient;
-  const isGetFromS3 = await isConsolidatedFromS3Enabled(cxId);
+  const isGetFromS3 = await isConsolidatedFromS3Enabled();
   const { log } = out(`getBundle - fromS3: ${isGetFromS3}`);
   if (isGetFromS3) {
     const startedAt = new Date();

--- a/packages/core/src/external/aws/app-config.ts
+++ b/packages/core/src/external/aws/app-config.ts
@@ -29,6 +29,7 @@ export type BooleanFF = z.infer<typeof ffBooleanSchema>;
 export const booleanFFsSchema = z.object({
   commonwellFeatureFlag: ffBooleanSchema,
   carequalityFeatureFlag: ffBooleanSchema,
+  cxsWithConsolidatedFromS3: ffBooleanSchema.optional(),
 });
 export type BooleanFeatureFlags = z.infer<typeof booleanFFsSchema>;
 
@@ -43,7 +44,6 @@ export const cxBasedFFsSchema = z.object({
   cxsWithIncreasedSandboxLimitFeatureFlag: ffStringValuesSchema,
   cxsWithEpicEnabled: ffStringValuesSchema,
   cxsWithDemoAugEnabled: ffStringValuesSchema,
-  cxsWithConsolidatedFromS3: ffStringValuesSchema.optional(),
 });
 export type CxBasedFFsSchema = z.infer<typeof cxBasedFFsSchema>;
 
@@ -250,7 +250,6 @@ export async function isAiBriefFeatureFlagEnabledForCx(cxId: string): Promise<bo
   return cxsWithADHDFeatureFlagValue.includes(cxId);
 }
 
-export async function isConsolidatedFromS3Enabled(cxId: string): Promise<boolean> {
-  const customerIds = await getCxsWithFeatureFlagEnabled("cxsWithConsolidatedFromS3");
-  return customerIds.includes(cxId);
+export async function isConsolidatedFromS3Enabled(): Promise<boolean> {
+  return await isFeatureFlagEnabled("cxsWithConsolidatedFromS3");
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#2215

### Dependencies

none

### Description

FF for consolidated on s3 for all customers - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1726932468368799?thread_ts=1726716296.259739&cid=C04DMKE9DME)

### Testing

- Local
  - none
- Staging
  - [ ] FF without the `values` array still results in consolidated from S3
- Sandbox
  - none
- Production
  - [ ] monitor a couple patients after release

### Release Plan

- [ ] Merge this
- [ ] To minimize confusion, remove the `values` array from the FF in all envs
