### PR TITLE
2215 Create new empty bundles on each consolidate create

### DIFF
--- a/packages/api/src/external/commonwell/proxy/cw-process-request.ts
+++ b/packages/api/src/external/commonwell/proxy/cw-process-request.ts
@@ -137,13 +137,13 @@ function getAllowedSearchParams(searchParams: URLSearchParams): URLSearchParams 
 export function prepareBundle(resources: Resource[], params: URLSearchParams): Bundle<Resource> {
   const { documentReferences, otherResources } = splitResources(resources);
   const filteredDocRefs = applyFilterParams(documentReferences, params);
-  if (filteredDocRefs.length < 1) return buildBundle([]);
+  if (filteredDocRefs.length < 1) return buildBundle();
 
   const updatedDocRefs = adjustAttachmentURLs(filteredDocRefs);
   const consolidatedResources = [...updatedDocRefs, ...otherResources];
   const uniqueResources = uniqBy(consolidatedResources, r => r.id);
   const bundleEntries: BundleEntry[] = uniqueResources.map(r => ({ resource: r }));
-  const bundle = buildBundle(bundleEntries);
+  const bundle = buildBundle({ entries: bundleEntries });
   return bundle;
 }
 

--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -3,7 +3,7 @@ import { createConsolidatedDataFilePath } from "../../domain/consolidated/filena
 import { createFolderName } from "../../domain/filename";
 import { executeWithRetriesS3, S3Utils } from "../../external/aws/s3";
 import { deduplicate } from "../../external/fhir/consolidated/deduplicate";
-import { makeBundle } from "../../external/fhir/shared/bundle";
+import { buildBundle } from "../../external/fhir/shared/bundle";
 import { executeAsynchronously, out } from "../../util";
 import { Config } from "../../util/config";
 import { getConsolidatedLocation, getConsolidatedSourceLocation } from "./consolidated-shared";
@@ -45,7 +45,7 @@ export async function createConsolidatedFromConversions({
     return undefined;
   }
 
-  const consolidated = makeBundle("collection");
+  const consolidated = buildBundle({ type: "collection" });
 
   await executeAsynchronously(
     inputBundles,

--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -3,6 +3,7 @@ import { createConsolidatedDataFilePath } from "../../domain/consolidated/filena
 import { createFolderName } from "../../domain/filename";
 import { executeWithRetriesS3, S3Utils } from "../../external/aws/s3";
 import { deduplicate } from "../../external/fhir/consolidated/deduplicate";
+import { makeBundle } from "../../external/fhir/shared/bundle";
 import { executeAsynchronously, out } from "../../util";
 import { Config } from "../../util/config";
 import { getConsolidatedLocation, getConsolidatedSourceLocation } from "./consolidated-shared";
@@ -14,12 +15,6 @@ const numberOfParallelExecutions = 10;
 const defaultS3RetriesConfig = {
   maxAttempts: 3,
   initialDelay: 500,
-};
-const emptyBundle: Bundle = {
-  resourceType: "Bundle",
-  type: "collection",
-  total: 0,
-  entry: [],
 };
 
 export type ConsolidatePatientDataCommand = {
@@ -50,7 +45,7 @@ export async function createConsolidatedFromConversions({
     return undefined;
   }
 
-  const consolidated = emptyBundle;
+  const consolidated = makeBundle("collection");
 
   await executeAsynchronously(
     inputBundles,

--- a/packages/core/src/external/fhir/__tests__/reference.ts
+++ b/packages/core/src/external/fhir/__tests__/reference.ts
@@ -1,0 +1,8 @@
+import { Reference, Resource } from "@medplum/fhirtypes";
+
+export function makeReferece<T extends Resource>(res: T): Reference<T> {
+  return {
+    reference: res.resourceType + "/" + res.id,
+    type: res.resourceType,
+  };
+}

--- a/packages/core/src/external/fhir/bundle/__tests__/qa.test.ts
+++ b/packages/core/src/external/fhir/bundle/__tests__/qa.test.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { makeCondition } from "../../../../fhir-to-cda/cda-templates/components/__tests__/make-condition";
+import { uuidv7 } from "../../../../util/uuid-v7";
+import { makeAllergyIntollerance } from "../../__tests__/allergy-intolerance";
+import { makeBundle } from "../../__tests__/bundle";
+import { makePatient } from "../../__tests__/patient";
+import { makeReferece } from "../../__tests__/reference";
+import { checkBundleForPatient } from "../qa";
+
+describe("Bundle QA", () => {
+  describe("checkBundleForPatient", () => {
+    it(`returns true when only the expected patient is in the bundle`, async () => {
+      const cxId = uuidv7();
+      const patient = makePatient();
+      const bundle = makeBundle({
+        entries: [makeAllergyIntollerance({ patient }), makeAllergyIntollerance({ patient })],
+      });
+      const res = checkBundleForPatient(bundle, cxId, patient.id);
+      expect(res).toBeTruthy();
+    });
+    it(`returns true when the bundle is empty`, async () => {
+      const cxId = uuidv7();
+      const patient = makePatient();
+      const bundle = makeBundle({ entries: [] });
+      const res = checkBundleForPatient(bundle, cxId, patient.id);
+      expect(res).toBeTruthy();
+    });
+    it(`throw when the bundle w/ AllergyIntollerance has a diff patient`, async () => {
+      const cxId = uuidv7();
+      const patient1 = makePatient();
+      const patient2 = makePatient();
+      const bundle = makeBundle({
+        entries: [
+          makeAllergyIntollerance({ patient: patient1 }),
+          makeAllergyIntollerance({ patient: patient2 }),
+        ],
+      });
+      expect(() => checkBundleForPatient(bundle, cxId, patient1.id)).toThrow(
+        "Bundle contains invalid data"
+      );
+    });
+    it(`throw when the bundle w/ Condition has a diff patient`, async () => {
+      const cxId = uuidv7();
+      const patient1 = makePatient();
+      const patient2 = makePatient();
+      const bundle = makeBundle({
+        entries: [
+          makeCondition({ subject: makeReferece(patient1) }),
+          makeCondition({ subject: makeReferece(patient2) }),
+        ],
+      });
+      expect(() => checkBundleForPatient(bundle, cxId, patient1.id)).toThrow(
+        "Bundle contains invalid data"
+      );
+    });
+  });
+});

--- a/packages/core/src/external/fhir/bundle/qa.ts
+++ b/packages/core/src/external/fhir/bundle/qa.ts
@@ -1,0 +1,47 @@
+import { Bundle, Resource } from "@medplum/fhirtypes";
+import { MetriportError } from "@metriport/shared";
+import { filterTruthy } from "@metriport/shared/common/filter-map";
+import { uniq } from "lodash";
+import { out } from "../../../util";
+
+/**
+ * Check the FHIR bundle only contains references for the given patient.
+ * @param bundle
+ * @param cxId
+ * @param patientId
+ * @returns true if the bundle is valid, otherwise throws an error
+ */
+export function checkBundleForPatient(
+  bundle: Bundle<Resource>,
+  cxId: string,
+  patientId: string
+): true {
+  const { log } = out(`checkBundleForPatient - cx ${cxId}, pat ${patientId}`);
+
+  const patientsIdInBundle = getPatientIdsFromBundle(bundle);
+  const mismatchingPatientsIds = patientsIdInBundle.filter(id => id !== patientId);
+
+  if (mismatchingPatientsIds.length > 0) {
+    log(
+      `Found ${mismatchingPatientsIds.length} mismatching patients in bundle: ${mismatchingPatientsIds}`
+    );
+    throw new MetriportError(`Bundle contains invalid data`, undefined, {
+      cxId,
+      patientId,
+      mismatchingPatientsIds: mismatchingPatientsIds.join(", "),
+    });
+  }
+  return true;
+}
+
+export function getPatientIdsFromBundle(bundle: Bundle<Resource>): string[] {
+  const contents = JSON.stringify(bundle);
+  const matches = contents.match(/"Patient\/(.+?)"/g);
+  const uniquePatientIds = uniq(matches).map(getPatientIdFromRef).flatMap(filterTruthy);
+  return uniquePatientIds;
+}
+
+export function getPatientIdFromRef(ref: string): string | undefined {
+  const id = ref.split("/")[1];
+  return id ? id.replace(/"/g, "") : undefined;
+}

--- a/packages/core/src/external/fhir/consolidated/consolidated.ts
+++ b/packages/core/src/external/fhir/consolidated/consolidated.ts
@@ -1,11 +1,5 @@
 import { OperationOutcomeError } from "@medplum/core";
-import {
-  BundleEntry,
-  ExtractResource,
-  OperationOutcomeIssue,
-  Resource,
-  ResourceType,
-} from "@medplum/fhirtypes";
+import { ExtractResource, OperationOutcomeIssue, Resource, ResourceType } from "@medplum/fhirtypes";
 import { ResourceTypeForConsolidation, SearchSetBundle } from "@metriport/shared/medical";
 import { Patient } from "../../../domain/patient";
 import { Config } from "../../../util/config";
@@ -13,7 +7,7 @@ import { out } from "../../../util/log";
 import { capture } from "../../../util/notifications";
 import { makeFhirApi } from "../api/api-factory";
 import { fullDateQueryForResource, getPatientFilter } from "../patient/resource-filter";
-import { buildBundle, getReferencesFromResources } from "../shared/bundle";
+import { buildSearchSetBundle, getReferencesFromResources } from "../shared/bundle";
 import { getReferencesFromFHIR } from "../shared/references";
 
 const MAX_HYDRATION_ROUNDS = 3;
@@ -115,8 +109,8 @@ export async function getConsolidatedFhirBundle({
     filtered = [...filtered, ...missingRefsOnFHIR];
   }
 
-  const entry: BundleEntry[] = filtered.map(r => ({ resource: r }));
-  return buildBundle(entry);
+  const entries = filtered.map(r => ({ resource: r }));
+  return buildSearchSetBundle({ entries });
 }
 
 const searchResources = async <K extends ResourceType>(

--- a/packages/core/src/external/fhir/shared/bundle.ts
+++ b/packages/core/src/external/fhir/shared/bundle.ts
@@ -105,17 +105,22 @@ function getReferencesFromRaw(
   );
 }
 
-export function makeBundle(
-  type: Bundle["type"] = "searchset",
-  entries: BundleEntry[] = []
-): Bundle {
+export function buildBundle({
+  type = "searchset",
+  entries = [],
+}: {
+  type?: Bundle["type"];
+  entries?: BundleEntry[];
+} = {}): Bundle {
   return { resourceType: "Bundle", total: entries.length, type, entry: entries };
 }
-/**
- * @deprecated Use `makeBundle` instead.
- */
-export function buildBundle(entries: BundleEntry[]): SearchSetBundle<Resource> {
-  return { resourceType: "Bundle", total: entries.length, type: "searchset", entry: entries };
+
+export function buildSearchSetBundle<T extends Resource = Resource>({
+  entries = [],
+}: {
+  entries?: BundleEntry<T>[];
+} = {}): SearchSetBundle<T> {
+  return buildBundle({ type: "searchset", entries }) as SearchSetBundle<T>;
 }
 
 export const buildBundleEntry = <T extends Resource>(resource: T): BundleEntry<T> => {

--- a/packages/core/src/external/fhir/shared/bundle.ts
+++ b/packages/core/src/external/fhir/shared/bundle.ts
@@ -105,6 +105,15 @@ function getReferencesFromRaw(
   );
 }
 
+export function makeBundle(
+  type: Bundle["type"] = "searchset",
+  entries: BundleEntry[] = []
+): Bundle {
+  return { resourceType: "Bundle", total: entries.length, type, entry: entries };
+}
+/**
+ * @deprecated Use `makeBundle` instead.
+ */
 export function buildBundle(entries: BundleEntry[]): SearchSetBundle<Resource> {
   return { resourceType: "Bundle", total: entries.length, type: "searchset", entry: entries };
 }

--- a/packages/utils/src/s3/remove-objects.ts
+++ b/packages/utils/src/s3/remove-objects.ts
@@ -50,7 +50,7 @@ async function main() {
     const file = await s3.getFileInfoFromS3(fileName, bucketName);
     if (!file || !file.exists) {
       console.log(`File ${fileName} not found.`);
-      return;
+      continue;
     }
     console.log(`File ${fileName} found. Size: ${file.size}`);
     if (dryRun) {
@@ -60,7 +60,7 @@ async function main() {
         await s3.deleteFile({ bucket: bucketName, key: fileName });
       } catch (error) {
         console.error(`Error removing file ${fileName}: ${error}`);
-        return;
+        continue;
       }
       console.log(`...File ${fileName} removed`);
     }


### PR DESCRIPTION
Ref. metriport/metriport-internal#2215

### Dependencies

none

### Description

Create new empty bundles on each consolidate create - [context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1727137104190069?thread_ts=1727121353.235279&cid=C04GEQ1GH9D).

Also added a function to validate the contents of the bundle for mingled data.

### Testing

- Local
  - [ ] subsequent runs of `createConsolidatedFromConversions` don't result in mingled data
  - [ ] bundle with mingled data throws error
- Staging
  - [ ] subsequent runs of `createConsolidatedFromConversions` don't result in mingled data
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
- [ ] Re-enable consolidated from S3
