### PR TITLE
2215 Add doc refs to consolidated from S3

### DIFF
--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -36,16 +36,16 @@ export async function createConsolidatedFromConversions({
   destinationBucketName = getConsolidatedLocation(),
   sourceBucketName = getConsolidatedSourceLocation(),
   logMemUsage,
-}: ConsolidatePatientDataCommand): Promise<Bundle | undefined> {
+}: ConsolidatePatientDataCommand): Promise<Bundle> {
   const { log } = out(`createConsolidatedFromConversions - cx ${cxId}, pat ${patientId}`);
+
+  const consolidated = buildConsolidatedBundle();
 
   const inputBundles = await listConversionBundles({ cxId, patientId, sourceBucketName, log });
   if (!inputBundles || inputBundles.length < 1) {
     log(`No conversion bundles found.`);
-    return undefined;
+    return consolidated;
   }
-
-  const consolidated = buildBundle({ type: "collection" });
 
   await executeAsynchronously(
     inputBundles,
@@ -79,6 +79,10 @@ export async function createConsolidatedFromConversions({
 
   log(`Done`);
   return deduped;
+}
+
+function buildConsolidatedBundle(): Bundle {
+  return buildBundle({ type: "collection" });
 }
 
 async function listConversionBundles({

--- a/packages/core/src/command/consolidated/consolidated-get.ts
+++ b/packages/core/src/command/consolidated/consolidated-get.ts
@@ -1,6 +1,7 @@
 import { Bundle, Resource } from "@medplum/fhirtypes";
 import { createConsolidatedDataFilePath } from "../../domain/consolidated/filename";
 import { executeWithRetriesS3, returnUndefinedOn404, S3Utils } from "../../external/aws/s3";
+import { out } from "../../util";
 import { Config } from "../../util/config";
 import { getConsolidatedLocation } from "./consolidated-shared";
 
@@ -21,13 +22,12 @@ export async function getConsolidated({
   cxId,
   patientId,
   fileLocation = getConsolidatedLocation(),
-  log = console.log,
 }: {
   cxId: string;
   patientId: string;
   fileLocation?: string;
-  log?: typeof console.log;
 }): Promise<Consolidated> {
+  const { log } = out(`getConsolidated - cx ${cxId}, pat ${patientId}`);
   const fileName = createConsolidatedDataFilePath(cxId, patientId);
 
   const consolidatedDataRaw = await executeWithRetriesS3<string | undefined>(

--- a/packages/core/src/command/consolidated/get-snapshot-local.ts
+++ b/packages/core/src/command/consolidated/get-snapshot-local.ts
@@ -1,6 +1,6 @@
-import { Bundle, Resource } from "@medplum/fhirtypes";
 import { executeWithNetworkRetries, InternalSendConsolidated } from "@metriport/shared";
 import { elapsedTimeFromNow } from "@metriport/shared/common/date";
+import { SearchSetBundle } from "@metriport/shared/medical";
 import axios from "axios";
 import { isConsolidatedFromS3Enabled } from "../../external/aws/app-config";
 import { checkBundleForPatient } from "../../external/fhir/bundle/qa";
@@ -33,6 +33,7 @@ export class ConsolidatedSnapshotConnectorLocal implements ConsolidatedSnapshotC
     const fhirPatient = patientToFhir(params.patient);
     const patientEntry = buildBundleEntry(fhirPatient);
     originalBundle.entry = [patientEntry, ...(originalBundle.entry ?? [])];
+    originalBundle.total = originalBundle.entry.length;
 
     const dedupedBundle = deduplicate({ cxId, patientId, bundle: originalBundle });
 
@@ -75,7 +76,7 @@ export class ConsolidatedSnapshotConnectorLocal implements ConsolidatedSnapshotC
 
 async function getBundle(
   params: ConsolidatedSnapshotRequestSync | ConsolidatedSnapshotRequestAsync
-): Promise<Bundle<Resource>> {
+): Promise<SearchSetBundle> {
   const { cxId, id: patientId } = params.patient;
   const isGetFromS3 = await isConsolidatedFromS3Enabled();
   const { log } = out(`getBundle - fromS3: ${isGetFromS3}`);

--- a/packages/core/src/external/fhir/document/get-documents.ts
+++ b/packages/core/src/external/fhir/document/get-documents.ts
@@ -1,4 +1,5 @@
 import { chunk } from "lodash";
+import { out } from "../../../util";
 import { Config } from "../../../util/config";
 import { capture } from "../../../util/notifications";
 import { makeFhirApi } from "../api/api-factory";
@@ -18,6 +19,8 @@ export async function getDocuments({
   to?: string | undefined;
   documentIds?: string[];
 }): Promise<DocumentReferenceWithId[]> {
+  const { log } = out(`getDocuments - cx ${cxId}, pat ${patientId}`);
+  const startedAt = new Date().getTime();
   try {
     const api = makeFhirApi(cxId, Config.getFHIRServerUrl());
     const docs: DocumentReferenceWithId[] = [];
@@ -29,10 +32,12 @@ export async function getDocuments({
         docs.push(...page.filter(hasId));
       }
     }
+    const duration = new Date().getTime() - startedAt;
+    log(`Got ${docs.length} doc refs from the FHIR server in ${duration}ms`);
     return docs;
   } catch (error) {
     const msg = `Error getting documents from FHIR server`;
-    console.log(`${msg} - patientId: ${patientId}, error: ${error}`);
+    log(`${msg} - patientId: ${patientId}, error: ${error}`);
     capture.error(msg, { extra: { patientId, error } });
     throw error;
   }


### PR DESCRIPTION
Ref. metriport/metriport-internal#2215

### Dependencies

none

### Description

Add doc refs to consolidated from S3 - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1727188691351699?thread_ts=1726716296.259739&cid=C04DMKE9DME).

### Testing

- Local
  - [x] Includes DocumentReferences in the consolidated bundle
- Staging
  - [ ] Includes DocumentReferences in the consolidated bundle
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
