### PR TITLE
2215 Fix adding doc refs to bundle upon creation

### DIFF
--- a/packages/core/src/domain/consolidated/filename.ts
+++ b/packages/core/src/domain/consolidated/filename.ts
@@ -1,10 +1,14 @@
 import { createFilePath } from "../filename";
 
 const extension = ".json";
-const consolidatedDataFilenameSuffix = `CONSOLIDATED_DATA${extension}`;
 
-export function createConsolidatedDataFilePath(cxId: string, patientId: string): string {
-  return createFilePath(cxId, patientId, consolidatedDataFilenameSuffix);
+export function createConsolidatedDataFilePath(
+  cxId: string,
+  patientId: string,
+  deduped = true
+): string {
+  const additionalSuffix = deduped ? "" : "_with-duplicates";
+  return createFilePath(cxId, patientId, `CONSOLIDATED_DATA${additionalSuffix}${extension}`);
 }
 
 export function createConsolidatedSnapshotFileName(
@@ -17,6 +21,6 @@ export function createConsolidatedSnapshotFileName(
   return createFilePath(
     cxId,
     patientId,
-    `consolidated_${date}_${requestId}${isDeduped ? "_deduped" : ""}.json`
+    `consolidated_${date}_${requestId}${isDeduped ? "_deduped" : ""}${extension}`
   );
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#2215

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2809
- Downstream: none

### Description

Fix adding doc refs to bundle upon creation - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1727201080532229?thread_ts=1726716296.259739&cid=C04DMKE9DME).

Also storing the original, non-deduped version of the consolidated bundle for debugging purposes.

### Testing

- Local
  - [x] Includes DocumentReferences in the consolidated bundle when a new one is created
  - [x] Includes DocumentReferences in the consolidated bundle when returning existing ones
- Staging
  - [ ] Includes DocumentReferences in the consolidated bundle when a new one is created
  - [ ] Includes DocumentReferences in the consolidated bundle when returning existing ones
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
