### PR TITLE
fix(core): patient resource kept in deduped bundle

### DIFF
--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -36,6 +36,7 @@ const medicationRelatedTypes = [
 export function deduplicateFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> {
   const deduplicatedBundle: Bundle = cloneDeep(fhirBundle);
   let resourceArrays = extractFhirTypesFromBundle(fhirBundle);
+  const patientResource = cloneDeep(resourceArrays.patient);
 
   const medicationsResult = deduplicateMedications(resourceArrays.medications);
   /* WARNING we need to replace references in the following resource arrays before deduplicating them because their deduplication keys 
@@ -177,6 +178,7 @@ export function deduplicateFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> 
     deletedRefs
   );
   resourceArrays = updatedResourceArrays2;
+  resourceArrays.patient = patientResource;
 
   deduplicatedBundle.entry = Object.entries(resourceArrays)
     .filter(([resourceType]) => resourceType !== "devices")


### PR DESCRIPTION
refs. metriport/metriport-internal#779

### Description
- Patch fix to keep patient resource in the deduplication result bundle

### Testing

- Local
  - [x] Patient resource is back in the bundle!

### Release Plan

- [ ] Merge this
