### PR TITLE
2569 fix missing patient again

### DIFF
--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -8,6 +8,8 @@ import { buildBundle, buildBundleEntry } from "../../external/fhir/shared/bundle
 import { executeAsynchronously, out } from "../../util";
 import { Config } from "../../util/config";
 import { getConsolidatedLocation, getConsolidatedSourceLocation } from "./consolidated-shared";
+import { Patient } from "../../domain/patient";
+import { toFHIR as patientToFhir } from "../../external/fhir/patient/conversion";
 
 const s3Utils = new S3Utils(Config.getAWSRegion());
 
@@ -21,6 +23,7 @@ const defaultS3RetriesConfig = {
 export type ConsolidatePatientDataCommand = {
   cxId: string;
   patientId: string;
+  patient: Patient;
   destinationBucketName?: string | undefined;
   sourceBucketName?: string | undefined;
 };
@@ -33,19 +36,23 @@ type BundleLocation = { bucket: string; key: string };
 export async function createConsolidatedFromConversions({
   cxId,
   patientId,
+  patient,
   destinationBucketName = getConsolidatedLocation(),
   sourceBucketName = getConsolidatedSourceLocation(),
 }: ConsolidatePatientDataCommand): Promise<Bundle> {
   const { log } = out(`createConsolidatedFromConversions - cx ${cxId}, pat ${patientId}`);
 
+  const fhirPatient = patientToFhir(patient);
+  const patientEntry = buildBundleEntry(fhirPatient);
+
   const [conversions, docRefs] = await Promise.all([
-    getConversions({ cxId, patientId, sourceBucketName }),
+    getConversions({ cxId, patientId, patient, sourceBucketName }),
     getDocumentReferences({ cxId, patientId }),
   ]);
   log(`Got ${conversions} resources from conversions`);
 
   const withDups = buildConsolidatedBundle();
-  withDups.entry = [...conversions, ...docRefs.map(buildBundleEntry)];
+  withDups.entry = [...conversions, ...docRefs.map(buildBundleEntry), patientEntry];
   withDups.total = withDups.entry.length;
   log(`Added ${docRefs.length} docRefs, to a total of ${withDups.entry.length} entries`);
 

--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -49,7 +49,7 @@ export async function createConsolidatedFromConversions({
     getConversions({ cxId, patientId, patient, sourceBucketName }),
     getDocumentReferences({ cxId, patientId }),
   ]);
-  log(`Got ${conversions} resources from conversions`);
+  log(`Got ${conversions.length} resources from conversions`);
 
   const withDups = buildConsolidatedBundle();
   withDups.entry = [...conversions, ...docRefs.map(buildBundleEntry), patientEntry];

--- a/packages/core/src/command/consolidated/consolidated-filter.ts
+++ b/packages/core/src/command/consolidated/consolidated-filter.ts
@@ -10,7 +10,7 @@ import { createConsolidatedFromConversions } from "./consolidated-create";
 import { filterBundleByDate } from "./consolidated-filter-by-date";
 import { filterBundleByResource } from "./consolidated-filter-by-resource";
 import { getConsolidated } from "./consolidated-get";
-
+import { Patient } from "../../domain/patient";
 const maxHydrationIterations = 5;
 
 /**
@@ -21,10 +21,12 @@ const maxHydrationIterations = 5;
 export async function getConsolidatedFromS3({
   cxId,
   patientId,
+  patient,
   ...params
 }: {
   cxId: string;
   patientId: string;
+  patient: Patient;
   resources?: ResourceTypeForConsolidation[] | undefined;
   dateFrom?: string | undefined;
   dateTo?: string | undefined;
@@ -32,7 +34,7 @@ export async function getConsolidatedFromS3({
   const { log } = out(`getConsolidatedFromS3 - cx ${cxId}, pat ${patientId}`);
   log(`Running with params: ${JSON.stringify(params)}`);
 
-  const consolidated = await getOrCreateConsolidatedOnS3({ cxId, patientId });
+  const consolidated = await getOrCreateConsolidatedOnS3({ cxId, patientId, patient });
   log(`Consolidated with ${consolidated.entry?.length} entries`);
 
   const filtered = await filterConsolidated(consolidated, params);
@@ -43,9 +45,11 @@ export async function getConsolidatedFromS3({
 async function getOrCreateConsolidatedOnS3({
   cxId,
   patientId,
+  patient,
 }: {
   cxId: string;
   patientId: string;
+  patient: Patient;
 }): Promise<Bundle> {
   const { log } = out(`getOrCreateConsolidatedOnS3 - cx ${cxId}, pat ${patientId}`);
   const preGenerated = await getConsolidated({
@@ -57,7 +61,7 @@ async function getOrCreateConsolidatedOnS3({
     return preGenerated.bundle;
   }
   log(`Did not found pre-generated consolidated, creating a new one...`);
-  const newConsolidated = await createConsolidatedFromConversions({ cxId, patientId });
+  const newConsolidated = await createConsolidatedFromConversions({ cxId, patientId, patient });
   return newConsolidated;
 }
 

--- a/packages/core/src/command/consolidated/consolidated-filter.ts
+++ b/packages/core/src/command/consolidated/consolidated-filter.ts
@@ -34,7 +34,7 @@ export async function getConsolidatedFromS3({
   const { log } = out(`getConsolidatedFromS3 - cx ${cxId}, pat ${patientId}`);
   log(`Running with params: ${JSON.stringify(params)}`);
 
-  const consolidated = await getOrCreateConsolidatedOnS3({ cxId, patientId, patient });
+  const consolidated = await getOrCreateConsolidatedOnS3({ cxId, patient });
   log(`Consolidated with ${consolidated.entry?.length} entries`);
 
   const filtered = await filterConsolidated(consolidated, params);
@@ -44,13 +44,12 @@ export async function getConsolidatedFromS3({
 
 async function getOrCreateConsolidatedOnS3({
   cxId,
-  patientId,
   patient,
 }: {
   cxId: string;
-  patientId: string;
   patient: Patient;
 }): Promise<Bundle> {
+  const patientId = patient.id;
   const { log } = out(`getOrCreateConsolidatedOnS3 - cx ${cxId}, pat ${patientId}`);
   const preGenerated = await getConsolidated({
     cxId,
@@ -61,7 +60,7 @@ async function getOrCreateConsolidatedOnS3({
     return preGenerated.bundle;
   }
   log(`Did not found pre-generated consolidated, creating a new one...`);
-  const newConsolidated = await createConsolidatedFromConversions({ cxId, patientId, patient });
+  const newConsolidated = await createConsolidatedFromConversions({ cxId, patient });
   return newConsolidated;
 }
 

--- a/packages/core/src/command/consolidated/consolidated-filter.ts
+++ b/packages/core/src/command/consolidated/consolidated-filter.ts
@@ -20,17 +20,16 @@ const maxHydrationIterations = 5;
  */
 export async function getConsolidatedFromS3({
   cxId,
-  patientId,
   patient,
   ...params
 }: {
   cxId: string;
-  patientId: string;
   patient: Patient;
   resources?: ResourceTypeForConsolidation[] | undefined;
   dateFrom?: string | undefined;
   dateTo?: string | undefined;
 }): Promise<SearchSetBundle> {
+  const patientId = patient.id;
   const { log } = out(`getConsolidatedFromS3 - cx ${cxId}, pat ${patientId}`);
   log(`Running with params: ${JSON.stringify(params)}`);
 

--- a/packages/core/src/command/consolidated/get-snapshot-local.ts
+++ b/packages/core/src/command/consolidated/get-snapshot-local.ts
@@ -77,12 +77,12 @@ export class ConsolidatedSnapshotConnectorLocal implements ConsolidatedSnapshotC
 async function getBundle(
   params: ConsolidatedSnapshotRequestSync | ConsolidatedSnapshotRequestAsync
 ): Promise<SearchSetBundle> {
-  const { cxId, id: patientId } = params.patient;
+  const { cxId } = params.patient;
   const isGetFromS3 = await isConsolidatedFromS3Enabled();
   const { log } = out(`getBundle - fromS3: ${isGetFromS3}`);
   if (isGetFromS3) {
     const startedAt = new Date();
-    const consolidatedBundle = await getConsolidatedFromS3({ ...params, cxId, patientId });
+    const consolidatedBundle = await getConsolidatedFromS3({ ...params, cxId });
     if (consolidatedBundle) {
       log(`(from S3) Took ${elapsedTimeFromNow(startedAt)}ms`);
       return consolidatedBundle;

--- a/packages/core/src/command/patient-loader-metriport-api.ts
+++ b/packages/core/src/command/patient-loader-metriport-api.ts
@@ -109,7 +109,7 @@ function validatePatient(patient: Patient): boolean {
 }
 
 //
-function getDomainFromDTO(dto: PatientDTO): Patient {
+export function getDomainFromDTO(dto: PatientDTO): Patient {
   return {
     id: dto.id,
     eTag: dto.eTag ?? "",

--- a/packages/core/src/external/fhir/consolidated/deduplicate.ts
+++ b/packages/core/src/external/fhir/consolidated/deduplicate.ts
@@ -13,7 +13,7 @@ export function deduplicate({
   bundle: Bundle<Resource>;
 }): Bundle<Resource> {
   const startedAt = new Date();
-  const dedupedBundle = deduplicateFhir(bundle);
+  const dedupedBundle = deduplicateFhir(bundle, cxId, patientId);
 
   const deduplicationAnalyticsProps = {
     distinctId: cxId,

--- a/packages/core/src/fhir-deduplication/__tests__/deduplicate-fhir.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/deduplicate-fhir.test.ts
@@ -43,6 +43,8 @@ let medication: Medication;
 let medication2: Medication;
 let bundle: Bundle;
 let patient: Patient;
+let patientId: string;
+let cxId: string;
 beforeAll(() => {
   medicationId = faker.string.uuid();
   medicationId2 = faker.string.uuid();
@@ -65,6 +67,8 @@ beforeAll(() => {
       },
     ],
   });
+  patientId = faker.string.uuid();
+  cxId = faker.string.uuid();
 });
 
 beforeEach(() => {
@@ -111,7 +115,7 @@ describe("deduplicateFhir", () => {
     bundle.entry = entries;
     bundle.type = "searchset";
 
-    bundle = deduplicateFhir(bundle);
+    bundle = deduplicateFhir(bundle, cxId, patientId);
     expect(bundle.entry?.length).toBe(5);
     const resMedications = findMedicationResources(bundle);
     const resMedAdmins = findMedicationAdministrationResources(bundle);
@@ -155,7 +159,7 @@ describe("deduplicateFhir", () => {
       { resource: patient },
     ] as BundleEntry<Resource>[];
     bundle.entry = entries;
-    bundle = deduplicateFhir(bundle);
+    bundle = deduplicateFhir(bundle, cxId, patientId);
     expect(bundle.entry?.length).toBe(1);
   });
 
@@ -196,7 +200,7 @@ describe("deduplicateFhir", () => {
       { resource: patient },
     ] as BundleEntry<Resource>[];
     bundle.entry = entries;
-    bundle = deduplicateFhir(bundle);
+    bundle = deduplicateFhir(bundle, cxId, patientId);
     expect(bundle.entry?.length).toBe(5);
     expect(JSON.stringify(bundle)).not.toContain(medicationId);
     expect(JSON.stringify(bundle)).toContain(medicationId2);
@@ -220,7 +224,7 @@ describe("deduplicateFhir", () => {
     ] as BundleEntry<Resource>[];
 
     bundle.entry = entries;
-    bundle = deduplicateFhir(bundle);
+    bundle = deduplicateFhir(bundle, cxId, patientId);
     expect(bundle.entry?.length).toBe(2);
 
     const diagnosticReports = findDiagnosticReportResources(bundle);
@@ -266,7 +270,7 @@ describe("deduplicateFhir", () => {
     ] as BundleEntry<Resource>[];
 
     bundle.entry = entries;
-    bundle = deduplicateFhir(bundle);
+    bundle = deduplicateFhir(bundle, cxId, patientId);
     expect(bundle.entry?.length).toBe(3);
 
     const resComposition = findCompositionResource(bundle);
@@ -362,7 +366,7 @@ describe("deduplicateFhir", () => {
     ] as BundleEntry<Resource>[];
 
     bundle.entry = entries;
-    bundle = deduplicateFhir(bundle);
+    bundle = deduplicateFhir(bundle, cxId, patientId);
     expect(bundle.entry?.length).toBe(4);
     const resComposition = findCompositionResource(bundle);
     expect(resComposition).not.toEqual(undefined);
@@ -413,7 +417,7 @@ describe("deduplicateFhir", () => {
     ] as BundleEntry<Resource>[];
 
     bundle.entry = entries;
-    bundle = deduplicateFhir(bundle);
+    bundle = deduplicateFhir(bundle, cxId, patientId);
     const deduplicatedEncounters = findEncounterResources(bundle);
     const deduplicatedEncounter = deduplicatedEncounters[0];
     expect(deduplicatedEncounter?.diagnosis?.length).toBe(1);
@@ -452,7 +456,7 @@ describe("deduplicateFhir", () => {
     ] as BundleEntry<Resource>[];
 
     bundle.entry = entries;
-    bundle = deduplicateFhir(bundle);
+    bundle = deduplicateFhir(bundle, cxId, patientId);
     const deduplicatedDiagnosticReports = findDiagnosticReportResources(bundle);
     const deduplicatedDiagnosticReport = deduplicatedDiagnosticReports[0];
     expect(deduplicatedDiagnosticReport?.result?.length).toBe(1);

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -183,13 +183,13 @@ export function deduplicateFhir(
   resourceArrays = updatedResourceArrays2;
 
   if (!resourceArrays.patient) {
-    capture.message("Critical Missing Patient", {
+    capture.message("Critical Missing Patient in Deduplicate FHIR", {
       extra: {
         cxId,
         patientId,
         patient: resourceArrays.patient,
       },
-      level: "fatal",
+      level: "error",
     });
   }
 

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -35,7 +35,7 @@ const medicationRelatedTypes = [
 
 export function deduplicateFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> {
   const deduplicatedBundle: Bundle = cloneDeep(fhirBundle);
-  let resourceArrays = extractFhirTypesFromBundle(fhirBundle);
+  let resourceArrays = extractFhirTypesFromBundle(deduplicatedBundle);
 
   const medicationsResult = deduplicateMedications(resourceArrays.medications);
   /* WARNING we need to replace references in the following resource arrays before deduplicating them because their deduplication keys 

--- a/packages/utils/src/fhir-deduplication/dedup-files.ts
+++ b/packages/utils/src/fhir-deduplication/dedup-files.ts
@@ -9,6 +9,7 @@ import dayjs from "dayjs";
 import fs from "fs";
 import { getFileContents, getFileNames, makeDir } from "../shared/fs";
 import { validateReferences } from "./report/validate-references";
+import { v4 as uuidv4 } from "uuid";
 
 /**
  * Folder with consolidated files/bundles.
@@ -49,7 +50,9 @@ async function main() {
 
     const startedAt = new Date();
 
-    const resultingBundle = deduplicateFhir(initialBundle);
+    const cxId = uuidv4();
+    const patientId = uuidv4();
+    const resultingBundle = deduplicateFhir(initialBundle, cxId, patientId);
 
     console.log(
       `Went from ${initialBundle.entry?.length} to ${

--- a/packages/utils/src/fhir/consolidate-patient-data.ts
+++ b/packages/utils/src/fhir/consolidate-patient-data.ts
@@ -39,7 +39,6 @@ async function main() {
 
   await createConsolidatedFromConversions({
     cxId,
-    patientId,
     patient: getDomainFromDTO(patient),
     sourceBucketName: inputBundleBucket,
     destinationBucketName: consolidatedBucket,

--- a/packages/utils/src/fhir/consolidate-patient-data.ts
+++ b/packages/utils/src/fhir/consolidate-patient-data.ts
@@ -4,6 +4,8 @@ dotenv.config();
 import { createConsolidatedFromConversions } from "@metriport/core/command/consolidated/consolidated-create";
 import { getEnvVarOrFail, sleep } from "@metriport/shared";
 import { elapsedTimeAsStr } from "../shared/duration";
+import { MetriportMedicalApi } from "@metriport/api-sdk";
+import { Patient } from "@metriport/core/domain/patient";
 
 /**
  * Utility to run the function that recreates the patient consolidated bundle from the terminal.
@@ -21,15 +23,23 @@ const patientId = "";
  */
 const inputBundleBucket = "";
 const consolidatedBucket = getEnvVarOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
+const apiKey = getEnvVarOrFail("API_KEY");
+const apiUrl = getEnvVarOrFail("API_URL");
 
+const sdk = new MetriportMedicalApi(apiKey, {
+  baseAddress: apiUrl,
+});
 async function main() {
   await sleep(50); // Give some time to avoid mixing logs w/ Node's
   const startedAt = Date.now();
   console.log(`########################## Started at ${new Date(startedAt).toISOString()}`);
 
+  const patient = await sdk.getPatient(patientId);
+
   await createConsolidatedFromConversions({
     cxId,
     patientId,
+    patient: patient as unknown as Patient,
     sourceBucketName: inputBundleBucket,
     destinationBucketName: consolidatedBucket,
   });

--- a/packages/utils/src/fhir/consolidate-patient-data.ts
+++ b/packages/utils/src/fhir/consolidate-patient-data.ts
@@ -16,12 +16,12 @@ import { getDomainFromDTO } from "@metriport/core/command/patient-loader-metripo
  * - Run `ts-node src/fhir/consolidate-patient-data.ts`
  */
 
-const cxId = "e2829f11-875e-4c4b-bf46-b4f890281d03";
-const patientId = "018df170-26aa-75df-9b65-f2df02bf84c9";
+const cxId = "";
+const patientId = "";
 /**
  * The bucket and key of the input bundle to be merged into the consolidated bundle.
  */
-const inputBundleBucket = "metriport-ccda-to-fhir-conversions-staging";
+const inputBundleBucket = "";
 const consolidatedBucket = getEnvVarOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
 const apiKey = getEnvVarOrFail("API_KEY");
 const apiUrl = getEnvVarOrFail("API_URL");

--- a/packages/utils/src/fhir/consolidate-patient-data.ts
+++ b/packages/utils/src/fhir/consolidate-patient-data.ts
@@ -5,7 +5,7 @@ import { createConsolidatedFromConversions } from "@metriport/core/command/conso
 import { getEnvVarOrFail, sleep } from "@metriport/shared";
 import { elapsedTimeAsStr } from "../shared/duration";
 import { MetriportMedicalApi } from "@metriport/api-sdk";
-import { Patient } from "@metriport/core/domain/patient";
+import { getDomainFromDTO } from "@metriport/core/command/patient-loader-metriport-api";
 
 /**
  * Utility to run the function that recreates the patient consolidated bundle from the terminal.
@@ -16,12 +16,12 @@ import { Patient } from "@metriport/core/domain/patient";
  * - Run `ts-node src/fhir/consolidate-patient-data.ts`
  */
 
-const cxId = "";
-const patientId = "";
+const cxId = "e2829f11-875e-4c4b-bf46-b4f890281d03";
+const patientId = "018df170-26aa-75df-9b65-f2df02bf84c9";
 /**
  * The bucket and key of the input bundle to be merged into the consolidated bundle.
  */
-const inputBundleBucket = "";
+const inputBundleBucket = "metriport-ccda-to-fhir-conversions-staging";
 const consolidatedBucket = getEnvVarOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
 const apiKey = getEnvVarOrFail("API_KEY");
 const apiUrl = getEnvVarOrFail("API_URL");
@@ -29,6 +29,7 @@ const apiUrl = getEnvVarOrFail("API_URL");
 const sdk = new MetriportMedicalApi(apiKey, {
   baseAddress: apiUrl,
 });
+
 async function main() {
   await sleep(50); // Give some time to avoid mixing logs w/ Node's
   const startedAt = Date.now();
@@ -39,7 +40,7 @@ async function main() {
   await createConsolidatedFromConversions({
     cxId,
     patientId,
-    patient: patient as unknown as Patient,
+    patient: getDomainFromDTO(patient),
     sourceBucketName: inputBundleBucket,
     destinationBucketName: consolidatedBucket,
   });


### PR DESCRIPTION
Refs: #2569

### Upstream:
- https://github.com/metriport/metriport/pull/2828
### Description
- bug fix for patient missing in `createConsolodatedFromConversions`

### Testing

- local:
  - [x] tested with utils script `consolidate-patient-data`
- staging
  - [ ] patient without consolidated bundle no errors
  - [ ] patient with consolidated bundle no errors

Check each PR.

### Release Plan

- [ ] Merge this
- [ ] update bundles on drive
