### PR TITLE
feat(utils): fhir server dlq log utils

### DIFF
--- a/packages/utils/src/cloudwatch/fhir-server-lambda.ts
+++ b/packages/utils/src/cloudwatch/fhir-server-lambda.ts
@@ -1,0 +1,111 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import { sleep } from "@metriport/shared";
+import dayjs from "dayjs";
+import fs from "fs";
+import { MessageDetails } from "../sqs/peek-dlq-print-details";
+import { queryLogs } from "./query";
+
+/**
+ * This script queries the logs of the FHIR Server Lambda for each message in the DLQ.
+ *
+ * !!! PREREQUISITE !!!
+ * Run the `peek-dlq-print-details.ts` script to get the messages from the DLQ.
+ * Put the absolute path to the resulting file in peekDlqOutput.
+ *
+ * For each message in the DLQ, the script will first query the logs using the file name from the message to get the request ID.
+ * Then, using the request ID, it will get all the logs for that request and save them in a file.
+ *
+ * All files are stored in the `runs/fhir-to-server-lambda` folder in a sorted manner (from oldest to newest).
+ *
+ */
+
+const peekDlqOutput = "";
+const LOG_GROUP_NAME = "/aws/lambda/FHIRServerLambda";
+const fhirServerLogRegex = /Z\s+([a-f0-9-]{36})\s+INFO/;
+const startDate = Date.now();
+const outputFolder = `runs/fhir-to-server-lambda/${startDate}`;
+
+function parseLogEvents(logEvents: string[]): string {
+  let result: string | undefined;
+
+  logEvents.forEach(event => {
+    const match = event.match(fhirServerLogRegex);
+    if (match) {
+      const [, cxId] = match;
+      result = cxId;
+    }
+  });
+
+  if (!result) throw new Error("No log events found");
+  return result;
+}
+
+async function handleSingleMessage({
+  logGroupName,
+  filterPattern,
+  startDate,
+  endDate,
+  index,
+}: {
+  logGroupName: string;
+  filterPattern: string;
+  startDate: number;
+  endDate: number;
+  index: number;
+}) {
+  console.log("Starting log query...");
+  if (!fs.existsSync(outputFolder)) {
+    fs.mkdirSync(outputFolder, { recursive: true });
+  }
+
+  try {
+    const simpleEvents = await queryLogs(logGroupName, filterPattern, startDate, endDate);
+    console.log(`Query completed. Total simple events received: ${simpleEvents.length}`);
+    const newFilterString = parseLogEvents(simpleEvents);
+    const detailedEvents = await queryLogs(
+      logGroupName,
+      `"${newFilterString}"`,
+      startDate,
+      endDate
+    );
+    fs.writeFileSync(
+      `${outputFolder}/${index}_${newFilterString}.txt`,
+      JSON.stringify(detailedEvents, null, 2)
+    );
+    await sleep(1000);
+  } catch (error) {
+    console.error("An error occurred during the query:", error);
+  }
+  console.log(`Log query completed for index ${index}`);
+}
+
+async function playground() {
+  const messagesBlob = fs.readFileSync(peekDlqOutput, "utf-8");
+  const messages = JSON.parse(messagesBlob) as MessageDetails[];
+  // deduplicate messages by all contents
+  const uniqueMessages = Array.from(new Set(messages.map(a => JSON.stringify(a)))).map(str =>
+    JSON.parse(str)
+  ) as MessageDetails[];
+
+  const updatedMessages = uniqueMessages.sort((a, b) => {
+    return dayjs(a.startedAt).isBefore(dayjs(b.startedAt)) ? -1 : 1;
+  });
+
+  for (const [index, message] of updatedMessages.entries()) {
+    const startTime = new Date(message.startedAt).getTime();
+    // End time = startTime + 3 hours
+    const endTime = startTime + 3 * 60 * 60 * 1000;
+
+    await handleSingleMessage({
+      logGroupName: LOG_GROUP_NAME,
+      filterPattern: `"${message.fileName}"`,
+      startDate: startTime,
+      endDate: endTime,
+      index: index + 1,
+    });
+  }
+}
+
+playground();

--- a/packages/utils/src/sqs/peek-dlq-print-details.ts
+++ b/packages/utils/src/sqs/peek-dlq-print-details.ts
@@ -1,0 +1,186 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import { BadRequestError } from "@metriport/shared";
+import { SQS } from "aws-sdk";
+import fs from "fs";
+import { Config } from "../../../api/src/shared/config";
+
+/**
+ * This script saves the details of the messages in the DLQ to a file.
+ */
+
+// Link to the FHIR Server DLQ (https://sqs....)
+const fhirServerDlqUrl = "";
+const maxNumberOfMessagesPerQuery = 1;
+
+export type MessageDetails = {
+  messageId: string | undefined;
+  bucketName: string | undefined;
+  fileName: string;
+  cxId: string | undefined;
+  jobId: string | undefined;
+  startedAt: string;
+  patientId: string | undefined;
+};
+
+async function peekIntoQueue() {
+  const s3FileNames = new Set<string>();
+  if (!fhirServerDlqUrl) throw new BadRequestError("Missing FHIR Server DLQ URL");
+
+  const messageCount = await getMessageCountFromQueue(fhirServerDlqUrl);
+  console.log(`>>> Message count: ${messageCount}`);
+
+  const messageDetails: MessageDetails[] = [];
+  console.log(`>>> Getting messages from source queue...`);
+  for (let i = 0; i < messageCount; i++) {
+    const messagesOfRequest = await peekMessagesFromQueue(fhirServerDlqUrl, {
+      maxNumberOfMessagesPerQuery,
+      maxNumberOfMessages: maxNumberOfMessagesPerQuery,
+    });
+
+    if (!messagesOfRequest || !messagesOfRequest.length) {
+      console.log(`>>> No messages found`);
+      return { messageCount: 0, first10Items: [] };
+    }
+
+    messagesOfRequest.map(async m => {
+      const patientId = m.MessageAttributes?.patientId?.StringValue ?? "na";
+      const body = m.Body ? JSON.parse(m.Body) : undefined;
+      const s3FileName = body.s3FileName ?? "na";
+
+      const attr = m.MessageAttributes;
+      if (!attr) return;
+      const startedAt = attr.jobStartedAt.StringValue;
+      if (!startedAt) return;
+
+      const details: MessageDetails = {
+        messageId: m.MessageId,
+        bucketName: body.s3BucketName,
+        fileName: body.s3FileName,
+        cxId: attr.cxId?.StringValue,
+        jobId: attr.jobId?.StringValue,
+        startedAt: startedAt,
+        patientId: attr.patientId?.StringValue,
+      };
+
+      messageDetails.push(details);
+      s3FileNames.add(`${patientId}|||${s3FileName}`);
+    });
+  }
+
+  fs.writeFileSync("messages-details.json", JSON.stringify(messageDetails));
+}
+
+const sqsConfig = {
+  awsRegion: Config.getAWSRegion(),
+};
+/**
+ * @deprecated Use @metriport/core instead
+ */
+const sqs = new SQS({
+  apiVersion: "2012-11-05",
+  region: sqsConfig.awsRegion,
+});
+
+type GetMessageSQSParameters = SharedInternalGetMessageSQSParameters & {
+  /**
+   * How many messages to return per query, from 1 to 10. Defaults to 1.
+   */
+  maxNumberOfMessagesPerQuery?: number;
+  /**
+   * Maximum number of messages to return. Defaults to 10.
+   */
+  maxNumberOfMessages?: number;
+  /**
+   * Determines whether it should keep pooling until the queue is empty or `maxNumberOfMessages`
+   * has been reached. Defaults to false, which means it will only pool once.
+   */
+  poolUntilEmpty?: boolean;
+};
+
+/**
+ * Reads messages from the queue, returns them, but does not remove them.
+ * Only queries the queue once.
+ */
+async function peekMessagesFromQueue(
+  queueUrl: string,
+  sqsParams: GetMessageSQSParameters
+): Promise<SQS.Message[]> {
+  return _getMessagesFromQueue(queueUrl, {
+    ...sqsParams,
+    removeMessages: false,
+    poolUntilEmpty: false,
+    visibilityTimeout: 1, // we don't want to leave them "in flight" after we peek into them
+  });
+}
+
+type SharedInternalGetMessageSQSParameters = {
+  maxNumberOfMessagesPerQuery?: number;
+  visibilityTimeout?: number;
+  waitTimeSeconds?: number;
+};
+type InternalGetMessageSQSParameters = SharedInternalGetMessageSQSParameters & {
+  maxNumberOfMessages?: number;
+  removeMessages: boolean;
+  poolUntilEmpty: boolean;
+};
+
+async function _getMessagesFromQueue(
+  queueUrl: string,
+  sqsParams: InternalGetMessageSQSParameters,
+  rollingResult: SQS.Message[] = []
+): Promise<SQS.Message[]> {
+  const {
+    removeMessages,
+    poolUntilEmpty,
+    maxNumberOfMessages = 10,
+    maxNumberOfMessagesPerQuery = 1,
+  } = sqsParams;
+  if (!removeMessages && poolUntilEmpty) {
+    throw new Error("Cannot pool until empty if not removing messages");
+  }
+
+  const remainingMessagesToQuery = maxNumberOfMessages - rollingResult.length;
+  const maxMessagesOnQuery = Math.min(maxNumberOfMessagesPerQuery, remainingMessagesToQuery);
+  if (maxMessagesOnQuery <= 0) return rollingResult;
+
+  const messageParams: SQS.Types.ReceiveMessageRequest = {
+    QueueUrl: queueUrl,
+    MaxNumberOfMessages: maxMessagesOnQuery,
+    VisibilityTimeout: sqsParams.visibilityTimeout,
+    WaitTimeSeconds: sqsParams.waitTimeSeconds ?? 1,
+    AttributeNames: ["All"],
+    MessageAttributeNames: ["All"],
+  };
+
+  const resultReceive = await sqs.receiveMessage(messageParams).promise();
+  const messages = resultReceive.Messages ?? [];
+  const result = [...rollingResult, ...messages];
+
+  if (poolUntilEmpty) {
+    // SQS is a distributed system and the consensus about the message count take some time to be reached.
+    const preUpdatedTotal1 = await getMessageCountFromQueue(queueUrl);
+    const preUpdatedTotal2 = await getMessageCountFromQueue(queueUrl);
+    const updatedTotal = Math.max(preUpdatedTotal1, preUpdatedTotal2);
+    if (updatedTotal <= 0) return result;
+    return _getMessagesFromQueue(queueUrl, sqsParams, result);
+  }
+  return result;
+}
+
+/**
+ * Returns the approximate count of messages in the queue. Returns -1 if not available.
+ */
+async function getMessageCountFromQueue(queueUrl: string): Promise<number> {
+  const resultTotal = await sqs
+    .getQueueAttributes({
+      QueueUrl: queueUrl,
+      AttributeNames: ["ApproximateNumberOfMessages"],
+    })
+    .promise();
+  const total = Number(resultTotal.Attributes?.ApproximateNumberOfMessages ?? "-1");
+  return total;
+}
+
+peekIntoQueue();


### PR DESCRIPTION
refs. metriport/metriport-internal#799

### Description
- FHIR Server DLQ utils scripts to get logs from all the failed messages

### Testing

- Local
  - [x] Works locally


### Release Plan
- [ ] Merge this
