### PR TITLE
2215 CCD generation uses consolidated from S3

### DIFF
--- a/packages/api/src/command/medical/patient/consolidated-get.ts
+++ b/packages/api/src/command/medical/patient/consolidated-get.ts
@@ -57,6 +57,8 @@ type GetConsolidatedPatientData = {
   dateTo?: string;
   generateAiBrief?: boolean;
   fromDashboard?: boolean;
+  // TODO 2215 Remove this when we have contributed data as part of get consolidated (from S3)
+  forceDataFromFhir?: boolean;
 };
 
 export type GetConsolidatedSendToCxParams = GetConsolidatedParams & {
@@ -421,6 +423,7 @@ export async function getConsolidatedPatientData({
   dateTo,
   generateAiBrief,
   fromDashboard = false,
+  forceDataFromFhir = false,
 }: GetConsolidatedPatientData): Promise<SearchSetBundle<Resource>> {
   const payload: ConsolidatedSnapshotRequestSync = {
     patient,
@@ -430,6 +433,7 @@ export async function getConsolidatedPatientData({
     generateAiBrief,
     isAsync: false,
     fromDashboard,
+    forceDataFromFhir,
   };
   const connector = buildConsolidatedSnapshotConnector();
   const { bundleLocation, bundleFilename } = await connector.execute(payload);

--- a/packages/api/src/external/cda/generate-ccd.ts
+++ b/packages/api/src/external/cda/generate-ccd.ts
@@ -64,7 +64,7 @@ export async function generateCcd(
 async function getFhirResourcesForCcd(
   patient: Patient
 ): Promise<BundleEntry<Resource>[] | undefined> {
-  const allResources = await getConsolidatedPatientData({ patient });
+  const allResources = await getConsolidatedPatientData({ patient, forceDataFromFhir: true });
   return allResources.entry?.filter(entry => {
     const resource = entry.resource;
     if (resource?.resourceType === "Composition") return false;

--- a/packages/core/src/command/consolidated/get-snapshot-local.ts
+++ b/packages/core/src/command/consolidated/get-snapshot-local.ts
@@ -77,9 +77,11 @@ export class ConsolidatedSnapshotConnectorLocal implements ConsolidatedSnapshotC
 async function getBundle(
   params: ConsolidatedSnapshotRequestSync | ConsolidatedSnapshotRequestAsync
 ): Promise<SearchSetBundle> {
+  const { forceDataFromFhir } = !params.isAsync ? params : { forceDataFromFhir: false };
   const { cxId } = params.patient;
-  const isGetFromS3 = await isConsolidatedFromS3Enabled();
+  const isGetFromS3 = !forceDataFromFhir && (await isConsolidatedFromS3Enabled());
   const { log } = out(`getBundle - fromS3: ${isGetFromS3}`);
+  log(`forceDataFromFhir: ${forceDataFromFhir}`);
   if (isGetFromS3) {
     const startedAt = new Date();
     const consolidatedBundle = await getConsolidatedFromS3({ ...params, cxId });

--- a/packages/core/src/command/consolidated/get-snapshot.ts
+++ b/packages/core/src/command/consolidated/get-snapshot.ts
@@ -22,6 +22,8 @@ export type ConsolidatedSnapshotRequestSync = ConsolidatedSnapshotRequest & {
   isAsync: false;
   requestId?: string | undefined;
   fromDashboard?: boolean | undefined;
+  // TODO 2215 Remove this when we have contributed data as part of get consolidated (from S3)
+  forceDataFromFhir?: boolean | undefined;
 };
 
 export type ConsolidatedSnapshotResponse = {


### PR DESCRIPTION
Ref. metriport/metriport-internal#2215

### Dependencies

none

### Description

CCD generation uses consolidated from S3 - [context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1727476915021909?thread_ts=1727121353.235279&cid=C04GEQ1GH9D).

### Testing

- Local
  - [x] Uses consolidated from FHIR when building CCD
  - [x] Uses consolidated from S3 elsewhere
- Staging
  - [ ] Uses consolidated from FHIR when building CCD - bundle exists and contains contributed data
  - [ ] Uses consolidated from S3 elsewhere - bundle exists and doesn't contain contributed data
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
