### PR TITLE
2170 athena appointment subscription endpoint

### DIFF
--- a/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
@@ -57,7 +57,7 @@ export async function getPatientIdOrFail({
   triggerDq?: boolean;
 }): Promise<string> {
   const { log } = out(
-    `AthenaHealth getPatient - cxId ${cxId} athenaPracticeId ${athenaPracticeId} athenaPatientId ${athenaPatientId}`
+    `AthenaHealth getPatientIdOrFail - cxId ${cxId} athenaPracticeId ${athenaPracticeId} athenaPatientId ${athenaPatientId}`
   );
   const existingPatient = await getPatientMapping({
     cxId,
@@ -118,7 +118,7 @@ export async function getPatientIdOrFail({
     capture.error("Failed to get patient by demo", {
       extra: {
         cxId,
-        patientDemoFiltersCount: patientDemoFilters.length,
+        getPatientByDemoArgsCount: getPatientByDemoArgs.length,
         errorCount: getPatientByDemoErrors.length,
         errors: getPatientByDemoErrors.join(","),
         context: "athenahealth.get-patient",

--- a/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
@@ -46,6 +46,7 @@ export async function getPatientIdOrFail({
   athenaPracticeId,
   athenaPatientId,
   accessToken,
+  api,
   useSearch = false,
   triggerDq = false,
 }: {
@@ -53,6 +54,7 @@ export async function getPatientIdOrFail({
   athenaPracticeId: string;
   athenaPatientId: string;
   accessToken?: string;
+  api?: AthenaHealthApi;
   useSearch?: boolean;
   triggerDq?: boolean;
 }): Promise<string> {
@@ -76,15 +78,18 @@ export async function getPatientIdOrFail({
   }
   const athenaClientKey = await getSecretValueOrFail(athenaClientKeySecretArn, region);
   const athenaClientSecret = await getSecretValueOrFail(athenaClientSecretSecretArn, region);
-  const api = await AthenaHealthApi.create({
-    threeLeggedAuthToken: accessToken,
-    practiceId: athenaPracticeId,
-    environment: athenaEnvironment as AthenaEnv,
-    clientKey: athenaClientKey,
-    clientSecret: athenaClientSecret,
-  });
+  let athenaApi = api;
+  if (!athenaApi) {
+    athenaApi = await AthenaHealthApi.create({
+      threeLeggedAuthToken: accessToken,
+      practiceId: athenaPracticeId,
+      environment: athenaEnvironment as AthenaEnv,
+      clientKey: athenaClientKey,
+      clientSecret: athenaClientSecret,
+    });
+  }
   const athenaPatient = await getPatientFromAthena({
-    api,
+    api: athenaApi,
     cxId,
     patientId: athenaPatientId,
     useSearch,

--- a/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
@@ -34,6 +34,8 @@ const athenaClientKeySecretArn = Config.getAthenaHealthClientKeyArn();
 const athenaClientSecretSecretArn = Config.getAthenaHealthClientSecretArn();
 const defaultFacilityMappingExternalId = "default";
 
+const parallelPatientMatches = 5;
+
 export async function getPatientIdOrFail({
   cxId,
   athenaPracticeId,
@@ -112,7 +114,7 @@ export async function getPatientIdOrFail({
   });
 
   await executeAsynchronously(getPatientByDemoArgs, getPatientByDemo, {
-    numberOfParallelExecutions: 5,
+    numberOfParallelExecutions: parallelPatientMatches,
   });
 
   if (getPatientByDemoErrors.length > 0) {

--- a/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
@@ -103,6 +103,8 @@ export async function getPatientIdOrFail({
   const getPatientByDemoArgs = patientDemoFilters.map(demo => {
     return {
       cxId,
+      athenaPracticeId,
+      athenaPatientId,
       demo,
       patients,
       errors: getPatientByDemoErrors,
@@ -204,12 +206,16 @@ function createMetriportPatientDemo(
 
 async function getPatientByDemo({
   cxId,
+  athenaPracticeId,
+  athenaPatientId,
   demo,
   patients,
   errors,
   log,
 }: {
   cxId: string;
+  athenaPracticeId: string;
+  athenaPatientId: string;
   demo: PatientDemoData;
   patients: Patient[];
   errors: string[];
@@ -219,7 +225,9 @@ async function getPatientByDemo({
     const patient = await singleGetMetriportPatientByDemo({ cxId, demo });
     if (patient) patients.push(patient);
   } catch (error) {
-    const msg = `Failed to get patient by demo. Cause: ${errorToString(error)}`;
+    const msg = `Failed to get patient by demo. cxId ${cxId} athenaPracticeId ${athenaPracticeId} athenaPatientId ${athenaPatientId}. Cause: ${errorToString(
+      error
+    )}`;
     log(msg);
     errors.push(msg);
   }

--- a/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
@@ -225,11 +225,11 @@ async function getPatientByDemo({
     const patient = await singleGetMetriportPatientByDemo({ cxId, demo });
     if (patient) patients.push(patient);
   } catch (error) {
-    const msg = `Failed to get patient by demo. cxId ${cxId} athenaPracticeId ${athenaPracticeId} athenaPatientId ${athenaPatientId}. Cause: ${errorToString(
-      error
-    )}`;
-    log(msg);
-    errors.push(msg);
+    const cause = `Cause: ${errorToString(error)}`;
+    const details = `cxId ${cxId} athenaPracticeId ${athenaPracticeId} athenaPatientId ${athenaPatientId}.`;
+    const msg = "Failed to get patient by demo.";
+    log(`${msg} ${cause}`);
+    errors.push(`${msg} ${details} ${cause}`);
   }
 }
 

--- a/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
@@ -57,7 +57,7 @@ export async function getPatientIdOrFail({
   triggerDq?: boolean;
 }): Promise<string> {
   const { log } = out(
-    `AthenaHealth getPatient - cxId ${cxId} athenaPracticeId athenaPracticeId ${athenaPracticeId} athenaPatientId ${athenaPatientId}`
+    `AthenaHealth getPatient - cxId ${cxId} athenaPracticeId ${athenaPracticeId} athenaPatientId ${athenaPatientId}`
   );
   const existingPatient = await getPatientMapping({
     cxId,

--- a/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
@@ -56,7 +56,9 @@ export async function getPatientIdOrFail({
   useSearch?: boolean;
   triggerDq?: boolean;
 }): Promise<string> {
-  const { log } = out(`AthenaHealth getPatient - cxId ${cxId} athenaPatientId ${athenaPatientId}`);
+  const { log } = out(
+    `AthenaHealth getPatient - cxId ${cxId} athenaPracticeId athenaPracticeId ${athenaPracticeId} athenaPatientId ${athenaPatientId}`
+  );
   const existingPatient = await getPatientMapping({
     cxId,
     externalId: athenaPatientId,
@@ -101,8 +103,6 @@ export async function getPatientIdOrFail({
   const getPatientByDemoArgs = patientDemoFilters.map(demo => {
     return {
       cxId,
-      athenaPracticeId,
-      athenaPatientId,
       demo,
       patients,
       errors: getPatientByDemoErrors,
@@ -204,16 +204,12 @@ function createMetriportPatientDemo(
 
 async function getPatientByDemo({
   cxId,
-  athenaPracticeId,
-  athenaPatientId,
   demo,
   patients,
   errors,
   log,
 }: {
   cxId: string;
-  athenaPracticeId: string;
-  athenaPatientId: string;
   demo: PatientDemoData;
   patients: Patient[];
   errors: string[];
@@ -223,9 +219,7 @@ async function getPatientByDemo({
     const patient = await singleGetMetriportPatientByDemo({ cxId, demo });
     if (patient) patients.push(patient);
   } catch (error) {
-    const msg = `Failed to get patient by demo. cxId ${cxId} athenaPracticeId ${athenaPracticeId} athenaPatientId ${athenaPatientId}. Cause: ${errorToString(
-      error
-    )}`;
+    const msg = `Failed to get patient by demo. Cause: ${errorToString(error)}`;
     log(msg);
     errors.push(msg);
   }

--- a/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
@@ -29,7 +29,7 @@ type PatientAppointment = {
 };
 
 export async function getPatientIdsOrFailFromAppointmentsSub(): Promise<void> {
-  const { log } = out(`AthenaHealth getPatientIdsOrFailFromAppointments`);
+  const { log } = out(`AthenaHealth getPatientIdsOrFailFromAppointmentsSub`);
   if (!athenaEnvironment || !athenaClientKeySecretArn || !athenaClientSecretSecretArn) {
     throw new Error("AthenaHealth not setup");
   }
@@ -160,7 +160,7 @@ async function getAppointmentsFromSubAndCreateOrUpdatePatient({
       })
     );
   } catch (error) {
-    const msg = `Failed to get appointments. cxId ${cxId} practiceId: ${practiceId} departmentIds: ${departmentIds}. Cause: ${errorToString(
+    const msg = `Failed to get appointments. cxId ${cxId} practiceId ${practiceId} departmentIds ${departmentIds}. Cause: ${errorToString(
       error
     )}`;
     log(msg);
@@ -197,7 +197,7 @@ async function getPatientIdOrFail({
       triggerDq,
     });
   } catch (error) {
-    const msg = `Failed to find or create patients. cxId ${cxId} athenaPracticeId: ${athenaPracticeId} athenaPatientId: ${athenaPatientId}. Cause: ${errorToString(
+    const msg = `Failed to find or create patients. cxId ${cxId} athenaPracticeId ${athenaPracticeId} athenaPatientId ${athenaPatientId}. Cause: ${errorToString(
       error
     )}`;
     log(msg);

--- a/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
@@ -15,7 +15,7 @@ import { getPatientIdOrFail as singleGetPatientIdOrFail } from "./get-patient";
 dayjs.extend(duration);
 
 const delayBetweenBatches = dayjs.duration(30, "seconds");
-const lastModifiedHoursLookback = 4;
+const lastModifiedHoursLookback = 36;
 
 const region = Config.getAWSRegion();
 const athenaEnvironment = Config.getAthenaHealthEnv();

--- a/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
@@ -15,7 +15,7 @@ import { getPatientIdOrFail as singleGetPatientIdOrFail } from "./get-patient";
 dayjs.extend(duration);
 
 const delayBetweenBatches = dayjs.duration(30, "seconds");
-const lastModifiedHoursLookback = 36;
+const lastModifiedHoursLookback = 12;
 
 const region = Config.getAWSRegion();
 const athenaEnvironment = Config.getAthenaHealthEnv();
@@ -46,7 +46,11 @@ export async function getPatientIdsOrFailFromAppointmentsSub({
     .hour(currentDatetime.hour() - lastModifiedHoursLookback)
     .toDate();
   const endLastModifiedDate = buildDayjs(currentDatetime).toDate();
-  log(`Getting appointments from ${startLastModifiedDate} to ${endLastModifiedDate}`);
+  if (catchUp) {
+    log(`Getting appointments from ${startLastModifiedDate} to ${endLastModifiedDate}`);
+  } else {
+    log(`Getting appointments since last run`);
+  }
 
   const patientAppointments: PatientAppointment[] = [];
   const getAppointmentsErrors: string[] = [];

--- a/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
@@ -28,7 +28,11 @@ type PatientAppointment = {
   athenaPatientId: string;
 };
 
-export async function getPatientIdsOrFailFromAppointmentsSub(): Promise<void> {
+export async function getPatientIdsOrFailFromAppointmentsSub({
+  catchUp,
+}: {
+  catchUp: boolean;
+}): Promise<void> {
   const { log } = out(`AthenaHealth getPatientIdsOrFailFromAppointmentsSub`);
   if (!athenaEnvironment || !athenaClientKeySecretArn || !athenaClientSecretSecretArn) {
     throw new Error("AthenaHealth not setup");
@@ -61,8 +65,8 @@ export async function getPatientIdsOrFailFromAppointmentsSub(): Promise<void> {
       clientKey: athenaClientKey,
       clientSecret: athenaClientSecret,
       patientAppointments,
-      startLastModifiedDate,
-      endLastModifiedDate,
+      startLastModifiedDate: catchUp ? startLastModifiedDate : undefined,
+      endLastModifiedDate: catchUp ? endLastModifiedDate : undefined,
       errors: getAppointmentsErrors,
       log,
     };
@@ -135,8 +139,8 @@ async function getAppointmentsFromSubAndCreateOrUpdatePatient({
   clientKey: string;
   clientSecret: string;
   patientAppointments: PatientAppointment[];
-  startLastModifiedDate: Date;
-  endLastModifiedDate: Date;
+  startLastModifiedDate?: Date;
+  endLastModifiedDate?: Date;
   errors: string[];
   log: typeof console.log;
 }): Promise<void> {

--- a/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
@@ -37,14 +37,15 @@ export async function getPatientIdsOrFailFromAppointmentsSub(): Promise<void> {
   const athenaClientKey = await getSecretValueOrFail(athenaClientKeySecretArn, region);
   const athenaClientSecret = await getSecretValueOrFail(athenaClientSecretSecretArn, region);
 
-  const patientAppointments: PatientAppointment[] = [];
-  const getAppointmentsErrors: string[] = [];
   const currentDatetime = buildDayjs(new Date());
   const startLastModifiedDate = buildDayjs(currentDatetime)
     .hour(currentDatetime.hour() - lastModifiedHoursLookback)
     .toDate();
   const endLastModifiedDate = buildDayjs(currentDatetime).toDate();
   log(`Getting appointments from ${startLastModifiedDate} to ${endLastModifiedDate}`);
+
+  const patientAppointments: PatientAppointment[] = [];
+  const getAppointmentsErrors: string[] = [];
   const getAppointmentsArgs = cxMappings.flatMap(mapping => {
     const practiceId = mapping.externalId;
     const departmentIds = mapping.secondaryMappings?.departmentIds;

--- a/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
@@ -54,7 +54,7 @@ export async function getPatientIdsOrFailFromAppointmentsSub({
 
   const patientAppointments: PatientAppointment[] = [];
   const getAppointmentsErrors: string[] = [];
-  const getAppointmentsArgs = cxMappings.flatMap(mapping => {
+  const getAppointmentsArgs = cxMappings.map(mapping => {
     const practiceId = mapping.externalId;
     const departmentIds = mapping.secondaryMappings?.departmentIds;
     if (departmentIds && !Array.isArray(departmentIds)) {

--- a/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
@@ -93,7 +93,9 @@ export async function getPatientIdsOrFailFromAppointmentsSub({
   }
 
   const patientAppointmentsUnique = [
-    ...new Map(patientAppointments.map(app => [app.athenaPatientId, app])).values(),
+    ...new Map(
+      patientAppointments.map(app => [`${app.athenaPracticeId} ${app.athenaPatientId}`, app])
+    ).values(),
   ];
   const getPatientIdOrFailErrors: string[] = [];
   const getPatientIdOrFaiLArgs = patientAppointmentsUnique.map(appointment => {

--- a/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
@@ -67,7 +67,7 @@ export async function getPatientIdsOrFailFromAppointmentsSub(): Promise<void> {
     };
   });
 
-  await executeAsynchronously(getAppointmentsArgs, getAppointmentsAndCreateOrUpdatePatient, {
+  await executeAsynchronously(getAppointmentsArgs, getAppointmentsFromSubAndCreateOrUpdatePatient, {
     numberOfParallelExecutions: 10,
     delay: delayBetweenBatches.asMilliseconds(),
   });
@@ -78,42 +78,42 @@ export async function getPatientIdsOrFailFromAppointmentsSub(): Promise<void> {
         patientCreateCount: getAppointmentsErrors.length,
         errorCount: getAppointmentsErrors.length,
         errors: getAppointmentsErrors.join(","),
-        context: "athenahealth.get-patients-from-appointments",
+        context: "athenahealth.get-patients-from-appointments-sub",
       },
     });
   }
 
-  const getPatientOrFailErrors: string[] = [];
-  const getPatientIdOrFaiLArg = patientAppointments.map(appointment => {
+  const getPatientIdOrFailErrors: string[] = [];
+  const getPatientIdOrFaiLArgs = patientAppointments.map(appointment => {
     return {
       cxId: appointment.cxId,
       athenaPracticeId: appointment.athenaPracticeId,
       athenaPatientId: appointment.athenaPatientId,
       useSearch: true,
       triggerDq: true,
-      errors: getPatientOrFailErrors,
+      errors: getPatientIdOrFailErrors,
       log,
     };
   });
 
-  await executeAsynchronously(getPatientIdOrFaiLArg, getPatientIdOrFail, {
+  await executeAsynchronously(getPatientIdOrFaiLArgs, getPatientIdOrFail, {
     numberOfParallelExecutions: 10,
     delay: delayBetweenBatches.asMilliseconds(),
   });
 
-  if (getPatientOrFailErrors.length > 0) {
+  if (getPatientIdOrFailErrors.length > 0) {
     capture.error("Failed to find or create patients", {
       extra: {
-        patientCreateCount: getPatientOrFailErrors.length,
-        errorCount: getPatientOrFailErrors.length,
-        errors: getPatientOrFailErrors.join(","),
+        patientCreateCount: getPatientIdOrFailErrors.length,
+        errorCount: getPatientIdOrFailErrors.length,
+        errors: getPatientIdOrFailErrors.join(","),
         context: "athenahealth.get-patients-from-appointments",
       },
     });
   }
 }
 
-async function getAppointmentsAndCreateOrUpdatePatient({
+async function getAppointmentsFromSubAndCreateOrUpdatePatient({
   cxId,
   practiceId,
   departmentIds,

--- a/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
@@ -50,7 +50,7 @@ export async function getPatientIdsOrFailFromAppointmentsSub(): Promise<void> {
     const departmentIds = mapping.secondaryMappings?.departmentIds;
     if (departmentIds && !Array.isArray(departmentIds)) {
       throw new Error(
-        `departmentIds exists but is malformed for cxId ${cxId} practiceId ${practiceId}`
+        `departmentIds exists but is malformed for cxId ${mapping.cxId} practiceId ${practiceId}`
       );
     }
     return {

--- a/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
@@ -76,7 +76,7 @@ export async function getPatientIdsOrFailFromAppointmentsSub(): Promise<void> {
   if (getAppointmentsErrors.length > 0) {
     capture.error("Failed to get appointments", {
       extra: {
-        patientCreateCount: getAppointmentsErrors.length,
+        getAppointmentsArgsCount: getAppointmentsArgs.length,
         errorCount: getAppointmentsErrors.length,
         errors: getAppointmentsErrors.join(","),
         context: "athenahealth.get-patients-from-appointments-sub",
@@ -84,8 +84,11 @@ export async function getPatientIdsOrFailFromAppointmentsSub(): Promise<void> {
     });
   }
 
+  const patientAppointmentsUnique = [
+    ...new Map(patientAppointments.map(app => [app.athenaPatientId, app])).values(),
+  ];
   const getPatientIdOrFailErrors: string[] = [];
-  const getPatientIdOrFaiLArgs = patientAppointments.map(appointment => {
+  const getPatientIdOrFaiLArgs = patientAppointmentsUnique.map(appointment => {
     return {
       cxId: appointment.cxId,
       athenaPracticeId: appointment.athenaPracticeId,
@@ -105,7 +108,7 @@ export async function getPatientIdsOrFailFromAppointmentsSub(): Promise<void> {
   if (getPatientIdOrFailErrors.length > 0) {
     capture.error("Failed to find or create patients", {
       extra: {
-        patientCreateCount: getPatientIdOrFailErrors.length,
+        getPatientIdOrFaiLArgsCount: getPatientIdOrFaiLArgs.length,
         errorCount: getPatientIdOrFailErrors.length,
         errors: getPatientIdOrFailErrors.join(","),
         context: "athenahealth.get-patients-from-appointments",

--- a/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
@@ -186,11 +186,11 @@ async function getAppointmentsFromSubscriptionByPractice({
       })
     );
   } catch (error) {
-    const msg = `Failed to get appointments. cxId ${cxId} practiceId ${practiceId} departmentIds ${departmentIds}. Cause: ${errorToString(
-      error
-    )}`;
-    log(msg);
-    errors.push(msg);
+    const cause = `Cause: ${errorToString(error)}`;
+    const details = `cxId ${cxId} practiceId ${practiceId} departmentIds ${departmentIds}.`;
+    const msg = "Failed to get appointments.";
+    log(`${details} ${msg} ${cause}`);
+    errors.push(`${msg} ${details} ${cause}`);
   }
 }
 
@@ -268,10 +268,10 @@ async function getPatientIdOrFail({
       triggerDq,
     });
   } catch (error) {
-    const msg = `Failed to find or create patients. cxId ${cxId} athenaPracticeId ${athenaPracticeId} athenaPatientId ${athenaPatientId}. Cause: ${errorToString(
-      error
-    )}`;
-    log(msg);
-    errors.push(msg);
+    const cause = `Cause: ${errorToString(error)}`;
+    const details = `cxId ${cxId} athenaPracticeId ${athenaPracticeId} athenaPatientId ${athenaPatientId}.`;
+    const msg = "Failed to find or create patients";
+    log(`${details} ${msg} ${cause}`);
+    errors.push(`${msg} ${details} ${cause}`);
   }
 }

--- a/packages/api/src/routes/ehr-internal/athenahealth/internal/patient.ts
+++ b/packages/api/src/routes/ehr-internal/athenahealth/internal/patient.ts
@@ -1,7 +1,7 @@
 import Router from "express-promise-router";
 import httpStatus from "http-status";
 import { Request, Response } from "express";
-import { getPatientIdsOrFailFromAppointments } from "../../../../external/ehr/athenahealth/command/get-patients-from-appointments";
+import { getPatientIdsOrFailFromAppointmentsSub } from "../../../../external/ehr/athenahealth/command/get-patients-from-appointments";
 import { requestLogger } from "../../../helpers/request-logger";
 import { asyncHandler } from "../../../util";
 const router = Router();
@@ -12,10 +12,10 @@ const router = Router();
  * Fetches appointments in a predefined window and creates all patients not already existing
  */
 router.post(
-  "/from-appointments",
+  "/from-appointments-sub",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
-    getPatientIdsOrFailFromAppointments();
+    getPatientIdsOrFailFromAppointmentsSub();
     return res.sendStatus(httpStatus.OK);
   })
 );

--- a/packages/api/src/routes/ehr-internal/athenahealth/internal/patient.ts
+++ b/packages/api/src/routes/ehr-internal/athenahealth/internal/patient.ts
@@ -3,7 +3,7 @@ import httpStatus from "http-status";
 import { Request, Response } from "express";
 import { getPatientIdsOrFailFromAppointmentsSub } from "../../../../external/ehr/athenahealth/command/get-patients-from-appointments";
 import { requestLogger } from "../../../helpers/request-logger";
-import { asyncHandler } from "../../../util";
+import { asyncHandler, getFromQueryAsBoolean } from "../../../util";
 const router = Router();
 
 /**
@@ -15,22 +15,8 @@ router.post(
   "/from-appointments-sub",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
-    getPatientIdsOrFailFromAppointmentsSub({ catchUp: false });
-    return res.sendStatus(httpStatus.OK);
-  })
-);
-
-/**
- * POST /internal/ehr/athenahealth/patient/from-appointments/catchup
- *
- * Fetches appointments in a predefined window that have already been processed,
- * and creates all patients not already existing
- */
-router.post(
-  "/from-appointments-sub/catchup",
-  requestLogger,
-  asyncHandler(async (req: Request, res: Response) => {
-    getPatientIdsOrFailFromAppointmentsSub({ catchUp: true });
+    const catchUp = getFromQueryAsBoolean("catchUp", req) ?? false;
+    getPatientIdsOrFailFromAppointmentsSub({ catchUp });
     return res.sendStatus(httpStatus.OK);
   })
 );

--- a/packages/api/src/routes/ehr-internal/athenahealth/internal/patient.ts
+++ b/packages/api/src/routes/ehr-internal/athenahealth/internal/patient.ts
@@ -7,12 +7,12 @@ import { asyncHandler, getFromQueryAsBoolean } from "../../../util";
 const router = Router();
 
 /**
- * POST /internal/ehr/athenahealth/patient/from-appointments
+ * POST /internal/ehr/athenahealth/patient/from-appointments-subscription
  *
  * Fetches appointments since last call creates all patients not already existing
  */
 router.post(
-  "/from-appointments-sub",
+  "/from-appointments-subscription",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const catchUp = getFromQueryAsBoolean("catchUp", req) ?? false;

--- a/packages/api/src/routes/ehr-internal/athenahealth/internal/patient.ts
+++ b/packages/api/src/routes/ehr-internal/athenahealth/internal/patient.ts
@@ -9,13 +9,28 @@ const router = Router();
 /**
  * POST /internal/ehr/athenahealth/patient/from-appointments
  *
- * Fetches appointments in a predefined window and creates all patients not already existing
+ * Fetches appointments since last call creates all patients not already existing
  */
 router.post(
   "/from-appointments-sub",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
-    getPatientIdsOrFailFromAppointmentsSub();
+    getPatientIdsOrFailFromAppointmentsSub({ catchUp: false });
+    return res.sendStatus(httpStatus.OK);
+  })
+);
+
+/**
+ * POST /internal/ehr/athenahealth/patient/from-appointments/catchup
+ *
+ * Fetches appointments in a predefined window that have already been processed,
+ * and creates all patients not already existing
+ */
+router.post(
+  "/from-appointments-sub/catchup",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    getPatientIdsOrFailFromAppointmentsSub({ catchUp: true });
     return res.sendStatus(httpStatus.OK);
   })
 );

--- a/packages/core/src/external/athenahealth/index.ts
+++ b/packages/core/src/external/athenahealth/index.ts
@@ -57,6 +57,8 @@ export type MedicationWithRefs = {
   statement?: MedicationStatement;
 };
 
+export type FeedType = "appointments";
+
 class AthenaHealthApi {
   private axiosInstanceFhirApi: AxiosInstance;
   private axiosInstanceProprietary: AxiosInstance;
@@ -413,7 +415,7 @@ class AthenaHealthApi {
     return medicationOptions;
   }
 
-  async subscribeToEvent({ cxId, feedtype }: { cxId: string; feedtype: string }): Promise<void> {
+  async subscribeToEvent({ cxId, feedtype }: { cxId: string; feedtype: FeedType }): Promise<void> {
     const { log, debug } = out(
       `AthenaHealth subscribe to events - cxId ${cxId} practiceId ${this.practiceId} feedtype ${feedtype}`
     );
@@ -548,8 +550,6 @@ class AthenaHealthApi {
     const urlParams = new URLSearchParams(params);
     if (departmentIds && departmentIds.length > 0) {
       departmentIds.map(dpId => urlParams.append("departmentid", this.stripDepartmentId(dpId)));
-    } else {
-      urlParams.append("departmentid", "");
     }
     const appointmentUrl = `/appointments/changed?${urlParams.toString()}`;
     try {

--- a/packages/core/src/external/athenahealth/index.ts
+++ b/packages/core/src/external/athenahealth/index.ts
@@ -17,6 +17,7 @@ import {
   bookedAppointmentsGetResponseSchema,
   subscriptionCreateResponseSchema,
   departmentsGetResponseSchema,
+  FeedType,
 } from "@metriport/shared";
 import { errorToString, NotFoundError } from "@metriport/shared";
 import { buildDayjs } from "@metriport/shared/common/date";
@@ -56,8 +57,6 @@ export type MedicationWithRefs = {
   dispense?: MedicationDispense;
   statement?: MedicationStatement;
 };
-
-export type FeedType = "appointments";
 
 class AthenaHealthApi {
   private axiosInstanceFhirApi: AxiosInstance;
@@ -417,7 +416,7 @@ class AthenaHealthApi {
 
   async subscribeToEvent({ cxId, feedtype }: { cxId: string; feedtype: FeedType }): Promise<void> {
     const { log, debug } = out(
-      `AthenaHealth subscribe to events - cxId ${cxId} practiceId ${this.practiceId} feedtype ${feedtype}`
+      `AthenaHealth subscribe to event - cxId ${cxId} practiceId ${this.practiceId} feedtype ${feedtype}`
     );
     const subscribeUrl = `/${feedtype}/changed/subscription`;
     try {
@@ -443,7 +442,7 @@ class AthenaHealthApi {
       const outcome = subscriptionCreateResponseSchema.parse(response.data);
       if (!outcome.success) throw new Error(`Subscription for ${feedtype} not successful`);
     } catch (error) {
-      const msg = `Failure while subscribing to events @ AthenaHealth`;
+      const msg = `Failure while subscribing to event @ AthenaHealth`;
       log(`${msg}. Cause: ${errorToString(error)}`);
       capture.error(msg, {
         extra: {
@@ -578,7 +577,7 @@ class AthenaHealthApi {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       if (error.response?.status === 403) {
-        log(`Subscribing to appointment events for cxId ${cxId}`);
+        log(`Subscribing to appointment event for cxId ${cxId}`);
         await this.subscribeToEvent({
           cxId,
           feedtype: "appointments",

--- a/packages/core/src/external/athenahealth/index.ts
+++ b/packages/core/src/external/athenahealth/index.ts
@@ -468,7 +468,7 @@ class AthenaHealthApi {
     endAppointmentDate,
   }: {
     cxId: string;
-    departmentIds: string[];
+    departmentIds?: string[];
     startAppointmentDate: Date;
     endAppointmentDate: Date;
   }): Promise<BookedAppointment[]> {
@@ -480,7 +480,7 @@ class AthenaHealthApi {
       enddate: this.formatDate(endAppointmentDate.toISOString()) ?? "",
     };
     const urlParams = new URLSearchParams(params);
-    if (departmentIds.length > 0) {
+    if (departmentIds && departmentIds.length > 0) {
       departmentIds.map(dpId => urlParams.append("departmentid", this.stripDepartmentId(dpId)));
     } else {
       const fetchedDepartmentIds = await this.getDepartments({ cxId });
@@ -533,7 +533,7 @@ class AthenaHealthApi {
     endLastModifiedDate,
   }: {
     cxId: string;
-    departmentIds: string[];
+    departmentIds?: string[];
     startLastModifiedDate: Date;
     endLastModifiedDate: Date;
   }): Promise<BookedAppointment[]> {
@@ -545,7 +545,7 @@ class AthenaHealthApi {
       showprocessedenddatetime: this.formatDateTime(endLastModifiedDate.toISOString()) ?? "",
     };
     const urlParams = new URLSearchParams(params);
-    if (departmentIds.length > 0) {
+    if (departmentIds && departmentIds.length > 0) {
       departmentIds.map(dpId => urlParams.append("departmentid", this.stripDepartmentId(dpId)));
     } else {
       urlParams.append("departmentid", "");

--- a/packages/core/src/external/athenahealth/index.ts
+++ b/packages/core/src/external/athenahealth/index.ts
@@ -302,8 +302,8 @@ class AthenaHealthApi {
       unstructuredsig: "Metriport",
       medicationid: `${medicationOptions[0]?.medicationid}`,
       hidden: "false",
-      startdate: this.formatDate(medication.statement?.effectivePeriod?.start) ?? undefined,
-      stopdate: this.formatDate(medication.statement?.effectivePeriod?.end) ?? undefined,
+      startdate: this.formatDate(medication.statement?.effectivePeriod?.start),
+      stopdate: this.formatDate(medication.statement?.effectivePeriod?.end),
       stopreason: undefined,
       patientnote: undefined,
       THIRDPARTYUSERNAME: undefined,
@@ -531,15 +531,19 @@ class AthenaHealthApi {
   }: {
     cxId: string;
     departmentIds?: string[];
-    startLastModifiedDate: Date;
-    endLastModifiedDate: Date;
+    startLastModifiedDate?: Date;
+    endLastModifiedDate?: Date;
   }): Promise<BookedAppointment[]> {
     const { log, debug } = out(
       `AthenaHealth get appointments from sub - cxId ${cxId} practiceId ${this.practiceId} departmentIds ${departmentIds}`
     );
     const params = {
-      showprocessedstartdatetime: this.formatDateTime(startLastModifiedDate.toISOString()) ?? "",
-      showprocessedenddatetime: this.formatDateTime(endLastModifiedDate.toISOString()) ?? "",
+      showprocessedstartdatetime: startLastModifiedDate
+        ? this.formatDateTime(startLastModifiedDate.toISOString()) ?? ""
+        : "",
+      showprocessedenddatetime: endLastModifiedDate
+        ? this.formatDateTime(endLastModifiedDate.toISOString()) ?? ""
+        : "",
     };
     const urlParams = new URLSearchParams(params);
     if (departmentIds && departmentIds.length > 0) {

--- a/packages/core/src/external/athenahealth/index.ts
+++ b/packages/core/src/external/athenahealth/index.ts
@@ -255,8 +255,9 @@ class AthenaHealthApi {
           .catch(processAsyncError("Error saving to s3 @ AthenaHealth - getPatientViaSearch"));
       }
       const searchSet = patientSearchResourceSchema.parse(response.data);
-      if (searchSet.entry.length > 1)
+      if (searchSet.entry.length > 1) {
         throw new NotFoundError("More than one AthenaHealth patient found");
+      }
       return searchSet.entry[0]?.resource;
     } catch (error) {
       const msg = `Failure while searching patient @ AthenaHealth`;
@@ -438,7 +439,7 @@ class AthenaHealthApi {
           .catch(processAsyncError("Error saving to s3 @ AthenaHealth - subscribeToEvent"));
       }
       const outcome = subscriptionCreateResponseSchema.parse(response.data);
-      if (!outcome.success) throw new Error("Subscription not successful");
+      if (!outcome.success) throw new Error(`Subscription for ${feedtype} not successful`);
     } catch (error) {
       const msg = `Failure while subscribing to events @ AthenaHealth`;
       log(`${msg}. Cause: ${errorToString(error)}`);
@@ -573,7 +574,7 @@ class AthenaHealthApi {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       if (error.response?.status === 403) {
-        log(`Subscribging to appointment events for cxId ${cxId}`);
+        log(`Subscribing to appointment events for cxId ${cxId}`);
         await this.subscribeToEvent({
           cxId,
           feedtype: "appointments",

--- a/packages/shared/src/interface/external/athenahealth/appointment.ts
+++ b/packages/shared/src/interface/external/athenahealth/appointment.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+const bookedAppointmentSchema = z.object({
+  patientid: z.string(),
+});
+export type BookedAppointment = z.infer<typeof bookedAppointmentSchema>;
+export const bookedAppointmentResponseSchema = z.object({
+  appointments: bookedAppointmentSchema.array(),
+});

--- a/packages/shared/src/interface/external/athenahealth/appointment.ts
+++ b/packages/shared/src/interface/external/athenahealth/appointment.ts
@@ -4,6 +4,6 @@ const bookedAppointmentSchema = z.object({
   patientid: z.string(),
 });
 export type BookedAppointment = z.infer<typeof bookedAppointmentSchema>;
-export const bookedAppointmentResponseSchema = z.object({
+export const bookedAppointmentsGetResponseSchema = z.object({
   appointments: bookedAppointmentSchema.array(),
 });

--- a/packages/shared/src/interface/external/athenahealth/department.ts
+++ b/packages/shared/src/interface/external/athenahealth/department.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const departmentSchema = z.object({
+  departmentid: z.string(),
+});
+export type Department = z.infer<typeof departmentSchema>;
+export const departmentsGetResponseSchema = z.object({
+  departments: departmentSchema.array(),
+});

--- a/packages/shared/src/interface/external/athenahealth/index.ts
+++ b/packages/shared/src/interface/external/athenahealth/index.ts
@@ -4,3 +4,4 @@ export * from "./jwt-token";
 export * from "./appointment";
 export * from "./medication";
 export * from "./subscription";
+export * from "./department";

--- a/packages/shared/src/interface/external/athenahealth/index.ts
+++ b/packages/shared/src/interface/external/athenahealth/index.ts
@@ -1,3 +1,6 @@
 export * from "./patient";
 export * from "./cx-mapping";
 export * from "./jwt-token";
+export * from "./appointment";
+export * from "./medication";
+export * from "./subscription";

--- a/packages/shared/src/interface/external/athenahealth/medication.ts
+++ b/packages/shared/src/interface/external/athenahealth/medication.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const medicationCreateResponseSchema = z.object({
+  success: z.string(),
+  errormessage: z.string().optional(),
+  medicationentryid: z.number().optional(),
+});
+export type MedicationCreateResponse = z.infer<typeof medicationCreateResponseSchema>;
+
+const medicationReferenceSchema = z.object({
+  medication: z.string(),
+  medicationid: z.number(),
+});
+export type MedicationReference = z.infer<typeof medicationReferenceSchema>;
+export const medicationReferenceResponseSchema = medicationReferenceSchema.array();

--- a/packages/shared/src/interface/external/athenahealth/medication.ts
+++ b/packages/shared/src/interface/external/athenahealth/medication.ts
@@ -12,4 +12,4 @@ const medicationReferenceSchema = z.object({
   medicationid: z.number(),
 });
 export type MedicationReference = z.infer<typeof medicationReferenceSchema>;
-export const medicationReferenceResponseSchema = medicationReferenceSchema.array();
+export const medicationReferencesGetResponseSchema = medicationReferenceSchema.array();

--- a/packages/shared/src/interface/external/athenahealth/subscription.ts
+++ b/packages/shared/src/interface/external/athenahealth/subscription.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const subscriptionCreateResponseSchema = z.object({
+  success: z.string(),
+});

--- a/packages/shared/src/interface/external/athenahealth/subscription.ts
+++ b/packages/shared/src/interface/external/athenahealth/subscription.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+export type FeedType = "appointments";
+
 export const subscriptionCreateResponseSchema = z.object({
   success: z.string(),
 });


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/2170

### Dependencies

- Downstream: https://github.com/metriport/metriport-internal/pull/2320

### Description

- added response types for Athena (carry-over from https://github.com/metriport/metriport/pull/2812)
- added buildDayjs for dates (carry-over from https://github.com/metriport/metriport/pull/2812)
- added async S3 calls (carry-over from https://github.com/metriport/metriport/pull/2812)
- added getting appointments from subscription endpoint
- added signing up for appointments feed if we get a 403 from the endpoint
- other improvements

### Testing

- Local
  - [x] fetching appoinments works
  - [x] subscribing to appointments if not subscribed works
  - [x] fetching department ids works
- Staging
  - [ ] fetching appoinments works
  - [ ] subscribing to appointments if not subscribed works
- Production
  - [ ] fetching appoinments works
  - [ ] subscribing to appointments if not subscribed works

### Release Plan

- [ ] Merge this
