### PR TITLE
PATCH: Leading zero saml CQ

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/saml/security/insert-key-info.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/saml/security/insert-key-info.ts
@@ -29,6 +29,7 @@ export function insertKeyInfo({
   });
 
   const obj = parser.parse(xmlContent);
+
   const security = obj["soap:Envelope"]["soap:Header"]["wsse:Security"];
 
   const certPemStripped = stripPemCertificate(publicCert);
@@ -83,5 +84,19 @@ export function insertKeyInfo({
       ...keyInfoStructure,
     };
   }
-  return builder.build(obj);
+  const build = builder.build(obj);
+
+  return updatePostalCode(build);
+}
+
+// TODO: #2323 - Remove this function once the issue is above
+function updatePostalCode(xml: string): string {
+  // Regex to find both <urn:postalCode> and <postalCode> with exactly 4 digits
+  return xml.replace(
+    /(<(urn:)?postalCode>)(\d{4})(<\/(urn:)?postalCode>)/g,
+    (match, p1, p2, p3, p4) => {
+      // Prepend '0' to the captured postal code value
+      return `${p1}0${p3}${p4}`;
+    }
+  );
 }


### PR DESCRIPTION
Ref. metriport/metriport#2323

Ticket: #_[ticket-number]_

### Dependencies

- Upstream: none
- Downstream: none

### Description

- Issue sending request to gw with leading zero removed - [context](https://metriport.slack.com/archives/C065BLRBUDQ/p1727799373907319)

### Testing

_[Regular PRs:]_

- Local
  - [x] Able to send request to failed gw
- Production
  - [ ] Able to send request to failed gw

_[Release PRs:]_

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
