### PR TITLE
2330 Patient import infra

### DIFF
--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -292,6 +292,10 @@ export class Config {
     return getEnvVar("OUTBOUND_DOC_RETRIEVAL_LAMBDA_NAME");
   }
 
+  static getPatientImportLambdaName(): string {
+    return getEnvVarOrFail("PATIENT_IMPORT_LAMBDA_NAME");
+  }
+
   static getSearchIngestionQueueUrl(): string {
     return getEnvVarOrFail("SEARCH_INGESTION_QUEUE_URL");
   }

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -2,6 +2,7 @@ import { EnvType } from "../lib/env-type";
 import { RDSAlarmThresholds } from "./aws/rds";
 import { IHEGatewayProps } from "./ihe-gateway-config";
 import { OpenSearchConnectorConfig } from "./open-search-config";
+import { PatientImportProps } from "./patient-import";
 
 export type ConnectWidgetConfig = {
   stackName: string;
@@ -195,6 +196,7 @@ type EnvConfigBase = {
     CW_GATEWAY_AUTHORIZATION_CLIENT_SECRET: string;
   };
   iheGateway?: IHEGatewayProps;
+  patientImport: PatientImportProps;
   canvas?: {
     secretNames: {
       CANVAS_CLIENT_ID: string;

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -76,6 +76,9 @@ export const config: EnvConfigNonSandbox = {
     CW_GATEWAY_AUTHORIZATION_CLIENT_ID: "CW_GATEWAY_AUTHORIZATION_CLIENT_ID",
     CW_GATEWAY_AUTHORIZATION_CLIENT_SECRET: "CW_GATEWAY_AUTHORIZATION_CLIENT_SECRET",
   },
+  patientImport: {
+    bucketName: "your-bucket-name",
+  },
   connectWidget: {
     stackName: "MetriportConnectInfraStack",
     region: "us-east-1",

--- a/packages/infra/config/patient-import.ts
+++ b/packages/infra/config/patient-import.ts
@@ -1,0 +1,3 @@
+export type PatientImportProps = {
+  bucketName: string;
+};

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -341,16 +341,16 @@ export class APIStack extends Stack {
       },
     });
 
-    const { patientCreateLambda, patientQueryLambda } = new PatientImportNestedStack(
-      this,
-      "PatientImportNestedStack",
-      {
-        config: props.config,
-        lambdaLayers,
-        vpc: this.vpc,
-        alarmAction: slackNotification?.alarmAction,
-      }
-    );
+    const {
+      importFileLambda: patientImportLambda,
+      patientCreateLambda,
+      patientQueryLambda,
+    } = new PatientImportNestedStack(this, "PatientImportNestedStack", {
+      config: props.config,
+      lambdaLayers,
+      vpc: this.vpc,
+      alarmAction: slackNotification?.alarmAction,
+    });
 
     //-------------------------------------------
     // OPEN SEARCH Domains
@@ -452,6 +452,7 @@ export class APIStack extends Stack {
       outboundPatientDiscoveryLambda,
       outboundDocumentQueryLambda,
       outboundDocumentRetrievalLambda,
+      patientImportLambda,
       generalBucket,
       medicalDocumentsUploadBucket,
       ehrResponsesBucket,

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -46,6 +46,7 @@ import { createAppConfigStack } from "./app-config-stack";
 import { EnvType } from "./env-type";
 import { IHEGatewayV2LambdasNestedStack } from "./ihe-gateway-v2-stack";
 import { CDA_TO_VIS_TIMEOUT, LambdasNestedStack } from "./lambdas-nested-stack";
+import { PatientImportNestedStack } from "./patient-import-nested-stack";
 import * as AppConfigUtils from "./shared/app-config";
 import { DailyBackup } from "./shared/backup";
 import { addErrorAlarmToLambdaFunc, createLambda, MAXIMUM_LAMBDA_TIMEOUT } from "./shared/lambda";
@@ -340,6 +341,17 @@ export class APIStack extends Stack {
       },
     });
 
+    const { patientCreateLambda, patientQueryLambda } = new PatientImportNestedStack(
+      this,
+      "PatientImportNestedStack",
+      {
+        config: props.config,
+        lambdaLayers,
+        vpc: this.vpc,
+        alarmAction: slackNotification?.alarmAction,
+      }
+    );
+
     //-------------------------------------------
     // OPEN SEARCH Domains
     //-------------------------------------------
@@ -542,6 +554,8 @@ export class APIStack extends Stack {
     outboundDocumentQueryLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
     outboundDocumentRetrievalLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
     fhirToBundleLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
+    patientCreateLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
+    patientQueryLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
 
     // Access grant for medical documents bucket
     sandboxSeedDataBucket &&

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -95,6 +95,7 @@ export function createAPIService({
   outboundPatientDiscoveryLambda,
   outboundDocumentQueryLambda,
   outboundDocumentRetrievalLambda,
+  patientImportLambda,
   generalBucket,
   medicalDocumentsUploadBucket,
   ehrResponsesBucket,
@@ -126,6 +127,7 @@ export function createAPIService({
   outboundPatientDiscoveryLambda: ILambda;
   outboundDocumentQueryLambda: ILambda;
   outboundDocumentRetrievalLambda: ILambda;
+  patientImportLambda: ILambda;
   generalBucket: s3.Bucket;
   medicalDocumentsUploadBucket: s3.Bucket;
   ehrResponsesBucket: s3.Bucket | undefined;
@@ -245,6 +247,7 @@ export function createAPIService({
           OUTBOUND_PATIENT_DISCOVERY_LAMBDA_NAME: outboundPatientDiscoveryLambda.functionName,
           OUTBOUND_DOC_QUERY_LAMBDA_NAME: outboundDocumentQueryLambda.functionName,
           OUTBOUND_DOC_RETRIEVAL_LAMBDA_NAME: outboundDocumentRetrievalLambda.functionName,
+          PATIENT_IMPORT_LAMBDA_NAME: patientImportLambda.functionName,
           FHIR_TO_BUNDLE_LAMBDA_NAME: fhirToBundleLambda.functionName,
           ...(fhirToMedicalRecordLambda && {
             FHIR_TO_MEDICAL_RECORD_LAMBDA_NAME: fhirToMedicalRecordLambda.functionName,
@@ -368,11 +371,13 @@ export function createAPIService({
   }
   // RW grant for Dynamo DB
   dynamoDBTokenTable.grantReadWriteData(fargateService.taskDefinition.taskRole);
+
   cdaToVisualizationLambda.grantInvoke(fargateService.taskDefinition.taskRole);
   documentDownloaderLambda.grantInvoke(fargateService.taskDefinition.taskRole);
   outboundPatientDiscoveryLambda.grantInvoke(fargateService.taskDefinition.taskRole);
   outboundDocumentQueryLambda.grantInvoke(fargateService.taskDefinition.taskRole);
   outboundDocumentRetrievalLambda.grantInvoke(fargateService.taskDefinition.taskRole);
+  patientImportLambda.grantInvoke(fargateService.taskDefinition.taskRole);
   fhirToCdaConverterLambda?.grantInvoke(fargateService.taskDefinition.taskRole);
   fhirToBundleLambda.grantInvoke(fargateService.taskDefinition.taskRole);
 

--- a/packages/infra/lib/patient-import-nested-stack.ts
+++ b/packages/infra/lib/patient-import-nested-stack.ts
@@ -1,0 +1,324 @@
+import { Duration, NestedStack, NestedStackProps } from "aws-cdk-lib";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { Function as Lambda } from "aws-cdk-lib/aws-lambda";
+import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { IBucket } from "aws-cdk-lib/aws-s3";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { Construct } from "constructs";
+import { EnvConfig } from "../config/env-config";
+import { EnvType } from "./env-type";
+import { createLambda } from "./shared/lambda";
+import { LambdaLayers } from "./shared/lambda-layers";
+import { createQueue } from "./shared/sqs";
+
+function settings() {
+  // TODO 2330 CUSTOMIZE THIS
+  // TODO 2330 CUSTOMIZE THIS
+  // TODO 2330 CUSTOMIZE THIS
+  const waitTime = Duration.seconds(20);
+  const fileImportLambdaTimeout = Duration.minutes(15).minus(Duration.seconds(5));
+  const fileImport = {
+    name: "PatientImportFile",
+    entry: "patient-import-file",
+    lambdaMemory: 2048,
+    lambdaTimeout: fileImportLambdaTimeout,
+  };
+  const patientCreateLambdaTimeout = Duration.minutes(5).minus(Duration.seconds(5));
+  const patientCreate: QueueAndLambdaSettings = {
+    name: "PatientImportCreate",
+    entry: "patient-import-create",
+    lambda: {
+      memory: 1024,
+      batchSize: 1,
+      timeout: patientCreateLambdaTimeout,
+      reportBatchItemFailures: true,
+    },
+    queue: {
+      alarmMaxAgeOfOldestMessage: patientCreateLambdaTimeout.minus(Duration.seconds(10)),
+      maxMessageCountAlarmThreshold: 5_000,
+      maxReceiveCount: 3,
+      visibilityTimeout: Duration.seconds(patientCreateLambdaTimeout.toSeconds() * 2 + 1),
+    },
+    waitTime,
+  };
+  const patientQueryLambdaTimeout = Duration.minutes(15).minus(Duration.seconds(5));
+  const patientQuery: QueueAndLambdaSettings = {
+    name: "PatientImportQuery",
+    entry: "patient-import-query",
+    lambda: {
+      memory: 512,
+      batchSize: 1,
+      timeout: patientQueryLambdaTimeout,
+      reportBatchItemFailures: true,
+    },
+    queue: {
+      alarmMaxAgeOfOldestMessage: patientQueryLambdaTimeout.minus(Duration.seconds(10)),
+      maxReceiveCount: 3,
+      visibilityTimeout: Duration.seconds(patientQueryLambdaTimeout.toSeconds() * 2 + 1),
+    },
+    waitTime,
+  };
+  return {
+    fileImport,
+    patientCreate,
+    patientQuery,
+  };
+}
+
+type QueueAndLambdaSettings = {
+  name: string;
+  entry: string;
+  lambda: {
+    memory: 512 | 1024 | 2048 | 4096;
+    /** Number of messages the lambda pull from SQS at once  */
+    batchSize: number;
+    /** How long can the lambda run for, max is 900 seconds (15 minutes)  */
+    timeout: Duration;
+    /** Partial batch response: https://docs.aws.amazon.com/prescriptive-guidance/latest/lambda-event-filtering-partial-batch-responses-for-sqs/welcome.html */
+    reportBatchItemFailures: boolean;
+  };
+  queue: {
+    alarmMaxAgeOfOldestMessage: Duration;
+    maxMessageCountAlarmThreshold?: number;
+    /** The number of times a message can be unsuccesfully dequeued before being moved to the dead-letter queue. */
+    maxReceiveCount: number;
+    /** How long messages should be invisible for other consumers, based on the lambda timeout */
+    /** We don't care if the message gets reprocessed, so no need to have a huge visibility timeout that makes it harder to move messages to the DLQ */
+    visibilityTimeout: Duration;
+  };
+  waitTime: Duration;
+};
+
+interface PatientImportNestedStackProps extends NestedStackProps {
+  config: EnvConfig;
+  vpc: ec2.IVpc;
+  alarmAction?: SnsAction;
+  lambdaLayers: LambdaLayers;
+}
+
+export class PatientImportNestedStack extends NestedStack {
+  readonly bucket: IBucket;
+  readonly importFileLambda: Lambda;
+  readonly patientCreateLambda: Lambda;
+  readonly patientCreateQueue: Queue;
+  readonly patientQueryLambda: Lambda;
+  readonly patientQueryQueue: Queue;
+
+  constructor(scope: Construct, id: string, props: PatientImportNestedStackProps) {
+    super(scope, id, props);
+    const config = props.config.patientImport;
+
+    this.terminationProtection = true;
+
+    this.bucket = this.setupBucket({
+      bucketName: config.bucketName,
+    });
+
+    const patientQuery = this.setupPatientQuery({
+      lambdaLayers: props.lambdaLayers,
+      vpc: props.vpc,
+      envType: props.config.environmentType,
+      bucket: this.bucket,
+      sentryDsn: props.config.lambdasSentryDSN,
+      alarmAction: props.alarmAction,
+    });
+    this.patientQueryLambda = patientQuery.lambda;
+    this.patientQueryQueue = patientQuery.queue;
+
+    const patientCreate = this.setupPatientCreate({
+      lambdaLayers: props.lambdaLayers,
+      vpc: props.vpc,
+      envType: props.config.environmentType,
+      bucket: this.bucket,
+      patientQueryQueue: this.patientQueryQueue,
+      sentryDsn: props.config.lambdasSentryDSN,
+      alarmAction: props.alarmAction,
+    });
+    this.patientCreateLambda = patientCreate.lambda;
+    this.patientCreateQueue = patientCreate.queue;
+
+    this.importFileLambda = this.setupLambdaImportFile({
+      lambdaLayers: props.lambdaLayers,
+      vpc: props.vpc,
+      envType: props.config.environmentType,
+      bucket: this.bucket,
+      patientCreateQueue: this.patientCreateQueue,
+      sentryDsn: props.config.lambdasSentryDSN,
+      alarmAction: props.alarmAction,
+    });
+  }
+
+  private setupBucket({ bucketName }: { bucketName: string }): IBucket {
+    const bucket = new s3.Bucket(this, "PatientImportBucket", {
+      bucketName: bucketName,
+      publicReadAccess: false,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      versioned: true,
+    });
+    return bucket;
+  }
+
+  private setupLambdaImportFile(ownProps: {
+    lambdaLayers: LambdaLayers;
+    vpc: ec2.IVpc;
+    bucket: s3.IBucket;
+    envType: EnvType;
+    patientCreateQueue: Queue;
+    sentryDsn: string | undefined;
+    alarmAction: SnsAction | undefined;
+  }): Lambda {
+    const { lambdaLayers, vpc, bucket, envType, patientCreateQueue, sentryDsn, alarmAction } =
+      ownProps;
+    const { name, entry, lambdaMemory, lambdaTimeout } = settings().fileImport;
+
+    const lambda = createLambda({
+      stack: this,
+      name,
+      entry,
+      envType,
+      envVars: {
+        PATIENT_IMPORT_BUCKET_NAME: bucket.bucketName,
+        PATIENT_CREATE_QUEUE_URL: patientCreateQueue.queueUrl,
+        ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
+      },
+      layers: [lambdaLayers.shared],
+      memory: lambdaMemory,
+      timeout: lambdaTimeout,
+      vpc,
+      alarmSnsAction: alarmAction,
+    });
+
+    bucket.grantReadWrite(lambda);
+    patientCreateQueue.grantSendMessages(lambda);
+
+    return lambda;
+  }
+
+  private setupPatientCreate(ownProps: {
+    lambdaLayers: LambdaLayers;
+    vpc: ec2.IVpc;
+    bucket: s3.IBucket;
+    envType: EnvType;
+    patientQueryQueue: Queue;
+    sentryDsn: string | undefined;
+    alarmAction: SnsAction | undefined;
+  }): { lambda: Lambda; queue: Queue } {
+    const { lambdaLayers, vpc, bucket, patientQueryQueue, envType, sentryDsn, alarmAction } =
+      ownProps;
+    const {
+      name,
+      entry,
+      lambda: { memory, timeout, batchSize, reportBatchItemFailures },
+      queue: {
+        visibilityTimeout,
+        maxReceiveCount,
+        alarmMaxAgeOfOldestMessage,
+        maxMessageCountAlarmThreshold,
+      },
+      waitTime,
+    } = settings().patientCreate;
+
+    const queue = createQueue({
+      stack: this,
+      name,
+      fifo: true,
+      createDLQ: true,
+      visibilityTimeout,
+      maxReceiveCount,
+      lambdaLayers: [lambdaLayers.shared],
+      envType,
+      alarmSnsAction: alarmAction,
+      alarmMaxAgeOfOldestMessage,
+      maxMessageCountAlarmThreshold,
+    });
+
+    const lambda = createLambda({
+      stack: this,
+      name,
+      entry,
+      envType,
+      envVars: {
+        // API_URL set on the api-stack after the OSS API is created
+        WAIT_TIME_IN_MILLIS: waitTime.toMilliseconds().toString(),
+        PATIENT_IMPORT_BUCKET_NAME: bucket.bucketName,
+        PATIENT_QUERY_QUEUE_URL: patientQueryQueue.queueUrl,
+        ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
+      },
+      layers: [lambdaLayers.shared],
+      memory: memory,
+      timeout: timeout,
+      vpc,
+      alarmSnsAction: alarmAction,
+    });
+
+    lambda.addEventSource(new SqsEventSource(queue, { batchSize, reportBatchItemFailures }));
+
+    bucket.grantReadWrite(lambda);
+    patientQueryQueue.grantSendMessages(lambda);
+
+    return { lambda, queue };
+  }
+
+  private setupPatientQuery(ownProps: {
+    lambdaLayers: LambdaLayers;
+    vpc: ec2.IVpc;
+    bucket: s3.IBucket;
+    envType: EnvType;
+    sentryDsn: string | undefined;
+    alarmAction: SnsAction | undefined;
+  }): { lambda: Lambda; queue: Queue } {
+    const { lambdaLayers, vpc, bucket, envType, sentryDsn, alarmAction } = ownProps;
+    const {
+      name,
+      entry,
+      lambda: { memory, timeout, batchSize, reportBatchItemFailures },
+      queue: {
+        visibilityTimeout,
+        maxReceiveCount,
+        alarmMaxAgeOfOldestMessage,
+        maxMessageCountAlarmThreshold,
+      },
+      waitTime,
+    } = settings().patientQuery;
+
+    const queue = createQueue({
+      stack: this,
+      name,
+      fifo: true,
+      createDLQ: true,
+      visibilityTimeout,
+      maxReceiveCount,
+      lambdaLayers: [lambdaLayers.shared],
+      envType,
+      alarmSnsAction: alarmAction,
+      alarmMaxAgeOfOldestMessage,
+      maxMessageCountAlarmThreshold,
+    });
+
+    const lambda = createLambda({
+      stack: this,
+      name,
+      entry,
+      envType,
+      envVars: {
+        // API_URL set on the api-stack after the OSS API is created
+        WAIT_TIME_IN_MILLIS: waitTime.toMilliseconds().toString(),
+        PATIENT_IMPORT_BUCKET_NAME: bucket.bucketName,
+        ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
+      },
+      layers: [lambdaLayers.shared],
+      memory: memory,
+      timeout: timeout,
+      vpc,
+      alarmSnsAction: alarmAction,
+    });
+
+    lambda.addEventSource(new SqsEventSource(queue, { batchSize, reportBatchItemFailures }));
+
+    bucket.grantReadWrite(lambda);
+
+    return { lambda, queue };
+  }
+}

--- a/packages/infra/lib/patient-import-nested-stack.ts
+++ b/packages/infra/lib/patient-import-nested-stack.ts
@@ -40,6 +40,7 @@ function settings() {
       maxMessageCountAlarmThreshold: 5_000,
       maxReceiveCount: 3,
       visibilityTimeout: Duration.seconds(patientCreateLambdaTimeout.toSeconds() * 2 + 1),
+      createRetryLambda: false,
     },
     waitTime,
   };
@@ -57,6 +58,7 @@ function settings() {
       alarmMaxAgeOfOldestMessage: patientQueryLambdaTimeout.minus(Duration.seconds(10)),
       maxReceiveCount: 3,
       visibilityTimeout: Duration.seconds(patientQueryLambdaTimeout.toSeconds() * 2 + 1),
+      createRetryLambda: false,
     },
     waitTime,
   };
@@ -87,6 +89,7 @@ type QueueAndLambdaSettings = {
     /** How long messages should be invisible for other consumers, based on the lambda timeout */
     /** We don't care if the message gets reprocessed, so no need to have a huge visibility timeout that makes it harder to move messages to the DLQ */
     visibilityTimeout: Duration;
+    createRetryLambda: boolean;
   };
   waitTime: Duration;
 };
@@ -216,6 +219,7 @@ export class PatientImportNestedStack extends NestedStack {
         maxReceiveCount,
         alarmMaxAgeOfOldestMessage,
         maxMessageCountAlarmThreshold,
+        createRetryLambda,
       },
       waitTime,
     } = settings().patientCreate;
@@ -232,6 +236,7 @@ export class PatientImportNestedStack extends NestedStack {
       alarmSnsAction: alarmAction,
       alarmMaxAgeOfOldestMessage,
       maxMessageCountAlarmThreshold,
+      createRetryLambda,
     });
 
     const lambda = createLambda({
@@ -279,6 +284,7 @@ export class PatientImportNestedStack extends NestedStack {
         maxReceiveCount,
         alarmMaxAgeOfOldestMessage,
         maxMessageCountAlarmThreshold,
+        createRetryLambda,
       },
       waitTime,
     } = settings().patientQuery;
@@ -295,6 +301,7 @@ export class PatientImportNestedStack extends NestedStack {
       alarmSnsAction: alarmAction,
       alarmMaxAgeOfOldestMessage,
       maxMessageCountAlarmThreshold,
+      createRetryLambda,
     });
 
     const lambda = createLambda({

--- a/packages/infra/lib/shared/sqs.ts
+++ b/packages/infra/lib/shared/sqs.ts
@@ -32,19 +32,12 @@ export type QueueProps = (StandardQueueProps | FifoQueueProps) & {
   consumer?: IGrantable;
   alarmSnsAction?: SnsAction;
   alarmMaxAgeOfOldestMessage?: Duration;
-} & (
-    | {
-        createDLQ: false;
-        createRetryLambda: false;
-      }
-    | {
-        createDLQ?: true | undefined;
-        createRetryLambda?: true | undefined;
-        lambdaLayers: ILayerVersion[];
-        envType: EnvType;
-        alarmMaxAgeOfOldestMessageDlq?: Duration;
-      }
-  );
+  createDLQ?: boolean | undefined;
+  createRetryLambda?: boolean | undefined;
+  lambdaLayers: ILayerVersion[];
+  envType: EnvType;
+  alarmMaxAgeOfOldestMessageDlq?: Duration;
+};
 
 /**
  * Creates a SQS queue.
@@ -67,6 +60,7 @@ export function createQueue(props: QueueProps): Queue {
           : undefined),
       })
     : undefined;
+  const isCreateRetryLambda = props.createRetryLambda ?? true;
   const defaultQueueProps = {
     ...(dlq ? { dlq: dlq } : {}),
   };
@@ -96,7 +90,7 @@ export function createQueue(props: QueueProps): Queue {
     alarmAction: props?.alarmSnsAction,
   });
 
-  if (createDLQ && dlq) {
+  if (dlq && isCreateRetryLambda) {
     createRetryLambda({
       ...props,
       sourceQueue: dlq,

--- a/packages/lambdas/src/patient-import-create.ts
+++ b/packages/lambdas/src/patient-import-create.ts
@@ -1,0 +1,126 @@
+import { errorToString, MetriportError, sleep } from "@metriport/shared";
+import { SQSEvent } from "aws-lambda";
+import AWS from "aws-sdk";
+import { PatientImportQueryBody } from "./patient-import-query";
+import { capture } from "./shared/capture";
+import { getEnvOrFail } from "./shared/env";
+import { prefixedLog } from "./shared/log";
+import { getSingleMessageOrFail } from "./shared/sqs";
+
+// Keep this as early on the file as possible
+capture.init();
+
+// Automatically set by AWS
+const lambdaName = getEnvOrFail("AWS_LAMBDA_FUNCTION_NAME");
+const region = getEnvOrFail("AWS_REGION");
+// Set by us
+const patientImportBucket = getEnvOrFail("PATIENT_IMPORT_BUCKET_NAME");
+const apiURL = getEnvOrFail("API_URL");
+const patientQueryQueueURL = getEnvOrFail("PATIENT_QUERY_QUEUE_URL");
+const waitTimeMillisRaw = getEnvOrFail("WAIT_TIME_IN_MILLIS");
+const waitTimeMillis = parseInt(waitTimeMillisRaw);
+
+export type PatientImportCreateBody = {
+  cxId: string;
+  jobId: string;
+  jobStartedAt: string; // TODO consider moving to Date if we need to work with it here
+  // TODO 2230 Prob want to expand this to include the columns of the CSV
+  patientId: string;
+};
+
+const sqs = new AWS.SQS({ region });
+
+// Don't use Sentry's default error handler b/c we want to use our own and send more context-aware data
+export async function handler(event: SQSEvent) {
+  let errorHandled = false;
+  const errorMsg = "Error processing event on " + lambdaName;
+  const startedAt = new Date().getTime();
+  try {
+    const message = getSingleMessageOrFail(event.Records, lambdaName);
+    if (!message) return;
+
+    console.log(`Body: ${message.body}, patientImportBucket ${patientImportBucket}`);
+    const parsedBody = parseBody(message.body);
+    const { cxId, patientId, jobId, jobStartedAt } = parsedBody;
+
+    const log = prefixedLog(`cxId ${cxId}, patientId ${patientId}, job ${jobId}`);
+    try {
+      // TODO 2330 call the logic from Core
+      // TODO 2330 call the logic from Core
+      // TODO 2330 call the logic from Core
+      log(`apiURL: ${apiURL}`);
+      log(`Parsed: ${JSON.stringify(parsedBody)}`);
+
+      // TODO 2330 MOCKED BEHAVIOR
+      // TODO 2330 MOCKED BEHAVIOR
+      // TODO 2330 MOCKED BEHAVIOR
+      await sleep(waitTimeMillis);
+
+      // TODO 2330 Move this to Core, we should have diff implementations for this, so we can run it
+      // local and on the cloud
+      const body: PatientImportQueryBody = {
+        cxId,
+        jobId,
+        jobStartedAt,
+        patientId,
+      };
+      const sendParams = {
+        MessageBody: JSON.stringify(body),
+        QueueUrl: patientQueryQueueURL,
+        MessageGroupId: cxId,
+        MessageDeduplicationId: patientId,
+      };
+      log(`Sending message to query lambda...`);
+      await sqs.sendMessage(sendParams).promise();
+
+      const finishedAt = new Date().getTime();
+      console.log(`Done local duration: ${finishedAt - startedAt}ms`);
+    } catch (error) {
+      errorHandled = true;
+      console.log(`${errorMsg}: ${errorToString(error)}`);
+      capture.error(errorMsg, {
+        extra: { event, context: lambdaName, error },
+      });
+      throw new MetriportError(errorMsg, error, { ...parsedBody });
+    }
+  } catch (error) {
+    if (errorHandled) throw error;
+    console.log(`${errorMsg}: ${errorToString(error)}`);
+    capture.error(errorMsg, {
+      extra: { event, context: lambdaName, error },
+    });
+    throw new MetriportError(errorMsg, error);
+  }
+}
+
+function parseBody(body?: unknown): PatientImportCreateBody {
+  if (!body) throw new Error(`Missing message body`);
+
+  const bodyString = typeof body === "string" ? (body as string) : undefined;
+  if (!bodyString) throw new Error(`Invalid body`);
+
+  const bodyAsJson = JSON.parse(bodyString);
+
+  const cxIdRaw = bodyAsJson.cxId;
+  if (!cxIdRaw) throw new Error(`Missing cxId`);
+  if (typeof cxIdRaw !== "string") throw new Error(`Invalid cxId`);
+
+  const patientIdRaw = bodyAsJson.patientId;
+  if (!patientIdRaw) throw new Error(`Missing patientId`);
+  if (typeof patientIdRaw !== "string") throw new Error(`Invalid patientId`);
+
+  const jobIdRaw = bodyAsJson.jobId;
+  if (!jobIdRaw) throw new Error(`Missing jobId`);
+  if (typeof jobIdRaw !== "string") throw new Error(`Invalid jobId`);
+
+  const jobStartedAtRaw = bodyAsJson.jobStartedAt;
+  if (!jobStartedAtRaw) throw new Error(`Missing jobStartedAt`);
+  if (typeof jobStartedAtRaw !== "string") throw new Error(`Invalid jobStartedAt`);
+
+  const cxId = cxIdRaw as string;
+  const patientId = patientIdRaw as string;
+  const jobId = jobIdRaw as string;
+  const jobStartedAt = jobStartedAtRaw as string;
+
+  return { cxId, patientId, jobId, jobStartedAt };
+}

--- a/packages/lambdas/src/patient-import-file.ts
+++ b/packages/lambdas/src/patient-import-file.ts
@@ -35,7 +35,7 @@ export async function handler(event: EventBody) {
   const errorMsg = "Error processing event on " + lambdaName;
   const startedAt = new Date().getTime();
   try {
-    console.log(`Running with unparsed body: ${event}`);
+    console.log(`Running with unparsed body: ${JSON.stringify(event)}`);
     const parsedBody = parseBody(event);
     const { cxId, jobId = uuidv7(), s3BucketName, s3FileName, amountOfPatients } = parsedBody;
 
@@ -125,9 +125,12 @@ function parseBody(body?: unknown): EventBody {
 
   // TODO 2230 remove this
   const amountOfPatientsRaw = bodyAsJson.amountOfPatients;
-  if (!amountOfPatientsRaw) throw new Error(`Missing amountOfPatients`);
-  if (typeof amountOfPatientsRaw !== "number") throw new Error(`Invalid amountOfPatients`);
-  const amountOfPatients = amountOfPatientsRaw as number;
+  const amountOfPatients =
+    typeof amountOfPatientsRaw === "number"
+      ? (amountOfPatientsRaw as number)
+      : typeof amountOfPatientsRaw === "string"
+      ? parseInt(amountOfPatientsRaw)
+      : 1;
 
   return { cxId, jobId, s3BucketName, s3FileName, amountOfPatients };
 }

--- a/packages/lambdas/src/patient-import-file.ts
+++ b/packages/lambdas/src/patient-import-file.ts
@@ -1,0 +1,141 @@
+import { uuidv7 } from "@metriport/core/util/uuid-v7";
+import { errorToString, MetriportError } from "@metriport/shared";
+import { SQSEvent } from "aws-lambda";
+import AWS from "aws-sdk";
+import { PatientImportCreateBody } from "./patient-import-create";
+import { capture } from "./shared/capture";
+import { getEnvOrFail } from "./shared/env";
+import { prefixedLog } from "./shared/log";
+import { getSingleMessageOrFail } from "./shared/sqs";
+
+// Keep this as early on the file as possible
+capture.init();
+
+// Automatically set by AWS
+const lambdaName = getEnvOrFail("AWS_LAMBDA_FUNCTION_NAME");
+const region = getEnvOrFail("AWS_REGION");
+// Set by us
+const patientImportBucket = getEnvOrFail("PATIENT_IMPORT_BUCKET_NAME");
+const patientCreateQueueURL = getEnvOrFail("PATIENT_CREATE_QUEUE_URL");
+
+type EventBody = {
+  cxId: string;
+  jobId?: string | undefined;
+  s3BucketName: string;
+  s3FileName: string;
+  // TODO 2230 Remove this
+  // TODO 2230 Remove this
+  // TODO 2230 Remove this
+  amountOfPatients: number;
+};
+
+const sqs = new AWS.SQS({ region });
+
+// Don't use Sentry's default error handler b/c we want to use our own and send more context-aware data
+export async function handler(event: SQSEvent) {
+  let errorHandled = false;
+  const errorMsg = "Error processing event on " + lambdaName;
+  const startedAt = new Date().getTime();
+  try {
+    const message = getSingleMessageOrFail(event.Records, lambdaName);
+    if (!message) return;
+
+    console.log(`Body: ${message.body}`);
+    const parsedBody = parseBody(message.body);
+    const { cxId, jobId = uuidv7(), s3BucketName, s3FileName, amountOfPatients } = parsedBody;
+
+    const jobStartedAt = new Date().toISOString();
+
+    const log = prefixedLog(`cxId ${cxId}, job ${jobId}`);
+    try {
+      // TODO 2330 call the logic from Core
+      // TODO 2330 call the logic from Core
+      // TODO 2330 call the logic from Core
+      log(
+        `Parsed: ${JSON.stringify(
+          parsedBody
+        )}, s3BucketName ${s3BucketName}, s3FileName ${s3FileName},patientImportBucket ${patientImportBucket}`
+      );
+
+      // TODO 2330 MOCKED BEHAVIOR
+      // TODO 2330 MOCKED BEHAVIOR
+      // TODO 2330 MOCKED BEHAVIOR
+      log(`(MOCKED) Creating ${amountOfPatients} patients`);
+      for (const i of Array(amountOfPatients).keys()) {
+        // TODO 2230 replace this w/ the data from the CSV
+        const patientId = uuidv7();
+        // TODO 2330 Move this to Core, we should have diff implementations for this, so we can run it
+        // local and on the cloud
+        const body: PatientImportCreateBody = {
+          cxId,
+          jobId,
+          jobStartedAt,
+          patientId,
+        };
+        const sendParams = {
+          MessageBody: JSON.stringify(body),
+          QueueUrl: patientCreateQueueURL,
+          MessageGroupId: cxId,
+          MessageDeduplicationId: patientId,
+        };
+        log(`Sending message ${i + 1}, patient ${patientId} to create lambda...`);
+        await sqs.sendMessage(sendParams).promise();
+      }
+
+      const finishedAt = new Date().getTime();
+      console.log(`Done local duration: ${finishedAt - startedAt}ms`);
+    } catch (error) {
+      errorHandled = true;
+      console.log(`${errorMsg}: ${errorToString(error)}`);
+      capture.error(errorMsg, {
+        extra: { event, context: lambdaName, error },
+      });
+      throw new MetriportError(errorMsg, error, { ...parsedBody });
+    }
+  } catch (error) {
+    if (errorHandled) throw error;
+    console.log(`${errorMsg}: ${errorToString(error)}`);
+    capture.error(errorMsg, {
+      extra: { event, context: lambdaName, error },
+    });
+    throw new MetriportError(errorMsg, error);
+  }
+}
+
+function parseBody(body?: unknown): EventBody {
+  if (!body) throw new Error(`Missing message body`);
+
+  const bodyString = typeof body === "string" ? (body as string) : undefined;
+  if (!bodyString) throw new Error(`Invalid body`);
+
+  const bodyAsJson = JSON.parse(bodyString);
+
+  const cxIdRaw = bodyAsJson.cxId;
+  if (!cxIdRaw) throw new Error(`Missing cxId`);
+  if (typeof cxIdRaw !== "string") throw new Error(`Invalid cxId`);
+
+  const jobIdRaw = bodyAsJson.jobId;
+  if (!jobIdRaw) throw new Error(`Missing jobId`);
+  if (typeof jobIdRaw !== "string") throw new Error(`Invalid jobId`);
+
+  const s3BucketNameRaw = bodyAsJson.s3BucketName;
+  if (!s3BucketNameRaw) throw new Error(`Missing s3BucketName`);
+  if (typeof s3BucketNameRaw !== "string") throw new Error(`Invalid s3BucketName`);
+
+  const s3FileNameRaw = bodyAsJson.s3FileName;
+  if (!s3FileNameRaw) throw new Error(`Missing s3FileName`);
+  if (typeof s3FileNameRaw !== "string") throw new Error(`Invalid s3FileName`);
+
+  const jobId = jobIdRaw as string;
+  const cxId = cxIdRaw as string;
+  const s3BucketName = s3BucketNameRaw as string;
+  const s3FileName = s3FileNameRaw as string;
+
+  // TODO 2230 remove this
+  const amountOfPatientsRaw = bodyAsJson.amountOfPatients;
+  if (!amountOfPatientsRaw) throw new Error(`Missing amountOfPatients`);
+  if (typeof amountOfPatientsRaw !== "number") throw new Error(`Invalid amountOfPatients`);
+  const amountOfPatients = amountOfPatientsRaw as number;
+
+  return { cxId, jobId, s3BucketName, s3FileName, amountOfPatients };
+}

--- a/packages/lambdas/src/patient-import-query.ts
+++ b/packages/lambdas/src/patient-import-query.ts
@@ -1,0 +1,106 @@
+import { errorToString, MetriportError, sleep } from "@metriport/shared";
+import { SQSEvent } from "aws-lambda";
+import { capture } from "./shared/capture";
+import { getEnvOrFail } from "./shared/env";
+import { prefixedLog } from "./shared/log";
+import { getSingleMessageOrFail } from "./shared/sqs";
+
+// Keep this as early on the file as possible
+capture.init();
+
+// Automatically set by AWS
+const lambdaName = getEnvOrFail("AWS_LAMBDA_FUNCTION_NAME");
+// Set by us
+const patientImportBucket = getEnvOrFail("PATIENT_IMPORT_BUCKET_NAME");
+const apiURL = getEnvOrFail("API_URL");
+const waitTimeMillisRaw = getEnvOrFail("WAIT_TIME_IN_MILLIS");
+const waitTimeMillis = parseInt(waitTimeMillisRaw);
+
+export type PatientImportQueryBody = {
+  cxId: string;
+  jobId: string;
+  jobStartedAt: string; // TODO consider moving to Date if we need to work with it here
+  patientId: string;
+};
+
+// Don't use Sentry's default error handler b/c we want to use our own and send more context-aware data
+export async function handler(event: SQSEvent) {
+  let errorHandled = false;
+  const errorMsg = "Error processing event on " + lambdaName;
+  const startedAt = new Date().getTime();
+  try {
+    const message = getSingleMessageOrFail(event.Records, lambdaName);
+    if (!message) return;
+
+    console.log(`Body: ${message.body}, patientImportBucket ${patientImportBucket}`);
+    const parsedBody = parseBody(message.body);
+    const { cxId, patientId, jobId, jobStartedAt } = parsedBody;
+
+    const log = prefixedLog(`cxId ${cxId}, patientId ${patientId}, job ${jobId}`);
+    try {
+      // TODO 2330 call the logic from Core
+      // TODO 2330 call the logic from Core
+      // TODO 2330 call the logic from Core
+      log(`apiURL: ${apiURL}`);
+      log(`Parsed: ${JSON.stringify(parsedBody)}`);
+
+      // TODO 2330 MOCKED BEHAVIOR
+      // TODO 2330 MOCKED BEHAVIOR
+      // TODO 2330 MOCKED BEHAVIOR
+      await sleep(waitTimeMillis);
+
+      const finishedAt = new Date().getTime();
+      console.log(
+        `Done local duration: ${finishedAt - startedAt}ms, total duration: ${
+          finishedAt - new Date(jobStartedAt).getTime()
+        }ms`
+      );
+    } catch (error) {
+      errorHandled = true;
+      console.log(`${errorMsg}: ${errorToString(error)}`);
+      capture.error(errorMsg, {
+        extra: { event, context: lambdaName, error },
+      });
+      throw new MetriportError(errorMsg, error, { ...parsedBody });
+    }
+  } catch (error) {
+    if (errorHandled) throw error;
+    console.log(`${errorMsg}: ${errorToString(error)}`);
+    capture.error(errorMsg, {
+      extra: { event, context: lambdaName, error },
+    });
+    throw new MetriportError(errorMsg, error);
+  }
+}
+
+function parseBody(body?: unknown): PatientImportQueryBody {
+  if (!body) throw new Error(`Missing message body`);
+
+  const bodyString = typeof body === "string" ? (body as string) : undefined;
+  if (!bodyString) throw new Error(`Invalid body`);
+
+  const bodyAsJson = JSON.parse(bodyString);
+
+  const cxIdRaw = bodyAsJson.cxId;
+  if (!cxIdRaw) throw new Error(`Missing cxId`);
+  if (typeof cxIdRaw !== "string") throw new Error(`Invalid cxId`);
+
+  const patientIdRaw = bodyAsJson.patientId;
+  if (!patientIdRaw) throw new Error(`Missing patientId`);
+  if (typeof patientIdRaw !== "string") throw new Error(`Invalid patientId`);
+
+  const jobIdRaw = bodyAsJson.jobId;
+  if (!jobIdRaw) throw new Error(`Missing jobId`);
+  if (typeof jobIdRaw !== "string") throw new Error(`Invalid jobId`);
+
+  const jobStartedAtRaw = bodyAsJson.jobStartedAt;
+  if (!jobStartedAtRaw) throw new Error(`Missing jobStartedAt`);
+  if (typeof jobStartedAtRaw !== "string") throw new Error(`Invalid jobStartedAt`);
+
+  const cxId = cxIdRaw as string;
+  const patientId = patientIdRaw as string;
+  const jobId = jobIdRaw as string;
+  const jobStartedAt = jobStartedAtRaw as string;
+
+  return { cxId, patientId, jobId, jobStartedAt };
+}

--- a/packages/lambdas/src/shared/sqs.ts
+++ b/packages/lambdas/src/shared/sqs.ts
@@ -64,7 +64,7 @@ export function getSingleMessageOrFail(
   lambdaName: string
 ): SQSRecord | undefined {
   if (!records || records.length < 1) {
-    console.log(`No records, discarding this event: ${JSON.stringify(event)}`);
+    console.log(`No records, discarding this event: ${JSON.stringify(records)}`);
     return undefined;
   }
   if (records.length > 1) {

--- a/packages/lambdas/src/shared/sqs.ts
+++ b/packages/lambdas/src/shared/sqs.ts
@@ -1,7 +1,9 @@
-import { SQSMessageAttributes } from "aws-lambda";
+import { MetriportError } from "@metriport/shared";
+import { SQSMessageAttributes, SQSRecord } from "aws-lambda";
 import * as AWS from "aws-sdk";
 import { SQS } from "aws-sdk";
 import { MessageBodyAttributeMap } from "aws-sdk/clients/sqs";
+import { capture } from "./capture";
 
 export class SQSUtils {
   public readonly _sqs: SQS;
@@ -55,4 +57,28 @@ export function toMessageGroupId(
     return replaced.slice(0, maxChars);
   }
   return replaced.slice(-maxChars);
+}
+
+export function getSingleMessageOrFail(
+  records: SQSRecord[],
+  lambdaName: string
+): SQSRecord | undefined {
+  if (!records || records.length < 1) {
+    console.log(`No records, discarding this event: ${JSON.stringify(event)}`);
+    return undefined;
+  }
+  if (records.length > 1) {
+    const msg = "Got more than one message from SQS";
+    capture.error(msg, {
+      extra: {
+        event,
+        context: lambdaName,
+        additional: `This lambda is supposed to run w/ only 1 message per batch, got ${records.length}`,
+      },
+    });
+    throw new MetriportError(msg, undefined, { amountOfRecords: records.length });
+  }
+  // Safe as we just checked the length
+  const message = records[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+  return message;
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#2330

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/2334
- Downstream: none

### Description

Infrastructure for Patient Import (bulk operation), to be used originally by Coverage Assessment and later on to be exposed to customers.

This PR only creates the infra with a mocked behavior in the lambdas. It's to be updated by downstream PRs related to the same ticket.

### Testing

- Local
  - [x] Branch to staging works
  - [x] Send this payload as cx1
     ```json
      {
        "cxId": "1111",
        "jobId":"1234",
        "s3BucketName": "bucket-name",
        "s3FileName": "file-name",
        "amountOfPatients": 4,
      }
     ```
  - [x] Send this payload as cx2
     ```json
      {
        "cxId": "2222",
        "jobId":"1234",
        "s3BucketName": "bucket-name",
        "s3FileName": "file-name",
        "amountOfPatients": 1,
      }
     ```
  - [x] cx2's patient get processed alongside patient 1 of cx1
- Staging
  - [ ] Infra gets provisioned
- Sandbox
  - [ ] Infra gets provisioned
- Production
  - [ ] Infra gets provisioned

### Release Plan

- :warning: Contains infra changes
- [ ] Merge this
