### PR TITLE
PATCH RELEASE 799 Recreate consolidated at end of conversions

### DIFF
--- a/packages/api/src/command/medical/patient/consolidated-delete.ts
+++ b/packages/api/src/command/medical/patient/consolidated-delete.ts
@@ -31,6 +31,7 @@ export type DeleteConsolidatedParams = {
   dryRun?: boolean;
 } & DeleteConsolidatedFilters;
 
+// TODO 2215 - Remove/merge this with `deleteConsolidated` from core.
 /**
  * HEADS UP! This is very destructive, it will delete all resources from the FHIR server that match
  * the filters provided. It will not delete DocumentReference resources.

--- a/packages/api/src/command/medical/patient/consolidated-recreate.ts
+++ b/packages/api/src/command/medical/patient/consolidated-recreate.ts
@@ -1,0 +1,44 @@
+import { ConsolidationConversionType } from "@metriport/api-sdk";
+import { deleteConsolidated } from "@metriport/core/command/consolidated/consolidated-delete";
+import { Organization } from "@metriport/core/domain/organization";
+import { Patient } from "@metriport/core/domain/patient";
+import { processAsyncError } from "@metriport/core/util/error/shared";
+import { out } from "@metriport/core/util/log";
+import { getConsolidated } from "../patient/consolidated-get";
+
+/**
+ * Recreates the consolidated bundle for a patient.
+ *
+ * Intentionally not throwing errors to avoid breaking the flow of the calling function.
+ *
+ * @param patient - The patient to recreate the consolidated bundle for.
+ * @param organization - The organization to recreate the consolidated bundle for.
+ * @param conversionType - The conversion type to use when converting to consolidatd.
+ * @param context - Optional context to log.
+ */
+export async function recreateConsolidated({
+  patient,
+  organization,
+  conversionType,
+  context = "",
+}: {
+  patient: Patient;
+  organization: Organization;
+  conversionType?: ConsolidationConversionType;
+  context?: string;
+}): Promise<void> {
+  const { log } = out(`${context}recreateConsolidated - pt ${patient.id}`);
+  try {
+    await deleteConsolidated({
+      cxId: patient.cxId,
+      patientId: patient.id,
+    });
+  } catch (err) {
+    processAsyncError(`Failed to delete consolidated bundle`, log)(err);
+  }
+  try {
+    await getConsolidated({ patient, organization, conversionType });
+  } catch (err) {
+    processAsyncError(`Post-DQ getConsolidated`, log)(err);
+  }
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Description

Recreate consolidated at end of conversions - [context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1727978058305349).

### Testing

- Local
  - [x] Recreates bundle at the end of conversion
  - [x] Recreates bundle in the sweeper job
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
- [ ] Follow a couple of new patient's consolidated query
