### PR TITLE
2330 Create new zip normalization and use it for bulk import

### DIFF
--- a/packages/core/src/command/patient-import/patient-import-cloud.ts
+++ b/packages/core/src/command/patient-import/patient-import-cloud.ts
@@ -3,7 +3,7 @@ import { uuidv7 } from "../../util/uuid-v7";
 import { makeLambdaClient } from "../../external/aws/lambda";
 import { SQSClient } from "../../external/aws/sqs";
 import { createJobRecord } from "./commands/create-job-record";
-import { validateAndParsePatientImportCsv } from "./commands/validate-and-parse-import";
+import { validateAndParsePatientImportCsvFromS3 } from "./commands/validate-and-parse-import";
 import { checkPatientRecord } from "./commands/check-patient-record";
 import { creatOrUpdatePatientRecord } from "./commands/create-or-update-patient-record";
 import { startDocumentQuery } from "./commands/start-document-query";
@@ -76,7 +76,7 @@ export class PatientImportHandlerCloud implements PatientImportHandler {
       data: { jobStartedAt },
       s3BucketName,
     });
-    const patients = await validateAndParsePatientImportCsv({
+    const patients = await validateAndParsePatientImportCsvFromS3({
       cxId,
       jobId,
       s3BucketName,

--- a/packages/core/src/command/patient-import/patient-import-local.ts
+++ b/packages/core/src/command/patient-import/patient-import-local.ts
@@ -1,7 +1,7 @@
 import { sleep } from "@metriport/shared";
 import { executeAsynchronously } from "../../util/concurrency";
 import { createJobRecord } from "./commands/create-job-record";
-import { validateAndParsePatientImportCsv } from "./commands/validate-and-parse-import";
+import { validateAndParsePatientImportCsvFromS3 } from "./commands/validate-and-parse-import";
 import { checkPatientRecord } from "./commands/check-patient-record";
 import { creatOrUpdatePatientRecord } from "./commands/create-or-update-patient-record";
 import { startDocumentQuery } from "./commands/start-document-query";
@@ -59,7 +59,7 @@ export class PatientImportHandlerLocal implements PatientImportHandler {
       data: { jobStartedAt },
       s3BucketName,
     });
-    const patients = await validateAndParsePatientImportCsv({
+    const patients = await validateAndParsePatientImportCsvFromS3({
       cxId,
       jobId,
       s3BucketName,

--- a/packages/core/src/command/patient-import/patient-import-shared.ts
+++ b/packages/core/src/command/patient-import/patient-import-shared.ts
@@ -1,12 +1,12 @@
 import {
-  PatientImportPatient,
   normalizeDate,
-  normalizeGender,
-  normalizeState,
-  normalizeZipCode,
-  normalizePhoneNumberStrict,
   normalizeEmailStrict,
   normalizeExternalId,
+  normalizeGender,
+  normalizePhoneNumberStrict,
+  normalizeState,
+  normalizeZipCodeNew,
+  PatientImportPatient,
   toTitleCase,
 } from "@metriport/shared";
 import { PatientPayload } from "./patient-import";
@@ -43,7 +43,7 @@ export function createFileKeyFiles(cxId: string, jobId: string, stage: FileStage
   return key;
 }
 
-export const PatientImportCsvHeaders = [
+export const patientImportCsvHeaders = [
   "externalid",
   "firstname",
   "lastname",
@@ -56,12 +56,13 @@ export const PatientImportCsvHeaders = [
   "addressline2",
   "phone1",
   "email1",
-  "phone2",
-  "email2",
+  // "phone2",
+  // "email2",
 ];
 
 const replaceCharacters = ["*"];
 
+// TODO gotta accept email, email1, phone, phone1, etc
 export function normalizeHeaders(headers: string[]): string[] {
   let newHeaders = headers;
   replaceCharacters.map(char => {
@@ -117,7 +118,7 @@ export function createPatientPayload(patient: PatientImportPatient): PatientPayl
         ...(patient.addressline2 ? { addressLine2: toTitleCase(patient.addressline2) } : undefined),
         city: toTitleCase(patient.city),
         state: normalizeState(patient.state),
-        zip: normalizeZipCode(patient.zip),
+        zip: normalizeZipCodeNew(patient.zip),
         country: "USA",
       },
     ],

--- a/packages/shared/src/domain/address/__tests__/normalize-zip.test.ts
+++ b/packages/shared/src/domain/address/__tests__/normalize-zip.test.ts
@@ -91,9 +91,14 @@ describe("zip", () => {
       expect(normalizeZipCodeNewSafe(input)).toBe(expectedOutput);
     });
 
+    it("should return undefined for zip codes that are too short", () => {
+      const input = "12";
+      expect(normalizeZipCodeNewSafe(input)).toBeUndefined();
+    });
+
     it("should handle short zip codes", () => {
-      const input = "1";
-      const expectedOutput = "00001";
+      const input = "123";
+      const expectedOutput = "00123";
       expect(normalizeZipCodeNewSafe(input)).toBe(expectedOutput);
     });
 

--- a/packages/shared/src/domain/address/__tests__/normalize-zip.test.ts
+++ b/packages/shared/src/domain/address/__tests__/normalize-zip.test.ts
@@ -1,42 +1,131 @@
-import { normalizeZipCode } from "../zip";
+import { faker } from "@faker-js/faker";
+import { normalizeZipCode, normalizeZipCodeNew, normalizeZipCodeNewSafe } from "../zip";
 
-describe("normalizeZipCode", () => {
-  test("should handle short zip codes", () => {
-    const input = "1234";
-    const expectedOutput = "1234";
-    expect(normalizeZipCode(input)).toBe(expectedOutput);
+function getFiveDigitZip() {
+  return faker.number.int({ min: 10000, max: 99999 }).toString();
+}
+
+describe("zip", () => {
+  describe("normalizeZipCode", () => {
+    test("should handle short zip codes", () => {
+      const input = "1234";
+      const expectedOutput = "1234";
+      expect(normalizeZipCode(input)).toBe(expectedOutput);
+    });
+
+    test("should return first 4 characters when zip code length is 9", () => {
+      const input = "1234-6677";
+      const expectedOutput = "1234";
+      expect(normalizeZipCode(input)).toBe(expectedOutput);
+    });
+
+    test("should return first 5 characters when zip code length is 10", () => {
+      const input = "12345-6677";
+      const expectedOutput = "12345";
+      expect(normalizeZipCode(input)).toBe(expectedOutput);
+    });
+
+    test("should return first 5 characters when zip code length is 5", () => {
+      const input = "54321";
+      const expectedOutput = "54321";
+      expect(normalizeZipCode(input)).toBe(expectedOutput);
+    });
+
+    test("should throw an error if zip contains non-digit and non-dash characters (length 9)", () => {
+      const input = "12345-667a";
+      expect(() => normalizeZipCode(input)).toThrow();
+    });
+
+    test("should throw an error if zip contains non-digit and non-dash characters (length 5)", () => {
+      const input = "1234a";
+      expect(() => normalizeZipCode(input)).toThrow();
+    });
+
+    test("should throw an error if zip is an empty string", () => {
+      const input = "";
+      expect(() => normalizeZipCode(input)).toThrow();
+    });
   });
 
-  test("should return first 4 characters when zip code length is 9", () => {
-    const input = "1234-6677";
-    const expectedOutput = "1234";
-    expect(normalizeZipCode(input)).toBe(expectedOutput);
+  describe("normalizeZipCodeNew", () => {
+    it("returns the result of the normalizeFn param", () => {
+      const expectedOutput = getFiveDigitZip();
+      const normalizeFn = jest.fn(() => expectedOutput);
+      expect(normalizeZipCodeNew("54321", normalizeFn)).toBe(expectedOutput);
+    });
+
+    it("should throw an error if zip is an empty string", () => {
+      const normalizeFn = jest.fn(() => undefined);
+      expect(() => normalizeZipCodeNew("54321", normalizeFn)).toThrow();
+    });
   });
 
-  test("should return first 5 characters when zip code length is 10", () => {
-    const input = "12345-6677";
-    const expectedOutput = "12345";
-    expect(normalizeZipCode(input)).toBe(expectedOutput);
-  });
+  describe("safe normalizeZipCodeNewSafe", () => {
+    it("should return undefined when it gets empty string", () => {
+      const input = "";
+      const expectedOutput = undefined;
+      expect(normalizeZipCodeNewSafe(input)).toBe(expectedOutput);
+    });
 
-  test("should return first 5 characters when zip code length is 5", () => {
-    const input = "54321";
-    const expectedOutput = "54321";
-    expect(normalizeZipCode(input)).toBe(expectedOutput);
-  });
+    it("should return undefined when it gets space", () => {
+      const input = " ";
+      const expectedOutput = undefined;
+      expect(normalizeZipCodeNewSafe(input)).toBe(expectedOutput);
+    });
 
-  test("should throw an error if zip contains non-digit and non-dash characters (length 9)", () => {
-    const input = "12345-667a";
-    expect(() => normalizeZipCode(input)).toThrow();
-  });
+    it("should handle 5 digits", () => {
+      const input = getFiveDigitZip();
+      const expectedOutput = input;
+      expect(normalizeZipCodeNewSafe(input)).toBe(expectedOutput);
+    });
 
-  test("should throw an error if zip contains non-digit and non-dash characters (length 5)", () => {
-    const input = "1234a";
-    expect(() => normalizeZipCode(input)).toThrow();
-  });
+    it("should trim input prefix", () => {
+      const expectedOutput = getFiveDigitZip();
+      const input = " " + expectedOutput;
+      expect(normalizeZipCodeNewSafe(input)).toBe(expectedOutput);
+    });
 
-  test("should throw an error if zip is an empty string", () => {
-    const input = "";
-    expect(() => normalizeZipCode(input)).toThrow();
+    it("should trim input suffix", () => {
+      const expectedOutput = getFiveDigitZip();
+      const input = expectedOutput + " ";
+      expect(normalizeZipCodeNewSafe(input)).toBe(expectedOutput);
+    });
+
+    it("should handle short zip codes", () => {
+      const input = "1";
+      const expectedOutput = "00001";
+      expect(normalizeZipCodeNewSafe(input)).toBe(expectedOutput);
+    });
+
+    it("should return padded first 4 characters when contains dash at position 4", () => {
+      const input = "1234-6677";
+      const expectedOutput = "01234";
+      expect(normalizeZipCodeNewSafe(input)).toBe(expectedOutput);
+    });
+
+    it("should return first 5 characters when zip code length is 10", () => {
+      const input = "12345-6677";
+      const expectedOutput = "12345";
+      expect(normalizeZipCodeNewSafe(input)).toBe(expectedOutput);
+    });
+
+    it("should return undefined if zip contains non-digit and non-dash characters (length 9)", () => {
+      const input = "12345-667a";
+      expect(normalizeZipCodeNewSafe(input)).toBeUndefined();
+    });
+
+    it("should return undefined if zip contains non-digit and non-dash characters (length 5)", () => {
+      const input = "1234a";
+      expect(normalizeZipCodeNewSafe(input)).toBeUndefined();
+    });
+
+    describe("examples from the wild", () => {
+      const tests = [{ input: "2468", expectedOutput: "02468" }];
+      for (const { input, expectedOutput } of tests) {
+        it(`should return ${expectedOutput} when input is ${input}`, () => {
+          expect(normalizeZipCodeNewSafe(input)).toBe(expectedOutput);
+        });
+      }
+    });
   });
 });

--- a/packages/shared/src/domain/address/zip.ts
+++ b/packages/shared/src/domain/address/zip.ts
@@ -34,3 +34,27 @@ export function normalizeZipCodeSafe(zipCode: string, strict = false): string | 
   if (trimmedZip.trim().length === 8) return trimmedZip.slice(0, 4);
   return trimmedZip.slice(0, 5);
 }
+
+// TODO 2330 Move/merge this to normalizeZipCode
+export function normalizeZipCodeNew(
+  zipCode: string,
+  normalizeFn = normalizeZipCodeNewSafe
+): string {
+  const zipOrUndefined = normalizeFn(zipCode);
+  if (!zipOrUndefined) throw new Error("Invalid Zip.");
+  return zipOrUndefined;
+}
+
+// TODO 2330 Move/merge this to normalizeZipCodeSafe
+// TODO Should prob look into something that indicates ranges of possible values, like https://www.fincen.gov/sites/default/files/shared/us_state_territory_zip_codes.pdf
+export function normalizeZipCodeNewSafe(zipCode: string): string | undefined {
+  const trimmedZip = zipCode.trim();
+  if (trimmedZip === "") return undefined;
+  if (!trimmedZip.match(/^[0-9-]+$/)) return undefined;
+  if (trimmedZip.includes("-") && trimmedZip.split("-").length !== 2) return undefined;
+  const mainPart = trimmedZip.split("-")[0];
+  if (!mainPart) return trimmedZip;
+  if (mainPart.length === 5) return mainPart;
+  if (mainPart.length < 5) return mainPart.padStart(5, "0");
+  return mainPart.slice(0, 5);
+}

--- a/packages/shared/src/domain/address/zip.ts
+++ b/packages/shared/src/domain/address/zip.ts
@@ -55,6 +55,7 @@ export function normalizeZipCodeNewSafe(zipCode: string): string | undefined {
   const mainPart = trimmedZip.split("-")[0];
   if (!mainPart) return trimmedZip;
   if (mainPart.length === 5) return mainPart;
+  if (mainPart.length < 3) return undefined;
   if (mainPart.length < 5) return mainPart.padStart(5, "0");
   return mainPart.slice(0, 5);
 }

--- a/packages/shared/src/domain/patient/patient-import.ts
+++ b/packages/shared/src/domain/patient/patient-import.ts
@@ -1,17 +1,17 @@
 import { z } from "zod";
+import { normalizeStateSafe } from "../address/state";
+import { normalizeZipCodeNewSafe } from "../address/zip";
+import { isEmailValid } from "../contact/email";
+import { isPhoneValid } from "../contact/phone";
 import { normalizeDateSafe } from "../dob";
 import { normalizeGenderSafe } from "../gender";
-import { normalizeZipCodeSafe } from "../address/zip";
-import { normalizeStateSafe } from "../address/state";
-import { isPhoneValid } from "../contact/phone";
-import { isEmailValid } from "../contact/email";
 
 export const patientImportPatientSchema = z.object({
   dob: z.string().refine(normalizeDateSafe, { message: "Invalid dob" }),
   gender: z.string().refine(normalizeGenderSafe, { message: "Invalid gender" }),
   firstname: z.string().min(1, { message: "First name must be defined" }),
   lastname: z.string().min(1, { message: "Last name must be defined" }),
-  zip: z.string().refine(arg => normalizeZipCodeSafe(arg, true), { message: "Invalid zip" }),
+  zip: z.string().refine(arg => normalizeZipCodeNewSafe(arg), { message: "Invalid zip" }),
   city: z.string().min(1, { message: "City must be defined" }),
   state: z.string().refine(normalizeStateSafe, { message: "Invalid state" }),
   addressline1: z.string().min(1, { message: "Address line must be defined" }),

--- a/packages/utils/src/patient-import/validate-file.ts
+++ b/packages/utils/src/patient-import/validate-file.ts
@@ -1,0 +1,81 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import {
+  RowError,
+  validateAndParsePatientImportCsv,
+} from "@metriport/core/command/patient-import/commands/validate-and-parse-import";
+import { PatientPayload } from "@metriport/core/command/patient-import/patient-import";
+import { createPatientPayload } from "@metriport/core/command/patient-import/patient-import-shared";
+import { PatientImportPatient, sleep } from "@metriport/shared";
+import dayjs from "dayjs";
+import fs from "fs";
+import { elapsedTimeAsStr } from "../shared/duration";
+import { getFileContents, makeDir } from "../shared/fs";
+
+/**
+/**
+ * Process a CSV file with patient data for bulk import.
+ * Validates and normalizes it.
+ * Outputs:
+ * - valid rows: file with valid rows
+ * - invalid rows: file with invalid rows
+ * - patients-validation: file with patients as they were validated
+ * - patients-creation: file with patients as they will be created
+ */
+
+const inputFileName = "";
+
+async function main() {
+  await sleep(50); // Give some time to avoid mixing logs w/ Node's
+  const startedAt = Date.now();
+  console.log(`############## Started at ${new Date(startedAt).toISOString()} ##############`);
+
+  const timestamp = dayjs().toISOString();
+  const outputFolderName = `runs/bulk-import-validation/${timestamp}`;
+  makeDir(outputFolderName);
+
+  console.log(`Reading file ${inputFileName}`);
+  const stringBundle = getFileContents(inputFileName);
+
+  const {
+    patients: patientsFromValidation,
+    headers,
+    validRows,
+    invalidRows,
+  } = await validateAndParsePatientImportCsv({
+    contents: stringBundle,
+  });
+
+  const patientsForCreate: PatientPayload[] = patientsFromValidation.map(createPatientPayload);
+
+  const outputValid = headers + "\n" + validRows.map(validToString).join("\n");
+  const outputInvalid = headers + ",error" + "\n" + invalidRows.map(invalidToString).join("\n");
+  const outputPatientsValidation = patientsFromValidation.map(patientValidationToString).join("\n");
+  const outputPatientsCreation = patientsForCreate.map(patientCreationToString).join("\n");
+
+  fs.writeFileSync(`./${outputFolderName}/valid.csv`, outputValid);
+  fs.writeFileSync(`./${outputFolderName}/invalid.csv`, outputInvalid);
+  fs.writeFileSync(`./${outputFolderName}/patients-validation.csv`, outputPatientsValidation);
+  fs.writeFileSync(`./${outputFolderName}/patients-creation.csv`, outputPatientsCreation);
+
+  console.log(`>>> Done in ${elapsedTimeAsStr(startedAt)}`);
+}
+
+function validToString(entry: string[]) {
+  return entry.join(",");
+}
+
+function invalidToString(entry: RowError) {
+  return entry.rowColumns.join(",") + "," + entry.error;
+}
+
+function patientValidationToString(request: PatientImportPatient) {
+  return JSON.stringify(request);
+}
+
+function patientCreationToString(request: PatientPayload) {
+  return JSON.stringify(request);
+}
+
+main();


### PR DESCRIPTION
Ref. metriport/metriport-internal#2330

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2853
- Downstream: none

### Description

Create new zip normalization and use it for bulk import. The existing implementation is not flexible and fails in many situations that we could normalize the input value.

Didn't replace the existing one because that requires more test across diff use cases. The idea is that on a follow-up PR we would do that so we have a single place to normalize and validate ZIP codes.

It also splits the `validateAndParsePatientImportCsv` in two functions, so we can more easily test the logic that's not dependent on S3.

### Testing

- Local
  - [x] unit tests
- Staging
  - [ ] patient import processes file and creates expected entries
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
