### PR TITLE
2215 Temporarily return fixed resource count

### DIFF
--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -38,7 +38,6 @@ import { getSandboxPatientLimitForCx } from "../../domain/medical/get-patient-li
 import { getFacilityIdOrFail } from "../../domain/medical/patient-facility";
 import BadRequestError from "../../errors/bad-request";
 import NotFoundError from "../../errors/not-found";
-import { countResources } from "../../external/fhir/patient/count-resources";
 import { PatientModel as Patient } from "../../models/medical/patient";
 import { REQUEST_ID_HEADER_NAME } from "../../routes/header";
 import { Config } from "../../shared/config";
@@ -465,12 +464,19 @@ router.get(
     const dateFrom = parseISODate(getFrom("query").optional("dateFrom", req));
     const dateTo = parseISODate(getFrom("query").optional("dateTo", req));
 
-    const resourceCount = await countResources({
-      patient: { id: patientId, cxId },
-      resources,
-      dateFrom,
-      dateTo,
-    });
+    // tmp added for Authorization purposes
+    await getPatientOrFail({ cxId, id: patientId });
+    // TODO 2215: revert this once we have count from the new consolidated flow
+    const resourceCount = {
+      total: 100,
+      resources: {},
+    };
+    // const resourceCount = await countResources({
+    //   patient: { id: patientId, cxId },
+    //   resources,
+    //   dateFrom,
+    //   dateTo,
+    // });
 
     return res.json({
       ...resourceCount,


### PR DESCRIPTION
Ref. metriport/metriport-internal#2215

### Dependencies

none

### Description

Temporarily return fixed resource count.

### Testing

- Local
  - [x] Always returns resource count = 100
  - [x] Checks for patient access
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
