### PR TITLE
PATCH RELEASE 2330 Disable the FHIRServer lambda for outbound ingestion

### DIFF
--- a/packages/infra/lib/shared/lambda.ts
+++ b/packages/infra/lib/shared/lambda.ts
@@ -51,6 +51,12 @@ export interface LambdaProps extends StackProps {
   readonly envType: EnvType;
   readonly timeout?: Duration;
   readonly memory?: number;
+  /**
+   * The maximum of concurrent executions you want to reserve for the function.
+   * Setting this to zero will throttle the lambda (disable its execution).
+   * Default: no specific limit - account limit.
+   * @see https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html
+   */
   readonly reservedConcurrentExecutions?: number;
   /** The maximum number of times to retry when the function returns an error. */
   readonly retryAttempts?: number;


### PR DESCRIPTION
Ref. metriport/metriport-internal#2330

### Description

Disable the FHIRServer lambda for outbound ingestion - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1728086552183879?thread_ts=1727883019.543829&cid=C04DMKE9DME)

### Testing

none

### Release Plan

- :warning: Points to `master`
- :warning: This contains infra changes
- [ ] Merge this
