### PR TITLE
feat(cq): adding proper leading 0 parsing throughout ihe

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/create/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/create/dq-response.ts
@@ -13,6 +13,10 @@ function createIti38SoapBody(response: InboundDocumentQueryResp): object {
     textNodeName: "_text",
     parseAttributeValue: false,
     removeNSPrefix: true,
+    numberParseOptions: {
+      hex: false,
+      leadingZeros: false,
+    },
   });
   const success = response?.extrinsicObjectXmls ? true : false;
   const extrinsicObjects = success

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/create/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/create/dq-response.ts
@@ -1,5 +1,6 @@
-import { XMLBuilder, XMLParser } from "fast-xml-parser";
+import { XMLBuilder } from "fast-xml-parser";
 import { v4 as uuidv4 } from "uuid";
+import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { InboundDocumentQueryResp } from "@metriport/ihe-gateway-sdk";
 import { successStatus, failureStatus, errorSeverity, createSecurityHeader } from "../../shared";
 import { xmlBuilderAttributes, attributeNamePrefix } from "../../../shared";
@@ -7,16 +8,12 @@ import { namespaces } from "../../../constants";
 import { wrapIdInUrnUuid } from "../../../../../../util/urn";
 
 function createIti38SoapBody(response: InboundDocumentQueryResp): object {
-  const parser = new XMLParser({
+  const parser = createXMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: attributeNamePrefix,
     textNodeName: "_text",
     parseAttributeValue: false,
     removeNSPrefix: true,
-    numberParseOptions: {
-      hex: false,
-      leadingZeros: false,
-    },
   });
   const success = response?.extrinsicObjectXmls ? true : false;
   const extrinsicObjects = success

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dq-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dq-request.ts
@@ -1,6 +1,6 @@
 import { InboundDocumentQueryReq, XCPDPatientId } from "@metriport/ihe-gateway-sdk";
 import { errorToString, toArray } from "@metriport/shared";
-import { XMLParser } from "fast-xml-parser";
+import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { stripUrnPrefix } from "../../../../../../util/urn";
 import { storeDqRequest } from "../../../monitor/store";
 import { Slot } from "../../../schema";
@@ -32,16 +32,12 @@ export async function processInboundDqRequest(request: string): Promise<InboundD
   const log = out("Inbound DQ Request").log;
   log(request);
   try {
-    const parser = new XMLParser({
+    const parser = createXMLParser({
       ignoreAttributes: false,
       attributeNamePrefix: "_",
       textNodeName: "_text",
       parseAttributeValue: false,
       removeNSPrefix: true,
-      numberParseOptions: {
-        hex: false,
-        leadingZeros: false,
-      },
     });
     const jsonObj = parser.parse(request);
     const iti38Request = iti38RequestSchema.parse(jsonObj);

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dq-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dq-request.ts
@@ -38,6 +38,10 @@ export async function processInboundDqRequest(request: string): Promise<InboundD
       textNodeName: "_text",
       parseAttributeValue: false,
       removeNSPrefix: true,
+      numberParseOptions: {
+        hex: false,
+        leadingZeros: false,
+      },
     });
     const jsonObj = parser.parse(request);
     const iti38Request = iti38RequestSchema.parse(jsonObj);

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dr-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dr-request.ts
@@ -28,6 +28,10 @@ export async function processInboundDrRequest(
       textNodeName: "_text",
       parseAttributeValue: false,
       removeNSPrefix: true,
+      numberParseOptions: {
+        hex: false,
+        leadingZeros: false,
+      },
     });
     const jsonObj = parser.parse(request);
     const iti39Request = iti39RequestSchema.parse(jsonObj);

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dr-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xca/process/dr-request.ts
@@ -1,6 +1,6 @@
 import { DocumentReference, InboundDocumentRetrievalReq } from "@metriport/ihe-gateway-sdk";
 import { errorToString, toArray } from "@metriport/shared";
-import { XMLParser } from "fast-xml-parser";
+import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { out } from "../../../../../../util/log";
 import { stripUrnPrefix } from "../../../../../../util/urn";
 import { extractText } from "../../../utils";
@@ -22,16 +22,12 @@ export async function processInboundDrRequest(
   const log = out("Inbound DR Request").log;
   log(request);
   try {
-    const parser = new XMLParser({
+    const parser = createXMLParser({
       ignoreAttributes: false,
       attributeNamePrefix: "_",
       textNodeName: "_text",
       parseAttributeValue: false,
       removeNSPrefix: true,
-      numberParseOptions: {
-        hex: false,
-        leadingZeros: false,
-      },
     });
     const jsonObj = parser.parse(request);
     const iti39Request = iti39RequestSchema.parse(jsonObj);

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/process/xcpd-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/process/xcpd-request.ts
@@ -1,6 +1,6 @@
-import { XMLParser } from "fast-xml-parser";
 import dayjs from "dayjs";
 import { PatientResource, InboundPatientDiscoveryReq } from "@metriport/ihe-gateway-sdk";
+import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { errorToString, toArray } from "@metriport/shared";
 import { Iti55Request, iti55RequestSchema } from "./schema";
 import { convertSamlHeaderToAttributes, extractTimestamp } from "../../shared";
@@ -58,16 +58,12 @@ export async function processInboundXcpdRequest(
   request: string
 ): Promise<InboundPatientDiscoveryReq> {
   const log = out("Inbound XCPD Request").log;
-  const parser = new XMLParser({
+  const parser = createXMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: "_",
     textNodeName: "_text",
     parseAttributeValue: false,
     removeNSPrefix: true,
-    numberParseOptions: {
-      hex: false,
-      leadingZeros: false,
-    },
   });
 
   const jsonObj = parser.parse(request);

--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/process/xcpd-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/process/xcpd-request.ts
@@ -64,6 +64,10 @@ export async function processInboundXcpdRequest(
     textNodeName: "_text",
     parseAttributeValue: false,
     removeNSPrefix: true,
+    numberParseOptions: {
+      hex: false,
+      leadingZeros: false,
+    },
   });
 
   const jsonObj = parser.parse(request);

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/constants.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/constants.ts
@@ -110,7 +110,7 @@ export const expectedXcpdResponse: OutboundPatientDiscoveryRespSuccessfulSchema 
     oid: "2.16.840.1.113883.3.787.0.0",
   },
   externalGatewayPatient: {
-    id: "ODFmMmVjNGUtYzcxYy00MDkwLWJmMWMtOWQ4NTI5ZjY1YjVhLzAxOGUxMDU4LTllMWEtN2MzMy1hMmRkLTVhNzg4NGU2ZmMzOA==",
+    id: "0ODFmMmVjNGUtYzcxYy00MDkwLWJmMWMtOWQ4NTI5ZjY1YjVhLzAxOGUxMDU4LTllMWEtN2MzMy1hMmRkLTVhNzg4NGU2ZmMzOA==",
     system: "2.16.840.1.113883.3.9621",
   },
   patientMatch: true,

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/constants.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/constants.ts
@@ -128,7 +128,7 @@ export const expectedXcpdResponse: OutboundPatientDiscoveryRespSuccessfulSchema 
         line: ["1100 Test Street"],
         city: "Helena",
         state: "AL",
-        postalCode: "35080",
+        postalCode: "05080",
         country: "USA",
       },
     ],

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/xcpd_match.xml
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/xcpd_match.xml
@@ -54,7 +54,7 @@
                         <statusCode code="active"/>
                         <subject1 typeCode="SBJ">
                             <patient classCode="PAT">
-                                <id extension="ODFmMmVjNGUtYzcxYy00MDkwLWJmMWMtOWQ4NTI5ZjY1YjVhLzAxOGUxMDU4LTllMWEtN2MzMy1hMmRkLTVhNzg4NGU2ZmMzOA==" root="2.16.840.1.113883.3.9621"/>
+                                <id extension="0ODFmMmVjNGUtYzcxYy00MDkwLWJmMWMtOWQ4NTI5ZjY1YjVhLzAxOGUxMDU4LTllMWEtN2MzMy1hMmRkLTVhNzg4NGU2ZmMzOA==" root="2.16.840.1.113883.3.9621"/>
                                 <statusCode code="active"/>
                                 <patientPerson>
                                     <name>

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/xcpd_match.xml
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/xcpd_match.xml
@@ -67,7 +67,7 @@
                                         <streetAddressLine>1100 Test Street</streetAddressLine>
                                         <city>Helena</city>
                                         <state>AL</state>
-                                        <postalCode>35080</postalCode>
+                                        <postalCode>05080</postalCode>
                                         <country>USA</country>
                                     </addr>
                                     <asOtherIDs classCode="PAT">

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/xcpd_match_multi_addr_name.xml
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/xcpd_match_multi_addr_name.xml
@@ -54,7 +54,7 @@
                         <statusCode code="active"/>
                         <subject1 typeCode="SBJ">
                             <patient classCode="PAT">
-                                <id extension="ODFmMmVjNGUtYzcxYy00MDkwLWJmMWMtOWQ4NTI5ZjY1YjVhLzAxOGUxMDU4LTllMWEtN2MzMy1hMmRkLTVhNzg4NGU2ZmMzOA==" root="2.16.840.1.113883.3.9621"/>
+                                <id extension="0ODFmMmVjNGUtYzcxYy00MDkwLWJmMWMtOWQ4NTI5ZjY1YjVhLzAxOGUxMDU4LTllMWEtN2MzMy1hMmRkLTVhNzg4NGU2ZmMzOA==" root="2.16.840.1.113883.3.9621"/>
                                 <statusCode code="active"/>
                                 <patientPerson>
                                     <name>

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/xcpd_match_multi_addr_name.xml
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/xmls/xcpd_match_multi_addr_name.xml
@@ -76,7 +76,7 @@
                                         <streetAddressLine>1100 Test Street</streetAddressLine>
                                         <city>Helena</city>
                                         <state>AL</state>
-                                        <postalCode>35080</postalCode>
+                                        <postalCode>05080</postalCode>
                                         <country>USA</country>
                                     </addr>
                                     <addr>

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
@@ -192,6 +192,10 @@ export function processDqResponse({
     textNodeName: "_text",
     parseAttributeValue: false,
     removeNSPrefix: true,
+    numberParseOptions: {
+      hex: false,
+      leadingZeros: false,
+    },
   });
   const jsonObj = parser.parse(response);
 

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
@@ -1,3 +1,5 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import {
   DocumentReference,
   OutboundDocumentQueryReq,
@@ -5,9 +7,7 @@ import {
   XCAGateway,
 } from "@metriport/ihe-gateway-sdk";
 import { toArray } from "@metriport/shared";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-import { XMLParser } from "fast-xml-parser";
+import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import {
   XDSDocumentEntryAuthor,
   XDSDocumentEntryClassCode,
@@ -186,16 +186,12 @@ export function processDqResponse({
       gateway: gateway,
     });
   }
-  const parser = new XMLParser({
+  const parser = createXMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: "_",
     textNodeName: "_text",
     parseAttributeValue: false,
     removeNSPrefix: true,
-    numberParseOptions: {
-      hex: false,
-      leadingZeros: false,
-    },
   });
   const jsonObj = parser.parse(response);
 

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
@@ -1,4 +1,3 @@
-import { XMLParser } from "fast-xml-parser";
 import dayjs from "dayjs";
 import {
   OutboundDocumentRetrievalReq,
@@ -12,6 +11,7 @@ import {
   handleEmptyResponse,
   handleSchemaErrorResponse,
 } from "./error";
+import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { parseFileFromString, parseFileFromBuffer } from "./parse-file-from-string";
 import { stripUrnPrefix } from "../../../../../../util/urn";
 import { DrSamlClientResponse } from "../send/dr-requests";
@@ -223,16 +223,12 @@ export async function processDrResponse({
     throw new Error("No mtom response found");
   }
   const soapData: Buffer = mtomResponse.parts[0]?.body || Buffer.from("");
-  const parser = new XMLParser({
+  const parser = createXMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: "_",
     textNodeName: "_text",
     parseAttributeValue: false,
     removeNSPrefix: true,
-    numberParseOptions: {
-      hex: false,
-      leadingZeros: false,
-    },
   });
   const jsonObj = parser.parse(soapData.toString());
 

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
@@ -229,6 +229,10 @@ export async function processDrResponse({
     textNodeName: "_text",
     parseAttributeValue: false,
     removeNSPrefix: true,
+    numberParseOptions: {
+      hex: false,
+      leadingZeros: false,
+    },
   });
   const jsonObj = parser.parse(soapData.toString());
 

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/parse-file-from-string.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/parse-file-from-string.ts
@@ -81,6 +81,10 @@ function extractNonXmlBody(
     textNodeName: "_text",
     parseAttributeValue: false,
     removeNSPrefix: true,
+    numberParseOptions: {
+      hex: false,
+      leadingZeros: false,
+    },
   });
 
   const cda = parser.parse(decodedString);

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/parse-file-from-string.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/parse-file-from-string.ts
@@ -1,6 +1,6 @@
+import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { detectFileType, isXMLContentType } from "../../../../../../util/file-type";
 import { XML_APP_MIME_TYPE, XML_TXT_MIME_TYPE } from "../../../../../../util/mime";
-import { XMLParser } from "fast-xml-parser";
 import { out } from "../../../../../../util/log";
 
 const { log } = out("[parseFileFromString] ");
@@ -75,16 +75,12 @@ function extractNonXmlBody(
     log(msg);
     throw new Error(msg);
   }
-  const parser = new XMLParser({
+  const parser = createXMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: "_",
     textNodeName: "_text",
     parseAttributeValue: false,
     removeNSPrefix: true,
-    numberParseOptions: {
-      hex: false,
-      leadingZeros: false,
-    },
   });
 
   const cda = parser.parse(decodedString);

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/process/xcpd-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/process/xcpd-response.ts
@@ -1,4 +1,3 @@
-import { XMLParser } from "fast-xml-parser";
 import {
   OutboundPatientDiscoveryResp,
   OutboundPatientDiscoveryReq,
@@ -10,6 +9,7 @@ import {
   PersonalIdentifier,
 } from "@metriport/ihe-gateway-sdk";
 import { errorToString, toArray } from "@metriport/shared";
+import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { XCPDSamlClientResponse } from "../send/xcpd-requests";
 import { out } from "../../../../../../util/log";
 import { extractText } from "../../../utils";
@@ -213,16 +213,12 @@ export function processXCPDResponse({
     });
   }
 
-  const parser = new XMLParser({
+  const parser = createXMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: "_",
     textNodeName: "_text",
     parseAttributeValue: false,
     removeNSPrefix: true,
-    numberParseOptions: {
-      hex: false,
-      leadingZeros: false,
-    },
   });
 
   const jsonObj = parser.parse(response);

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/process/xcpd-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/process/xcpd-response.ts
@@ -219,6 +219,10 @@ export function processXCPDResponse({
     textNodeName: "_text",
     parseAttributeValue: false,
     removeNSPrefix: true,
+    numberParseOptions: {
+      hex: false,
+      leadingZeros: false,
+    },
   });
 
   const jsonObj = parser.parse(response);

--- a/packages/core/src/external/carequality/ihe-gateway-v2/saml/security/insert-key-info.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/saml/security/insert-key-info.ts
@@ -1,4 +1,5 @@
-import { XMLParser, XMLBuilder } from "fast-xml-parser";
+import { XMLBuilder } from "fast-xml-parser";
+import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { v4 as uuidv4 } from "uuid";
 import {
   securityHeaderEnvelopedId,
@@ -18,14 +19,10 @@ export function insertKeyInfo({
   xmlContent: string;
   publicCert: string;
 }): string {
-  const parser = new XMLParser({
+  const parser = createXMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: "@_",
     parseAttributeValue: false,
-    numberParseOptions: {
-      hex: false,
-      leadingZeros: false,
-    },
   });
   const builder = new XMLBuilder({
     ignoreAttributes: false,

--- a/packages/core/src/external/cda/remove-b64.ts
+++ b/packages/core/src/external/cda/remove-b64.ts
@@ -1,12 +1,13 @@
 import { toArray } from "@metriport/shared";
-import { XMLBuilder, XMLParser } from "fast-xml-parser";
+import { XMLBuilder } from "fast-xml-parser";
+import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { BINARY_MIME_TYPES } from "../../util/mime";
 
 const notesTemplateId = "2.16.840.1.113883.10.20.22.2.65";
 const b64Representation = "B64";
 
 export function removeBase64PdfEntries(payloadRaw: string): string {
-  const parser = new XMLParser({
+  const parser = createXMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: "@_",
     removeNSPrefix: true,

--- a/packages/shared/src/common/xml-parser.ts
+++ b/packages/shared/src/common/xml-parser.ts
@@ -1,0 +1,15 @@
+import { XMLParser, X2jOptionsOptional } from "fast-xml-parser";
+
+export function createXMLParser(options: X2jOptionsOptional = {}): XMLParser {
+  const defaultOptions: X2jOptionsOptional = {
+    numberParseOptions: {
+      hex: false,
+      leadingZeros: false,
+    },
+  };
+
+  // Merge the default options with the provided options
+  const mergedOptions = { ...defaultOptions, ...options };
+
+  return new XMLParser(mergedOptions);
+}

--- a/packages/utils/src/saml/saml-server.ts
+++ b/packages/utils/src/saml/saml-server.ts
@@ -32,7 +32,7 @@ import { MockS3Utils } from "./mock-s3";
  * Metriport-IHE GW / XML + SAML Constructor - Postman collection
  */
 
-const env = "PRODUCTION";
+const env = "STAGING";
 const app = express();
 const port = 8043;
 app.use(json());

--- a/packages/utils/src/saml/saml-server.ts
+++ b/packages/utils/src/saml/saml-server.ts
@@ -32,7 +32,7 @@ import { MockS3Utils } from "./mock-s3";
  * Metriport-IHE GW / XML + SAML Constructor - Postman collection
  */
 
-const env = "STAGING";
+const env = "PRODUCTION";
 const app = express();
 const port = 8043;
 app.use(json());


### PR DESCRIPTION
Refs: #[2323](https://github.com/metriport/metriport-internal/issues/2323)

### Description

- better parsing 0s in the rest of the IHE gateway 

### Testing

- Local
  - [x] unit testing 
  - [x] testing with offending endpoints

### Release Plan

- [ ] Merge this
