### PR TITLE
feat(bugs): creating patient before waiting for coordinates, then udp…

### DIFF
--- a/packages/api/src/command/medical/patient/create-patient.ts
+++ b/packages/api/src/command/medical/patient/create-patient.ts
@@ -69,14 +69,29 @@ export async function createPatient({
       contact,
     },
   };
+
+  let newPatient = await PatientModel.create(patientCreate);
+
   const addressWithCoordinates = await addCoordinatesToAddresses({
     addresses: patientCreate.data.address,
     cxId: patientCreate.cxId,
     reportRelevance: true,
   });
-  if (addressWithCoordinates) patientCreate.data.address = addressWithCoordinates;
-
-  const newPatient = await PatientModel.create(patientCreate);
+  if (addressWithCoordinates) {
+    newPatient = await newPatient.update({
+      data: {
+        ...newPatient.data,
+        firstName,
+        lastName,
+        dob,
+        genderAtBirth,
+        personalIdentifiers,
+        address: addressWithCoordinates,
+        contact: contact,
+      },
+      externalId,
+    });
+  }
 
   const fhirPatient = toFHIR(newPatient);
   await upsertPatientToFHIRServer(newPatient.cxId, fhirPatient);


### PR DESCRIPTION
Ref: #1040


### Description

- first insert patient *THEN* update with coordinates to cut-down on duplicate patient creation

### Testing

- Local
  - [ ] check patient create effectively unchanged
- Staging
  - [ ] check patient create effectively unchanged
- Production
  -- [ ] check patient create effectively unchanged


### Release Plan

- [ ] Merge this
