### PR TITLE
fix(cq): not including identifier when empty

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/create/iti55-envelope.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/create/iti55-envelope.ts
@@ -161,7 +161,7 @@ function createSoapBodyContent({
                   [`${prefix}semanticsText`]: "LivingSubject.birthTime",
                 }
               : {},
-            ...(identifiers
+            ...(identifiers && identifiers.length > 0
               ? {
                   [`${prefix}livingSubjectId`]: {
                     [`${prefix}value`]: identifiers.map(identifier => ({
@@ -202,7 +202,7 @@ function createSoapBodyContent({
                   },
                 }
               : {}),
-            ...(patientTelecoms
+            ...(patientTelecoms && patientTelecoms.length > 0
               ? {
                   [`${prefix}patientTelecom`]: {
                     [`${prefix}value`]: patientTelecoms.map(telecom => ({


### PR DESCRIPTION
Refs: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- fixing bug where we included identifier xml block when we had no identifier, which caused particle to error

### Testing

- Local
  - [x] with erroring particle patients

### Release Plan

- [ ] Merge this
