### PR TITLE
feat(fhir-converter): mental health survey mapping

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Sections/HealthConcerns.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/HealthConcerns.hbs
@@ -27,11 +27,14 @@
 {{#with (getFirstCdaSectionsByTemplateId msg '2.16.840.1.113883.10.20.22.2.58')}}
     {{#each (toArray 2_16_840_1_113883_10_20_22_2_58.entry)}}
         {{#each (toArray this.act.entryRelationship) as |healthEntry|}}
+
             {{#if healthEntry.observation.value.code}}
                 {{>Resources/Condition.hbs conditionEntry=healthEntry.observation ID=(generateUUID (toJsonString healthEntry.observation))}},
                 {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
                 	{{>References/Condition/subject.hbs ID=(generateUUID (toJsonString healthEntry.observation)) REF=(concat 'Patient/' patientId.Id)}},
                 {{/with}}
+            {{else if healthEntry.observation.value.value}}
+                {{>Resources/Observation.hbs observationEntry=healthEntry.observation ID=(generateUUID (toJsonString healthEntry.observation))}},
             {{/if}}
         {{/each}}
     {{/each}}

--- a/packages/fhir-converter/src/templates/cda/Sections/HealthConcerns.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/HealthConcerns.hbs
@@ -34,7 +34,7 @@
                 	{{>References/Condition/subject.hbs ID=(generateUUID (toJsonString healthEntry.observation)) REF=(concat 'Patient/' patientId.Id)}},
                 {{/with}}
             {{else if healthEntry.observation.value.value}}
-                {{>Resources/Observation.hbs observationEntry=healthEntry.observation ID=(generateUUID (toJsonString healthEntry.observation))}},
+                {{>Resources/Observation.hbs observationCategory="survey" observationEntry=healthEntry.observation ID=(generateUUID (toJsonString healthEntry.observation))}},
             {{/if}}
         {{/each}}
     {{/each}}

--- a/packages/fhir-converter/src/templates/cda/Utils/ObservationCategoryDisplayFromCode.hbs
+++ b/packages/fhir-converter/src/templates/cda/Utils/ObservationCategoryDisplayFromCode.hbs
@@ -34,6 +34,8 @@
             "Laboratory"
         {{else if (eq code "procedure")}}
             "Procedure"
+        {{else if (eq code "survey")}}
+            "Survey"
         {{/if}}
 }
 


### PR DESCRIPTION
refs. metriport/metriport-internal#2360

### Description
- Health Concerns section of CDAs is now parsed for observations, which often includes PHQ-9 and PHQ-2 results

### Testing
- Local
  - [x] More observations shown (PHQ-9, PHQ-2 results often seen in FHIR outputs)
  - [x] Run the testing suite 

### Release Plan

- [ ] Merge this
