### PR TITLE
fix(inbound): reordering contact validity and normalization

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/process/xcpd-request.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/process/xcpd-request.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import { PatientResource, InboundPatientDiscoveryReq } from "@metriport/ihe-gateway-sdk";
-import { isEmailValid, isPhoneValid } from "@metriport/shared";
+import { isEmail, isPhoneNumber } from "@metriport/shared";
 import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { errorToString, toArray } from "@metriport/shared";
 import { Iti55Request, iti55RequestSchema } from "./schema";
@@ -31,9 +31,9 @@ export function transformIti55RequestToPatientResource(
 
   const telecom = toArray(queryParams.patientTelecom?.value).flatMap(tel => {
     const value = tel._value;
-    if (isPhoneValid(value)) {
+    if (isPhoneNumber(value)) {
       return [{ system: "phone", value }];
-    } else if (isEmailValid(value)) {
+    } else if (isEmail(value)) {
       return [{ system: "email", value }];
     }
     return [];

--- a/packages/core/src/mpi/normalize-patient.ts
+++ b/packages/core/src/mpi/normalize-patient.ts
@@ -113,7 +113,6 @@ function normalizeString(str: string): string {
  * @returns The normalized email address.
  */
 export function normalizeEmail(email: string): string {
-  // Remove "mailto:" prefix if present
   const cleanedEmail = email.replace(/^mailto:/i, "");
   return cleanedEmail.trim().toLowerCase();
 }

--- a/packages/core/src/mpi/normalize-patient.ts
+++ b/packages/core/src/mpi/normalize-patient.ts
@@ -113,8 +113,8 @@ function normalizeString(str: string): string {
  * @returns The normalized email address.
  */
 export function normalizeEmail(email: string): string {
-  const cleanedEmail = email.replace(/^mailto:/i, "");
-  return cleanedEmail.trim().toLowerCase();
+  const trimmedEmail = email.trim().toLowerCase();
+  return trimmedEmail.replace(/^mailto:/i, "");
 }
 
 /**

--- a/packages/core/src/mpi/normalize-patient.ts
+++ b/packages/core/src/mpi/normalize-patient.ts
@@ -107,12 +107,15 @@ function normalizeString(str: string): string {
 
 /**
  * Normalizes an email address by removing leading and trailing spaces, converting all characters to lowercase
+ * and removing the "mailto:" prefix if present.
  *
  * @param email - The email address to be normalized.
  * @returns The normalized email address.
  */
 export function normalizeEmail(email: string): string {
-  return email.trim().toLowerCase();
+  // Remove "mailto:" prefix if present
+  const cleanedEmail = email.replace(/^mailto:/i, "");
+  return cleanedEmail.trim().toLowerCase();
 }
 
 /**

--- a/packages/shared/src/domain/contact/email.ts
+++ b/packages/shared/src/domain/contact/email.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 
 export const exampleEmail = "test@test.com";
 
+export function isEmail(email: string): boolean {
+  return email.includes("@");
+}
+
 export function isEmailValid(email: string): boolean {
   if (!email) return false;
   if (email.length === 0) return false;

--- a/packages/shared/src/domain/contact/phone.ts
+++ b/packages/shared/src/domain/contact/phone.ts
@@ -3,6 +3,11 @@ import { stripNonNumericChars } from "../../common/string";
 export const phoneLength = 10;
 export const examplePhoneNumber = "1231231234";
 
+export function isPhoneNumber(phone: string): boolean {
+  const numericChars = phone.replace(/\D/g, "");
+  return numericChars.length >= 10 && !phone.includes("@");
+}
+
 export function isPhoneValid(phone: string): boolean {
   if (!phone) return false;
   if (phone.length !== phoneLength) return false;

--- a/packages/shared/src/domain/contact/phone.ts
+++ b/packages/shared/src/domain/contact/phone.ts
@@ -5,7 +5,7 @@ export const examplePhoneNumber = "1231231234";
 
 export function isPhoneNumber(phone: string): boolean {
   const numericChars = phone.replace(/\D/g, "");
-  return numericChars.length >= 10 && !phone.includes("@");
+  return !phone.includes("@") && numericChars.length >= 10;
 }
 
 export function isPhoneValid(phone: string): boolean {


### PR DESCRIPTION
Refs: #[1766](https://github.com/metriport/metriport-internal/issues/1766)

### Description

- dont normalize contact info in json extraction phase
- fix email normalization to remove mailto: prefix

### Testing

- Local
  - [x] tested with prod request on local mock-ihe-server

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
