### PR TITLE
feat(pd): run pd on stale patient

### DIFF
--- a/packages/api/src/external/aws/app-config.ts
+++ b/packages/api/src/external/aws/app-config.ts
@@ -69,6 +69,10 @@ export async function getCxsWitDemoAugEnabled(): Promise<string[]> {
   return getCxsWithFeatureFlagEnabled("cxsWithDemoAugEnabled");
 }
 
+export async function getCxsWitStalePatientUpdateEnabled(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithStalePatientUpdateEnabled");
+}
+
 export async function getE2eCxIds(): Promise<string | undefined> {
   if (Config.isDev()) {
     const apiKey = getEnvVar("TEST_API_KEY");
@@ -126,6 +130,11 @@ export async function isEpicEnabledForCx(cxId: string): Promise<boolean> {
 export async function isDemoAugEnabledForCx(cxId: string): Promise<boolean> {
   const cxIdsWithDemoAugEnabled = await getCxsWitDemoAugEnabled();
   return cxIdsWithDemoAugEnabled.some(i => i === cxId);
+}
+
+export async function isStalePatientUpdateEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithStalePatientUpdateEnabled = await getCxsWitStalePatientUpdateEnabled();
+  return cxIdsWithStalePatientUpdateEnabled.some(i => i === cxId);
 }
 
 export async function isCommonwellEnabled(): Promise<boolean> {

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -75,13 +75,12 @@ export async function getDocumentsFromCQ({
     const patientCQData = getCQData(patient.data.externalData);
     const hasNoCQStatus = !patientCQData || !patientCQData.discoveryStatus;
     const isProcessing = patientCQData?.discoveryStatus === "processing";
-    const mostRecentPdStartedAt = patientCQData?.discoveryParams?.startedAt
+    const now = buildDayjs(new Date());
+    const patientCreatedAt = buildDayjs(patient.createdAt);
+    const pdStartedAt = patientCQData?.discoveryParams?.startedAt
       ? buildDayjs(patientCQData.discoveryParams.startedAt)
       : undefined;
-    const now = buildDayjs(new Date());
-    const isStale =
-      mostRecentPdStartedAt === undefined ||
-      mostRecentPdStartedAt < now.subtract(staleLookbackHours, "hours");
+    const isStale = (pdStartedAt ?? patientCreatedAt) < now.subtract(staleLookbackHours, "hours");
 
     if (hasNoCQStatus || isProcessing || forcePatientDiscovery || isStale) {
       await scheduleDocQuery({

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -76,7 +76,7 @@ export async function getDocumentsFromCQ({
     const hasNoCQStatus = !patientCQData || !patientCQData.discoveryStatus;
     const isProcessing = patientCQData?.discoveryStatus === "processing";
     const mostRecentPdStartedAt = patientCQData?.discoveryParams?.startedAt
-      ? buildDayjs(patientCQData?.discoveryParams?.startedAt)
+      ? buildDayjs(patientCQData.discoveryParams.startedAt)
       : undefined;
     const now = buildDayjs(new Date());
     const isStale =

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -22,7 +22,7 @@ import { isFacilityEnabledToQueryCQ } from "../../carequality/shared";
 import { filterCqLinksByManagingOrg } from "./filter-oids-by-managing-org";
 import { processAsyncError } from "@metriport/core/util/error/shared";
 
-const staleLookBackHours = 24;
+const staleLookbackHours = 24;
 
 const resultPoller = makeOutboundResultPoller();
 
@@ -81,7 +81,7 @@ export async function getDocumentsFromCQ({
     const now = buildDayjs(new Date());
     const isStale =
       mostRecentPdStartedAt === undefined ||
-      mostRecentPdStartedAt < now.subtract(staleLookBackHours, "hours");
+      mostRecentPdStartedAt < now.subtract(staleLookbackHours, "hours");
 
     if (hasNoCQStatus || isProcessing || forcePatientDiscovery || isStale) {
       await scheduleDocQuery({

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -67,7 +67,7 @@ import {
   getFileName,
 } from "./shared";
 
-const staleLookBackHours = 24;
+const staleLookbackHours = 24;
 
 const DOC_DOWNLOAD_CHUNK_SIZE = 10;
 
@@ -157,7 +157,7 @@ export async function queryAndProcessDocuments({
     const now = buildDayjs(new Date());
     const isStale =
       mostRecentPdStartedAt === undefined ||
-      mostRecentPdStartedAt < now.subtract(staleLookBackHours, "hours");
+      mostRecentPdStartedAt < now.subtract(staleLookbackHours, "hours");
 
     if (hasNoCWStatus || isProcessing || forcePatientDiscovery || isStale) {
       await scheduleDocQuery({

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -151,13 +151,12 @@ export async function queryAndProcessDocuments({
     const patientCWData = getCWData(patientParam.data.externalData);
     const hasNoCWStatus = !patientCWData || !patientCWData.status;
     const isProcessing = patientCWData?.status === "processing";
-    const mostRecentPdStartedAt = patientCWData?.discoveryParams?.startedAt
+    const now = buildDayjs(new Date());
+    const patientCreatedAt = buildDayjs(patientParam.createdAt);
+    const pdStartedAt = patientCWData?.discoveryParams?.startedAt
       ? buildDayjs(patientCWData.discoveryParams.startedAt)
       : undefined;
-    const now = buildDayjs(new Date());
-    const isStale =
-      mostRecentPdStartedAt === undefined ||
-      mostRecentPdStartedAt < now.subtract(staleLookbackHours, "hours");
+    const isStale = (pdStartedAt ?? patientCreatedAt) < now.subtract(staleLookbackHours, "hours");
 
     if (hasNoCWStatus || isProcessing || forcePatientDiscovery || isStale) {
       await scheduleDocQuery({

--- a/packages/core/src/external/aws/app-config.ts
+++ b/packages/core/src/external/aws/app-config.ts
@@ -44,6 +44,7 @@ export const cxBasedFFsSchema = z.object({
   cxsWithIncreasedSandboxLimitFeatureFlag: ffStringValuesSchema,
   cxsWithEpicEnabled: ffStringValuesSchema,
   cxsWithDemoAugEnabled: ffStringValuesSchema,
+  cxsWithStalePatientUpdateEnabled: ffStringValuesSchema,
 });
 export type CxBasedFFsSchema = z.infer<typeof cxBasedFFsSchema>;
 


### PR DESCRIPTION
Ref: #1040

### Description

- run PD if last PD run was more than 24 hours ago (i.e. always refresh patient links if linking is stale)

### Testing

- Local
  - [x] check that PD runs if started at > 24 hours
  - [x] check that PD runs if started at is undefined and patient created > 24 hours
  - [x] check that PD does not run if started at is undefined and patient created < 24 hours
  - [x] check that PD doe snot run if started at < 24 hours
- Staging
  - [ ] check that PD runs if started at > 24 hours
  - [ ] check that PD runs if started at is undefined and patient created > 24 hours
  - [ ] check that PD does not run if started at is undefined and patient created < 24 hours
  - [ ] check that PD doe snot run if started at < 24 hours
- Production
  - [ ] check that PD runs if started at > 24 hours
  - [ ] check that PD runs if started at is undefined and patient created > 24 hours
  - [ ] check that PD does not run if started at is undefined and patient created < 24 hours
  - [ ] check that PD doe snot run if started at < 24 hours

### Release Plan

- [ ] Add `cxsWithStalePatientUpdateEnabled` FF with staging test CX to dev and staging before merge
- [ ] Merge this
