### PR TITLE
2215 Add conversion bucket name to CICD to fix E2E test

### DIFF
--- a/.github/workflows/_e2e-tests.yml
+++ b/.github/workflows/_e2e-tests.yml
@@ -15,6 +15,10 @@ on:
         description: "the url for the fhir server"
         required: true
         type: string
+      conversions_bucket_name:
+        description: "the name of the bucket with the CDA>FHIR conversions"
+        required: true
+        type: string
       test_patient_id:
         description: "the ID of a test patient for e2e tests"
         required: false
@@ -97,6 +101,7 @@ jobs:
           CW_MEMBER_NAME: ${{ secrets.CW_MEMBER_NAME }}
           API_URL: ${{ inputs.api_url }}
           FHIR_SERVER_URL: ${{ inputs.fhir_url }}
+          CONVERSION_RESULT_BUCKET_NAME: ${{ inputs.conversions_bucket_name }}
           ENV_TYPE: ${{ inputs.deploy_env }}
 
       - name: Store Test Results

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -175,6 +175,7 @@ jobs:
       deploy_env: "production"
       api_url: ${{ vars.API_URL_PRODUCTION }}
       fhir_url: ${{ vars.FHIR_SERVER_URL_PRODUCTION }}
+      conversions_bucket_name: ${{ vars.CONVERSION_RESULT_BUCKET_NAME_PRODUCTION }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -126,6 +126,7 @@ jobs:
       deploy_env: "staging"
       api_url: ${{ vars.API_URL_STAGING }}
       fhir_url: ${{ vars.FHIR_SERVER_URL_STAGING }}
+      conversions_bucket_name: ${{ vars.CONVERSION_RESULT_BUCKET_NAME_STAGING }}
       test_patient_id: ${{ vars.TEST_PATIENT_ID }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Ref. metriport/metriport-internal#2215

### Dependencies

none

### Description

Add conversion bucket name to CICD to fix E2E test - [context](https://metriport.slack.com/archives/C04CXLSAF7V/p1729025444264769?thread_ts=1729020302.503249&cid=C04CXLSAF7V)

### Testing

- Local
  - none
- Staging
  - [ ] E2E tests succeed
- Sandbox
  - none
- Production
  - [ ] E2E tests succeed

### Release Plan

- [x] Set env vars on the repo
   - `CONVERSION_RESULT_BUCKET_NAME_STAGING`
   - `CONVERSION_RESULT_BUCKET_NAME_PRODUCTION`
- [ ] Merge this
