### PR TITLE
2215 Add AWS_REGION to E2E test

### DIFF
--- a/.github/workflows/_e2e-tests.yml
+++ b/.github/workflows/_e2e-tests.yml
@@ -15,13 +15,16 @@ on:
         description: "the url for the fhir server"
         required: true
         type: string
-      conversions_bucket_name:
+      CONVERSION_RESULT_BUCKET_NAME:
         description: "the name of the bucket with the CDA>FHIR conversions"
         required: true
         type: string
       test_patient_id:
         description: "the ID of a test patient for e2e tests"
         required: false
+        type: string
+      AWS_REGION:
+        required: true
         type: string
     secrets:
       AWS_ACCESS_KEY_ID:
@@ -101,7 +104,8 @@ jobs:
           CW_MEMBER_NAME: ${{ secrets.CW_MEMBER_NAME }}
           API_URL: ${{ inputs.api_url }}
           FHIR_SERVER_URL: ${{ inputs.fhir_url }}
-          CONVERSION_RESULT_BUCKET_NAME: ${{ inputs.conversions_bucket_name }}
+          CONVERSION_RESULT_BUCKET_NAME: ${{ inputs.CONVERSION_RESULT_BUCKET_NAME }}
+          AWS_REGION: ${{ inputs.AWS_REGION }}
           ENV_TYPE: ${{ inputs.deploy_env }}
 
       - name: Store Test Results

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -175,7 +175,8 @@ jobs:
       deploy_env: "production"
       api_url: ${{ vars.API_URL_PRODUCTION }}
       fhir_url: ${{ vars.FHIR_SERVER_URL_PRODUCTION }}
-      conversions_bucket_name: ${{ vars.CONVERSION_RESULT_BUCKET_NAME_PRODUCTION }}
+      CONVERSION_RESULT_BUCKET_NAME: ${{ vars.CONVERSION_RESULT_BUCKET_NAME_PRODUCTION }}
+      AWS_REGION: ${{ vars.API_REGION_PRODUCTION }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -126,7 +126,8 @@ jobs:
       deploy_env: "staging"
       api_url: ${{ vars.API_URL_STAGING }}
       fhir_url: ${{ vars.FHIR_SERVER_URL_STAGING }}
-      conversions_bucket_name: ${{ vars.CONVERSION_RESULT_BUCKET_NAME_STAGING }}
+      CONVERSION_RESULT_BUCKET_NAME: ${{ vars.CONVERSION_RESULT_BUCKET_NAME_STAGING }}
+      AWS_REGION: ${{ vars.API_REGION_STAGING }}
       test_patient_id: ${{ vars.TEST_PATIENT_ID }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Ref. metriport/metriport-internal#2215

Ticket: #_[ticket-number]_

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2910
- Downstream: none

### Description

Add AWS_REGION to E2E test

### Testing

- Local
  - none
- Staging
  - [ ] E2E tests pass
- Sandbox
  - none
- Production
  - [ ] E2E tests pass

### Release Plan

- [ ] Merge this
