### PR TITLE
PATCH strip brackets

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
@@ -13,7 +13,7 @@ import {
 } from "./error";
 import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { parseFileFromString, parseFileFromBuffer } from "./parse-file-from-string";
-import { stripUrnPrefix } from "../../../../../../util/urn";
+import { stripUrnPrefix, stripBrackets } from "../../../../../../util/urn";
 import { DrSamlClientResponse } from "../send/dr-requests";
 import { MtomAttachments, MtomPart } from "../mtom/parser";
 import { successStatus, partialSuccessStatus } from "./constants";
@@ -92,7 +92,7 @@ async function processDocumentReference({
   try {
     const s3Utils = getS3UtilsInstance();
     const { mimeType, decodedBytes } = getMtomBytesAndMimeType(documentResponse, mtomResponse);
-    const strippedDocUniqueId = stripUrnPrefix(documentResponse.DocumentUniqueId);
+    const strippedDocUniqueId = stripBrackets(stripUrnPrefix(documentResponse.DocumentUniqueId));
     const metriportId = idMapping[strippedDocUniqueId];
     if (!metriportId) {
       throw new MetriportError("MetriportId not found for document");

--- a/packages/core/src/util/__tests__/urn.test.ts
+++ b/packages/core/src/util/__tests__/urn.test.ts
@@ -1,4 +1,4 @@
-import { stripUrnPrefix } from "../urn";
+import { stripUrnPrefix, stripBrackets } from "../urn";
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -31,6 +31,37 @@ describe("stripUrnPrefix", () => {
   it("returns string when its a normal oid", async () => {
     const original = "2.16.840.1.113883.3.9621";
     const res = stripUrnPrefix(original);
+    expect(res).toEqual("2.16.840.1.113883.3.9621");
+  });
+});
+
+describe("stripBrackets", () => {
+  it("returns empty string when gets undefined", async () => {
+    const res = stripBrackets(undefined);
+    expect(res).toEqual("");
+  });
+
+  it("returns string when gets number", async () => {
+    const original = 123;
+    const res = stripBrackets(original);
+    expect(res).toEqual("123");
+  });
+
+  it("returns stripped string when gets both brackets", async () => {
+    const original = "[2.16.840.1.113883.3.9621]";
+    const res = stripBrackets(original);
+    expect(res).toEqual("2.16.840.1.113883.3.9621");
+  });
+
+  it("returns stripped string when gets one left bracket", async () => {
+    const original = "[2.16.840.1.113883.3.9621";
+    const res = stripBrackets(original);
+    expect(res).toEqual("2.16.840.1.113883.3.9621");
+  });
+
+  it("returns stripped string when gets one right bracket", async () => {
+    const original = "2.16.840.1.113883.3.9621]";
+    const res = stripBrackets(original);
     expect(res).toEqual("2.16.840.1.113883.3.9621");
   });
 });

--- a/packages/core/src/util/__tests__/urn.test.ts
+++ b/packages/core/src/util/__tests__/urn.test.ts
@@ -64,4 +64,10 @@ describe("stripBrackets", () => {
     const res = stripBrackets(original);
     expect(res).toEqual("2.16.840.1.113883.3.9621");
   });
+
+  it("returns unstripped string when gets bracket in middle", async () => {
+    const original = "2.16.840.1.[113883.3.9621]";
+    const res = stripBrackets(original);
+    expect(res).toEqual("2.16.840.1.[113883.3.9621");
+  });
 });

--- a/packages/core/src/util/urn.ts
+++ b/packages/core/src/util/urn.ts
@@ -1,5 +1,5 @@
 const urnRegex = /^urn:(oid|uuid):/;
-const bracketRegex = /(\[|\])/g;
+const bracketRegex = /(^\[|\]$)/g;
 
 export function wrapIdInUrnUuid(id: string): string {
   return `urn:uuid:${id}`;

--- a/packages/core/src/util/urn.ts
+++ b/packages/core/src/util/urn.ts
@@ -1,4 +1,5 @@
 const urnRegex = /^urn:(oid|uuid):/;
+const bracketRegex = /(\[|\])/g;
 
 export function wrapIdInUrnUuid(id: string): string {
   return `urn:uuid:${id}`;
@@ -20,4 +21,14 @@ export function stripUrnPrefix(urn: string | number | undefined): string {
     return urn.toString();
   }
   return urn.replace(urnRegex, "");
+}
+
+export function stripBrackets(urn: string | number | undefined): string {
+  if (urn === undefined) {
+    return "";
+  }
+  if (typeof urn === "number") {
+    return urn.toString();
+  }
+  return urn.replace(bracketRegex, "");
 }


### PR DESCRIPTION
Ref: #1040

### Description

- sure-scripts started sending back doc unqiue ID in brackets as such `"DocumentUniqueId": "[X.XXX.XXXXXXXX.XXXX]",`

### Testing

- Local
  - [x] unit testing
- Production
  - [ ] requery surescripts

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
