### PR TITLE
2215 Temporarily disable E2E tests

### DIFF
--- a/packages/api/src/__tests__/e2e/mapi/mapi.test.e2e.ts
+++ b/packages/api/src/__tests__/e2e/mapi/mapi.test.e2e.ts
@@ -22,7 +22,7 @@ afterAll(async () => {
   await tearDownMapiE2e();
 });
 
-describe("MAPI E2E Tests", () => {
+describe.skip("MAPI E2E Tests", () => {
   const e2e: E2eContext = {};
 
   describe("Settings", () => {


### PR DESCRIPTION
Ref. metriport/metriport-internal#2215

### Description

Temporarily disable E2E tests - [context](https://metriport.slack.com/archives/C04CXLSAF7V/p1729104123253859?thread_ts=1729020302.503249&cid=C04CXLSAF7V)

### Testing

none

### Release Plan

- [ ] Merge this
