### PR TITLE
2453 DOB can't be in the future

### DIFF
--- a/packages/api/src/command/medical/patient/__tests__/validate.test.ts
+++ b/packages/api/src/command/medical/patient/__tests__/validate.test.ts
@@ -41,20 +41,22 @@ describe("validate", () => {
 
   describe("dob", () => {
     it("throws an error if dob is in the future", async () => {
-      const futureDate = dayjs().add(7, 'day').format('YYYY-MM-DD');
+      const futureDate = dayjs().add(1, 'day').format('YYYY-MM-DD');
       const patient = makePatientCreate({ dob: futureDate });
       expect(() => validate(patient)).toThrow(`Date must be in the past: ${futureDate}`);
     });
 
-    it("returns true when dob is valid", async () => {
+    it("returns true when dob is the current date", async () => {
       const currentDate = dayjs().format('YYYY-MM-DD');
-      let patient = makePatientCreate({ dob: currentDate });
-      let resp = validate(patient);
+      const patient = makePatientCreate({ dob: currentDate });
+      const resp = validate(patient);
       expect(resp).toBeTruthy();
+    })
 
-      const pastDate = dayjs().subtract(7, 'day').format('YYYY-MM-DD');
-      patient = makePatientCreate({ dob: pastDate });
-      resp = validate(patient);
+    it("returns true when dob is in the past", async () => {
+      const pastDate = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
+      const patient = makePatientCreate({ dob: pastDate });
+      const resp = validate(patient);
       expect(resp).toBeTruthy();
     })
   })

--- a/packages/api/src/command/medical/patient/__tests__/validate.test.ts
+++ b/packages/api/src/command/medical/patient/__tests__/validate.test.ts
@@ -1,7 +1,7 @@
+import dayjs from "dayjs";
 import { makeAddressStrict } from "../../../../domain/medical/__tests__/location-address";
 import { makePatientCreate } from "../../../../domain/medical/__tests__/patient";
 import { validate } from "../shared";
-import dayjs from "dayjs";
 
 describe("validate", () => {
   it("returns true when patient is valid", async () => {
@@ -41,23 +41,29 @@ describe("validate", () => {
 
   describe("dob", () => {
     it("throws an error if dob is in the future", async () => {
-      const futureDate = dayjs().add(1, 'day').format('YYYY-MM-DD');
+      const futureDate = dayjs().add(1, "day").format("YYYY-MM-DD");
       const patient = makePatientCreate({ dob: futureDate });
-      expect(() => validate(patient)).toThrow(`Date must be in the past: ${futureDate}`);
+      expect(() => validate(patient)).toThrow(`Date must be in the past`);
+    });
+
+    it("throws an error when dob is a minute in the future", async () => {
+      const futureDate = dayjs().add(1, "minute").toISOString();
+      const patient = makePatientCreate({ dob: futureDate });
+      expect(() => validate(patient)).toThrow(`Date must be in the past`);
     });
 
     it("returns true when dob is the current date", async () => {
-      const currentDate = dayjs().format('YYYY-MM-DD');
+      const currentDate = dayjs().format("YYYY-MM-DD");
       const patient = makePatientCreate({ dob: currentDate });
       const resp = validate(patient);
       expect(resp).toBeTruthy();
-    })
+    });
 
     it("returns true when dob is in the past", async () => {
-      const pastDate = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
+      const pastDate = dayjs().subtract(1, "day").format("YYYY-MM-DD");
       const patient = makePatientCreate({ dob: pastDate });
       const resp = validate(patient);
       expect(resp).toBeTruthy();
-    })
-  })
+    });
+  });
 });

--- a/packages/api/src/command/medical/patient/__tests__/validate.test.ts
+++ b/packages/api/src/command/medical/patient/__tests__/validate.test.ts
@@ -1,6 +1,7 @@
 import { makeAddressStrict } from "../../../../domain/medical/__tests__/location-address";
 import { makePatientCreate } from "../../../../domain/medical/__tests__/patient";
 import { validate } from "../shared";
+import dayjs from "dayjs";
 
 describe("validate", () => {
   it("returns true when patient is valid", async () => {
@@ -37,4 +38,24 @@ describe("validate", () => {
       expect(resp).toBeTruthy();
     });
   });
+
+  describe("dob", () => {
+    it("throws an error if dob is in the future", async () => {
+      const futureDate = dayjs().add(7, 'day').format('YYYY-MM-DD');
+      const patient = makePatientCreate({ dob: futureDate });
+      expect(() => validate(patient)).toThrow(`Date must be in the past: ${futureDate}`);
+    });
+
+    it("returns true when dob is valid", async () => {
+      const currentDate = dayjs().format('YYYY-MM-DD');
+      let patient = makePatientCreate({ dob: currentDate });
+      let resp = validate(patient);
+      expect(resp).toBeTruthy();
+
+      const pastDate = dayjs().subtract(7, 'day').format('YYYY-MM-DD');
+      patient = makePatientCreate({ dob: pastDate });
+      resp = validate(patient);
+      expect(resp).toBeTruthy();
+    })
+  })
 });

--- a/packages/api/src/command/medical/patient/convert-fhir-bundle.ts
+++ b/packages/api/src/command/medical/patient/convert-fhir-bundle.ts
@@ -1,21 +1,23 @@
 import { Bundle, Resource } from "@medplum/fhirtypes";
+import { ResourceTypeForConsolidation } from "@metriport/api-sdk";
 import {
   ConsolidationConversionType,
   Input as ConversionInput,
   MedicalRecordFormat,
   Output as ConversionOutput,
 } from "@metriport/core/domain/conversion/fhir-to-medical-record";
-import { createMRSummaryFileName } from "@metriport/core/domain/medical-record-summary";
+import {
+  createMRSummaryFileName,
+  createSandboxMRSummaryFileName,
+} from "@metriport/core/domain/medical-record-summary";
 import { Patient } from "@metriport/core/domain/patient";
 import { getLambdaResultPayload, makeLambdaClient } from "@metriport/core/external/aws/lambda";
 import { makeS3Client, S3Utils } from "@metriport/core/external/aws/s3";
 import { SearchSetBundle } from "@metriport/shared/medical";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
-import { ResourceTypeForConsolidation } from "@metriport/api-sdk";
 import { Config } from "../../../shared/config";
 import { getSandboxSeedData } from "../../../shared/sandbox/sandbox-seed-data";
-import { createSandboxMRSummaryFileName } from "./shared";
 
 dayjs.extend(duration);
 

--- a/packages/api/src/command/medical/patient/create-medical-record.ts
+++ b/packages/api/src/command/medical/patient/create-medical-record.ts
@@ -1,9 +1,11 @@
-import { createMRSummaryFileName } from "@metriport/core/domain/medical-record-summary";
+import {
+  createMRSummaryFileName,
+  createSandboxMRSummaryFileName,
+} from "@metriport/core/domain/medical-record-summary";
 import { S3Utils } from "@metriport/core/external/aws/s3";
 import { Config } from "../../../shared/config";
 import { getSignedURL } from "../document/document-download";
 import { getPatient } from "./get-patient";
-import { createSandboxMRSummaryFileName } from "./shared";
 
 const awsRegion = Config.getAWSRegion();
 const s3Utils = new S3Utils(awsRegion);

--- a/packages/api/src/command/medical/patient/shared.ts
+++ b/packages/api/src/command/medical/patient/shared.ts
@@ -19,6 +19,7 @@ export function validate<T extends PatientCreateCmd | PatientUpdateCmd | Patient
 ): boolean {
   if (!patient.address || patient.address.length < 1) return false;
   patient.personalIdentifiers?.forEach(pid => pid.period && validatePeriod(pid.period));
+  validateIsPast(patient.dob);
   return true;
 }
 

--- a/packages/api/src/command/medical/patient/shared.ts
+++ b/packages/api/src/command/medical/patient/shared.ts
@@ -1,10 +1,10 @@
 import { Period } from "@metriport/core/domain/patient";
+import { BadRequestError } from "@metriport/shared";
 import dayjs from "dayjs";
 import { cloneDeep } from "lodash";
-import BadRequestError from "../../../errors/bad-request";
 import { PatientCreateCmd } from "./create-patient";
-import { PatientUpdateCmd } from "./update-patient";
 import { PatientMatchCmd } from "./get-patient";
+import { PatientUpdateCmd } from "./update-patient";
 
 export function sanitize<T extends PatientCreateCmd | PatientUpdateCmd | PatientMatchCmd>(
   patient: T
@@ -34,18 +34,17 @@ function validatePeriod(period: Period): boolean {
 }
 
 function validateIsPast(date: string): boolean {
-  if (dayjs(date).isAfter(dayjs())) throw new BadRequestError(`Date must be in the past: ${date}`);
+  if (dayjs(date).isAfter(dayjs()))
+    throw new BadRequestError(`Date must be in the past`, undefined, { date });
   return true;
 }
 
 function validateDateRange(start: string, end: string): boolean {
-  if (dayjs(start).isAfter(end)) throw new BadRequestError(`'start' must be before 'end'`);
+  if (dayjs(start).isAfter(end)) {
+    throw new BadRequestError(`Invalid date range: 'start' must be before 'end'`, undefined, {
+      start,
+      end,
+    });
+  }
   return true;
-}
-
-export function createSandboxMRSummaryFileName(
-  firstName: string,
-  extension: "pdf" | "html"
-): string {
-  return extension === "pdf" ? `${firstName}_MR.html.pdf` : `${firstName}_MR.html`;
 }

--- a/packages/core/src/domain/medical-record-summary.ts
+++ b/packages/core/src/domain/medical-record-summary.ts
@@ -23,6 +23,13 @@ export const createMRSummaryFileName = (
   );
 };
 
+export function createSandboxMRSummaryFileName(
+  firstName: string,
+  extension: "pdf" | "html"
+): string {
+  return extension === "pdf" ? `${firstName}_MR.html.pdf` : `${firstName}_MR.html`;
+}
+
 export const createMRSummaryBriefFileName = (
   cxId: string,
   patientId: string,


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport/issues/2453

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2725
- Downstream: none

### Description

This is merging the external contribution from @jamestran201 (PR https://github.com/metriport/metriport/pull/2725) into `develop`.

It also includes a couple other tweaks:
- test w/ DOB 1min in the future
- move sandbox MR filename function away from the patient shared into its respective domain (on core)

### Testing

- Local
  - [x] Unit tests
  - [ ] Creates patient w/ DOB in the past
  - [ ] Creates patient w/ DOB as current date
  - [ ] Fails to create a patient w/ DOB in the future
- Staging
  - [ ] Creates patient w/ DOB in the past
  - [ ] Creates patient w/ DOB as current date
  - [ ] Fails to create a patient w/ DOB in the future
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
