### PR TITLE
PATCH RELEASE 799 Accept non-array DiagnosticReport.category

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/__tests__/bundle-to-html-shared.test.ts
+++ b/packages/core/src/external/aws/lambda-logic/__tests__/bundle-to-html-shared.test.ts
@@ -1,0 +1,42 @@
+import { CodeableConcept } from "@medplum/fhirtypes";
+import {
+  makeDiagnosticReport,
+  makeDiagnosticReportCategory,
+} from "../../../../fhir-to-cda/cda-templates/components/__tests__/make-diagnostic-report";
+import { buildEncounterSections } from "../bundle-to-html-shared";
+
+describe("bundle-to-html-shared", () => {
+  describe("buildEncounterSections", () => {
+    it("processes array category", async () => {
+      const effectiveDateTime = "2024-01-01";
+      const category = makeDiagnosticReportCategory();
+      category.text = "LAB";
+      const diagReport = makeDiagnosticReport({
+        effectiveDateTime,
+        category: [category],
+      });
+      const res = buildEncounterSections([diagReport]);
+      expect(res).toEqual(
+        expect.objectContaining({
+          [effectiveDateTime]: { labs: [diagReport] },
+        })
+      );
+    });
+
+    it("processes category that's not an array (backwards compatibility)", async () => {
+      const effectiveDateTime = "2024-01-01";
+      const category = makeDiagnosticReportCategory();
+      category.text = "LAB";
+      const diagReport = makeDiagnosticReport({
+        effectiveDateTime,
+        category: category as CodeableConcept[],
+      });
+      const res = buildEncounterSections([diagReport]);
+      expect(res).toEqual(
+        expect.objectContaining({
+          [effectiveDateTime]: { labs: [diagReport] },
+        })
+      );
+    });
+  });
+});

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
@@ -609,7 +609,7 @@ function createDiagnosticReportsSection(
 
   const visitDateDict = getConditionDatesFromEncounters(encounters);
 
-  const encounterSections = buildEncounterSections({}, diagnosticReports);
+  const encounterSections = buildEncounterSections(diagnosticReports);
 
   const encountersWithoutAWEAndADHD = Object.entries(encounterSections)
     .filter(([key]) => {
@@ -683,7 +683,7 @@ function createFilteredReportSection(
     return "";
   }
 
-  const encounterSections = buildEncounterSections({}, diagnosticReports);
+  const encounterSections = buildEncounterSections(diagnosticReports);
 
   const conditionDateDict = getConditionDatesFromEncounters(encounters);
 
@@ -958,7 +958,7 @@ function getLatestDrPerSpecialty(
     }
   }
 
-  const encounterSectionsBySpecialty = buildEncounterSections({}, reportsBySpecialty);
+  const encounterSectionsBySpecialty = buildEncounterSections(reportsBySpecialty);
 
   return encounterSectionsBySpecialty;
 }

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-no-dedup.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-no-dedup.ts
@@ -589,7 +589,7 @@ function createAWESection(
     return "";
   }
 
-  const encounterSections: EncounterSection = buildEncounterSections({}, diagnosticReports);
+  const encounterSections: EncounterSection = buildEncounterSections(diagnosticReports);
 
   const AWEreports = buildReports(
     encounterSections,
@@ -631,7 +631,7 @@ function createDiagnosticReportsSection(
     return "";
   }
 
-  const encounterSections: EncounterSection = buildEncounterSections({}, diagnosticReports);
+  const encounterSections: EncounterSection = buildEncounterSections(diagnosticReports);
 
   const nonAWEreports = buildReports(
     encounterSections,
@@ -661,10 +661,8 @@ function createDiagnosticReportsSection(
 }
 // assumes date is defined
 // doesnt deduplicate reports of key (type + date)
-function buildEncounterSections(
-  encounterSections: EncounterSection,
-  diagnosticReports: DiagnosticReport[]
-): EncounterSection {
+function buildEncounterSections(diagnosticReports: DiagnosticReport[]): EncounterSection {
+  const encounterSections: EncounterSection = {};
   for (const report of diagnosticReports) {
     const time = report.effectiveDateTime ?? report.effectivePeriod?.start;
     const formattedDate = dayjs(time).format(ISO_DATE) ?? "";
@@ -676,7 +674,8 @@ function buildEncounterSections(
     let diagnosticReportsType: EncounterTypes = "documentation";
 
     if (report.category) {
-      for (const iterator of report.category) {
+      const categories = Array.isArray(report.category) ? report.category : [report.category];
+      for (const iterator of categories) {
         if (iterator.text?.toLowerCase() === "lab") {
           diagnosticReportsType = "labs";
           break;

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
@@ -16,7 +16,7 @@ type EncounterTypes =
  * EncounterSection is a map of strings to DiagnosticReport arrays.
  * NOTE: don't assume key is a date, it might be MISSING_DATE_KEY, in case the date is not available.
  */
-type EncounterSection = {
+export type EncounterSection = {
   [key: string]: {
     [k in EncounterTypes]?: DiagnosticReport[];
   };
@@ -33,10 +33,8 @@ export function formatDateForDisplay(date?: Date | string | undefined): string {
  * @returns EncounterSection - NOTE: don't assume key is a date, it might be MISSING_DATE_KEY, in
  * case the date is not available. See EncounterSection type for more details.
  */
-export function buildEncounterSections(
-  encounterSections: EncounterSection,
-  diagnosticReports: DiagnosticReport[]
-): EncounterSection {
+export function buildEncounterSections(diagnosticReports: DiagnosticReport[]): EncounterSection {
+  const encounterSections: EncounterSection = {};
   for (const report of diagnosticReports) {
     const time = report.effectiveDateTime ?? report.effectivePeriod?.start;
     const reportDate =
@@ -49,7 +47,8 @@ export function buildEncounterSections(
     let diagnosticReportsType: EncounterTypes | undefined = "documentation";
 
     if (report.category) {
-      for (const iterator of report.category) {
+      const categories = Array.isArray(report.category) ? report.category : [report.category];
+      for (const iterator of categories) {
         if (iterator.text?.toLowerCase() === "lab") {
           diagnosticReportsType = "labs";
         }

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -25,6 +25,7 @@ import { uniqWith } from "lodash";
 import { Brief } from "./bundle-to-brief";
 import {
   buildEncounterSections,
+  EncounterSection,
   formatDateForDisplay,
   ISO_DATE,
   MISSING_DATE_KEY,
@@ -564,19 +565,6 @@ export function createBrief(brief?: Brief): string {
   return createSection("Brief (AI-generated)", briefContents);
 }
 
-type EncounterTypes =
-  | "labs"
-  | "progressNotes"
-  | "afterInstructions"
-  | "reasonForVisit"
-  | "documentation";
-
-type EncounterSection = {
-  [key: string]: {
-    [k in EncounterTypes]?: DiagnosticReport[];
-  };
-};
-
 function createAWESection(
   diagnosticReports: DiagnosticReport[],
   practitioners: Practitioner[],
@@ -590,7 +578,7 @@ function createAWESection(
     return "";
   }
 
-  const encounterSections = buildEncounterSections({}, diagnosticReports);
+  const encounterSections = buildEncounterSections(diagnosticReports);
 
   const aweReports = buildReports(
     encounterSections,
@@ -632,7 +620,7 @@ function createDiagnosticReportsSection(
     return "";
   }
 
-  const encounterSections = buildEncounterSections({}, diagnosticReports);
+  const encounterSections = buildEncounterSections(diagnosticReports);
 
   const nonAWEreports = buildReports(
     encounterSections,

--- a/packages/core/src/fhir-to-cda/cda-templates/components/__tests__/make-diagnostic-report.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/components/__tests__/make-diagnostic-report.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { DiagnosticReport } from "@medplum/fhirtypes";
+import { CodeableConcept, Coding, DiagnosticReport } from "@medplum/fhirtypes";
 import { makeSubjectReference } from "./shared";
 
 export function makeDiagnosticReport(params: Partial<DiagnosticReport> = {}): DiagnosticReport {
@@ -32,3 +32,15 @@ export const resultExample = [
     reference: "Observation/some-obs-ID",
   },
 ];
+
+export function makeDiagnosticReportCategory(
+  coding: Coding = {
+    code: "30954-2",
+    display: "Relevant diagnostic tests/laboratory data Narrative",
+    system: "http://loinc.org",
+  }
+): CodeableConcept {
+  return {
+    coding: [coding],
+  };
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Dependencies

none

### Description

Accept non-array `DiagnosticReport.category`, for backwards compatibility - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1729285517248289?thread_ts=1729262903.053189&cid=C0616FCPAKZ)

### Testing

- Local
  - [x] Unit tests
- Staging
  - none
- Sandbox
  - none
- Production
  - [ ] Generates HTML version of MR for affected patient

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
