### PR TITLE
1667 dr connectivity increase

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
@@ -24,6 +24,7 @@ export const pointClickCareOid = "2.16.840.1.113883.3.6448";
 export const centralOhioPrimaryCarePhysiciansOid = "1.2.840.114350.1.13.698.2.7.3.688884.100";
 export const familyCareNetworkOid = "1.2.840.114350.1.13.699.2.7.3.688884.100";
 export const hattiesburgClinicOid = "1.2.840.114350.1.13.281.2.7.3.688884.100";
+export const healthPointOid = "1.2.840.114350.1.13.756.2.7.3.688884.100";
 export const surescriptsOid = "2.16.840.1.113883.3.2054.2.1.1";
 
 export const epicOidPrefix = "1.2.840.114350.1.13";
@@ -57,6 +58,7 @@ const docRefsPerRequestByGateway: Record<string, number> = {
   [surescriptsOid]: 1,
   [centralOhioPrimaryCarePhysiciansOid]: 9,
   [familyCareNetworkOid]: 9,
+  [healthPointOid]: 9,
   [hattiesburgClinicOid]: 3,
 };
 

--- a/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
@@ -22,10 +22,13 @@ export const eHexUrlPrefix = "https://hub002prodcq.ehealthexchange.org";
 
 export const pointClickCareOid = "2.16.840.1.113883.3.6448";
 export const centralOhioPrimaryCarePhysiciansOid = "1.2.840.114350.1.13.698.2.7.3.688884.100";
+export const familyCareNetworkOid = "1.2.840.114350.1.13.699.2.7.3.688884.100";
+export const hattiesburgClinicOid = "1.2.840.114350.1.13.281.2.7.3.688884.100";
 export const surescriptsOid = "2.16.840.1.113883.3.2054.2.1.1";
 
 export const epicOidPrefix = "1.2.840.114350.1.13";
 export const redoxOidPrefix = "2.16.840.1.113883.3.6147";
+export const ntstPrefix = "2.16.840.1.113883.3.3569";
 
 export const kno2OidPrefix = "2.16.840.1.113883.3.3126.2.3";
 
@@ -46,12 +49,15 @@ const gatewaysThatAcceptOneDocRefPerRequest = [pointClickCareOid, surescriptsOid
 const prefixDocRefsPerRequest: Record<string, number> = {
   [epicOidPrefix]: 10,
   [redoxOidPrefix]: 1,
+  [ntstPrefix]: 1,
 };
 
 const docRefsPerRequestByGateway: Record<string, number> = {
   [pointClickCareOid]: 1,
   [surescriptsOid]: 1,
   [centralOhioPrimaryCarePhysiciansOid]: 9,
+  [familyCareNetworkOid]: 9,
+  [hattiesburgClinicOid]: 3,
 };
 
 export const defaultDocRefsPerRequest = 5;

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dr.test.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/process-dr.test.ts
@@ -200,5 +200,17 @@ describe("dr-response", () => {
       });
       expect(response.operationOutcome?.issue[0]?.code).toEqual(schemaErrorCode);
     });
+    it("should process response that is an empty buffer correctly", async () => {
+      const randomResponse = "";
+      const mtomResponse = await createMtomMessageWithoutAttachments(randomResponse);
+      const response = await processDrResponse({
+        response: {
+          mtomResponse: mtomResponse,
+          gateway: outboundDrRequest.gateway,
+          outboundRequest: outboundDrRequest,
+        },
+      });
+      expect(response.operationOutcome?.issue[0]?.code).toEqual(schemaErrorCode);
+    });
   });
 });

--- a/packages/core/src/external/carequality/ihe-gateway-v2/saml/saml-client.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/saml/saml-client.ts
@@ -188,6 +188,10 @@ export async function sendSignedXmlMtom({
     ? response.data
     : Buffer.from(response.data, "binary");
 
+  if (binaryData.length === 0) {
+    throw new Error("Received empty response from server");
+  }
+
   const boundary = getBoundaryFromMtomResponse(response.headers["content-type"]);
   if (boundary) {
     return { mtomParts: await parseMtomResponse(binaryData, boundary), rawResponse: binaryData };


### PR DESCRIPTION
Ticket: #[1667](https://github.com/metriport/metriport-internal/issues/1667)

### Description

- fixing schema error issue where we would get empty responses and then create MTOM bundles out of those and then throw a schema error downstream, when we should have just thrown an http error and retried. For ehex and athena
- fixing XDSRepositoryErrors where ntst and a few epic facilities each had very specific limits on the number of documents they accept being requested at a time (1,3,9)

### Testing

- Local
  - [x] tested on offending production endpoints. 

Check each PR.

### Release Plan

- [ ] Merge this
