### PR TITLE
PATCH RELEASE Recreate consolidated after DQ on sandbox

### DIFF
--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -114,6 +114,7 @@ export async function queryDocumentsAcrossHIEs({
   let triggeredDocumentQuery = false;
 
   const commonwellEnabled = await isCommonwellEnabled();
+  // Why? Please add a comment explaining why we're not running CW if there's no CQ managing org name.
   if (!cqManagingOrgName) {
     if (commonwellEnabled || forceCommonwell) {
       getDocumentsFromCW({

--- a/packages/api/src/external/commonwell/document/document-query-sandbox.ts
+++ b/packages/api/src/external/commonwell/document/document-query-sandbox.ts
@@ -12,7 +12,9 @@ import {
   MAPIWebhookStatus,
   processPatientDocumentRequest,
 } from "../../../command/medical/document/document-webhook";
+import { getOrganizationOrFail } from "../../../command/medical/organization/get-organization";
 import { appendDocQueryProgress } from "../../../command/medical/patient/append-doc-query-progress";
+import { recreateConsolidated } from "../../../command/medical/patient/consolidated-recreate";
 import { toDTO } from "../../../routes/medical/dtos/documentDTO";
 import { Config } from "../../../shared/config";
 import { getSandboxSeedData } from "../../../shared/sandbox/sandbox-seed-data";
@@ -153,6 +155,11 @@ export async function sandboxGetDocRefsAndUpsert({
       });
     }
   }
+
+  // After docs are converted (and conversion bundles are stored in S3), we recreate the consolidated
+  // bundle to make sure it's up-to-date.
+  const organization = await getOrganizationOrFail({ cxId });
+  await recreateConsolidated({ patient, organization });
 
   await appendDocQueryProgress({
     patient: { id: patientId, cxId },


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/799

### Description

Recreate consolidated after DQ on sandbox - [context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1729527314440949).

### Testing

- Local
  - none
- Staging
  - none
- Sandbox
  - [ ] create new patient w/ pre-canned demo, consolidated data is displayed automatically when patient page is loaded (after DQ runs)
- Production
  - none

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
