### PR TITLE
1040 Get consolidated doesn't need Org as param

### DIFF
--- a/packages/api/src/command/medical/document/check-doc-queries.ts
+++ b/packages/api/src/command/medical/document/check-doc-queries.ts
@@ -9,7 +9,6 @@ import { QueryTypes } from "sequelize";
 import { PatientModel } from "../../../models/medical/patient";
 import { executeOnDBTx } from "../../../models/transaction-wrapper";
 import { capture } from "../../../shared/notifications";
-import { getOrganizationOrFail } from "../organization/get-organization";
 import { recreateConsolidated } from "../patient/consolidated-recreate";
 import { getPatientOrFail } from "../patient/get-patient";
 import { sendWHNotifications } from "./check-doc-queries-notification";
@@ -168,13 +167,10 @@ async function updatePatientsInSequence([patientId, { cxId, ...whatToUpdate }]: 
       return updatedPatient;
     });
   }
-  const [patient, organization] = await Promise.all([
-    updatePatient(),
-    getOrganizationOrFail({ cxId }),
-  ]);
+  const patient = await updatePatient();
   if (!patient) return;
   // we want to await here to ensure the consolidated bundle is created before we send the webhook
-  await recreateConsolidated({ patient, organization, context: "check-queries" });
+  await recreateConsolidated({ patient, context: "check-queries" });
 }
 
 export async function getPatientsToUpdate(patientIds?: string[]): Promise<Patient[]> {

--- a/packages/api/src/command/medical/patient/consolidated-get.ts
+++ b/packages/api/src/command/medical/patient/consolidated-get.ts
@@ -13,7 +13,6 @@ import {
 import { buildConsolidatedSnapshotConnector } from "@metriport/core/command/consolidated/get-snapshot-factory";
 import { getConsolidatedSnapshotFromS3 } from "@metriport/core/command/consolidated/snapshot-on-s3";
 import { createMRSummaryFileName } from "@metriport/core/domain/medical-record-summary";
-import { Organization } from "@metriport/core/domain/organization";
 import { Patient } from "@metriport/core/domain/patient";
 import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
 import { out } from "@metriport/core/util";
@@ -44,7 +43,6 @@ dayjs.extend(duration);
 
 export type GetConsolidatedParams = {
   patient: Patient;
-  organization: Organization;
   bundle?: SearchSetBundle;
   requestId?: string;
   documentIds?: string[];

--- a/packages/api/src/command/medical/patient/consolidated-recreate.ts
+++ b/packages/api/src/command/medical/patient/consolidated-recreate.ts
@@ -1,6 +1,5 @@
 import { ConsolidationConversionType } from "@metriport/api-sdk";
 import { deleteConsolidated } from "@metriport/core/command/consolidated/consolidated-delete";
-import { Organization } from "@metriport/core/domain/organization";
 import { Patient } from "@metriport/core/domain/patient";
 import { processAsyncError } from "@metriport/core/util/error/shared";
 import { out } from "@metriport/core/util/log";
@@ -18,12 +17,10 @@ import { getConsolidated } from "../patient/consolidated-get";
  */
 export async function recreateConsolidated({
   patient,
-  organization,
   conversionType,
   context,
 }: {
   patient: Patient;
-  organization: Organization;
   conversionType?: ConsolidationConversionType;
   context?: string;
 }): Promise<void> {
@@ -37,7 +34,7 @@ export async function recreateConsolidated({
     processAsyncError(`Failed to delete consolidated bundle`, log)(err);
   }
   try {
-    await getConsolidated({ patient, organization, conversionType });
+    await getConsolidated({ patient, conversionType });
   } catch (err) {
     processAsyncError(`Post-DQ getConsolidated`, log)(err);
   }

--- a/packages/api/src/external/commonwell/document/document-query-sandbox.ts
+++ b/packages/api/src/external/commonwell/document/document-query-sandbox.ts
@@ -12,7 +12,6 @@ import {
   MAPIWebhookStatus,
   processPatientDocumentRequest,
 } from "../../../command/medical/document/document-webhook";
-import { getOrganizationOrFail } from "../../../command/medical/organization/get-organization";
 import { appendDocQueryProgress } from "../../../command/medical/patient/append-doc-query-progress";
 import { recreateConsolidated } from "../../../command/medical/patient/consolidated-recreate";
 import { toDTO } from "../../../routes/medical/dtos/documentDTO";
@@ -158,8 +157,7 @@ export async function sandboxGetDocRefsAndUpsert({
 
   // After docs are converted (and conversion bundles are stored in S3), we recreate the consolidated
   // bundle to make sure it's up-to-date.
-  const organization = await getOrganizationOrFail({ cxId });
-  await recreateConsolidated({ patient, organization });
+  await recreateConsolidated({ patient });
 
   await appendDocQueryProgress({
     patient: { id: patientId, cxId },


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Get consolidated doesn't need Organization as param, so remove it.

### Testing

- Local
  - [x] Get consolidated works
  - [x] Count resources works
- Staging
  - [ ] DQ works
  - [ ] Get consolidated works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
