### PR TITLE
2453 Adjust error message on date validation not future

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30774,7 +30774,7 @@
       }
     },
     "packages/api": {
-      "version": "1.22.5",
+      "version": "1.22.6",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -30858,12 +30858,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "12.2.0",
+      "version": "12.2.1",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.1.5",
-        "@metriport/shared": "^0.14.0",
+        "@metriport/commonwell-sdk": "^5.1.6",
+        "@metriport/shared": "^0.14.1",
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -30919,10 +30919,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.11.5",
+      "version": "1.11.6",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.12.5",
+        "@metriport/ihe-gateway-sdk": "^0.12.6",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -30936,7 +30936,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.13.5",
+      "version": "0.13.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -30946,10 +30946,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.19.5",
+      "version": "1.19.6",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.1.5",
+        "@metriport/commonwell-sdk": "^5.1.6",
         "axios": "^1.4.0",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -30988,10 +30988,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.17.5",
+      "version": "1.17.6",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.1.5",
+        "@metriport/commonwell-sdk": "^5.1.6",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -31023,10 +31023,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.1.5",
+      "version": "5.1.6",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.14.0",
+        "@metriport/shared": "^0.14.1",
         "axios": "^1.4.0",
         "http-status": "^1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -31074,7 +31074,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.17.5",
+      "version": "1.17.6",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.616.0",
@@ -31157,17 +31157,17 @@
     "packages/core/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.14.0",
+        "@metriport/shared": "^0.14.1",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.15.5",
+      "version": "1.15.6",
       "dependencies": {
         "aws-cdk-lib": "^2.122.0",
         "constructs": "^10.2.69",
@@ -31215,7 +31215,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.14.5",
+      "version": "1.14.6",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -32242,14 +32242,14 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^8.0.2"
       }
     },
     "packages/utils": {
-      "version": "1.18.5",
+      "version": "1.18.6",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-bedrock-agent-runtime": "^3.616.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.1.5",
-    "@metriport/shared": "^0.14.0",
+    "@metriport/commonwell-sdk": "^5.1.6",
+    "@metriport/shared": "^0.14.1",
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/src/shared.ts
+++ b/packages/api-sdk/src/shared.ts
@@ -1,4 +1,4 @@
-import { isValidISODate, validateIsPastSafe } from "@metriport/shared/common/date";
+import { isValidISODate, validateIsPastOrPresentSafe } from "@metriport/shared/common/date";
 import dayjs from "dayjs";
 import { z, ZodString } from "zod";
 
@@ -20,7 +20,7 @@ export const defaultOptionalString = optionalString(defaultString);
 export const defaultDateString = defaultString.refine(isValidISODate, {
   message: `Date must be a valid ISO 8601 date formatted ${ISO_DATE}. Example: 2023-03-15`,
 });
-export const pastOrTodayDateString = defaultDateString.refine(validateIsPastSafe, {
+export const pastOrTodayDateString = defaultDateString.refine(validateIsPastOrPresentSafe, {
   message: `Date can't be in the future`,
 });
 export const defaultNameString = defaultString.min(1);

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.22.5",
+  "version": "1.22.6",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/src/command/medical/patient/__tests__/validate.test.ts
+++ b/packages/api/src/command/medical/patient/__tests__/validate.test.ts
@@ -43,13 +43,13 @@ describe("validate", () => {
     it("throws an error if dob is in the future", async () => {
       const futureDate = dayjs().add(1, "day").format("YYYY-MM-DD");
       const patient = makePatientCreate({ dob: futureDate });
-      expect(() => validate(patient)).toThrow(`Date must be in the past`);
+      expect(() => validate(patient)).toThrow(`Date can't be in the future`);
     });
 
     it("throws an error when dob is a minute in the future", async () => {
       const futureDate = dayjs().add(1, "minute").toISOString();
       const patient = makePatientCreate({ dob: futureDate });
-      expect(() => validate(patient)).toThrow(`Date must be in the past`);
+      expect(() => validate(patient)).toThrow(`Date can't be in the future`);
     });
 
     it("returns true when dob is the current date", async () => {

--- a/packages/api/src/command/medical/patient/shared.ts
+++ b/packages/api/src/command/medical/patient/shared.ts
@@ -1,5 +1,5 @@
 import { Period } from "@metriport/core/domain/patient";
-import { validateDateRange, validateIsPast } from "@metriport/shared/common/date";
+import { validateDateRange, validateIsPastOrPresent } from "@metriport/shared/common/date";
 import { cloneDeep } from "lodash";
 import { PatientCreateCmd } from "./create-patient";
 import { PatientMatchCmd } from "./get-patient";
@@ -18,16 +18,16 @@ export function validate<T extends PatientCreateCmd | PatientUpdateCmd | Patient
 ): boolean {
   if (!patient.address || patient.address.length < 1) return false;
   patient.personalIdentifiers?.forEach(pid => pid.period && validatePeriod(pid.period));
-  validateIsPast(patient.dob);
+  validateIsPastOrPresent(patient.dob);
   return true;
 }
 
 function validatePeriod(period: Period): boolean {
   if (period.start && period.end) {
-    return validateIsPast(period.start) && validateDateRange(period.start, period.end);
+    return validateIsPastOrPresent(period.start) && validateDateRange(period.start, period.end);
   }
   if (period.start) {
-    return validateIsPast(period.start);
+    return validateIsPastOrPresent(period.start);
   }
   return true;
 }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.12.5",
+    "@metriport/ihe-gateway-sdk": "^0.12.6",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.19.5",
+  "version": "1.19.6",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.1.5",
+    "@metriport/commonwell-sdk": "^5.1.6",
     "axios": "^1.4.0",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.1.5",
+    "@metriport/commonwell-sdk": "^5.1.6",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.14.0",
+    "@metriport/shared": "^0.14.1",
     "axios": "^1.4.0",
     "http-status": "^1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.14.0",
+    "@metriport/shared": "^0.14.1",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.15.5",
+  "version": "1.15.6",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/src/common/date.ts
+++ b/packages/shared/src/common/date.ts
@@ -16,13 +16,13 @@ function isValidISODateOptional(date: string | undefined | null): boolean {
   return date ? isValidISODate(date) : true;
 }
 
-export function validateIsPast(date: string): boolean {
-  if (dayjs(date).isAfter(dayjs())) {
-    throw new BadRequestError(`Date must be in the past`, undefined, { date });
+export function validateIsPastOrPresent(date: string): boolean {
+  if (!validateIsPastOrPresentSafe(date)) {
+    throw new BadRequestError(`Date can't be in the future`, undefined, { date });
   }
   return true;
 }
-export function validateIsPastSafe(date: string): boolean {
+export function validateIsPastOrPresentSafe(date: string): boolean {
   if (dayjs(date).isAfter(dayjs())) return false;
   return true;
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.18.5",
+  "version": "1.18.6",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ref. metriport/metriport#2453

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2919
- Downstream: none

### Description

Adjust error message on date validation to indicate it can't be in the future

### Testing

- Local
  - [x] Unit test
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [x] Publish NPM packages
- [ ] Merge this
