### PR TITLE
1040 Router-level authorization for patient and facility

### DIFF
--- a/packages/api/src/@types/custom.d.ts
+++ b/packages/api/src/@types/custom.d.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 namespace Express {
   interface Request {
+    id: string | undefined;
     cxId: string | undefined;
+    patient: any | undefined; //eslint-disable-line @typescript-eslint/no-explicit-any
+    facility: any | undefined; //eslint-disable-line @typescript-eslint/no-explicit-any
     email: string | undefined;
   }
 }

--- a/packages/api/src/routes/medical/facility-root.ts
+++ b/packages/api/src/routes/medical/facility-root.ts
@@ -1,0 +1,78 @@
+import { OrgType } from "@metriport/core/domain/organization";
+import { Request, Response } from "express";
+import Router from "express-promise-router";
+import status from "http-status";
+import { createFacility } from "../../command/medical/facility/create-facility";
+import { getFacilities } from "../../command/medical/facility/get-facility";
+import { createOrganization } from "../../command/medical/organization/create-organization";
+import { getOrganization } from "../../command/medical/organization/get-organization";
+import { Config } from "../../shared/config";
+import { requestLogger } from "../helpers/request-logger";
+import { asyncHandler, getCxIdOrFail } from "../util";
+import { dtoFromModel } from "./dtos/facilityDTO";
+import { facilityCreateSchema } from "./schemas/facility";
+
+const router = Router();
+
+/** ---------------------------------------------------------------------------
+ * POST /facility
+ *
+ * Creates a new facility.
+ *
+ * @return {FacilityDTO} The facility.
+ */
+router.post(
+  "/",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getCxIdOrFail(req);
+    const facilityData = facilityCreateSchema.parse(req.body);
+
+    if (Config.isSandbox()) {
+      const existingOrg = await getOrganization({ cxId });
+      if (!existingOrg) {
+        await createOrganization({
+          cxId,
+          data: {
+            name: facilityData.name,
+            type: OrgType.ambulatory,
+            location: facilityData.address,
+          },
+        });
+      }
+    }
+
+    const facility = await createFacility({
+      cxId,
+      data: {
+        ...facilityData,
+        tin: facilityData.tin ?? undefined,
+        active: facilityData.active ?? undefined,
+      },
+    });
+
+    return res.status(status.CREATED).json(dtoFromModel(facility));
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * GET /facility
+ *
+ * Gets all of the facilities associated with this account.
+ *
+ * @return {FacilityDTO} The list of facilities.
+ */
+router.get(
+  "/",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getCxIdOrFail(req);
+
+    const facilities = await getFacilities({ cxId });
+
+    const facilitiesData = facilities.map(dtoFromModel);
+    return res.status(status.OK).json({ facilities: facilitiesData });
+  })
+);
+
+export default router;

--- a/packages/api/src/routes/medical/facility.ts
+++ b/packages/api/src/routes/medical/facility.ts
@@ -1,64 +1,18 @@
-import { OrgType } from "@metriport/core/domain/organization";
 import NotFoundError from "@metriport/core/util/error/not-found";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import status from "http-status";
-import { createFacility } from "../../command/medical/facility/create-facility";
 import { deleteFacility } from "../../command/medical/facility/delete-facility";
 import { getFacilities } from "../../command/medical/facility/get-facility";
 import { updateFacility } from "../../command/medical/facility/update-facility";
-import { createOrganization } from "../../command/medical/organization/create-organization";
-import { getOrganization } from "../../command/medical/organization/get-organization";
-import { Config } from "../../shared/config";
 import { getETag } from "../../shared/http";
 import { requestLogger } from "../helpers/request-logger";
-import { asyncHandler, getCxIdOrFail, getFromParamsOrFail } from "../util";
+import { getFacilityInfoOrFail } from "../middlewares/facility-authorization";
+import { asyncHandler } from "../util";
 import { dtoFromModel } from "./dtos/facilityDTO";
-import { facilityCreateSchema, facilityUpdateSchema } from "./schemas/facility";
+import { facilityUpdateSchema } from "./schemas/facility";
 
 const router = Router();
-
-/** ---------------------------------------------------------------------------
- * POST /facility
- *
- * Creates a new facility.
- *
- * @return {FacilityDTO} The facility.
- */
-router.post(
-  "/",
-  requestLogger,
-  asyncHandler(async (req: Request, res: Response) => {
-    const cxId = getCxIdOrFail(req);
-
-    const facilityData = facilityCreateSchema.parse(req.body);
-
-    if (Config.isSandbox()) {
-      const existingOrg = await getOrganization({ cxId });
-      if (!existingOrg) {
-        await createOrganization({
-          cxId,
-          data: {
-            name: facilityData.name,
-            type: OrgType.ambulatory,
-            location: facilityData.address,
-          },
-        });
-      }
-    }
-
-    const facility = await createFacility({
-      cxId,
-      data: {
-        ...facilityData,
-        tin: facilityData.tin ?? undefined,
-        active: facilityData.active ?? undefined,
-      },
-    });
-
-    return res.status(status.CREATED).json(dtoFromModel(facility));
-  })
-);
 
 /** ---------------------------------------------------------------------------
  * PUT /facility/:id
@@ -68,11 +22,10 @@ router.post(
  * @return {FacilityDTO} The updated facility.
  */
 router.put(
-  "/:id",
+  "/",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
-    const cxId = getCxIdOrFail(req);
-    const facilityId = getFromParamsOrFail("id", req);
+    const { cxId, id: facilityId } = getFacilityInfoOrFail(req);
     const facilityData = facilityUpdateSchema.parse(req.body);
 
     const facility = await updateFacility({
@@ -91,26 +44,6 @@ router.put(
 );
 
 /** ---------------------------------------------------------------------------
- * GET /facility
- *
- * Gets all of the facilities associated with this account.
- *
- * @return {FacilityDTO} The list of facilities.
- */
-router.get(
-  "/",
-  requestLogger,
-  asyncHandler(async (req: Request, res: Response) => {
-    const cxId = getCxIdOrFail(req);
-
-    const facilities = await getFacilities({ cxId });
-
-    const facilitiesData = facilities.map(dtoFromModel);
-    return res.status(status.OK).json({ facilities: facilitiesData });
-  })
-);
-
-/** ---------------------------------------------------------------------------
  * GET /facility/:id
  *
  * Return a facility.
@@ -118,11 +51,10 @@ router.get(
  * @return {FacilityDTO} The facility.
  */
 router.get(
-  "/:id",
+  "/",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
-    const cxId = getCxIdOrFail(req);
-    const facilityId = getFromParamsOrFail("id", req);
+    const { cxId, id: facilityId } = getFacilityInfoOrFail(req);
 
     const facilities = await getFacilities({ cxId, ids: [facilityId] });
     if (facilities.length < 1) throw new NotFoundError(`No facility found`);
@@ -139,12 +71,11 @@ router.get(
  * @return 204 if successful.
  */
 router.delete(
-  "/:id",
+  "/",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
-    const cxId = getCxIdOrFail(req);
+    const { cxId, id: facilityId } = getFacilityInfoOrFail(req);
 
-    const facilityId = getFromParamsOrFail("id", req);
     await deleteFacility({ cxId, id: facilityId });
     return res.sendStatus(status.NO_CONTENT);
   })

--- a/packages/api/src/routes/medical/index.ts
+++ b/packages/api/src/routes/medical/index.ts
@@ -1,14 +1,23 @@
 import Router from "express-promise-router";
+import { facilityAuthorization } from "../middlewares/facility-authorization";
+import { patientAuthorization } from "../middlewares/patient-authorization";
+import document from "./document";
 import facility from "./facility";
+import facilityRoot from "./facility-root";
 import organization from "./organization";
 import patient from "./patient";
-import document from "./document";
+import patientRoot from "./patient-root";
 
 const routes = Router();
 
-routes.use("/facility", facility);
 routes.use("/organization", organization);
-routes.use("/patient", patient);
+
+routes.use("/facility", facilityRoot);
+routes.use("/facility/:id", facilityAuthorization("params"), facility);
+
+routes.use("/patient", patientRoot);
+routes.use("/patient/:id", patientAuthorization("params"), patient);
+
 routes.use("/document", document);
 
 export default routes;

--- a/packages/api/src/routes/medical/organization.ts
+++ b/packages/api/src/routes/medical/organization.ts
@@ -21,6 +21,7 @@ const router = Router();
 /** ---------------------------------------------------------------------------
  * POST /organization
  *
+ * @deprecated
  * Creates a new organization at Metriport and HIEs.
  *
  * @param req.body The data to create the organization.
@@ -49,6 +50,7 @@ router.post(
 /** ---------------------------------------------------------------------------
  * PUT /organization/:id
  *
+ * @deprecated
  * Updates the organization at Metriport and HIEs.
  *
  * @param req.body The data to update the organization.

--- a/packages/api/src/routes/medical/patient-root.ts
+++ b/packages/api/src/routes/medical/patient-root.ts
@@ -1,0 +1,125 @@
+import { demographicsSchema } from "@metriport/api-sdk";
+import { stringToBoolean } from "@metriport/shared";
+import { Request, Response } from "express";
+import Router from "express-promise-router";
+import status from "http-status";
+import { getPatientOrFail, matchPatient } from "../../command/medical/patient/get-patient";
+import NotFoundError from "../../errors/not-found";
+import { Config } from "../../shared/config";
+import { requestLogger } from "../helpers/request-logger";
+import { asyncHandler, getCxIdOrFail, getFrom } from "../util";
+import { dtoFromModel } from "./dtos/patientDTO";
+import { schemaDemographicsToPatientData } from "./schemas/patient";
+
+import { patientCreateSchema } from "@metriport/api-sdk";
+import { createPatient, PatientCreateCmd } from "../../command/medical/patient/create-patient";
+import { getPatients } from "../../command/medical/patient/get-patient";
+import { getSandboxPatientLimitForCx } from "../../domain/medical/get-patient-limit";
+import { PatientModel as Patient } from "../../models/medical/patient";
+import { getFromQueryOrFail } from "../util";
+import { schemaCreateToPatientData } from "./schemas/patient";
+
+const router = Router();
+
+/** ---------------------------------------------------------------------------
+ * POST /patient
+ *
+ * Creates the patient corresponding to the specified facility at the
+ * customer's organization if it doesn't exist already.
+ *
+ * @param  req.query.facilityId The ID of the Facility the Patient should be associated with.
+ * @return The newly created patient.
+ */
+router.post(
+  "/",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getCxIdOrFail(req);
+    const facilityId = getFromQueryOrFail("facilityId", req);
+    const rerunPdOnNewDemographics = stringToBoolean(
+      getFrom("query").optional("rerunPdOnNewDemographics", req)
+    );
+    const forceCommonwell = stringToBoolean(getFrom("query").optional("commonwell", req));
+    const forceCarequality = stringToBoolean(getFrom("query").optional("carequality", req));
+    const payload = patientCreateSchema.parse(req.body);
+
+    if (Config.isSandbox()) {
+      // limit the amount of patients that can be created in sandbox mode
+      const numPatients = await Patient.count({ where: { cxId } });
+      const patientLimit = await getSandboxPatientLimitForCx(cxId);
+      if (numPatients >= patientLimit) {
+        return res.status(status.BAD_REQUEST).json({
+          message: `Cannot create more than ${Config.SANDBOX_PATIENT_LIMIT} patients in Sandbox mode!`,
+        });
+      }
+    }
+
+    const patientCreate: PatientCreateCmd = {
+      ...schemaCreateToPatientData(payload),
+      cxId,
+      facilityId,
+    };
+
+    const patient = await createPatient({
+      patient: patientCreate,
+      rerunPdOnNewDemographics,
+      forceCommonwell,
+      forceCarequality,
+    });
+
+    return res.status(status.CREATED).json(dtoFromModel(patient));
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * GET /patient
+ *
+ * Gets all patients corresponding to the specified facility at the customer's organization.
+ *
+ * @param   req.cxId              The customer ID.
+ * @param   req.query.facilityId  The ID of the facility the user patient is associated with (optional).
+ * @return  The customer's patients associated with the given facility.
+ */
+router.get(
+  "/",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getCxIdOrFail(req);
+    const facilityId = getFrom("query").optional("facilityId", req);
+
+    const patients = await getPatients({ cxId, facilityId: facilityId });
+
+    const patientsData = patients.map(dtoFromModel);
+    return res.status(status.OK).json({ patients: patientsData });
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * POST /patient/match
+ *
+ * Searches for a patient previously created at Metriport, based on a demographic data. Returns the matched patient, if it exists.
+ *
+ * @return The matched patient.
+ * @throws NotFoundError if the patient does not exist.
+ */
+router.post(
+  "/match",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getCxIdOrFail(req);
+    const payload = demographicsSchema.parse(req.body);
+
+    const patientData = schemaDemographicsToPatientData(payload);
+
+    const patient = await matchPatient({ cxId, ...patientData });
+
+    if (patient) {
+      // Authorization
+      await getPatientOrFail({ cxId, id: patient.id });
+      return res.status(status.OK).json(dtoFromModel(patient));
+    }
+    throw new NotFoundError("Cannot find patient");
+  })
+);
+
+export default router;

--- a/packages/api/src/routes/middlewares/__tests__/auth.test.ts
+++ b/packages/api/src/routes/middlewares/__tests__/auth.test.ts
@@ -1,39 +1,115 @@
 import { faker } from "@faker-js/faker";
+import { Request, Response } from "express";
+import status from "http-status";
 import { nanoid } from "nanoid";
-import { getCxIdFromApiKey } from "../auth";
+import * as mapiAccessFile from "../../../command/medical/mapi-access";
+import { Config } from "../../../shared/config";
+import { checkMAPIAccess, getCxIdFromApiKey } from "../auth";
 
-describe("getCxIdFromApiKey", () => {
-  const makeEncodedKey = (cxId?: string | undefined) => {
-    const input = cxId !== undefined ? `${nanoid()}:${cxId}` : nanoid();
-    return Buffer.from(input).toString("base64");
-  };
+describe("auth", () => {
+  describe("getCxIdFromApiKey", () => {
+    const makeEncodedKey = (cxId?: string | undefined) => {
+      const input = cxId !== undefined ? `${nanoid()}:${cxId}` : nanoid();
+      return Buffer.from(input).toString("base64");
+    };
 
-  it("throws when no encoded API key is provided", async () => {
-    expect(() => getCxIdFromApiKey(undefined)).toThrow();
+    it("throws when no encoded API key is provided", async () => {
+      expect(() => getCxIdFromApiKey(undefined)).toThrow();
+    });
+
+    it(`throws when it gets empty encoded string`, async () => {
+      expect(() => getCxIdFromApiKey("")).toThrow();
+    });
+
+    it(`throws when it gets invalid encoded string`, async () => {
+      expect(() => getCxIdFromApiKey("N1Hqevi6FA")).toThrow();
+    });
+
+    it("throws when API key doesnt include separator and cxId", async () => {
+      const encodedKey = makeEncodedKey();
+      expect(() => getCxIdFromApiKey(encodedKey)).toThrow();
+    });
+
+    it("throws when API key doesnt include cxId", async () => {
+      const encodedKey = makeEncodedKey("");
+      expect(() => getCxIdFromApiKey(encodedKey)).toThrow();
+    });
+
+    it("cxId when its encoded correctly", async () => {
+      const expectedCxId = faker.string.uuid();
+      const encodedKey = makeEncodedKey(expectedCxId);
+      const cxId = getCxIdFromApiKey(encodedKey);
+      expect(cxId).toEqual(expectedCxId);
+    });
   });
 
-  it(`throws when it gets empty encoded string`, async () => {
-    expect(() => getCxIdFromApiKey("")).toThrow();
-  });
+  describe("checkMAPIAccess", () => {
+    const mockRequest = (cxId?: string) => {
+      return {
+        cxId,
+        header: jest.fn().mockReturnValue("mocked-header"),
+      } as unknown as Request;
+    };
 
-  it(`throws when it gets invalid encoded string`, async () => {
-    expect(() => getCxIdFromApiKey("N1Hqevi6FA")).toThrow();
-  });
+    const mockResponse = () => {
+      const res = {} as Response;
+      res.sendStatus = jest.fn().mockReturnValue(res);
+      return res;
+    };
 
-  it("throws when API key doesnt include separator and cxId", async () => {
-    const encodedKey = makeEncodedKey();
-    expect(() => getCxIdFromApiKey(encodedKey)).toThrow();
-  });
+    let next_mock: jest.Mock;
+    let hasMapiAccess_mock: jest.SpyInstance;
+    let isSandbox_mock: jest.SpyInstance;
+    let req_mock: Request;
+    let res_mock: Response;
 
-  it("throws when API key doesnt include cxId", async () => {
-    const encodedKey = makeEncodedKey("");
-    expect(() => getCxIdFromApiKey(encodedKey)).toThrow();
-  });
+    beforeEach(() => {
+      jest.restoreAllMocks();
+      next_mock = jest.fn();
+      hasMapiAccess_mock = jest.spyOn(mapiAccessFile, "hasMapiAccess");
+      isSandbox_mock = jest.spyOn(Config, "isSandbox");
+      req_mock = mockRequest("validCxId");
+      res_mock = mockResponse();
+    });
+    afterAll(() => jest.restoreAllMocks());
 
-  it("cxId when its encoded correctly", async () => {
-    const expectedCxId = faker.string.uuid();
-    const encodedKey = makeEncodedKey(expectedCxId);
-    const cxId = getCxIdFromApiKey(encodedKey);
-    expect(cxId).toEqual(expectedCxId);
+    it("calls next when cxId has MAPI access", async () => {
+      hasMapiAccess_mock.mockReturnValueOnce(true);
+      isSandbox_mock.mockReturnValueOnce(false);
+
+      await checkMAPIAccess(req_mock, res_mock, next_mock);
+
+      expect(next_mock).toHaveBeenCalled();
+      expect(res_mock.sendStatus).not.toHaveBeenCalled();
+    });
+
+    it("calls next when in sandbox mode", async () => {
+      hasMapiAccess_mock.mockReturnValueOnce(false);
+      isSandbox_mock.mockReturnValueOnce(true);
+
+      await checkMAPIAccess(req_mock, res_mock, next_mock);
+
+      expect(next_mock).toHaveBeenCalled();
+      expect(res_mock.sendStatus).not.toHaveBeenCalled();
+    });
+
+    it("sends FORBIDDEN status when cxId does not have MAPI access and not in sandbox mode", async () => {
+      hasMapiAccess_mock.mockReturnValueOnce(false);
+      isSandbox_mock.mockReturnValueOnce(false);
+
+      await checkMAPIAccess(req_mock, res_mock, next_mock);
+
+      expect(next_mock).not.toHaveBeenCalled();
+      expect(res_mock.sendStatus).toHaveBeenCalledWith(status.FORBIDDEN);
+    });
+
+    it("sends INTERNAL_SERVER_ERROR status when an error occurs", async () => {
+      hasMapiAccess_mock.mockRejectedValue(new Error("Test error"));
+
+      await checkMAPIAccess(req_mock, res_mock, next_mock);
+
+      expect(next_mock).not.toHaveBeenCalled();
+      expect(res_mock.sendStatus).toHaveBeenCalledWith(status.INTERNAL_SERVER_ERROR);
+    });
   });
 });

--- a/packages/api/src/routes/middlewares/auth.ts
+++ b/packages/api/src/routes/middlewares/auth.ts
@@ -3,7 +3,7 @@ import { out } from "@metriport/core/util/log";
 import { NextFunction, Request, Response } from "express";
 import status from "http-status";
 import * as jwt from "jsonwebtoken";
-import { MAPIAccess } from "../../models/medical/mapi-access";
+import { hasMapiAccess } from "../../command/medical/mapi-access";
 import { Config } from "../../shared/config";
 import { getCxIdOrFail } from "../util";
 import { getAuth, getCxId, PropelAuth } from "./propelauth";
@@ -84,19 +84,20 @@ export async function checkMAPIAccess(
   res: Response,
   next: NextFunction
 ): Promise<void> {
-  let hasMAPIAccess = false;
   try {
     const cxId = getCxIdOrFail(req);
-    const mapiAccess = await MAPIAccess.findOne({ where: { id: cxId } });
-    hasMAPIAccess = mapiAccess != null;
+    const hasMAPIAccess = await hasMapiAccess(cxId);
+    if (hasMAPIAccess || Config.isSandbox()) {
+      next();
+      return;
+    } else {
+      res.sendStatus(status.FORBIDDEN);
+      return;
+    }
   } catch (error) {
     out().log(`Failed checking MAPI access with error ${error}`);
-  }
-  if (hasMAPIAccess || Config.isSandbox()) {
-    next();
-  } else {
-    res.status(status.FORBIDDEN);
-    res.end();
+    res.sendStatus(status.INTERNAL_SERVER_ERROR);
+    return;
   }
 }
 

--- a/packages/api/src/routes/middlewares/facility-authorization.ts
+++ b/packages/api/src/routes/middlewares/facility-authorization.ts
@@ -1,0 +1,41 @@
+import { NextFunction, Request, Response } from "express";
+import { getFacilityOrFail } from "../../command/medical/facility/get-facility";
+import { Facility } from "../../domain/medical/facility";
+import { getCxIdOrFail, getFromParamsOrFail, getFromQueryOrFail } from "../util";
+
+/**
+ * Validates the customer has access to the facility and adds the facility and related info to the
+ * request.
+ */
+export function facilityAuthorization(
+  context: "query" | "params" = "params"
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+  return async (req: Request, _: Response, next: NextFunction): Promise<void> => {
+    const cxId = getCxIdOrFail(req);
+    const facilityId =
+      context === "query" ? getFromQueryOrFail("facilityId", req) : getFromParamsOrFail("id", req);
+
+    const facility = await getFacilityOrFail({ id: facilityId, cxId });
+
+    req.facility = facility;
+    req.cxId = cxId;
+    req.id = facilityId;
+
+    next();
+  };
+}
+
+/**
+ * Returns the facility, cxId, and id from the request, throwing an error if any are missing.
+ */
+export function getFacilityInfoOrFail(req: Request): {
+  facility: Facility;
+  cxId: string;
+  id: string;
+} {
+  const { facility, cxId, id } = { facility: req.facility, cxId: req.cxId, id: req.id };
+  if (!facility || !cxId || !id) {
+    throw new Error("Missing facility information in request");
+  }
+  return { facility, cxId, id };
+}

--- a/packages/api/src/routes/middlewares/patient-authorization.ts
+++ b/packages/api/src/routes/middlewares/patient-authorization.ts
@@ -1,0 +1,41 @@
+import { Patient } from "@metriport/core/domain/patient";
+import { NextFunction, Request, Response } from "express";
+import { getPatientOrFail } from "../../command/medical/patient/get-patient";
+import { getCxIdOrFail, getFromParamsOrFail, getFromQueryOrFail } from "../util";
+
+/**
+ * Validates the customer has access to the patient and adds the patient and related info to the
+ * request.
+ */
+export function patientAuthorization(
+  context: "query" | "params" = "params"
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+  return async (req: Request, _: Response, next: NextFunction): Promise<void> => {
+    const cxId = getCxIdOrFail(req);
+    const patientId =
+      context === "query" ? getFromQueryOrFail("patientId", req) : getFromParamsOrFail("id", req);
+
+    const patient = await getPatientOrFail({ id: patientId, cxId });
+
+    req.patient = patient;
+    req.cxId = cxId;
+    req.id = patientId;
+
+    next();
+  };
+}
+
+/**
+ * Returns the patient, cxId, and id from the request, throwing an error if any are missing.
+ */
+export function getPatientInfoOrFail(req: Request): {
+  patient: Patient;
+  cxId: string;
+  id: string;
+} {
+  const { patient, cxId, id } = { patient: req.patient, cxId: req.cxId, id: req.id };
+  if (!patient || !cxId || !id) {
+    throw new Error("Missing patient information in request");
+  }
+  return { patient, cxId, id };
+}

--- a/packages/api/src/routes/util.ts
+++ b/packages/api/src/routes/util.ts
@@ -143,6 +143,15 @@ export const getCxIdOrFail = (req: Request): string => {
   return cxId;
 };
 
+export const getId = (req: Request): string | undefined => {
+  return req.id;
+};
+export const getIdOrFail = (req: Request): string => {
+  const id = getId(req);
+  if (!id) throw new BadRequestError("Missing id on the request");
+  return id;
+};
+
 export const getCxIdFromQuery = (req: Request): string | undefined => {
   const cxId = req.query.cxId as string | undefined;
   cxId && capture.setUser({ id: cxId });


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Router-level authorization for patient and facility - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1729799240713459)

### Testing

- Local
  - [x] All endpoints work with expected id
  - [x] All endpoints fail with id from another customer
- Staging
  - [ ] general testing
  - [ ] E2E testing
- Sandbox
  - none
- Production
  - [ ] dash works
  - [ ] monitor the platform for 15min

### Release Plan

- [ ] Merge this
