### PR TITLE
feat(api): middleware to deactivate dapi routes

### DIFF
--- a/packages/api/src/routes/activity.ts
+++ b/packages/api/src/routes/activity.ts
@@ -5,7 +5,10 @@ import status from "http-status";
 import { ConsumerHealthDataType } from "../providers/provider";
 import { getProviderDataForType } from "./helpers/provider-route-helper";
 import { asyncHandler } from "./util";
+import { deprecateAllRoutes } from "./middlewares/deprecate-routes";
+
 const router = Router();
+router.use(deprecateAllRoutes);
 
 /** ---------------------------------------------------------------------------
  * GET /activity

--- a/packages/api/src/routes/biometrics.ts
+++ b/packages/api/src/routes/biometrics.ts
@@ -5,7 +5,10 @@ import status from "http-status";
 import { ConsumerHealthDataType } from "../providers/provider";
 import { getProviderDataForType } from "./helpers/provider-route-helper";
 import { asyncHandler } from "./util";
+import { deprecateAllRoutes } from "./middlewares/deprecate-routes";
+
 const router = Router();
+router.use(deprecateAllRoutes);
 
 /** ---------------------------------------------------------------------------
  * GET /biometrics

--- a/packages/api/src/routes/body.ts
+++ b/packages/api/src/routes/body.ts
@@ -5,7 +5,10 @@ import status from "http-status";
 import { ConsumerHealthDataType } from "../providers/provider";
 import { getProviderDataForType } from "./helpers/provider-route-helper";
 import { asyncHandler } from "./util";
+import { deprecateAllRoutes } from "./middlewares/deprecate-routes";
+
 const router = Router();
+router.use(deprecateAllRoutes);
 
 /** ---------------------------------------------------------------------------
  * GET /body

--- a/packages/api/src/routes/connect.ts
+++ b/packages/api/src/routes/connect.ts
@@ -21,8 +21,10 @@ import { processOAuth1 } from "./middlewares/oauth1";
 import { processOAuth2 } from "./middlewares/oauth2";
 import { getUserIdFrom } from "./schemas/user-id";
 import { asyncHandler, getCxIdFromHeaders } from "./util";
+import { deprecateAllRoutes } from "./middlewares/deprecate-routes";
 
 const router = Router();
+router.use(deprecateAllRoutes);
 
 /** ---------------------------------------------------------------------------
  * Builds the success or error connect widget redirect URL based on the

--- a/packages/api/src/routes/middlewares/deprecate-routes.ts
+++ b/packages/api/src/routes/middlewares/deprecate-routes.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from "express";
+
+export function deprecateAllRoutes(req: Request, res: Response) {
+  return res.status(404).json({ message: "This route is no longer available." });
+}

--- a/packages/api/src/routes/nutrition.ts
+++ b/packages/api/src/routes/nutrition.ts
@@ -5,7 +5,10 @@ import status from "http-status";
 import { ConsumerHealthDataType } from "../providers/provider";
 import { getProviderDataForType } from "./helpers/provider-route-helper";
 import { asyncHandler } from "./util";
+import { deprecateAllRoutes } from "./middlewares/deprecate-routes";
+
 const router = Router();
+router.use(deprecateAllRoutes);
 
 /** ---------------------------------------------------------------------------
  * GET /nutrition

--- a/packages/api/src/routes/sleep.ts
+++ b/packages/api/src/routes/sleep.ts
@@ -5,7 +5,10 @@ import status from "http-status";
 import { ConsumerHealthDataType } from "../providers/provider";
 import { getProviderDataForType } from "./helpers/provider-route-helper";
 import { asyncHandler } from "./util";
+import { deprecateAllRoutes } from "./middlewares/deprecate-routes";
+
 const router = Router();
+router.use(deprecateAllRoutes);
 
 /** ---------------------------------------------------------------------------
  * GET /sleep

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -27,8 +27,10 @@ import { RawParams, getRawParams } from "../shared/raw-params";
 import { getProviderDataForType } from "./helpers/provider-route-helper";
 import { getUserIdFrom } from "./schemas/user-id";
 import { asyncHandler, getCxIdOrFail, getFrom } from "./util";
+import { deprecateAllRoutes } from "./middlewares/deprecate-routes";
 
 const router = Router();
+router.use(deprecateAllRoutes);
 
 /** ---------------------------------------------------------------------------
  * GET /user

--- a/packages/api/src/routes/webhook/index.ts
+++ b/packages/api/src/routes/webhook/index.ts
@@ -5,7 +5,10 @@ import withings from "./withings";
 import { processCxId } from "../middlewares/auth";
 import fitbit from "./fitbit";
 import tenovi from "./tenovi";
+import { deprecateAllRoutes } from "../middlewares/deprecate-routes";
+
 const routes = Router();
+routes.use(deprecateAllRoutes);
 
 routes.use("/garmin", garmin);
 routes.use("/withings", withings);


### PR DESCRIPTION
refs. metriport/metriport-internal#1411

### Description
- Added middleware to disable DAPI routes

### Testing

- Local
  - [x] DAPI routes no longer work
  - [x] MAPI routes still work locally
- Staging
  - [ ] DAPI routes no longer work
  - [ ] MAPI routes still work locally

### Release Plan
- [ ] Merge this
