### PR TITLE
1040 API SDK E2E test to not filter doc by content

### DIFF
--- a/packages/api-sdk/src/medical/client/__tests__/metriport.test.e2e.ts
+++ b/packages/api-sdk/src/medical/client/__tests__/metriport.test.e2e.ts
@@ -125,7 +125,6 @@ describe("listDocuments", () => {
     const filters = {
       dateFrom: dayjs().subtract(10, "years").format(ISO_DATE),
       dateTo: dayjs().add(1, "day").format(ISO_DATE),
-      content: "john",
     };
     const { documents } = await metriport.listDocuments(patientId, filters);
     expect(documents).toBeTruthy();


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

API SDK E2E test to not filter doc by content.

### Testing

- Local
  - none
- Staging
  - [ ] E2E test runs successfully
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
