### PR TITLE
fix(api): settings check mapi access

### DIFF
--- a/packages/api/src/routes/settings.ts
+++ b/packages/api/src/routes/settings.ts
@@ -14,6 +14,7 @@ import BadRequestError from "../errors/bad-request";
 import { Settings } from "../models/settings";
 import { requestLogger } from "./helpers/request-logger";
 import { asyncHandler, getCxIdOrFail } from "./util";
+import { hasMapiAccess } from "../command/medical/mapi-access";
 
 const mrSectionsKeys = [
   "reports",
@@ -237,6 +238,23 @@ router.post(
     const cxId = getCxIdOrFail(req);
     await retryFailedRequests(cxId);
     res.sendStatus(status.OK);
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * GET /settings/mapi-access
+ *
+ * Returns a boolean indicating whether MAPI access has been provided.
+ *
+ * @return payload Indicating access has been given (prop hasMapiAccess).
+ */
+router.get(
+  "/mapi-access",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const id = getCxIdOrFail(req);
+    const hasMapi = await hasMapiAccess(id);
+    return res.status(status.OK).json({ hasMapiAccess: hasMapi });
   })
 );
 


### PR DESCRIPTION
Ref. metriport/metriport#2064

Ticket: #_[ticket-number]_

### Dependencies

- Upstream: None
- Downstream: IN PROGRESS

### Description

- Endpoint for dashboard to check if the cx has mapi access

### Testing

_[Regular PRs:]_

- Local
  - [x] returns mapi access
- Staging
  - [ ] returns mapi access
- Sandbox
  - [ ] returns mapi access
- Production
  - [ ] returns mapi access

_[Release PRs:]_

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
