### PR TITLE
1040 Init DQ progress before sleep for CW on sandbox

### DIFF
--- a/packages/api/src/external/commonwell/document/document-query-sandbox.ts
+++ b/packages/api/src/external/commonwell/document/document-query-sandbox.ts
@@ -5,6 +5,7 @@ import { Patient } from "@metriport/core/domain/patient";
 import { executeWithRetriesS3, S3Utils } from "@metriport/core/external/aws/s3";
 import { parseRawBundleForFhirServer } from "@metriport/core/external/fhir/parse-bundle";
 import { metriportDataSourceExtension } from "@metriport/core/external/fhir/shared/extensions/metriport";
+import { MedicalDataSource } from "@metriport/core/external/index";
 import { out } from "@metriport/core/util";
 import { getFileExtension } from "@metriport/core/util/mime";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
@@ -22,6 +23,7 @@ import { ContentMimeType, isConvertible } from "../../fhir-converter/converter";
 import { DocumentReferenceWithId } from "../../fhir/document";
 import { getDocumentsFromFHIR } from "../../fhir/document/get-documents";
 import { upsertDocumentToFHIRServer } from "../../fhir/document/save-document-reference";
+import { setDocQueryProgress } from "../../hie/set-doc-query-progress";
 import { sandboxSleepTime } from "./shared";
 
 const randomDates = [
@@ -47,6 +49,15 @@ export async function sandboxGetDocRefsAndUpsert({
 }): Promise<void> {
   const { log } = Util.out(`sandboxGetDocRefsAndUpsert - M patient ${patient.id}`);
   const { id: patientId, cxId } = patient;
+
+  await setDocQueryProgress({
+    patient: { id: patientId, cxId },
+    downloadProgress: { status: "processing" },
+    convertProgress: { status: "processing" },
+    requestId,
+    source: MedicalDataSource.COMMONWELL,
+    triggerConsolidated: false,
+  });
 
   // Mimic Prod by waiting for docs to download
   await Util.sleep(Math.random() * sandboxSleepTime.asMilliseconds());


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Init DQ progress before sleep for CW on sandbox - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1729608985125549?thread_ts=1729606883.740349&cid=C04DMKE9DME)

### Testing

...WIP

- Local
  - [ ] _testing step 1_
- Staging
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Sandbox
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Production
  - [ ] _testing step 1_
  - [ ] _testing step 2_

### Release Plan

- [ ] Merge this
