### PR TITLE
feat(api): added another xml-detection sequence

### DIFF
--- a/packages/core/src/util/file-type.ts
+++ b/packages/core/src/util/file-type.ts
@@ -42,13 +42,13 @@ const XML_MAGIC_NUMBER_3 = 0x78;
 const XML_MAGIC_NUMBER_4 = 0x6d;
 const XML_MAGIC_NUMBER_5 = 0x6c;
 const XML_MAGIC_NUMBER_6 = 0x20;
+const XML_MAGIC_NUMBER_6a = 0x2d;
 const XML_MAGIC_NUMBER_7 = 0x3c;
 const XML_MAGIC_NUMBER_8 = 0x43;
 const XML_MAGIC_NUMBER_9 = 0x6c;
 const XML_MAGIC_NUMBER_10 = 0x69;
 const XML_MAGIC_NUMBER_11 = 0x6e;
 const XML_MAGIC_NUMBER_12 = 0x69;
-const XML_MAGIC_NUMBER_13 = 0x2d;
 const PNG_MAGIC_NUMBER_1 = 0x89;
 const PNG_MAGIC_NUMBER_2 = 0x50;
 const PNG_MAGIC_NUMBER_3 = 0x4e;
@@ -220,7 +220,7 @@ export function isXMLContentType(bytesBuffer: Buffer): boolean {
       bytesBuffer[2] === XML_MAGIC_NUMBER_3 &&
       bytesBuffer[3] === XML_MAGIC_NUMBER_4 &&
       bytesBuffer[4] === XML_MAGIC_NUMBER_5 &&
-      bytesBuffer[5] === XML_MAGIC_NUMBER_13) ||
+      bytesBuffer[5] === XML_MAGIC_NUMBER_6a) ||
     (bytesBuffer[0] === XML_MAGIC_NUMBER_7 &&
       bytesBuffer[1] === XML_MAGIC_NUMBER_8 &&
       bytesBuffer[2] === XML_MAGIC_NUMBER_9 &&

--- a/packages/core/src/util/file-type.ts
+++ b/packages/core/src/util/file-type.ts
@@ -48,6 +48,7 @@ const XML_MAGIC_NUMBER_9 = 0x6c;
 const XML_MAGIC_NUMBER_10 = 0x69;
 const XML_MAGIC_NUMBER_11 = 0x6e;
 const XML_MAGIC_NUMBER_12 = 0x69;
+const XML_MAGIC_NUMBER_13 = 0x2d;
 const PNG_MAGIC_NUMBER_1 = 0x89;
 const PNG_MAGIC_NUMBER_2 = 0x50;
 const PNG_MAGIC_NUMBER_3 = 0x4e;
@@ -214,6 +215,12 @@ export function isXMLContentType(bytesBuffer: Buffer): boolean {
       bytesBuffer[3] === XML_MAGIC_NUMBER_4 &&
       bytesBuffer[4] === XML_MAGIC_NUMBER_5 &&
       bytesBuffer[5] === XML_MAGIC_NUMBER_6) ||
+    (bytesBuffer[0] === XML_MAGIC_NUMBER_1 &&
+      bytesBuffer[1] === XML_MAGIC_NUMBER_2 &&
+      bytesBuffer[2] === XML_MAGIC_NUMBER_3 &&
+      bytesBuffer[3] === XML_MAGIC_NUMBER_4 &&
+      bytesBuffer[4] === XML_MAGIC_NUMBER_5 &&
+      bytesBuffer[5] === XML_MAGIC_NUMBER_13) ||
     (bytesBuffer[0] === XML_MAGIC_NUMBER_7 &&
       bytesBuffer[1] === XML_MAGIC_NUMBER_8 &&
       bytesBuffer[2] === XML_MAGIC_NUMBER_9 &&


### PR DESCRIPTION
refs. metriport/metriport-internal#2352

### Description
- Added a string detection to classify files as xml (`<?xml-`)

### Testing

- Local
  - [x] Locally, invoking the `detectFileType` on text files that start with `<?xml-` results in correct results
  - [x] Invoking this function on other file types still results in the correct results (txt, pdf, etc)

### Release Plan
- [ ] Merge this
