### PR TITLE
fix(api): removing pt coordinates alert

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
@@ -1,11 +1,10 @@
 import { Patient } from "@metriport/core/domain/patient";
 import { Coordinates } from "@metriport/core/external/aws/location";
 import { out } from "@metriport/core/util/log";
-import { capture } from "@metriport/core/util/notifications";
 import convert from "convert-units";
 import { Sequelize } from "sequelize";
-import { CQDirectoryEntry } from "../../cq-directory";
 import { Config } from "../../../../shared/config";
+import { CQDirectoryEntry } from "../../cq-directory";
 import { CQDirectoryEntryModel } from "../../models/cq-directory";
 
 export const DEFAULT_RADIUS_IN_MILES = 50;
@@ -48,7 +47,6 @@ export async function searchCQDirectoriesAroundPatientAddresses({
   if (!coordinates.length) {
     const msg = "Patient address doesn't contain coordinates";
     log(`${msg}, addresses: ${JSON.stringify(patient.data.address)}`);
-    capture.error(msg, { extra: { patient: patient.id, address: patient.data.address } });
     return [];
   }
 


### PR DESCRIPTION
refs. metriport/metriport-internal#799

### Description
- Removing alert for missing patient coordinates, since we don't act on those anyway

### Testing
- N/A

### Release Plan
- [ ] Merge this
