### PR TITLE
fix(fhir-converter): corrected practitioner id assignment

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Resources/Practitioner.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/Practitioner.hbs
@@ -28,12 +28,12 @@
     "fullUrl":"urn:uuid:{{ID}}",
     "resource":{
         "resourceType": "Practitioner",
+        "id":"{{ID}}",
         "meta": 		{
 		    "profile": [
 			    "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
 			]
 		},
-        "id":"{{ID}}",
         "identifier":
   		[
         	{{#each (toArray practitioner.id)}}

--- a/packages/fhir-converter/src/templates/cda/Utils/GeneratePractitionerId.hbs
+++ b/packages/fhir-converter/src/templates/cda/Utils/GeneratePractitionerId.hbs
@@ -31,7 +31,7 @@
             {{#if (and FirstId.root FirstId.extension)}}
                 "{{generateUUID (concat (toString FirstId.root) '|' (toString FirstId.extension))}}"
             {{else if ../obj.assignedPerson.name}}
-                "{{generateUUID (concat ../obj.assignedPerson.name ../obj.addr ../obj.telecom)}}"
+                "{{generateUUID (concat (toJsonString ../obj.assignedPerson.name) (toJsonString../obj.addr) (toJsonString ../obj.telecom))}}"
             {{/if}}
     }
 {{/with}}

--- a/packages/utils/src/fhir-converter/fhir-resource-counts/develop-fhir-resource-count.json
+++ b/packages/utils/src/fhir-converter/fhir-resource-counts/develop-fhir-resource-count.json
@@ -1,5 +1,5 @@
 {
-  "total": 369685,
+  "total": 374015,
   "countPerType": {
     "AllergyIntolerance": 819,
     "Composition": 9445,
@@ -10,9 +10,9 @@
     "FamilyMemberHistory": 774,
     "Medication": 12384,
     "MedicationStatement": 8354,
-    "Observation": 160685,
+    "Observation": 163026,
     "Organization": 14764,
-    "Practitioner": 52418,
+    "Practitioner": 54407,
     "RelatedPerson": 12260,
     "DiagnosticReport": 27627,
     "Encounter": 10420,


### PR DESCRIPTION
refs. metriport/metriport-internal#2147

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2982

### Description
- Updated Practitioner ID generation to avoid multiple names being attached to the same resource

### Testing

- Local
  - [x] Made sure this fixes the issue with a couple of problematic files
  - [x] Ran the FHIR e2e-test suite
  - [x] Ran a subset of the test suite with FHIR insert

### Release Plan
- [ ] Merge this
