### PR TITLE
2402 Fix E2E for new WH signature verification

### DIFF
--- a/packages/api/src/__tests__/e2e/mapi/webhook/webhook-handler.ts
+++ b/packages/api/src/__tests__/e2e/mapi/webhook/webhook-handler.ts
@@ -22,8 +22,9 @@ export async function handleRequest(req: Request, res: Response) {
       console.log(`[WH] ====> Signature verification failed`);
       throw new Error("Signature verification failed");
     }
-    console.log(`[WH] ========> Handling request... type: ${req.body?.meta?.type}`);
-    const whRequest = MetriportMedicalApi.parseWebhookResponse(req.body);
+    const body = JSON.parse(req.body);
+    console.log(`[WH] ========> Handling request... type: ${body?.meta?.type}`);
+    const whRequest = MetriportMedicalApi.parseWebhookResponse(body);
     if (isPingWebhookRequest(whRequest)) {
       return handlePing(whRequest, res);
     }

--- a/packages/api/src/__tests__/e2e/mapi/webhook/webhook-server.ts
+++ b/packages/api/src/__tests__/e2e/mapi/webhook/webhook-server.ts
@@ -3,7 +3,7 @@ dotenv.config();
 // Keep dotenv import and config before everything else.
 import { getEnvVar, getEnvVarOrFail, sleep } from "@metriport/shared";
 import ngrok, { Session } from "@ngrok/ngrok";
-import express, { Request, Response } from "express";
+import express, { raw, Request, Response } from "express";
 import { Server } from "http";
 import { asyncHandler } from "../../../../routes/util";
 import whHandler from "./webhook-handler";
@@ -11,14 +11,15 @@ import whHandler from "./webhook-handler";
 const port = 8478;
 
 const app = express();
-app.use(express.json({ limit: "20mb" }));
 
 app.post(
   "/",
+  raw({ type: "*/*" }),
   asyncHandler(async (req: Request, res: Response) => {
     await whHandler.handleRequest(req, res);
   }, true)
 );
+app.use(express.json({ limit: "20mb" }));
 
 let server: Server;
 let session: Session;

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -7,6 +7,7 @@ import { PingWebhookRequest, WebhookMetadata } from "@metriport/shared/medical";
 import Axios from "axios";
 import crypto from "crypto";
 import dayjs from "dayjs";
+import stringify from "json-stringify-safe";
 import { nanoid } from "nanoid";
 import { v4 as uuidv4 } from "uuid";
 import { z, ZodError } from "zod";
@@ -142,12 +143,12 @@ export async function processRequest(
           isE2eCx(webhookRequest.cxId),
         ]);
         if (isE2e) {
-          log(`[E2E] WH Payload: ${JSON.stringify(fullPayload)}`);
+          log(`[E2E] WH Payload: ${stringify(fullPayload)}`);
           log(
             `[E2E] Error details: ${
               "cause" in error && "response" in error.cause
-                ? JSON.stringify(error.cause.response)
-                : JSON.stringify(error)
+                ? stringify(error.cause.response)
+                : stringify(error)
             }`
           );
         }


### PR DESCRIPTION
Tickets:
- https://github.com/metriport/metriport-internal/issues/2402
- https://github.com/metriport/metriport-internal/issues/2266

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3004
- Downstream: none

### Description

- Fix E2E test so WH requests don't have the body converted to JSON by default, in order to pass signature verification
- Add `./tmp` folder to repository initialization - [context](https://metriport.slack.com/archives/C04GEQ1GH9D/p1731619697192249?thread_ts=1731613784.116149&cid=C04GEQ1GH9D)

### Testing

- Local
  - [ ] E2E tests pass
  - [ ] `./tmp` folder created
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
