### PR TITLE
2402 Publish NPM packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30774,7 +30774,7 @@
       }
     },
     "packages/api": {
-      "version": "1.22.8-alpha.0",
+      "version": "1.22.8",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -30858,12 +30858,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "13.0.3-alpha.0",
+      "version": "13.0.3",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.1.8-alpha.0",
-        "@metriport/shared": "^0.14.3-alpha.0",
+        "@metriport/commonwell-sdk": "^5.1.8",
+        "@metriport/shared": "^0.14.3",
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -30919,10 +30919,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.11.8-alpha.0",
+      "version": "1.11.8",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.12.8-alpha.0",
+        "@metriport/ihe-gateway-sdk": "^0.12.8",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -30936,7 +30936,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.13.8-alpha.0",
+      "version": "0.13.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -30946,10 +30946,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.19.8-alpha.0",
+      "version": "1.19.8",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.1.8-alpha.0",
+        "@metriport/commonwell-sdk": "^5.1.8",
         "axios": "^1.4.0",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -30988,10 +30988,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.17.8-alpha.0",
+      "version": "1.17.8",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.1.8-alpha.0",
+        "@metriport/commonwell-sdk": "^5.1.8",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -31023,10 +31023,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.1.8-alpha.0",
+      "version": "5.1.8",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.14.3-alpha.0",
+        "@metriport/shared": "^0.14.3",
         "axios": "^1.4.0",
         "http-status": "^1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -31074,7 +31074,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.17.8-alpha.0",
+      "version": "1.17.8",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.616.0",
@@ -31157,17 +31157,17 @@
     "packages/core/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.12.8-alpha.0",
+      "version": "0.12.8",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.14.3-alpha.0",
+        "@metriport/shared": "^0.14.3",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.15.8-alpha.0",
+      "version": "1.15.8",
       "dependencies": {
         "aws-cdk-lib": "^2.122.0",
         "constructs": "^10.2.69",
@@ -31215,7 +31215,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.14.8-alpha.0",
+      "version": "1.14.8",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -32242,7 +32242,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.14.3-alpha.0",
+      "version": "0.14.3",
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^8.0.2",
@@ -32259,7 +32259,7 @@
       }
     },
     "packages/utils": {
-      "version": "1.18.8-alpha.0",
+      "version": "1.18.8",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-bedrock-agent-runtime": "^3.616.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "13.0.3-alpha.0",
+  "version": "13.0.3",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.1.8-alpha.0",
-    "@metriport/shared": "^0.14.3-alpha.0",
+    "@metriport/commonwell-sdk": "^5.1.8",
+    "@metriport/shared": "^0.14.3",
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.22.8-alpha.0",
+  "version": "1.22.8",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.11.8-alpha.0",
+  "version": "1.11.8",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.12.8-alpha.0",
+    "@metriport/ihe-gateway-sdk": "^0.12.8",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.13.8-alpha.0",
+  "version": "0.13.8",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.19.8-alpha.0",
+  "version": "1.19.8",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.1.8-alpha.0",
+    "@metriport/commonwell-sdk": "^5.1.8",
     "axios": "^1.4.0",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.17.8-alpha.0",
+  "version": "1.17.8",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.1.8-alpha.0",
+    "@metriport/commonwell-sdk": "^5.1.8",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.1.8-alpha.0",
+  "version": "5.1.8",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.14.3-alpha.0",
+    "@metriport/shared": "^0.14.3",
     "axios": "^1.4.0",
     "http-status": "^1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.17.8-alpha.0",
+  "version": "1.17.8",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.12.8-alpha.0",
+  "version": "0.12.8",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.14.3-alpha.0",
+    "@metriport/shared": "^0.14.3",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.15.8-alpha.0",
+  "version": "1.15.8",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.14.8-alpha.0",
+  "version": "1.14.8",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.14.3-alpha.0",
+  "version": "0.14.3",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "utils",
-  "version": "1.17.3",
+  "version": "1.18.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "utils",
-      "version": "1.17.3",
+      "version": "1.18.8",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-bedrock-agent-runtime": "^3.616.0",
         "@aws-sdk/client-bedrock-runtime": "^3.616.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.301.0",
-        "@medplum/core": "^2.0.32",
-        "@medplum/fhirtypes": "^2.0.32",
+        "@medplum/core": "^2.2.10",
         "@metriport/api-sdk": "file:packages/api-sdk",
         "@metriport/core": "file:packages/core",
         "@metriport/shared": "file:packages/shared",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.18.8-alpha.0",
+  "version": "1.18.8",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/2402

 - api@1.22.8
 - @metriport/api-sdk@13.0.3
 - @metriport/carequality-cert-runner@1.11.8
 - @metriport/carequality-sdk@0.13.8
 - @metriport/commonwell-cert-runner@1.19.8
 - @metriport/commonwell-jwt-maker@1.17.8
 - @metriport/commonwell-sdk@5.1.8
 - @metriport/core@1.17.8
 - @metriport/ihe-gateway-sdk@0.12.8
 - infrastructure@1.15.8
 - @metriport/react-native-sdk@1.14.8
 - @metriport/shared@0.14.3
 - utils@1.18.8

### Testing

- Local
  - [ ] WH sample server works
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
