### PR TITLE
PATCH RELEASE 2024-11-18 Safe Trim

### DIFF
--- a/packages/api/src/domain/medical/patient-demographics.ts
+++ b/packages/api/src/domain/medical/patient-demographics.ts
@@ -278,9 +278,10 @@ export function normalizeAddress({
   return {
     line:
       line
-        ?.filter(l => l !== "")
+        ?.filter(l => Boolean(l))
         .map(l => {
           return l
+            .toString()
             .trim()
             .toLowerCase()
             .replaceAll("street", "st")

--- a/packages/api/src/domain/medical/patient-demographics.ts
+++ b/packages/api/src/domain/medical/patient-demographics.ts
@@ -278,10 +278,11 @@ export function normalizeAddress({
   return {
     line:
       line
-        ?.filter(l => Boolean(l))
+        ?.filter(l => l !== undefined && l !== null)
+        .map(String)
+        .filter(l => l !== "")
         .map(l => {
           return l
-            .toString()
             .trim()
             .toLowerCase()
             .replaceAll("street", "st")
@@ -298,6 +299,7 @@ export function normalizeAddress({
         .toLowerCase()
         .replaceAll("us", "usa")
         .replaceAll("united states", "usa")
+        .replaceAll("united", "usa")
         .slice(0, 3) ?? "usa",
   };
 }

--- a/packages/core/src/mpi/__tests__/normalize-address-lines.test.ts
+++ b/packages/core/src/mpi/__tests__/normalize-address-lines.test.ts
@@ -1,10 +1,10 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { normalizeAddressLines } from "../normalize-address";
 
 describe("normalizeAddressLines", () => {
   it("should normalize number to a string", () => {
     const lines = [123];
 
-    /* eslint-disable @typescript-eslint/ban-ts-comment */
     // @ts-ignore
     const norm = normalizeAddressLines(lines);
     expect(norm).toEqual(["123"]);

--- a/packages/core/src/mpi/__tests__/normalize-address-lines.test.ts
+++ b/packages/core/src/mpi/__tests__/normalize-address-lines.test.ts
@@ -1,0 +1,76 @@
+import { normalizeAddressLines } from "../normalize-address";
+
+describe("normalizeAddressLines", () => {
+  it("should normalize number to a string", () => {
+    const lines = [123];
+
+    /* eslint-disable @typescript-eslint/ban-ts-comment */
+    // @ts-ignore
+    const norm = normalizeAddressLines(lines);
+    expect(norm).toEqual(["123"]);
+  });
+
+  it("should filter out empty strings", () => {
+    const lines = [""];
+
+    const norm = normalizeAddressLines(lines);
+    expect(norm).toEqual([]);
+  });
+
+  it("should filter out null", () => {
+    const lines = [null];
+
+    // @ts-ignore
+    const norm = normalizeAddressLines(lines);
+    expect(norm).toEqual([]);
+  });
+
+  it("should filter out undefined", () => {
+    const lines = [undefined];
+
+    // @ts-ignore
+    const norm = normalizeAddressLines(lines);
+    expect(norm).toEqual([]);
+  });
+
+  it("should not filter out 0 or 1", () => {
+    const lines = [0, 1];
+
+    // @ts-ignore
+    const norm = normalizeAddressLines(lines);
+    expect(norm).toEqual(["0", "1"]);
+  });
+
+  it("should normalize drive", () => {
+    const lines = ["Drive"];
+
+    const norm = normalizeAddressLines(lines);
+    expect(norm).toEqual(["dr"]);
+  });
+
+  it("should normalize street", () => {
+    const lines = ["STREET"];
+
+    const norm = normalizeAddressLines(lines);
+    expect(norm).toEqual(["st"]);
+  });
+
+  it("should normalize avenue", () => {
+    const lines = ["avenue"];
+
+    const norm = normalizeAddressLines(lines);
+    expect(norm).toEqual(["ave"]);
+  });
+
+  it("should normalize road", () => {
+    const lines = ["RoAd"];
+
+    const norm = normalizeAddressLines(lines);
+    expect(norm).toEqual(["rd"]);
+  });
+
+  it("should return empty array if no line provided", () => {
+    const norm = normalizeAddressLines(undefined);
+    expect(norm).toEqual([]);
+  });
+});

--- a/packages/core/src/mpi/normalize-address.ts
+++ b/packages/core/src/mpi/normalize-address.ts
@@ -5,9 +5,10 @@ export function normalizeAddress({ line, city, state, postalCode, country }: Add
   return {
     line:
       line
-        ?.filter(l => l !== "")
+        ?.filter(l => Boolean(l))
         .map(l => {
           return l
+            .toString()
             .trim()
             .toLowerCase()
             .replace(/street/g, "st")

--- a/packages/core/src/mpi/normalize-address.ts
+++ b/packages/core/src/mpi/normalize-address.ts
@@ -3,20 +3,7 @@ import { Address } from "@medplum/fhirtypes";
 
 export function normalizeAddress({ line, city, state, postalCode, country }: Address): Address {
   return {
-    line:
-      line
-        ?.filter(l => Boolean(l))
-        .map(l => {
-          return l
-            .toString()
-            .trim()
-            .toLowerCase()
-            .replace(/street/g, "st")
-            .replace(/drive/g, "dr")
-            .replace(/road/g, "rd")
-            .replace(/avenue/g, "ave")
-            .replace(/-/g, "");
-        }) ?? [],
+    line: normalizeAddressLines(line),
     city: city?.trim().toLowerCase().replace(/-/g, "") ?? "",
     state: state?.trim().toLowerCase().slice(0, 2) ?? "",
     postalCode: stripNonNumericChars(postalCode ?? "")
@@ -27,7 +14,27 @@ export function normalizeAddress({ line, city, state, postalCode, country }: Add
         ?.trim()
         .toLowerCase()
         .replace(/us/g, "usa")
+        .replace(/united states/g, "usa")
         .replace(/united/g, "usa")
         .slice(0, 3) ?? "usa",
   };
+}
+
+export function normalizeAddressLines(lines: string[] | undefined): string[] {
+  return (
+    lines
+      ?.filter(l => l !== undefined && l !== null)
+      .map(String)
+      .filter(l => l !== "")
+      .map(l => {
+        return l
+          .trim()
+          .toLowerCase()
+          .replace(/street/g, "st")
+          .replace(/drive/g, "dr")
+          .replace(/road/g, "rd")
+          .replace(/avenue/g, "ave")
+          .replace(/-/g, "");
+      }) ?? []
+  );
 }


### PR DESCRIPTION
Ticket: #metriport/metriport-internal#799

### Description
- Fixing the two places where trim() was called without making sure each item is a string 

### Testing
- N/A

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
