### PR TITLE
fix(fhir-converter): removing extra quotes

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
@@ -129,7 +129,7 @@
                             {{/if}}
                             {{#if obsEntry.procedure.text._b64}}
                                 {{>References/Procedure/report.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'DiagnosticReport/' (generateUUID (toJsonString drEntry.organizer)))}}
-                                {{>References/DiagnosticReport/assessment.hbs text=(toJsonString (base64Decode obsEntry.procedure.text._b64)) ID=(generateUUID (toJsonString drEntry.organizer))}}
+                                {{>References/DiagnosticReport/assessment.hbs text=(base64Decode obsEntry.procedure.text._b64) ID=(generateUUID (toJsonString drEntry.organizer))}}
                             {{/if}}
                         {{/if}}
                     {{/each}}


### PR DESCRIPTION
refs. metriport/metriport-internal#2485

### Description
- Minor update to remove double quotes around the doctors notes

### Testing

- Local
  - [x] Works locally

### Release Plan
- [ ] Merge this
