### PR TITLE
feat(ehr): fixing conflicting external ids

### DIFF
--- a/packages/api/src/command/mapping/facility.ts
+++ b/packages/api/src/command/mapping/facility.ts
@@ -1,11 +1,12 @@
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
-import NotFoundError from "../../errors/not-found";
-import { FacilityMappingModel } from "../../models/facility-mapping";
+import { NotFoundError } from "@metriport/shared";
 import { FacilityMapping, FacilityMappingPerSource } from "../../domain/facility-mapping";
+import { FacilityMappingModel } from "../../models/facility-mapping";
 
 export type FacilityMappingParams = FacilityMappingPerSource;
 
 export type FacilityMappingLookUpParams = Omit<FacilityMappingParams, "facilityId">;
+export type FacilityMappingLookupByIdParams = Pick<FacilityMappingParams, "cxId"> & { id: string };
 
 export async function findOrCreateFacilityMapping({
   cxId,
@@ -53,24 +54,58 @@ export async function getFacilityMappingOrFail({
   return mapping;
 }
 
-export async function getFacilityMappingsForCustomer(where: {
+export async function getFacilityMappingsByCustomer({
+  cxId,
+  source,
+}: {
   cxId: string;
   source?: string;
 }): Promise<FacilityMapping[]> {
-  const rows = await FacilityMappingModel.findAll({ where });
-  return rows.map(r => r.dataValues);
+  const mappings = await FacilityMappingModel.findAll({
+    where: { cxId, ...(source && { source }) },
+  });
+  return mappings.map(m => m.dataValues);
+}
+
+async function getFacilityMappingModelById({
+  cxId,
+  id,
+}: FacilityMappingLookupByIdParams): Promise<FacilityMappingModel | undefined> {
+  const existing = await FacilityMappingModel.findOne({
+    where: { cxId, id },
+  });
+  if (!existing) return undefined;
+  return existing;
+}
+
+async function getFacilityMappingModelByIdOrFail({
+  cxId,
+  id,
+}: FacilityMappingLookupByIdParams): Promise<FacilityMappingModel> {
+  const mapping = await getFacilityMappingModelById({
+    cxId,
+    id,
+  });
+  if (!mapping) {
+    throw new NotFoundError("FacilityMapping not found", undefined, { cxId, id });
+  }
+  return mapping;
+}
+
+export async function setExternalIdOnFacilityMapping({
+  cxId,
+  id,
+  externalId,
+}: FacilityMappingLookupByIdParams & { externalId: string }): Promise<FacilityMapping> {
+  const existing = await getFacilityMappingModelByIdOrFail({ cxId, id });
+  const updated = await existing.update({ externalId });
+  return updated.dataValues;
 }
 
 export async function deleteFacilityMapping({
   cxId,
-  externalId,
-  source,
-}: FacilityMappingLookUpParams): Promise<void> {
-  const existing = await FacilityMappingModel.findOne({
-    where: { cxId, externalId, source },
-  });
-  if (!existing) {
-    throw new NotFoundError("Entry not found", undefined, { cxId, externalId, source });
-  }
+  id,
+}: FacilityMappingLookupByIdParams): Promise<void> {
+  const existing = await getFacilityMappingModelByIdOrFail({ cxId, id });
   await existing.destroy();
 }

--- a/packages/api/src/command/mapping/patient.ts
+++ b/packages/api/src/command/mapping/patient.ts
@@ -1,7 +1,7 @@
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
-import NotFoundError from "../../errors/not-found";
-import { PatientMappingModel } from "../../models/patient-mapping";
+import { NotFoundError } from "@metriport/shared";
 import { PatientMapping, PatientMappingPerSource } from "../../domain/patient-mapping";
+import { PatientMappingModel } from "../../models/patient-mapping";
 
 export type PatientMappingParams = PatientMappingPerSource;
 
@@ -51,20 +51,6 @@ export async function getPatientMappingOrFail({
     throw new NotFoundError("PatientMapping not found", undefined, { cxId, externalId, source });
   }
   return mapping;
-}
-
-export async function deletePatientMapping({
-  cxId,
-  externalId,
-  source,
-}: PatientMappingLookUpParams): Promise<void> {
-  const existing = await PatientMappingModel.findOne({
-    where: { cxId, externalId, source },
-  });
-  if (!existing) {
-    throw new NotFoundError("Entry not found", undefined, { cxId, externalId, source });
-  }
-  await existing.destroy();
 }
 
 export async function deleteAllPatientMappings({

--- a/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
@@ -146,7 +146,7 @@ export async function getPatientIdOrFail({
   } else {
     const defaultFacility = await getFacilityMappingOrFail({
       cxId,
-      externalId: defaultFacilityMappingExternalId,
+      externalId: `${athenaPracticeId}-${defaultFacilityMappingExternalId}`,
       source: EhrSources.athena,
     });
     metriportPatient = await createMetriportPatient({

--- a/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patient.ts
@@ -32,7 +32,6 @@ const region = Config.getAWSRegion();
 const athenaEnvironment = Config.getAthenaHealthEnv();
 const athenaClientKeySecretArn = Config.getAthenaHealthClientKeyArn();
 const athenaClientSecretSecretArn = Config.getAthenaHealthClientSecretArn();
-const defaultFacilityMappingExternalId = "default";
 
 const parallelPatientMatches = 5;
 
@@ -146,7 +145,7 @@ export async function getPatientIdOrFail({
   } else {
     const defaultFacility = await getFacilityMappingOrFail({
       cxId,
-      externalId: `${athenaPracticeId}-${defaultFacilityMappingExternalId}`,
+      externalId: athenaPracticeId,
       source: EhrSources.athena,
     });
     metriportPatient = await createMetriportPatient({

--- a/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/get-patients-from-appointments.ts
@@ -7,7 +7,7 @@ import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import AthenaHealthApi, { AthenaEnv } from "@metriport/core/external/athenahealth/index";
 import { EhrSources } from "../../shared";
-import { getCxMappings } from "../../../../command/mapping/cx";
+import { getCxMappingsBySource } from "../../../../command/mapping/cx";
 import { getSecretValueOrFail } from "@metriport/core/external/aws/secret-manager";
 import { Config } from "../../../../shared/config";
 import { getPatientIdOrFail as singleGetPatientIdOrFail } from "./get-patient";
@@ -39,7 +39,7 @@ export async function getPatientIdsOrFailFromAppointmentsSub({
   if (!athenaEnvironment || !athenaClientKeySecretArn || !athenaClientSecretSecretArn) {
     throw new Error("AthenaHealth not setup");
   }
-  const cxMappings = await getCxMappings({ source: EhrSources.athena });
+  const cxMappings = await getCxMappingsBySource({ source: EhrSources.athena });
 
   const athenaClientKey = await getSecretValueOrFail(athenaClientKeySecretArn, region);
   const athenaClientSecret = await getSecretValueOrFail(athenaClientSecretSecretArn, region);

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -6,18 +6,20 @@ import { updateCxHieEnabledFFs } from "../command/internal/update-hie-enabled-fe
 import {
   deleteCxMapping,
   findOrCreateCxMapping,
-  getCxMappingsForCustomer,
+  getCxMappingsByCustomer,
+  setExternalIdOnCxMapping,
 } from "../command/mapping/cx";
 import {
   deleteFacilityMapping,
   findOrCreateFacilityMapping,
-  getFacilityMappingsForCustomer,
+  getFacilityMappingsByCustomer,
+  setExternalIdOnFacilityMapping,
 } from "../command/mapping/facility";
 import { checkApiQuota } from "../command/medical/admin/api";
 import { dbMaintenance } from "../command/medical/admin/db-maintenance";
 import {
-  populateFhirServer,
   PopulateFhirServerResponse,
+  populateFhirServer,
 } from "../command/medical/admin/populate-fhir";
 import { getFacilities, getFacilityOrFail } from "../command/medical/facility/get-facility";
 import { allowMapiAccess, hasMapiAccess, revokeMapiAccess } from "../command/medical/mapi-access";
@@ -341,7 +343,7 @@ router.get(
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const source = getFrom("query").optional("source", req);
-    const result = await getCxMappingsForCustomer({
+    const result = await getCxMappingsByCustomer({
       cxId,
       ...(source && { source }),
     });
@@ -350,23 +352,45 @@ router.get(
 );
 
 /**
- * DELETE /internal/cx-mapping
+ * PUT /internal/cx-mapping
+ *
+ * Update cx mapping external ID
+ *
+ * @param req.query.cxId - The cutomer's ID.
+ * @param req.query.externalId - Mapped external ID.
+ */
+router.put(
+  "/cx-mapping/:id/external-id",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").orFail();
+    const id = getFrom("params").orFail("id", req);
+    const externalId = getFromQueryOrFail("externalId", req);
+    await setExternalIdOnCxMapping({
+      cxId,
+      id,
+      externalId,
+    });
+    return res.sendStatus(httpStatus.OK);
+  })
+);
+
+/**
+ * DELETE /internal/cx-mapping/:id
  *
  * Delete cx mapping
  *
  * @param req.query.cxId - The cutomer's ID.
- * @param req.query.source - Mapping source
- * @param req.query.externalId - Mapped external ID.
  */
 router.delete(
-  "/cx-mapping",
+  "/cx-mapping/:id",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
-    const source = getFromQueryOrFail("source", req);
-    const externalId = getFromQueryOrFail("externalId", req);
+    const cxId = getUUIDFrom("query", req, "cxId").orFail();
+    const id = getFrom("params").orFail("id", req);
     await deleteCxMapping({
-      source: source as CxSources,
-      externalId,
+      cxId,
+      id,
     });
     return res.sendStatus(httpStatus.NO_CONTENT);
   })
@@ -418,7 +442,7 @@ router.get(
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const source = getFrom("query").optional("source", req);
-    const result = await getFacilityMappingsForCustomer({
+    const result = await getFacilityMappingsByCustomer({
       cxId,
       ...(source && { source }),
     });
@@ -427,25 +451,45 @@ router.get(
 );
 
 /**
- * DELETE /internal/facility-mapping
+ * PUT /internal/facility-mapping/:id
+ *
+ * Update facility mapping external ID
+ *
+ * @param req.query.cxId - The cutomer's ID.
+ * @param req.query.externalId - Mapped external ID.
+ */
+router.put(
+  "/facility-mapping/:id/external-id",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").orFail();
+    const id = getFrom("params").orFail("id", req);
+    const externalId = getFromQueryOrFail("externalId", req);
+    await setExternalIdOnFacilityMapping({
+      cxId,
+      id,
+      externalId,
+    });
+    return res.sendStatus(httpStatus.OK);
+  })
+);
+
+/**
+ * DELETE /internal/facility-mapping/:id
  *
  * Delete facility mapping
  *
  * @param req.query.cxId - The cutomer's ID.
- * @param req.query.source - Mapping source
- * @param req.query.externalId - Mapped external ID.
  */
 router.delete(
-  "/facility-mapping",
+  "/facility-mapping/:id",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
-    const source = getFromQueryOrFail("source", req);
-    const externalId = getFromQueryOrFail("externalId", req);
+    const id = getFrom("params").orFail("id", req);
     await deleteFacilityMapping({
       cxId,
-      source: source as FacilitySources,
-      externalId,
+      id,
     });
     return res.sendStatus(httpStatus.NO_CONTENT);
   })

--- a/packages/api/src/routes/internal.ts
+++ b/packages/api/src/routes/internal.ts
@@ -352,7 +352,7 @@ router.get(
 );
 
 /**
- * PUT /internal/cx-mapping
+ * PUT /internal/cx-mapping/:id/external-id
  *
  * Update cx mapping external ID
  *
@@ -451,7 +451,7 @@ router.get(
 );
 
 /**
- * PUT /internal/facility-mapping/:id
+ * PUT /internal/facility-mapping/:id/external-id
  *
  * Update facility mapping external ID
  *


### PR DESCRIPTION
Ref: #1040

### Description

- updating the default external ID to be practice specific -- this allows us to do facility per practice and gets rid of the constraint conflict of multiple `default / athenahealth` entries.
- REPLACEMENT FOR https://github.com/metriport/metriport/pull/3037

### Testing

- Local
  - [x] make sure new endpoints work (POST / PUT / GET / DELETE)
- Staging
  - [ ] make sure new endpoints work
- Production
  - [ ] make sure new endpoints work

### Release Plan

- [ ] Merge this
