### PR TITLE
1040 CICD checks develop is ahead of master

### DIFF
--- a/.github/workflows/pull-request_compare-develop-and-master.yml
+++ b/.github/workflows/pull-request_compare-develop-and-master.yml
@@ -1,0 +1,17 @@
+name: PR Check - compare develop and master
+
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  compare-develop-and-master:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Is develop ahead of master?
+        run: |
+          ./packages/scripts/check-base-commits.sh

--- a/packages/scripts/check-base-commits.sh
+++ b/packages/scripts/check-base-commits.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Exit on any error
+set -e
+
+main_branch="master"
+run_on_branch="develop"
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+# Only run checks if on develop branch
+if [ "$current_branch" != "$run_on_branch" ]; then
+    echo "✅ Skipping base commit check - not on branch $run_on_branch"
+    exit 0
+fi
+
+# Get the common ancestor commit between current and main branch
+merge_base=$(git merge-base $current_branch $main_branch)
+
+# Find non-merge commits between merge-base and main branch
+non_merge_commits=$(git log --no-merges $merge_base..$main_branch --oneline)
+
+if [ -n "$non_merge_commits" ]; then
+    echo "❌ Error: found non-merge commits on $main_branch branch:"
+    echo "$non_merge_commits"
+    exit 1
+else
+    echo "✅ No non-merge commits found on $main_branch branch"
+    exit 0
+fi


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

CICD checks `develop` is ahead of `master`.

### Testing

- Local
  - [ ] Updated script returns error when it identifies changes upstream
  - [ ] Updated script return OK when it doesn't identify changes upstream
  - [ ] CICD runs the script for this PR, and it returns OK (not running on develop)
- Staging
  - none
- Sandbox
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Production
  - [ ] _testing step 1_
  - [ ] _testing step 2_

_[Release PRs:]_

Check each PR.

### Release Plan

_[How does the changes on this PR impact/interact with the existing environment (database, configs, secrets, FFs, api contracts, etc.)?
Consider creating 2+ PRs if we need to ship those changes in a staged way]_

_[This is the release plan for production]_

_[You should execute the exact same steps when releasing to staging to validate it works]_

_[Add and remove items below accordingly]_

- :warning: Points to `master`
- :warning: This contains a DB migration
- [ ] Maintenance window scheduled/created at Checkly (if needed)
- [ ] Execute this on <env1>, <env2>
  - [ ] _step1_
  - [ ] _step2_
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (deprecates a feature that needs to be communicated with customers)
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (introduce a feature that would be useful customers)
- [ ] Upstream dependencies are met/released
- [ ] Release NPM packages
- [ ] Fern Definition Updated
- [ ] Release Fern SDKs
- [ ] FFs have been set in Staging, Production, and Sandbox
- [ ] No dependencies between API and Infra that will cause errors during deployment
- [ ] _[action n-1]_
- [ ] _[action n]_
- [ ] Merge this
