### PR TITLE
2343 large file conversion

### DIFF
--- a/packages/core/src/external/cda/partition-payload.ts
+++ b/packages/core/src/external/cda/partition-payload.ts
@@ -3,9 +3,10 @@ import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { sizeInBytes } from "../../util/string";
 import { XMLBuilder } from "fast-xml-parser";
 
-const MAX_CHUNK_SIZE = 10_000_000; // 10MB in bytes
+const MAX_CHUNK_SIZE = 3_000_000; // 10MB in bytes
 
 export function partitionPayload(payloadRaw: string): string[] {
+  console.log("sizeInBytes(payloadRaw)", sizeInBytes(payloadRaw));
   if (sizeInBytes(payloadRaw) < MAX_CHUNK_SIZE) return [payloadRaw];
 
   const parser = createXMLParser({
@@ -15,9 +16,11 @@ export function partitionPayload(payloadRaw: string): string[] {
   });
   const json = parser.parse(payloadRaw);
 
+  console.log("TOO BIG");
   if (!json.ClinicalDocument?.component?.structuredBody?.component) {
     return [payloadRaw];
   }
+  console.log("GOT HERE");
 
   const components = toArray(json.ClinicalDocument?.component?.structuredBody?.component);
 
@@ -51,7 +54,7 @@ export function partitionPayload(payloadRaw: string): string[] {
   }
 
   for (const component of components) {
-    const componentSize = sizeInBytes(component);
+    const componentSize = sizeInBytes(JSON.stringify(component));
 
     if (currentSize + componentSize > MAX_CHUNK_SIZE && currentComponents.length > 0) {
       chunks.push(createChunk(currentComponents));

--- a/packages/core/src/external/cda/partition-payload.ts
+++ b/packages/core/src/external/cda/partition-payload.ts
@@ -1,0 +1,81 @@
+import { toArray } from "@metriport/shared";
+import { createXMLParser } from "@metriport/shared/common/xml-parser";
+import { sizeInBytes } from "../../util/string";
+import { XMLBuilder } from "fast-xml-parser";
+
+const MAX_CHUNK_SIZE = 10_000_000; // 10MB in bytes
+
+export function partitionPayload(payloadRaw: string): string[] {
+  if (sizeInBytes(payloadRaw) < MAX_CHUNK_SIZE) return [payloadRaw];
+
+  const parser = createXMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "_",
+    removeNSPrefix: true,
+  });
+  const json = parser.parse(payloadRaw);
+
+  if (!json.ClinicalDocument?.component?.structuredBody?.component) {
+    return [payloadRaw];
+  }
+
+  const components = toArray(json.ClinicalDocument?.component?.structuredBody?.component);
+
+  const chunks: string[] = [];
+  let currentComponents: string[] = [];
+  let currentSize = 0;
+
+  const builder = new XMLBuilder({
+    format: false,
+    ignoreAttributes: false,
+    attributeNamePrefix: "_",
+    suppressEmptyNode: true,
+    suppressBooleanAttributes: false,
+  });
+
+  function createChunk(comps: string[]) {
+    const chunk = {
+      ...json,
+      ClinicalDocument: {
+        ...json.ClinicalDocument,
+        component: {
+          ...json.ClinicalDocument.component,
+          structuredBody: {
+            ...json.ClinicalDocument.component.structuredBody,
+            component: comps,
+          },
+        },
+      },
+    };
+    return builder.build(chunk);
+  }
+
+  for (const component of components) {
+    const componentSize = sizeInBytes(component);
+
+    if (currentSize + componentSize > MAX_CHUNK_SIZE && currentComponents.length > 0) {
+      chunks.push(createChunk(currentComponents));
+      currentComponents = [];
+      currentSize = 0;
+    }
+
+    if (componentSize > MAX_CHUNK_SIZE) {
+      if (currentComponents.length > 0) {
+        chunks.push(createChunk(currentComponents));
+        currentComponents = [];
+        currentSize = 0;
+      }
+      chunks.push(createChunk([component]));
+      continue;
+    }
+
+    currentComponents.push(component);
+    currentSize += componentSize;
+  }
+
+  if (currentComponents.length > 0) {
+    chunks.push(createChunk(currentComponents));
+  }
+
+  return chunks.length > 0 ? chunks : [payloadRaw];
+}


### PR DESCRIPTION
Ticket: #_[ticket-number]_

### Description
- Added functionality to partition large XML CDAs into chunks, and convert them separately. After all parts are converted, the results are combined into one bundle and sent back to the caller
- We are going to be saving pre-conversion XMLs for each part separately on S3, but only one final conversion result JSON

### Testing

- Local
  - [ ] Tested with a handful of large files using the FHIR integration test
- Staging
  - [ ] Upload a fake (Synthea) CDA that's above the partition limit
    - [ ] Pull it thru HIEs
    - [ ] Make sure it converts as expected
    - [ ] Check S3 contents - [link](https://us-east-2.console.aws.amazon.com/s3/buckets/metriport-ccda-to-fhir-conversions-staging?prefix=10cce4ac-3628-4f79-bda1-61c73da58759/0192e51c-8b3c-7d5a-b99f-b7622b4a3fa1/&region=us-east-2&bucketType=general)


### Release Plan
- [ ] Merge this
