### PR TITLE
feat(fhir-converter): improved coverage resource generation

### DIFF
--- a/packages/core/src/external/fhir/consolidated/normalize.ts
+++ b/packages/core/src/external/fhir/consolidated/normalize.ts
@@ -1,0 +1,21 @@
+import { Bundle, Resource } from "@medplum/fhirtypes";
+import { elapsedTimeFromNow } from "@metriport/shared/common/date";
+import { out } from "../../../util";
+import { normalizeFhir } from "../normalization/ normalize-fhir";
+
+export function normalize({
+  cxId,
+  patientId,
+  bundle,
+}: {
+  cxId?: string;
+  patientId: string;
+  bundle: Bundle<Resource>;
+}): Bundle<Resource> {
+  const { log } = out(`Normalizing FHIR for cxId ${cxId}, patientId ${patientId}`);
+  const startedAt = new Date();
+  const normalizedBundle = normalizeFhir(bundle);
+
+  log(`Finished normalization in ${elapsedTimeFromNow(startedAt)} ms...`);
+  return normalizedBundle;
+}

--- a/packages/core/src/external/fhir/normalization/ normalize-fhir.ts
+++ b/packages/core/src/external/fhir/normalization/ normalize-fhir.ts
@@ -11,7 +11,7 @@ export function normalizeFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> {
 
   normalizedBundle.entry = Object.entries(resourceArrays).flatMap(([, resources]) => {
     const entriesArray = Array.isArray(resources) ? resources : [resources];
-    return entriesArray.flatMap(v => v || []).map(entry => buildBundleEntry(entry as Resource));
+    return entriesArray.flatMap(v => buildBundleEntry(v) || []);
   });
 
   return normalizedBundle;

--- a/packages/core/src/external/fhir/normalization/ normalize-fhir.ts
+++ b/packages/core/src/external/fhir/normalization/ normalize-fhir.ts
@@ -1,0 +1,18 @@
+import { Bundle, Resource } from "@medplum/fhirtypes";
+import { cloneDeep } from "lodash";
+import { buildBundleEntry, extractFhirTypesFromBundle } from "../shared/bundle";
+import { normalizeCoverages } from "./resources/coverage";
+
+export function normalizeFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> {
+  const normalizedBundle: Bundle = cloneDeep(fhirBundle);
+  const resourceArrays = extractFhirTypesFromBundle(normalizedBundle);
+  const normalizedCoverages = normalizeCoverages(resourceArrays.coverages);
+  resourceArrays.coverages = normalizedCoverages;
+
+  normalizedBundle.entry = Object.entries(resourceArrays).flatMap(([, resources]) => {
+    const entriesArray = Array.isArray(resources) ? resources : [resources];
+    return entriesArray.flatMap(v => v || []).map(entry => buildBundleEntry(entry as Resource));
+  });
+
+  return normalizedBundle;
+}

--- a/packages/core/src/external/fhir/normalization/resources/coverage.ts
+++ b/packages/core/src/external/fhir/normalization/resources/coverage.ts
@@ -1,6 +1,12 @@
 import { Coverage } from "@medplum/fhirtypes";
 import { isValidUuid } from "../../../../util/uuid-v7";
 
+/**
+ * We want to remove useless identifiers that simply contain UUIDs from the CDA they came from.
+ * Instead, we'd prefer to keep the identifiers that might hold policy ID, member ID, or subscriber ID.
+ * @param coverages
+ * @returns
+ */
 export function normalizeCoverages(coverages: Coverage[]): Coverage[] {
   return coverages.map(coverage => {
     const identifiers = coverage.identifier;
@@ -17,6 +23,9 @@ export function normalizeCoverages(coverages: Coverage[]): Coverage[] {
       return true;
     });
     coverage.identifier = validIdentifiers;
+    coverage.subscriberId = validIdentifiers
+      .flatMap(identifier => identifier.value || [])
+      .join(", ");
     return coverage;
   });
 }

--- a/packages/core/src/external/fhir/normalization/resources/coverage.ts
+++ b/packages/core/src/external/fhir/normalization/resources/coverage.ts
@@ -1,0 +1,22 @@
+import { Coverage } from "@medplum/fhirtypes";
+import { isValidUuid } from "../../../../util/uuid-v7";
+
+export function normalizeCoverages(coverages: Coverage[]): Coverage[] {
+  return coverages.map(coverage => {
+    const identifiers = coverage.identifier;
+    if (!identifiers) return coverage;
+
+    const validIdentifiers = identifiers.filter(identifier => {
+      const value = identifier.value?.trim();
+      if (!value) return false;
+
+      if (value.includes("urn:uuid")) return false;
+      const potentialUuid = value.split(":").pop()?.trim();
+      if (isValidUuid(value) || (potentialUuid && isValidUuid(potentialUuid))) return false;
+
+      return true;
+    });
+    coverage.identifier = validIdentifiers;
+    return coverage;
+  });
+}

--- a/packages/fhir-converter/src/templates/cda/References/Coverage/identifier.hbs
+++ b/packages/fhir-converter/src/templates/cda/References/Coverage/identifier.hbs
@@ -1,0 +1,12 @@
+{
+    "resource":{
+        "resourceType": "Coverage",
+        "id":"{{ID}}",
+        "identifier":
+        [
+            {{#each (toArray payerEntry.id)}}
+            	{{>DataType/Identifier.hbs id=this}},
+            {{/each}}
+        ], 
+    },
+},

--- a/packages/fhir-converter/src/templates/cda/References/Coverage/subscriberId.hbs
+++ b/packages/fhir-converter/src/templates/cda/References/Coverage/subscriberId.hbs
@@ -1,0 +1,7 @@
+{
+    "resource":{
+        "resourceType": "Coverage",
+        "id":"{{ID}}",
+        "subscriberId": "{{subscriberId}}"
+    },
+},

--- a/packages/fhir-converter/src/templates/cda/Sections/Payers.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Payers.hbs
@@ -55,6 +55,12 @@
                           {{>References/Coverage/beneficiary.hbs ID=(generateUUID (toJsonString payerEntry.act)) canBeUnknown=true  }},
                     {{/if}}
                 {{/each}}
+                {{#each (toArray payerEntry.act.participant) as |participantEntry|}}
+                    {{#if participantEntry.participantRole.id.extension}}
+                        {{>References/Coverage/subscriberId.hbs subscriberId=participantEntry.participantRole.id.extension ID=(generateUUID (toJsonString payerEntry.act))}},
+                        {{>References/Coverage/identifier.hbs payerEntry=participantEntry.participantRole ID=(generateUUID (toJsonString payerEntry.act))}},
+                    {{/if}}
+                {{/each}}
             {{/each}}
         {{/each}}
     {{/with}}


### PR DESCRIPTION
refs. metriport/metriport-internal#2502

### Description
- Adding `subscriberId` field to the `Coverage` resource, which is going to contain policy ID 
- Adding more `Coverage.identifiers` to catch more cases of policy ID being provided in certain areas of the CDAs
- Adding FHIR Normalization into the consolidated data generation flow
  - Only `Coverage` resource normalization added for now

### Testing

- Local
  - [x] Check with a problematic file to make sure the issue is fixed
  - [x] Run the FHIR test suite
    - [x] Ensure the FHIR is still valid
- Staging
  - [ ] Check that the post normalization file is saved as expected

### Release Plan
- [ ] Merge this
