### PR TITLE
483 Do not paginate by default

### DIFF
--- a/packages/api/src/routes/pagination.ts
+++ b/packages/api/src/routes/pagination.ts
@@ -41,6 +41,12 @@ export const queryMetaSchema = z.intersection(
 );
 export type HttpMeta = z.infer<typeof queryMetaSchema>;
 
+// TODO 483 remove this once pagination is fully rolled out
+export function isPaginated(req: Request): boolean {
+  const meta = queryMetaSchema.parse(req.query);
+  return Object.keys(meta).length > 0;
+}
+
 export function getRequestMeta(req: Request): Pagination {
   const parsed = queryMetaSchema.parse(req.query);
   return {


### PR DESCRIPTION
Ref. metriport/metriport-internal#483

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3024
- Downstream: https://github.com/metriport/metriport-internal/pull/2496

### Description

Do not paginate by default - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1732824973461689?thread_ts=1731543357.768889&cid=C04DMKE9DME).

### Testing

- Local
  - [x] Doesn't paginate unless one of the pagination params is provided in the request
     - [x] Returns the same payload as before the upstream pagination PR
  - [x] Paginates if at least one of the pagination params is provided in the request
- Staging
  - [ ] Doesn't paginate unless one of the pagination params is provided in the request
     - [ ] Returns the same payload as before the upstream pagination PR
  - [ ] Paginates if at least one of the pagination params is provided in the request
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
