### PR TITLE
483 Publish NPM packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30788,7 +30788,7 @@
       }
     },
     "packages/api": {
-      "version": "1.22.10-alpha.0",
+      "version": "1.22.10",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -30872,12 +30872,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "14.0.3-alpha.0",
+      "version": "14.0.3",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.1.10-alpha.0",
-        "@metriport/shared": "^0.14.5-alpha.0",
+        "@metriport/commonwell-sdk": "^5.1.10",
+        "@metriport/shared": "^0.14.5",
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -30933,10 +30933,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.11.10-alpha.0",
+      "version": "1.11.10",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.12.10-alpha.0",
+        "@metriport/ihe-gateway-sdk": "^0.12.10",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -30950,7 +30950,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.13.10-alpha.0",
+      "version": "0.13.10",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -30960,10 +30960,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.19.10-alpha.0",
+      "version": "1.19.10",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.1.10-alpha.0",
+        "@metriport/commonwell-sdk": "^5.1.10",
         "axios": "^1.4.0",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -31002,10 +31002,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.17.10-alpha.0",
+      "version": "1.17.10",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.1.10-alpha.0",
+        "@metriport/commonwell-sdk": "^5.1.10",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -31037,10 +31037,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.1.10-alpha.0",
+      "version": "5.1.10",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.14.5-alpha.0",
+        "@metriport/shared": "^0.14.5",
         "axios": "^1.4.0",
         "http-status": "^1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -31088,7 +31088,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.17.10-alpha.0",
+      "version": "1.17.10",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.616.0",
@@ -31172,17 +31172,17 @@
     "packages/core/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.12.10-alpha.0",
+      "version": "0.12.10",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.14.5-alpha.0",
+        "@metriport/shared": "^0.14.5",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.15.10-alpha.0",
+      "version": "1.15.10",
       "dependencies": {
         "aws-cdk-lib": "^2.122.0",
         "constructs": "^10.2.69",
@@ -31230,7 +31230,7 @@
     },
     "packages/react-native-sdk": {
       "name": "@metriport/react-native-sdk",
-      "version": "1.14.10-alpha.0",
+      "version": "1.14.10",
       "license": "MIT",
       "dependencies": {
         "react-native-webview": "^11.26.1"
@@ -32257,7 +32257,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.14.5-alpha.0",
+      "version": "0.14.5",
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^8.0.2",
@@ -32274,7 +32274,7 @@
       }
     },
     "packages/utils": {
-      "version": "1.18.10-alpha.0",
+      "version": "1.18.10",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-bedrock-agent-runtime": "^3.616.0",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "14.0.3-alpha.0",
+  "version": "14.0.3",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.1.10-alpha.0",
-    "@metriport/shared": "^0.14.5-alpha.0",
+    "@metriport/commonwell-sdk": "^5.1.10",
+    "@metriport/shared": "^0.14.5",
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.22.10-alpha.0",
+  "version": "1.22.10",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.11.10-alpha.0",
+  "version": "1.11.10",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.12.10-alpha.0",
+    "@metriport/ihe-gateway-sdk": "^0.12.10",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.13.10-alpha.0",
+  "version": "0.13.10",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.19.10-alpha.0",
+  "version": "1.19.10",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.1.10-alpha.0",
+    "@metriport/commonwell-sdk": "^5.1.10",
     "axios": "^1.4.0",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.17.10-alpha.0",
+  "version": "1.17.10",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.1.10-alpha.0",
+    "@metriport/commonwell-sdk": "^5.1.10",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.1.10-alpha.0",
+  "version": "5.1.10",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.14.5-alpha.0",
+    "@metriport/shared": "^0.14.5",
     "axios": "^1.4.0",
     "http-status": "^1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.17.10-alpha.0",
+  "version": "1.17.10",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.12.10-alpha.0",
+  "version": "0.12.10",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.14.5-alpha.0",
+    "@metriport/shared": "^0.14.5",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.15.10-alpha.0",
+  "version": "1.15.10",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/react-native-sdk",
-  "version": "1.14.10-alpha.0",
+  "version": "1.14.10",
   "description": "A library to integrate with Metriport on React Native - including Apple Health integrations.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.14.5-alpha.0",
+  "version": "0.14.5",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "utils",
-  "version": "1.18.10-alpha.0",
+  "version": "1.18.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "utils",
-      "version": "1.18.10-alpha.0",
+      "version": "1.18.10",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-bedrock-agent-runtime": "^3.616.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.18.10-alpha.0",
+  "version": "1.18.10",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/483

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3043
- Downstream: https://github.com/metriport/metriport-internal/pull/2496

### Description

Ref: #000

 - api@1.22.10
 - @metriport/api-sdk@14.0.3
 - @metriport/carequality-cert-runner@1.11.10
 - @metriport/carequality-sdk@0.13.10
 - @metriport/commonwell-cert-runner@1.19.10
 - @metriport/commonwell-jwt-maker@1.17.10
 - @metriport/commonwell-sdk@5.1.10
 - @metriport/core@1.17.10
 - @metriport/ihe-gateway-sdk@0.12.10
 - infrastructure@1.15.10
 - @metriport/react-native-sdk@1.14.10
 - @metriport/shared@0.14.5
 - utils@1.18.10

### Testing

none

### Release Plan

- [x] Publish NPM packages
- [x] Merge this
