### PR TITLE
PATCH RELEASE 2024-12-02 FHIR Dedup

### DIFF
--- a/packages/api/src/command/medical/document/document-webhook.ts
+++ b/packages/api/src/command/medical/document/document-webhook.ts
@@ -87,7 +87,7 @@ export const processPatientDocumentRequest = async (
         metadata
       );
     } else {
-      log(`WH disabled. Not sending it - metadata: ${metadata}`);
+      log(`WH disabled. Not sending it - metadata: ${JSON.stringify(metadata)}`);
       await createWebhookRequest({
         cxId,
         type: whType,

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -40,6 +40,16 @@ export function deduplicateFhir(
   patientId: string
 ): Bundle<Resource> {
   const deduplicatedBundle: Bundle = cloneDeep(fhirBundle);
+
+  const resourceMap = new Map<string, Resource>();
+  deduplicatedBundle.entry?.filter(entry => {
+    if (!entry.resource?.id) return false;
+    const existing = resourceMap.get(entry.resource.id);
+    if (existing) return false;
+    resourceMap.set(entry.resource.id, entry.resource);
+    return true;
+  });
+
   let resourceArrays = extractFhirTypesFromBundle(deduplicatedBundle);
 
   const medicationsResult = deduplicateMedications(resourceArrays.medications);


### PR DESCRIPTION
refs. metriport/metriport-internal#799

### Description
- Filtering FHIR resources to remove the ones with the same IDs

### Testing

- Local
  - [x] Use a bundle that contains resources with identical IDs and make sure they get deduped

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
