### PR TITLE
1040 Fix mapping of created_at and updated_at on Sequelize

### DIFF
--- a/packages/api/src/models/_default.ts
+++ b/packages/api/src/models/_default.ts
@@ -40,8 +40,6 @@ export abstract class BaseModelNoId<T extends Model<any, any>>
       freezeTableName: true,
       underscored: true,
       timestamps: true,
-      createdAt: "created_at",
-      updatedAt: "updated_at",
     };
   }
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Fix mapping of created_at and updated_at on Sequelize - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1733167120266349?thread_ts=1733161624.294379&cid=C0616FCPAKZ)

### Testing

- Local
  - [x] Load patient on the API and it includes the `dateCreated` field
- Staging
  - [ ] Load patient on the API and it includes the `dateCreated` field
  - [ ] Dash patient list shows correct created at date
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
