### PR TITLE
feat(elation): logging secrets string on non-prod if bad format

### DIFF
--- a/packages/api/src/external/ehr/elation/shared.ts
+++ b/packages/api/src/external/ehr/elation/shared.ts
@@ -63,7 +63,11 @@ export async function getElationClientKeyAndSecret({
   const rawClientsMap = Config.getElationClientKeyAndSecretMap();
   if (!rawClientsMap) throw new MetriportError("Elation secrets map not set");
   const clientMap = cxClientKeyAndSecretMapSecretSchema.safeParse(JSON.parse(rawClientsMap));
-  if (!clientMap.success) throw new MetriportError("Elation clients map has invalid format");
+  if (!clientMap.success) {
+    throw new MetriportError("Elation clients map has invalid format", undefined, {
+      rawClientsMap: !Config.isProdEnv() ? rawClientsMap : undefined,
+    });
+  }
   const cxKey = `${cxId}_${practiceId}_key`;
   const cxKeyEntry = clientMap.data[cxKey];
   const cxSecret = `${cxId}_${practiceId}_secret`;

--- a/packages/api/src/external/ehr/shared.ts
+++ b/packages/api/src/external/ehr/shared.ts
@@ -3,7 +3,7 @@ import { buildDayjs } from "@metriport/shared/common/date";
 import dayjs from "dayjs";
 import { Duration } from "dayjs/plugin/duration";
 
-export const delayBetweenPracticeBatches = dayjs.duration(0, "seconds");
+export const delayBetweenPracticeBatches = dayjs.duration(30, "seconds");
 export const parallelPractices = 10;
 export const parallelPatients = 2;
 


### PR DESCRIPTION
Ref: #1040

### Description

- adding string to error message on non-prod
- adjusting delay to be non-develop value of 0 seconds

### Release Plan

- [ ] Merge this
