### PR TITLE
2525 improved condition dedup

### DIFF
--- a/packages/core/src/fhir-deduplication/__tests__/combine-two-resources.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/combine-two-resources.test.ts
@@ -32,6 +32,10 @@ describe("combineTwoResources", () => {
   });
 
   it("combines array properties", () => {
+    if (!snomedCodeMd.code || !icd10CodeMd.code) {
+      throw new Error("Test data is invalid - codes must be defined");
+    }
+
     condition.code = { coding: [snomedCodeMd] };
     condition2.code = { coding: [icd10CodeMd] };
 
@@ -40,10 +44,10 @@ describe("combineTwoResources", () => {
       expect.objectContaining({
         coding: expect.arrayContaining([
           expect.objectContaining({
-            code: expect.stringContaining(snomedCodeMd.code!),
+            code: expect.stringContaining(snomedCodeMd.code),
           }),
           expect.objectContaining({
-            code: expect.stringContaining(icd10CodeMd.code!),
+            code: expect.stringContaining(icd10CodeMd.code),
           }),
         ]),
       })

--- a/packages/core/src/fhir-deduplication/__tests__/combine-two-resources.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/combine-two-resources.test.ts
@@ -40,10 +40,10 @@ describe("combineTwoResources", () => {
       expect.objectContaining({
         coding: expect.arrayContaining([
           expect.objectContaining({
-            code: expect.stringContaining(snomedCodeMd.code),
+            code: expect.stringContaining(snomedCodeMd.code!),
           }),
           expect.objectContaining({
-            code: expect.stringContaining(icd10CodeMd.code),
+            code: expect.stringContaining(icd10CodeMd.code!),
           }),
         ]),
       })

--- a/packages/core/src/fhir-deduplication/__tests__/examples/condition-examples.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/examples/condition-examples.ts
@@ -1,17 +1,19 @@
-export const snomedCodeMd = { system: "http://snomed.info/sct", code: "422338006" };
-export const icd10CodeMd = {
+import { Coding } from "@medplum/fhirtypes";
+
+export const snomedCodeMd: Coding = { system: "http://snomed.info/sct", code: "422338006" };
+export const icd10CodeMd: Coding = {
   system: "http://hl7.org/fhir/sid/icd-10-cm",
   code: "H35.30",
   display: "Macular degeneration",
 };
-export const otherCodeSystemMd = {
+export const otherCodeSystemMd: Coding = {
   system: "http://terminology.hl7.org/CodeSystem-IMO.html",
   code: "86946",
   display: "Macular degeneration",
 };
 
-export const snomedCodeAo = { system: "http://snomed.info/sct", code: "87224000" };
-export const icd10CodeAo = {
+export const snomedCodeAo: Coding = { system: "http://snomed.info/sct", code: "87224000" };
+export const icd10CodeAo: Coding = {
   system: "http://hl7.org/fhir/sid/icd-10-cm",
   code: "H34.00",
   display: "Transient arterial occlusion of retina",

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-conditions.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-conditions.test.ts
@@ -99,16 +99,34 @@ describe("groupSameConditions", () => {
   });
 
   it("does not group conditions with different names", () => {
-    condition.code = { coding: [{ display: icd10CodeMd.display!, system: icd10CodeMd.system! }] };
-    condition2.code = { coding: [{ display: icd10CodeAo.display!, system: icd10CodeAo.system! }] };
+    if (
+      !icd10CodeMd.display ||
+      !icd10CodeMd.system ||
+      !icd10CodeAo.display ||
+      !icd10CodeAo.system
+    ) {
+      throw new Error("Test data is invalid - display and system must be defined");
+    }
+
+    condition.code = { coding: [{ display: icd10CodeMd.display, system: icd10CodeMd.system }] };
+    condition2.code = { coding: [{ display: icd10CodeAo.display, system: icd10CodeAo.system }] };
 
     const { conditionsMap } = groupSameConditions([condition, condition2]);
     expect(conditionsMap.size).toBe(2);
   });
 
   it("does not group conditions with different names", () => {
-    condition.code = { coding: [{ display: icd10CodeMd.display!, system: icd10CodeMd.system! }] };
-    condition2.code = { coding: [{ display: icd10CodeAo.display!, system: icd10CodeAo.system! }] };
+    if (
+      !icd10CodeMd.display ||
+      !icd10CodeMd.system ||
+      !icd10CodeAo.display ||
+      !icd10CodeAo.system
+    ) {
+      throw new Error("Test data is invalid - display must be defined");
+    }
+
+    condition.code = { coding: [{ display: icd10CodeMd.display, system: icd10CodeMd.system }] };
+    condition2.code = { coding: [{ display: icd10CodeAo.display, system: icd10CodeAo.system }] };
 
     const { conditionsMap } = groupSameConditions([condition, condition2]);
     expect(conditionsMap.size).toBe(2);
@@ -166,6 +184,10 @@ describe("groupSameConditions", () => {
   });
 
   it("strips away codes that aren't SNOMED or ICD-10", () => {
+    if (!snomedCodeMd.system || !icd10CodeMd.system || otherCodeSystemMd.system) {
+      throw new Error("Test data is invalid - system must be defined");
+    }
+
     condition.code = { coding: [icd10CodeMd] };
     condition2.code = { coding: [icd10CodeMd, snomedCodeMd, otherCodeSystemMd] };
     condition.onsetPeriod = dateTime;
@@ -179,10 +201,10 @@ describe("groupSameConditions", () => {
     expect(resultingCoding).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          system: expect.stringContaining(snomedCodeMd.system!),
+          system: expect.stringContaining(snomedCodeMd.system),
         }),
         expect.objectContaining({
-          system: expect.stringContaining(icd10CodeMd.system!),
+          system: expect.stringContaining(icd10CodeMd.system),
         }),
       ])
     );
@@ -190,7 +212,7 @@ describe("groupSameConditions", () => {
     expect(resultingCoding).toEqual(
       expect.not.arrayContaining([
         expect.objectContaining({
-          system: expect.stringContaining(otherCodeSystemMd.system!),
+          system: expect.stringContaining(otherCodeSystemMd.system),
         }),
       ])
     );

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-conditions.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-conditions.test.ts
@@ -184,7 +184,7 @@ describe("groupSameConditions", () => {
   });
 
   it("strips away codes that aren't SNOMED or ICD-10", () => {
-    if (!snomedCodeMd.system || !icd10CodeMd.system || otherCodeSystemMd.system) {
+    if (!snomedCodeMd.system || !icd10CodeMd.system || !otherCodeSystemMd.system) {
       throw new Error("Test data is invalid - system must be defined");
     }
 

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-conditions.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-conditions.test.ts
@@ -3,12 +3,11 @@ import { Condition } from "@medplum/fhirtypes";
 import { makeCondition } from "../../fhir-to-cda/cda-templates/components/__tests__/make-condition";
 import { groupSameConditions } from "../resources/condition";
 import {
-  icd10CodeAo,
-  icd10CodeMd,
   dateTime,
   dateTime2,
+  icd10CodeAo,
+  icd10CodeMd,
   otherCodeSystemMd,
-  snomedCodeAo,
   snomedCodeMd,
 } from "./examples/condition-examples";
 
@@ -21,78 +20,116 @@ beforeEach(() => {
   conditionId = faker.string.uuid();
   conditionId2 = faker.string.uuid();
   condition = makeCondition({ id: conditionId });
-  condition2 = makeCondition({ id: conditionId2, onsetPeriod: dateTime2 });
+  condition2 = makeCondition({ id: conditionId2 });
 });
 
 describe("groupSameConditions", () => {
   it("correctly groups duplicate conditions based on snomed codes", () => {
     condition.code = { coding: [snomedCodeMd] };
     condition2.code = { coding: [snomedCodeMd] };
-    condition.onsetPeriod = dateTime;
-    condition2.onsetPeriod = dateTime;
 
-    const { snomedMap } = groupSameConditions([condition, condition2]);
-    expect(snomedMap.size).toBe(1);
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(1);
   });
 
-  it("correctly groups duplicate conditions based on icd10 codes", () => {
-    condition.code = { coding: [icd10CodeMd] };
-    condition2.code = { coding: [icd10CodeMd] };
-    condition.onsetPeriod = dateTime;
-    condition2.onsetPeriod = dateTime;
-
-    const { icd10Map } = groupSameConditions([condition, condition2]);
-    expect(icd10Map.size).toBe(1);
-  });
-
-  it("does not group duplicate conditions that don't have overlapping codes", () => {
-    condition.code = { coding: [icd10CodeMd] };
+  it("correctly groups duplicate conditions based on snomed codes and dates", () => {
+    condition.code = { coding: [snomedCodeMd] };
     condition2.code = { coding: [snomedCodeMd] };
     condition.onsetPeriod = dateTime;
     condition2.onsetPeriod = dateTime;
 
-    const { icd10Map, snomedMap } = groupSameConditions([condition, condition2]);
-    expect(icd10Map.size).toBe(1);
-    expect(snomedMap.size).toBe(1);
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(1);
   });
 
-  it("removes conditions that have neither snomed nor icd-10 codes", () => {
-    condition.code = { coding: [{ system: "some other system", code: "123" }] };
-    condition.onsetPeriod = dateTime;
-
-    const { icd10Map, snomedMap } = groupSameConditions([condition]);
-    expect(icd10Map.size).toBe(0);
-    expect(snomedMap.size).toBe(0);
-  });
-
-  it("does not group conditions with different snomed codes", () => {
+  it("correctly groups duplicate conditions based on snomed codes, even if one condition is missing the date", () => {
     condition.code = { coding: [snomedCodeMd] };
-    condition2.code = { coding: [snomedCodeAo] };
-    condition.onsetPeriod = dateTime;
+    condition2.code = { coding: [snomedCodeMd] };
     condition2.onsetPeriod = dateTime;
 
-    const { snomedMap } = groupSameConditions([condition, condition2]);
-    expect(snomedMap.size).toBe(2);
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(1);
   });
 
-  it("does not group conditions with different icd10 codes", () => {
-    condition.code = { coding: [icd10CodeMd] };
-    condition2.code = { coding: [icd10CodeAo] };
-    condition.onsetPeriod = dateTime;
-    condition2.onsetPeriod = dateTime;
-
-    const { icd10Map } = groupSameConditions([condition, condition2]);
-    expect(icd10Map.size).toBe(2);
-  });
-
-  it("does not group conditions with different onset dates", () => {
+  it("does not group conditions with the same snomed codes, but different dates", () => {
     condition.code = { coding: [snomedCodeMd] };
     condition2.code = { coding: [snomedCodeMd] };
     condition.onsetPeriod = dateTime;
     condition2.onsetPeriod = dateTime2;
 
-    const { snomedMap } = groupSameConditions([condition, condition2]);
-    expect(snomedMap.size).toBe(2);
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(2);
+  });
+
+  it("correctly groups duplicate conditions based on icd10 codes", () => {
+    condition.code = { coding: [icd10CodeMd] };
+    condition2.code = { coding: [icd10CodeMd] };
+
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(1);
+  });
+
+  it("correctly groups duplicate conditions based on the same name despite different systems", () => {
+    condition.code = { coding: [icd10CodeMd] };
+    condition2.code = { coding: [otherCodeSystemMd] };
+
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(1);
+  });
+
+  it("correctly groups duplicate conditions based on overlapping codes from different systems", () => {
+    condition.code = { coding: [snomedCodeMd, icd10CodeMd, otherCodeSystemMd] };
+    condition2.code = { coding: [snomedCodeMd] };
+    const condition3 = makeCondition({ id: faker.string.uuid(), code: { coding: [icd10CodeMd] } });
+    const condition4 = makeCondition({
+      id: faker.string.uuid(),
+      code: { coding: [otherCodeSystemMd] },
+    });
+
+    const { conditionsMap } = groupSameConditions([condition, condition2, condition3, condition4]);
+    expect(conditionsMap.size).toBe(1);
+  });
+
+  it("does not group conditions with different codes", () => {
+    condition.code = { coding: [icd10CodeMd] };
+    condition2.code = { coding: [icd10CodeAo] };
+
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(2);
+  });
+
+  it("does not group conditions with different names", () => {
+    condition.code = { coding: [{ display: icd10CodeMd.display!, system: icd10CodeMd.system! }] };
+    condition2.code = { coding: [{ display: icd10CodeAo.display!, system: icd10CodeAo.system! }] };
+
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(2);
+  });
+
+  it("does not group conditions with different names", () => {
+    condition.code = { coding: [{ display: icd10CodeMd.display!, system: icd10CodeMd.system! }] };
+    condition2.code = { coding: [{ display: icd10CodeAo.display!, system: icd10CodeAo.system! }] };
+
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(2);
+  });
+
+  it("does not group conditions with different codes despite the same date", () => {
+    condition.code = { coding: [icd10CodeMd] };
+    condition2.code = { coding: [snomedCodeMd] };
+    condition.onsetPeriod = dateTime;
+    condition2.onsetPeriod = dateTime;
+
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(2);
+  });
+
+  it("removes conditions that have neither snomed, nor icd-10 codes, nor display", () => {
+    condition.code = { coding: [{ system: "some other system", code: "123" }] };
+    condition.onsetPeriod = dateTime;
+
+    const { conditionsMap } = groupSameConditions([condition]);
+    expect(conditionsMap.size).toBe(0);
   });
 
   it("removes conditions that only have one coding that just says 'Problem'", () => {
@@ -107,8 +144,8 @@ describe("groupSameConditions", () => {
     };
     condition.onsetPeriod = dateTime;
 
-    const { snomedMap } = groupSameConditions([condition]);
-    expect(snomedMap.size).toBe(0);
+    const { conditionsMap } = groupSameConditions([condition]);
+    expect(conditionsMap.size).toBe(0);
   });
 
   it("keeps the conditions that only have more than one coding, where one just says 'Problem'", () => {
@@ -124,8 +161,8 @@ describe("groupSameConditions", () => {
     };
     condition.onsetPeriod = dateTime;
 
-    const { snomedMap } = groupSameConditions([condition]);
-    expect(snomedMap.size).toBe(1);
+    const { conditionsMap } = groupSameConditions([condition]);
+    expect(conditionsMap.size).toBe(1);
   });
 
   it("strips away codes that aren't SNOMED or ICD-10", () => {
@@ -133,19 +170,19 @@ describe("groupSameConditions", () => {
     condition2.code = { coding: [icd10CodeMd, snomedCodeMd, otherCodeSystemMd] };
     condition.onsetPeriod = dateTime;
     condition2.onsetPeriod = dateTime;
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(1);
 
-    const { icd10Map } = groupSameConditions([condition, condition2]);
-    expect(icd10Map.size).toBe(1);
-    const resultingCoding = icd10Map.values().next().value.code.coding;
+    const resultingCoding = conditionsMap.values().next().value.code.coding;
 
     expect(resultingCoding.length).toEqual(2);
     expect(resultingCoding).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          system: expect.stringContaining(snomedCodeMd.system),
+          system: expect.stringContaining(snomedCodeMd.system!),
         }),
         expect.objectContaining({
-          system: expect.stringContaining(icd10CodeMd.system),
+          system: expect.stringContaining(icd10CodeMd.system!),
         }),
       ])
     );
@@ -153,20 +190,33 @@ describe("groupSameConditions", () => {
     expect(resultingCoding).toEqual(
       expect.not.arrayContaining([
         expect.objectContaining({
-          system: expect.stringContaining(otherCodeSystemMd.system),
+          system: expect.stringContaining(otherCodeSystemMd.system!),
         }),
       ])
     );
   });
-  it("do not remove code and preserve original coding when there is only one code of unrecognized system", () => {
+
+  it("do not remove code and preserve original coding when there is only one code of unrecognized system - without dates included", () => {
     condition.code = { coding: [otherCodeSystemMd] };
     condition2.code = { coding: [otherCodeSystemMd] };
     condition.onsetPeriod = dateTime;
     condition2.onsetPeriod = dateTime;
 
-    const { displayMap } = groupSameConditions([condition, condition2]);
-    expect(displayMap.size).toBe(1);
-    const groupedCondition = displayMap.values().next().value;
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(1);
+    const groupedCondition = conditionsMap.values().next().value;
+    expect(groupedCondition.code?.coding).toEqual([otherCodeSystemMd]);
+  });
+
+  it("do not remove code and preserve original coding when there is only one code of unrecognized system - with dates included", () => {
+    condition.code = { coding: [otherCodeSystemMd] };
+    condition2.code = { coding: [otherCodeSystemMd] };
+    condition.onsetPeriod = dateTime;
+    condition2.onsetPeriod = dateTime;
+
+    const { conditionsMap } = groupSameConditions([condition, condition2]);
+    expect(conditionsMap.size).toBe(1);
+    const groupedCondition = conditionsMap.values().next().value;
     expect(groupedCondition.code?.coding).toEqual([otherCodeSystemMd]);
   });
 });

--- a/packages/core/src/fhir-deduplication/resources/condition.ts
+++ b/packages/core/src/fhir-deduplication/resources/condition.ts
@@ -19,7 +19,7 @@ import {
  * 1. Group same Conditions based on:
  *      - Medical codes:
  *          - ICD-10
- *          - SNOMED // TODO: Introduce SNOMED cross-walk to match SNOMED with ICD-10
+ *          - SNOMED
  *          - ICD-9
  *      - Date
  *      - Condition name (from code->text or coding->display)
@@ -41,13 +41,9 @@ export function groupSameConditions(conditions: Condition[]): {
   refReplacementMap: Map<string, string>;
   danglingReferences: Set<string>;
 } {
-  // l1 points to l2
   const l1ConditionsMap = new Map<string, string>();
   const l2ConditionsMap = new Map<string, Condition>();
 
-  // const snomedMap = new Map<string, Condition>();
-  // const icd10Map = new Map<string, Condition>();
-  // const displayMap = new Map<string, Condition>();
   const refReplacementMap = new Map<string, string>();
   const danglingReferences = new Set<string>();
 

--- a/packages/core/src/fhir-deduplication/resources/condition.ts
+++ b/packages/core/src/fhir-deduplication/resources/condition.ts
@@ -1,33 +1,35 @@
 import { CodeableConcept, Condition } from "@medplum/fhirtypes";
-import { ICD_10_CODE, ICD_10_OID, SNOMED_CODE, SNOMED_OID, ICD_9_CODE } from "../../util/constants";
+import { ICD_10_CODE, ICD_10_OID, ICD_9_CODE, SNOMED_CODE, SNOMED_OID } from "../../util/constants";
 import {
   DeduplicationResult,
   combineResources,
+  createKeysFromObjectArray,
+  createKeysFromObjectArray3,
   createRef,
   extractDisplayFromConcept,
-  fillMaps,
+  fetchCodingCodeOrDisplayOrSystem,
+  fillL1L2Maps,
   getDateFromResource,
   hasBlacklistedText,
   isUnknownCoding,
-  fetchCodingCodeOrDisplayOrSystem,
 } from "../shared";
 
 /**
  * Approach:
  * 1. Group same Conditions based on:
  *      - Medical codes:
- *          - ICD-10, if possible
- *          // TODO: Introduce SNOMED cross-walk to match SNOMED with ICD-10
- *          - SNOMED, if possible
+ *          - ICD-10
+ *          - SNOMED // TODO: Introduce SNOMED cross-walk to match SNOMED with ICD-10
+ *          - ICD-9
  *      - Date
+ *      - Condition name (from code->text or coding->display)
  * 2. Combine the Conditions in each group into one master condition and return the array of only unique and maximally filled out Conditions
  */
 export function deduplicateConditions(conditions: Condition[]): DeduplicationResult<Condition> {
-  const { snomedMap, icd10Map, displayMap, refReplacementMap, danglingReferences } =
-    groupSameConditions(conditions);
+  const { conditionsMap, refReplacementMap, danglingReferences } = groupSameConditions(conditions);
   return {
     combinedResources: combineResources({
-      combinedMaps: [snomedMap, icd10Map, displayMap],
+      combinedMaps: [conditionsMap],
     }),
     refReplacementMap,
     danglingReferences,
@@ -35,41 +37,19 @@ export function deduplicateConditions(conditions: Condition[]): DeduplicationRes
 }
 
 export function groupSameConditions(conditions: Condition[]): {
-  snomedMap: Map<string, Condition>;
-  icd10Map: Map<string, Condition>;
-  displayMap: Map<string, Condition>;
+  conditionsMap: Map<string, Condition>;
   refReplacementMap: Map<string, string>;
   danglingReferences: Set<string>;
 } {
-  const snomedMap = new Map<string, Condition>();
-  const icd10Map = new Map<string, Condition>();
-  const displayMap = new Map<string, Condition>();
+  // l1 points to l2
+  const l1ConditionsMap = new Map<string, string>();
+  const l2ConditionsMap = new Map<string, Condition>();
+
+  // const snomedMap = new Map<string, Condition>();
+  // const icd10Map = new Map<string, Condition>();
+  // const displayMap = new Map<string, Condition>();
   const refReplacementMap = new Map<string, string>();
   const danglingReferences = new Set<string>();
-
-  function removeOtherCodes(master: Condition): Condition {
-    const code = master.code;
-    const filtered = code?.coding?.filter(coding => {
-      const system = fetchCodingCodeOrDisplayOrSystem(coding, "system");
-      return (
-        system?.includes(SNOMED_CODE) ||
-        system?.includes(SNOMED_OID) ||
-        system?.includes(ICD_10_CODE) ||
-        system?.includes(ICD_10_OID) ||
-        system?.includes(ICD_9_CODE)
-      );
-    });
-    if (filtered && filtered.length > 0) {
-      master.code = {
-        ...code,
-        coding: filtered,
-      };
-    } else {
-      master.code = { ...code };
-      delete master.code.coding;
-    }
-    return master;
-  }
 
   for (const condition of conditions) {
     if (hasBlacklistedText(condition.code) || !isKnownCondition(condition.code)) {
@@ -78,36 +58,73 @@ export function groupSameConditions(conditions: Condition[]): {
     }
 
     const date = getDateFromResource(condition);
-    if (!date) {
+    const { snomedCode, icd10Code } = extractCodes(condition.code);
+    const display = extractDisplayFromConcept(condition.code);
+
+    const identifiers = [
+      ...(snomedCode ? [{ snomedCode }] : []),
+      ...(icd10Code ? [{ icd10Code }] : []),
+      ...(display ? [{ display }] : []),
+    ];
+    const hasIdentifier = identifiers.length > 0;
+
+    if (!hasIdentifier) {
       danglingReferences.add(createRef(condition));
       continue;
     }
+    const getterKeys: string[] = [];
+    const setterKeys: string[] = [];
 
-    const { snomedCode, icd10Code } = extractCodes(condition.code);
-    if (icd10Code) {
-      const compKey = JSON.stringify({ icd10Code, date });
-      fillMaps(icd10Map, compKey, condition, refReplacementMap, undefined, removeOtherCodes);
-    } else if (snomedCode) {
-      const compKey = JSON.stringify({ snomedCode, date });
-      fillMaps(snomedMap, compKey, condition, refReplacementMap, undefined, removeOtherCodes);
+    if (date) {
+      // flagging the condition with each unique identifier + date
+      setterKeys.push(...createKeysFromObjectArray({ date }, identifiers));
+      // flagging the condition with each unique identifier + 1 date bit
+      setterKeys.push(...createKeysFromObjectArray3(identifiers, [1]));
+
+      // the condition will dedup using each unique identifier with the same date,
+      getterKeys.push(...createKeysFromObjectArray({ date }, identifiers));
+      // the condition will dedup using each unique identifier + 0 date bit
+      getterKeys.push(...createKeysFromObjectArray3(identifiers, [0]));
+    }
+
+    if (!date) {
+      // flagging the condition with each unique identifier + 0 date bit
+      setterKeys.push(...createKeysFromObjectArray3(identifiers, [0]));
+
+      // the condition will dedup using each unique identifier with 0 or 1 date bit
+      getterKeys.push(...createKeysFromObjectArray3(identifiers, [0]));
+      getterKeys.push(...createKeysFromObjectArray3(identifiers, [1]));
+    }
+
+    if (setterKeys.length > 0) {
+      fillL1L2Maps({
+        map1: l1ConditionsMap,
+        map2: l2ConditionsMap,
+        getterKeys,
+        setterKeys,
+        targetResource: condition,
+        refReplacementMap,
+        applySpecialModifications: removeOtherCodes,
+      });
     } else {
-      const display = extractDisplayFromConcept(condition.code);
-      if (display) {
-        const compKey = JSON.stringify({ display, date });
-        fillMaps(displayMap, compKey, condition, refReplacementMap, undefined);
-      } else {
-        danglingReferences.add(createRef(condition));
-      }
+      danglingReferences.add(createRef(condition));
     }
   }
 
   return {
-    snomedMap,
-    icd10Map,
-    displayMap,
+    conditionsMap: l2ConditionsMap,
     refReplacementMap,
     danglingReferences,
   };
+}
+
+export function createKeyWithBits(
+  object: object,
+  date: string | undefined,
+  dateBit: number
+): string {
+  const keyObject = { ...object, date: dateBit === 1 ? date : undefined, dateBit };
+  return JSON.stringify(keyObject);
 }
 
 function isKnownCondition(concept: CodeableConcept | undefined) {
@@ -142,4 +159,38 @@ export function extractCodes(concept: CodeableConcept | undefined): {
     }
   }
   return { snomedCode, icd10Code };
+}
+
+function removeOtherCodes(master: Condition): Condition {
+  const code = master.code;
+  const codings = code?.coding;
+  if (!codings?.length) return master;
+
+  // If the condition only has one coding that provides insight with the `display` field, let's keep it
+  if (codings.length === 1 && codings[0]) {
+    const display = fetchCodingCodeOrDisplayOrSystem(codings[0], "display");
+    if (display) return master;
+  }
+
+  const filtered = codings.filter(coding => {
+    const system = fetchCodingCodeOrDisplayOrSystem(coding, "system");
+    return (
+      system?.includes(SNOMED_CODE) ||
+      system?.includes(SNOMED_OID) ||
+      system?.includes(ICD_10_CODE) ||
+      system?.includes(ICD_10_OID) ||
+      system?.includes(ICD_9_CODE)
+    );
+  });
+
+  if (filtered.length > 0) {
+    master.code = {
+      ...code,
+      coding: filtered,
+    };
+  } else {
+    master.code = { ...code };
+    delete master.code.coding;
+  }
+  return master;
 }

--- a/packages/core/src/fhir-deduplication/resources/condition.ts
+++ b/packages/core/src/fhir-deduplication/resources/condition.ts
@@ -4,7 +4,7 @@ import {
   DeduplicationResult,
   combineResources,
   createKeysFromObjectArray,
-  createKeysFromObjectArray3,
+  createKeysFromObjectArrayAndBits,
   createRef,
   extractDisplayFromConcept,
   fetchCodingCodeOrDisplayOrSystem,
@@ -79,21 +79,21 @@ export function groupSameConditions(conditions: Condition[]): {
       // flagging the condition with each unique identifier + date
       setterKeys.push(...createKeysFromObjectArray({ date }, identifiers));
       // flagging the condition with each unique identifier + 1 date bit
-      setterKeys.push(...createKeysFromObjectArray3(identifiers, [1]));
+      setterKeys.push(...createKeysFromObjectArrayAndBits(identifiers, [1]));
 
       // the condition will dedup using each unique identifier with the same date,
       getterKeys.push(...createKeysFromObjectArray({ date }, identifiers));
       // the condition will dedup using each unique identifier + 0 date bit
-      getterKeys.push(...createKeysFromObjectArray3(identifiers, [0]));
+      getterKeys.push(...createKeysFromObjectArrayAndBits(identifiers, [0]));
     }
 
     if (!date) {
       // flagging the condition with each unique identifier + 0 date bit
-      setterKeys.push(...createKeysFromObjectArray3(identifiers, [0]));
+      setterKeys.push(...createKeysFromObjectArrayAndBits(identifiers, [0]));
 
       // the condition will dedup using each unique identifier with 0 or 1 date bit
-      getterKeys.push(...createKeysFromObjectArray3(identifiers, [0]));
-      getterKeys.push(...createKeysFromObjectArray3(identifiers, [1]));
+      getterKeys.push(...createKeysFromObjectArrayAndBits(identifiers, [0]));
+      getterKeys.push(...createKeysFromObjectArrayAndBits(identifiers, [1]));
     }
 
     if (setterKeys.length > 0) {

--- a/packages/core/src/fhir-deduplication/resources/condition.ts
+++ b/packages/core/src/fhir-deduplication/resources/condition.ts
@@ -79,7 +79,7 @@ export function groupSameConditions(conditions: Condition[]): {
 
       // the condition will dedup using each unique identifier with the same date,
       getterKeys.push(...createKeysFromObjectArray({ date }, identifiers));
-      // the condition will dedup using each unique identifier + 0 date bit
+      // the condition will dedup against ones that don't have the date
       getterKeys.push(...createKeysFromObjectArrayAndBits(identifiers, [0]));
     }
 
@@ -87,7 +87,7 @@ export function groupSameConditions(conditions: Condition[]): {
       // flagging the condition with each unique identifier + 0 date bit
       setterKeys.push(...createKeysFromObjectArrayAndBits(identifiers, [0]));
 
-      // the condition will dedup using each unique identifier with 0 or 1 date bit
+      // the condition will dedup against ones that might or might not have the date
       getterKeys.push(...createKeysFromObjectArrayAndBits(identifiers, [0]));
       getterKeys.push(...createKeysFromObjectArrayAndBits(identifiers, [1]));
     }

--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -161,6 +161,14 @@ export function createKeysFromObjectArrayAndFlagBits(
   return contactsOrAddresses.map(item => JSON.stringify({ baseObject, ...item, flagBits }));
 }
 
+export function createKeysFromObjectArray(baseObject: object, keyObjects: object[]): string[] {
+  return keyObjects.map(item => JSON.stringify({ baseObject, ...item }));
+}
+
+export function createKeysFromObjectArrayAndBits(keyObjects: object[], bits: number[]): string[] {
+  return keyObjects.map(item => JSON.stringify({ item, bits }));
+}
+
 export function createKeysFromObjectAndFlagBits(object: object, bits: number[]): string[] {
   return [JSON.stringify({ ...object, bits })];
 }


### PR DESCRIPTION
Ticket: #metriport/metriport-internal/issues/2525

### Dependencies
- Downstream: https://github.com/metriport/metriport/pull/3090

### Description
- Reworked the FHIR `Condition` resource deduplication
  - Added flag bits to indicate in which cases conditions should use the date for deduplication
  - Added the ability to dedup from ICD-10/ICD-9/SNOMED/Name simultaneously, rather than by only one at a time
- Fixed and improved the tests

### Testing

- Local
  - [x] Thorough unit tests
  - [x] Ran on a few real-life bundles that had problems earlier

### Release Plan
- [ ] Merge this
