### PR TITLE
2510 Single AI brief function on MR template + Note on last year data on brief

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-brief.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-brief.ts
@@ -984,8 +984,12 @@ function filterOutOldLabs(reports: any[] | undefined): any[] | undefined {
 
   if (!reports) return undefined;
 
-  const labReports = reports.filter(report =>
-    report.category?.toLowerCase().includes("relevant diagnostic tests and/or laboratory data")
+  const labReports = reports.filter(
+    report =>
+      report.category &&
+      !Array.isArray(report.category) &&
+      typeof report.category === "string" &&
+      report.category.toLowerCase().includes("relevant diagnostic tests and/or laboratory data")
   );
   const nonLabReports = reports.filter(report => !report.category?.includes("laboratory data"));
 

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
@@ -23,9 +23,10 @@ import {
 import dayjs from "dayjs";
 import { uniqWith } from "lodash";
 import { Brief } from "./bundle-to-brief";
-import { createBrief } from "./bundle-to-html";
 import {
   buildEncounterSections,
+  createBrief,
+  createSection,
   formatDateForDisplay,
   ISO_DATE,
   MISSING_DATE_KEY,
@@ -2462,20 +2463,6 @@ function getConditionDatesFromEncounters(
   });
 
   return conditionDates;
-}
-
-function createSection(title: string, tableContents: string) {
-  return `
-    <div id="${title.toLowerCase().replace(/\s+/g, "-")}" class="section">
-      <div class="section-title">
-        <h3 id="${title}" title="${title}">&#x276F; ${title}</h3>
-        <a href="#mr-header">&#x25B2; Back to Top</a>
-      </div>
-      <div class="section-content">
-          ${tableContents}
-      </div>
-    </div>
-  `;
 }
 
 function mapResourceToId<ResourceType>(resources: Resource[]): Record<string, ResourceType> {

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-bmi.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-bmi.ts
@@ -20,12 +20,17 @@ import {
   Resource,
   Task,
 } from "@medplum/fhirtypes";
-import dayjs from "dayjs";
-import { fetchCodingCodeOrDisplayOrSystem } from "../../../fhir-deduplication/shared";
-import { cloneDeep, uniqWith } from "lodash";
-import { Brief } from "./bundle-to-brief";
-import { ISO_DATE, formatDateForDisplay } from "./bundle-to-html-shared";
 import { buildDayjs } from "@metriport/shared/common/date";
+import dayjs from "dayjs";
+import { cloneDeep, uniqWith } from "lodash";
+import { fetchCodingCodeOrDisplayOrSystem } from "../../../fhir-deduplication/shared";
+import { Brief } from "./bundle-to-brief";
+import {
+  createBrief,
+  createSection,
+  formatDateForDisplay,
+  ISO_DATE,
+} from "./bundle-to-html-shared";
 
 const RX_NORM_CODE = "rxnorm";
 const NDC_CODE = "ndc";
@@ -576,35 +581,6 @@ function createHeaderTableRow(label: string, value: string) {
       </td>
     </tr>
   `;
-}
-
-export function createBrief(brief?: Brief): string {
-  if (!brief || !brief.content) return ``;
-  const { link, content } = brief;
-  const briefContents = `
-  <div class="brief-section-content">
-    <div class="beta-flag">BETA</div>
-    <table><tbody><tr><td>${content.replace(/\n/g, "<br/>")}</td></tr></tbody></table>
-    <div style="border: 2px solid #FFCC00; background-color: #FFF8E1; padding: 10px; border-radius: 5px; margin-top: 20px;">
-      <div style="display: flex; align-items: center;">
-        <div style="margin-right: 10px;">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C11.448 2 11 2.448 11 3V11C11 11.552 11.448 12 12 12C12.552 12 13 11.552 13 11V3C13 2.448 12.552 2 12 2ZM11 15C11 14.448 11.448 14 12 14C12.552 14 13 14.448 13 15V17C13 17.552 12.552 18 12 18C11.448 18 11 17.552 11 17V15Z" fill="#FFCC00"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M22 20C22 21.1046 21.1046 22 20 22H4C2.89543 22 2 21.1046 2 20V4C2 2.89543 2.89543 2 4 2H20C21.1046 2 22 2.89543 22 4V20ZM20 4H4V20H20V4Z" fill="#FFCC00"/>
-          </svg>
-        </div>
-        <div>
-          <strong style="color: #FF6F00;">Warning:</strong>
-        </div>
-        <div style="margin-left: 10px;">
-          This Medical Record Brief was generated using AI technologies. The information contained within might contain errors. DO NOT use this as a single source of truth and verify this information with the data below.
-          Provide feedback about the AI-generated brief <a href="${link}" target="_blank">here</a>.
-        </div>
-      </div>
-    </div>
-  </div>
-  `;
-  return createSection("Brief (AI-generated)", briefContents);
 }
 
 function createBmiFromObservationVitalsSection(observations: Observation[]): {
@@ -1907,20 +1883,6 @@ function getConditionDatesFromEncounters(
   });
 
   return conditionDates;
-}
-
-function createSection(title: string, tableContents: string) {
-  return `
-    <div id="${title.toLowerCase().replace(/\s+/g, "-")}" class="section">
-      <div class="section-title">
-        <h3 id="${title}" title="${title}">&#x276F; ${title}</h3>
-        <a href="#mr-header">&#x25B2; Back to Top</a>
-      </div>
-      <div class="section-content">
-          ${tableContents}
-      </div>
-    </div>
-  `;
 }
 
 function mapResourceToId<ResourceType>(resources: Resource[]): Record<string, ResourceType> {

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-no-dedup.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-no-dedup.ts
@@ -23,6 +23,7 @@ import {
 import dayjs from "dayjs";
 import { uniqWith } from "lodash";
 import { Brief } from "./bundle-to-brief";
+import { createBrief, createSection } from "./bundle-to-html-shared";
 
 const ISO_DATE = "YYYY-MM-DD";
 
@@ -532,35 +533,6 @@ function createHeaderTableRow(label: string, value: string) {
       </td>
     </tr>
   `;
-}
-
-export function createBrief(brief?: Brief): string {
-  if (!brief || !brief.content) return ``;
-  const { link, content } = brief;
-  const briefContents = `
-  <div class="brief-section-content">
-    <div class="beta-flag">BETA</div>
-    <table><tbody><tr><td>${content.replace(/\n/g, "<br/>")}</td></tr></tbody></table>
-    <div style="border: 2px solid #FFCC00; background-color: #FFF8E1; padding: 10px; border-radius: 5px; margin-top: 20px;">
-      <div style="display: flex; align-items: center;">
-        <div style="margin-right: 10px;">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C11.448 2 11 2.448 11 3V11C11 11.552 11.448 12 12 12C12.552 12 13 11.552 13 11V3C13 2.448 12.552 2 12 2ZM11 15C11 14.448 11.448 14 12 14C12.552 14 13 14.448 13 15V17C13 17.552 12.552 18 12 18C11.448 18 11 17.552 11 17V15Z" fill="#FFCC00"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M22 20C22 21.1046 21.1046 22 20 22H4C2.89543 22 2 21.1046 2 20V4C2 2.89543 2.89543 2 4 2H20C21.1046 2 22 2.89543 22 4V20ZM20 4H4V20H20V4Z" fill="#FFCC00"/>
-          </svg>
-        </div>
-        <div>
-          <strong style="color: #FF6F00;">Warning:</strong>
-        </div>
-        <div style="margin-left: 10px;">
-          This Medical Record Brief was generated using AI technologies. The information contained within might contain errors. DO NOT use this as a single source of truth and verify this information with the data below.
-          Provide feedback about the AI-generated brief <a href="${link}" target="_blank">here</a>.
-        </div>
-      </div>
-    </div>
-  </div>
-  `;
-  return createSection("Brief (AI-generated)", briefContents);
 }
 
 type EncounterTypes =
@@ -2121,20 +2093,6 @@ function getConditionDatesFromEncounters(
   });
 
   return conditionDates;
-}
-
-function createSection(title: string, tableContents: string) {
-  return `
-    <div id="${title.toLowerCase().replace(/\s+/g, "-")}" class="section">
-      <div class="section-title">
-        <h3 id="${title}" title="${title}">&#x276F; ${title}</h3>
-        <a href="#mr-header">&#x25B2; Back to Top</a>
-      </div>
-      <div class="section-content">
-          ${tableContents}
-      </div>
-    </div>
-  `;
 }
 
 function mapResourceToId<ResourceType>(resources: Resource[]): Record<string, ResourceType> {

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
@@ -1,5 +1,6 @@
 import { DiagnosticReport } from "@medplum/fhirtypes";
 import dayjs from "dayjs";
+import { Brief } from "./bundle-to-brief";
 
 export const ISO_DATE = "YYYY-MM-DD";
 export const MISSING_DATE_KEY = "N/A";
@@ -89,4 +90,49 @@ export function buildEncounterSections(diagnosticReports: DiagnosticReport[]): E
   }
 
   return encounterSections;
+}
+
+export function createBrief(brief?: Brief): string {
+  if (!brief || !brief.content) return ``;
+  const { link, content } = brief;
+  const briefContents = `
+  <div class="brief-section-content">
+    <div class="beta-flag">BETA</div>
+    <table><tbody><tr><td>${content.replace(/\n/g, "<br/>")}</td></tr></tbody></table>
+    <div style="border: 2px solid #FFCC00; background-color: #FFF8E1; padding: 10px; border-radius: 5px; margin-top: 20px;">
+      <div style="display: flex; align-items: center;">
+        <div style="margin-right: 10px;">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C11.448 2 11 2.448 11 3V11C11 11.552 11.448 12 12 12C12.552 12 13 11.552 13 11V3C13 2.448 12.552 2 12 2ZM11 15C11 14.448 11.448 14 12 14C12.552 14 13 14.448 13 15V17C13 17.552 12.552 18 12 18C11.448 18 11 17.552 11 17V15Z" fill="#FFCC00"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M22 20C22 21.1046 21.1046 22 20 22H4C2.89543 22 2 21.1046 2 20V4C2 2.89543 2.89543 2 4 2H20C21.1046 2 22 2.89543 22 4V20ZM20 4H4V20H20V4Z" fill="#FFCC00"/>
+          </svg>
+        </div>
+        <div>
+          <strong style="color: #FF6F00;">Warning:</strong>
+        </div>
+        <div style="margin-left: 10px;">
+          This Medical Record Brief was generated using AI technologies using the last year of the patient's medical history.
+          The information contained within might contain errors.
+          DO NOT use this as a single source of truth and verify this information with the data below.
+          Provide feedback about the AI-generated brief <a href="${link}" target="_blank">here</a>.
+        </div>
+      </div>
+    </div>
+  </div>
+  `;
+  return createSection("Brief (AI-generated)", briefContents);
+}
+
+export function createSection(title: string, tableContents: string) {
+  return `
+    <div id="${title.toLowerCase().replace(/\s+/g, "-")}" class="section">
+      <div class="section-title">
+        <h3 id="${title}" title="${title}">&#x276F; ${title}</h3>
+        <a href="#mr-header">&#x25B2; Back to Top</a>
+      </div>
+      <div class="section-content">
+          ${tableContents}
+      </div>
+    </div>
+  `;
 }

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -24,12 +24,14 @@ import dayjs from "dayjs";
 import { intersection, uniqWith } from "lodash";
 import { Brief } from "./bundle-to-brief";
 import {
+  buildEncounterSections,
+  createBrief,
+  createSection,
   EncounterSection,
+  formatDateForDisplay,
   ISO_DATE,
   MISSING_DATE_KEY,
   MISSING_DATE_TEXT,
-  buildEncounterSections,
-  formatDateForDisplay,
 } from "./bundle-to-html-shared";
 
 const RX_NORM_CODE = "rxnorm";
@@ -534,35 +536,6 @@ function createHeaderTableRow(label: string, value: string) {
       </td>
     </tr>
   `;
-}
-
-export function createBrief(brief?: Brief): string {
-  if (!brief || !brief.content) return ``;
-  const { link, content } = brief;
-  const briefContents = `
-  <div class="brief-section-content">
-    <div class="beta-flag">BETA</div>
-    <table><tbody><tr><td>${content.replace(/\n/g, "<br/>")}</td></tr></tbody></table>
-    <div style="border: 2px solid #FFCC00; background-color: #FFF8E1; padding: 10px; border-radius: 5px; margin-top: 20px;">
-      <div style="display: flex; align-items: center;">
-        <div style="margin-right: 10px;">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C11.448 2 11 2.448 11 3V11C11 11.552 11.448 12 12 12C12.552 12 13 11.552 13 11V3C13 2.448 12.552 2 12 2ZM11 15C11 14.448 11.448 14 12 14C12.552 14 13 14.448 13 15V17C13 17.552 12.552 18 12 18C11.448 18 11 17.552 11 17V15Z" fill="#FFCC00"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M22 20C22 21.1046 21.1046 22 20 22H4C2.89543 22 2 21.1046 2 20V4C2 2.89543 2.89543 2 4 2H20C21.1046 2 22 2.89543 22 4V20ZM20 4H4V20H20V4Z" fill="#FFCC00"/>
-          </svg>
-        </div>
-        <div>
-          <strong style="color: #FF6F00;">Warning:</strong>
-        </div>
-        <div style="margin-left: 10px;">
-          This Medical Record Brief was generated using AI technologies. The information contained within might contain errors. DO NOT use this as a single source of truth and verify this information with the data below.
-          Provide feedback about the AI-generated brief <a href="${link}" target="_blank">here</a>.
-        </div>
-      </div>
-    </div>
-  </div>
-  `;
-  return createSection("Brief (AI-generated)", briefContents);
 }
 
 function createAWESection(
@@ -2236,20 +2209,6 @@ function getConditionDatesFromEncounters(
   });
 
   return conditionDates;
-}
-
-function createSection(title: string, tableContents: string) {
-  return `
-    <div id="${title.toLowerCase().replace(/\s+/g, "-")}" class="section">
-      <div class="section-title">
-        <h3 id="${title}" title="${title}">&#x276F; ${title}</h3>
-        <a href="#mr-header">&#x25B2; Back to Top</a>
-      </div>
-      <div class="section-content">
-          ${tableContents}
-      </div>
-    </div>
-  `;
 }
 
 function mapResourceToId<ResourceType>(resources: Resource[]): Record<string, ResourceType> {

--- a/packages/utils/src/customer-requests/medical-record-brief-input.ts
+++ b/packages/utils/src/customer-requests/medical-record-brief-input.ts
@@ -29,7 +29,6 @@ async function main() {
   const brief = await summarizeFilteredBundleWithAI(bundle, CX_ID, SOURCE_PATIENT_ID);
   const briefId = uuidv7();
 
-  // Response from FHIR Converter
   const html = bundleToHtml(
     bundle,
     brief ? { content: brief, id: briefId, link: `${dashUrl}/feedback/${briefId}` } : undefined

--- a/packages/utils/src/customer-requests/medical-records-local-with-brief.ts
+++ b/packages/utils/src/customer-requests/medical-records-local-with-brief.ts
@@ -56,7 +56,6 @@ async function main() {
   const briefFileName = createMRSummaryBriefFileName(cxId, patientId);
   const htmlFileName = createMRSummaryFileName(cxId, patientId, "html");
 
-  // Response from FHIR Converter
   const html = bundleToHtml(
     bundleParsed,
     brief ? { content: brief, id: briefId, link: `${dashUrl}/feedback/${briefId}` } : undefined


### PR DESCRIPTION
refs. metriport/metriport-internal#2510

### Dependencies

none

### Description

- Single AI brief function on MR template
- Note about using last year's data to generate AI brief

![image](https://github.com/user-attachments/assets/5ea697a1-3e57-4915-83cf-832c502a0b5d)


### Testing

- Local
  - [ ] Generate brief with updated message
- Staging
  - [ ] Generate brief with updated message
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
