### PR TITLE
fix(fhir-converter): removing unnecessary med stmnt generation

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Sections/Medication.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Medication.hbs
@@ -29,12 +29,14 @@
         {{#each medEntries}}
             {{#each (multipleToArray 2_16_840_1_113883_10_20_22_2_1_1.entry 2_16_840_1_113883_10_20_22_2_1.entry 2_16_840_1_113883_10_20_22_2_38.entry) as |medEntry|}}
                 {{#if medEntry.substanceAdministration}}
-                    {{>Resources/MedicationStatement.hbs medicationStatement=medEntry.substanceAdministration ID=(generateUUID (toJsonString medEntry.substanceAdministration))}},
-                   	{{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
-                    	{{>References/MedicationStatement/subject.hbs ID=(generateUUID (toJsonString medEntry.substanceAdministration)) REF=(concat 'Patient/' patientId.Id)}},
-                    {{/with}}
                     {{#if medEntry.substanceAdministration.consumable.manufacturedProduct.manufacturedMaterial}}
                         {{>Resources/Medication.hbs medication=medEntry.substanceAdministration.consumable.manufacturedProduct.manufacturedMaterial ID=(generateUUID (toJsonString medEntry.substanceAdministration.consumable.manufacturedProduct.manufacturedMaterial))}},
+                        
+                        {{>Resources/MedicationStatement.hbs medicationStatement=medEntry.substanceAdministration ID=(generateUUID (toJsonString medEntry.substanceAdministration))}},
+                        {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                            {{>References/MedicationStatement/subject.hbs ID=(generateUUID (toJsonString medEntry.substanceAdministration)) REF=(concat 'Patient/' patientId.Id)}},
+                        {{/with}}
+                        
                         {{>References/MedicationStatement/medicationReference.hbs ID=(generateUUID (toJsonString medEntry.substanceAdministration)) REF=(concat 'Medication/' (generateUUID (toJsonString medEntry.substanceAdministration.consumable.manufacturedProduct.manufacturedMaterial)))}},
                         {{#each (toArray medEntry.substanceAdministration.entryRelationship) as |medReq|}}
                             {{#if medReq.supply}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Medication.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Medication.hbs
@@ -70,8 +70,6 @@
                             {{/if}}
 
                         {{/each}}
-                    {{else}}
-                        {{>References/MedicationStatement/medicationReference.hbs ID=(generateUUID (toJsonString medEntry.substanceAdministration)) REF=(concat 'Medication/' (generateUUID (toJsonString medEntry.substanceAdministration.consumable.manufacturedProduct.manufacturedMaterial)))}},
                     {{/if}}
 
                     {{#if medEntry.substanceAdministration.informant.assignedEntity.representedOrganization.name._}}

--- a/packages/utils/src/fhir-converter/fhir-resource-counts/develop-fhir-resource-count.json
+++ b/packages/utils/src/fhir-converter/fhir-resource-counts/develop-fhir-resource-count.json
@@ -1,5 +1,5 @@
 {
-  "total": 382452,
+  "total": 382306,
   "countPerType": {
     "AllergyIntolerance": 819,
     "Composition": 9445,
@@ -9,12 +9,12 @@
     "Device": 9207,
     "FamilyMemberHistory": 774,
     "Medication": 12384,
-    "MedicationStatement": 8354,
+    "MedicationStatement": 8347,
     "Observation": 162910,
-    "Organization": 14832,
+    "Organization": 14827,
     "Practitioner": 54567,
     "RelatedPerson": 12260,
-    "DiagnosticReport": 28010,
+    "DiagnosticReport": 27876,
     "Encounter": 10420,
     "Location": 8262,
     "MedicationRequest": 7163,


### PR DESCRIPTION
refs. metriport/metriport-internal#2530

### Description
- Removing unnecessary MedicationStatement generation if the Medication information is missing in the XML
- Updated the resource counts: 
  - ⚠️ Looks like we forgot to update the counts at some point recently. The only real change in the counts based on the changes in this PR is the -6 MedicationStatements, which is expected

### Testing

- Local
  - [x] FHIR test suite
  - [x] Run on problematic XMLs and see that no useless MedStatements are generated

### Release Plan
- [ ] Merge this
