### PR TITLE
2533 improved diagreport dedup

### DIFF
--- a/packages/core/src/fhir-deduplication/__tests__/group-same-diag-reports.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-diag-reports.test.ts
@@ -41,13 +41,13 @@ describe("groupSameDiagnosticReports", () => {
     expect(diagReportsMap.size).toBe(1);
   });
 
-  it("groups diagReports with the same effectiveDateTime, if one of them has a performer", () => {
+  it("does not group diagReports with the same effectiveDateTime, if one of them has a performer and the other one does not", () => {
     diagReport.effectiveDateTime = dateTime.start;
     diagReport2.effectiveDateTime = dateTime.start;
     diagReport.performer = [practRef];
 
     const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
-    expect(diagReportsMap.size).toBe(1);
+    expect(diagReportsMap.size).toBe(2);
   });
 
   it("does not group diagReports with the same effectiveDateTime if none of them have a practitioner reference ", () => {

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-diag-reports.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-diag-reports.test.ts
@@ -86,7 +86,7 @@ describe("groupSameDiagnosticReports", () => {
     expect(diagReportsMap.size).toBe(2);
   });
 
-  it("discards diagReport if result is not present", () => {
+  it("discards diagReport if result and presented form are not present", () => {
     diagReport.effectiveDateTime = dateTime.start;
     diagReport.performer = [practRef];
     delete diagReport.result;
@@ -149,7 +149,6 @@ describe("groupSameDiagnosticReports", () => {
     const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
     expect(diagReportsMap.size).toBe(1);
     const masterReport = diagReportsMap.values().next().value as DiagnosticReport;
-    console.log("masterReport", JSON.stringify(masterReport));
 
     expect(masterReport.code?.coding?.length).toBe(2);
     expect(masterReport.code?.coding).toEqual(

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-diag-reports.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-diag-reports.test.ts
@@ -28,6 +28,16 @@ beforeEach(() => {
   diagReportId2 = faker.string.uuid();
   diagReport = makeDiagnosticReport({ id: diagReportId });
   diagReport2 = makeDiagnosticReport({ id: diagReportId2 });
+
+  delete diagReport.effectiveDateTime;
+  delete diagReport.performer;
+  delete diagReport.presentedForm;
+  delete diagReport.result;
+
+  delete diagReport2.effectiveDateTime;
+  delete diagReport2.performer;
+  delete diagReport2.presentedForm;
+  delete diagReport2.result;
 });
 
 describe("groupSameDiagnosticReports", () => {
@@ -73,12 +83,16 @@ describe("groupSameDiagnosticReports", () => {
     diagReport.effectiveDateTime = dateTime.start;
     diagReport2.effectiveDateTime = dateTime.start;
     diagReport.performer = [practRef];
+    diagReport2.performer = [];
 
     diagReport.result = resultExample;
     diagReport2.presentedForm = presentedFormExample;
 
     const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
     expect(diagReportsMap.size).toBe(2);
+
+    const diagReportIds = Array.from(diagReportsMap.values()).map(d => d.id);
+    expect(diagReportIds).toEqual(expect.arrayContaining([diagReport.id, diagReport2.id]));
   });
 
   it("groups diagReports with the same effectiveDateTime if neither has a practitioner reference", () => {
@@ -103,6 +117,9 @@ describe("groupSameDiagnosticReports", () => {
 
     const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
     expect(diagReportsMap.size).toBe(2);
+
+    const diagReportIds = Array.from(diagReportsMap.values()).map(d => d.id);
+    expect(diagReportIds).toEqual(expect.arrayContaining([diagReport.id, diagReport2.id]));
   });
 
   it("does not group duplicate diagReports if effectiveDateTime is not present", () => {
@@ -121,6 +138,9 @@ describe("groupSameDiagnosticReports", () => {
 
     const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
     expect(diagReportsMap.size).toBe(2);
+
+    const diagReportIds = Array.from(diagReportsMap.values()).map(d => d.id);
+    expect(diagReportIds).toEqual(expect.arrayContaining([diagReport.id, diagReport2.id]));
   });
 
   it("discards diagReport if result and presented form are not present", () => {

--- a/packages/core/src/fhir-deduplication/__tests__/group-same-diag-reports.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-diag-reports.test.ts
@@ -50,12 +50,12 @@ describe("groupSameDiagnosticReports", () => {
     expect(diagReportsMap.size).toBe(2);
   });
 
-  it("does not group diagReports with the same effectiveDateTime if none of them have a practitioner reference ", () => {
+  it("groups diagReports with the same effectiveDateTime if neither has a practitioner reference", () => {
     diagReport.effectiveDateTime = dateTime.start;
     diagReport2.effectiveDateTime = dateTime.start;
 
     const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
-    expect(diagReportsMap.size).toBe(2);
+    expect(diagReportsMap.size).toBe(1);
   });
 
   it("does not group diagReports with different performer refs", () => {

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -71,14 +71,11 @@ export function deduplicateFhir(
   resourceArrays.organizations = organizationsResult.combinedResources;
 
   /* WARNING we need to replace references in the following resource arrays before deduplicating them because their deduplication keys 
-  use practitioner and organization references.
+  use practitioner references.
   */
   resourceArrays = replaceResourceReferences(
     resourceArrays,
-    new Map<string, string>([
-      ...practitionersResult.refReplacementMap,
-      ...organizationsResult.refReplacementMap,
-    ]),
+    new Map<string, string>([...practitionersResult.refReplacementMap]),
     ["diagnosticReports"]
   );
 

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -67,6 +67,21 @@ export function deduplicateFhir(
   const practitionersResult = deduplicatePractitioners(resourceArrays.practitioners);
   resourceArrays.practitioners = practitionersResult.combinedResources;
 
+  const organizationsResult = deduplicateOrganizations(resourceArrays.organizations);
+  resourceArrays.organizations = organizationsResult.combinedResources;
+
+  /* WARNING we need to replace references in the following resource arrays before deduplicating them because their deduplication keys 
+  use practitioner and organization references.
+  */
+  resourceArrays = replaceResourceReferences(
+    resourceArrays,
+    new Map<string, string>([
+      ...practitionersResult.refReplacementMap,
+      ...organizationsResult.refReplacementMap,
+    ]),
+    ["diagnosticReports"]
+  );
+
   const conditionsResult = deduplicateConditions(resourceArrays.conditions);
   resourceArrays.conditions = conditionsResult.combinedResources;
 
@@ -107,9 +122,6 @@ export function deduplicateFhir(
     resourceArrays.familyMemberHistories
   );
   resourceArrays.familyMemberHistories = famMemHistoriesResult.combinedResources;
-
-  const organizationsResult = deduplicateOrganizations(resourceArrays.organizations);
-  resourceArrays.organizations = organizationsResult.combinedResources;
 
   resourceArrays = replaceResourceReferences(resourceArrays, medicationsResult.refReplacementMap, [
     "coverages",

--- a/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
+++ b/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
@@ -56,7 +56,8 @@ export function deduplicateDiagReports(
  * Approach:
  * 1 map, where the key is made of:
  * - date
- * - practitioner reference
+ * - code - not sure we want to be using codes as a part of the key.
+ *          The thing with them is that they very often contain a bunch of different ones, almost always containing the one for "Note" - 34109-9.
  */
 export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
   diagReportsMap: Map<string, DiagnosticReport>;
@@ -120,7 +121,15 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
       const practitionerAndDateKeys = createKeysFromObjectArray({ datetime }, practitionerRefs);
       setterKeys.push(...practitionerAndDateKeys);
       getterKeys.push(...practitionerAndDateKeys);
-    } else {
+    }
+
+    if (datetime && practitionerRefs.length === 0) {
+      const dateKey = JSON.stringify({ datetime });
+      setterKeys.push(dateKey);
+      getterKeys.push(dateKey);
+    }
+
+    if (!datetime) {
       const idKey = JSON.stringify({ id: diagReport.id });
       setterKeys.push(idKey);
       getterKeys.push(idKey);

--- a/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
+++ b/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
@@ -1,4 +1,5 @@
 import { DiagnosticReport } from "@medplum/fhirtypes";
+import crypto from "crypto";
 import { LOINC_CODE, LOINC_OID } from "../../util/constants";
 import {
   DeduplicationResult,
@@ -92,8 +93,10 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
 
   for (const diagReport of diagReports) {
     const datetime = getDateFromResource(diagReport, "datetime");
-    const isPresentedFormPresent = diagReport.presentedForm?.length;
-    const isResultPresent = diagReport.result?.length;
+    const isPresentedFormPresent = diagReport.presentedForm
+      ? diagReport.presentedForm?.length > 0
+      : false;
+    const isResultPresent = diagReport.result ? diagReport.result?.length > 0 : false;
 
     // If a diagnostic report does not contain any results or doctor's notes, it is useless and can be removed
     if (!isPresentedFormPresent && !isResultPresent) {
@@ -108,28 +111,41 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
 
     diagReport.performer?.forEach(perf => {
       const ref = perf.reference;
-      if (ref) {
-        if (ref.includes("Practitioner")) {
-          practitionerRefsSet.add(ref);
-          return;
-        }
+      if (ref && ref.includes("Practitioner")) {
+        practitionerRefsSet.add(ref);
+        return;
       }
     });
 
     const practitionerRefs = Array.from(practitionerRefsSet).map(p => ({ practitioner: p }));
-    if (datetime && practitionerRefs.length > 0) {
-      const practitionerAndDateKeys = createKeysFromObjectArray({ datetime }, practitionerRefs);
-      setterKeys.push(...practitionerAndDateKeys);
-      getterKeys.push(...practitionerAndDateKeys);
+
+    if (isResultPresent) {
+      const resultUuid = createUuidFromText(JSON.stringify(diagReport.result));
+      const key = JSON.stringify({ resultUuid });
+      setterKeys.push(key);
+      getterKeys.push(key);
     }
 
-    if (datetime && practitionerRefs.length === 0) {
-      const dateKey = JSON.stringify({ datetime });
-      setterKeys.push(dateKey);
-      getterKeys.push(dateKey);
+    if (isPresentedFormPresent) {
+      const presentedFormUuid = createUuidFromText(JSON.stringify(diagReport.presentedForm));
+      const key = JSON.stringify({ presentedFormUuid });
+      setterKeys.push(key);
+      getterKeys.push(key);
     }
 
-    if (!datetime) {
+    if (datetime) {
+      if (practitionerRefs.length > 0) {
+        const practitionerAndDateKeys = createKeysFromObjectArray({ datetime }, practitionerRefs);
+        setterKeys.push(...practitionerAndDateKeys);
+        getterKeys.push(...practitionerAndDateKeys);
+      }
+
+      if (practitionerRefs.length === 0) {
+        const dateKey = JSON.stringify({ datetime });
+        setterKeys.push(dateKey);
+        getterKeys.push(dateKey);
+      }
+    } else {
       const idKey = JSON.stringify({ id: diagReport.id });
       setterKeys.push(idKey);
       getterKeys.push(idKey);
@@ -155,4 +171,18 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
     refReplacementMap,
     danglingReferences,
   };
+}
+
+function createUuidFromText(input: string) {
+  const hash = crypto.createHash("sha256").update(input).digest("hex");
+
+  const uuid = [
+    hash.substring(0, 8),
+    hash.substring(8, 12),
+    hash.substring(12, 16),
+    hash.substring(16, 20),
+    hash.substring(20, 32),
+  ].join("-");
+
+  return uuid;
 }

--- a/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
+++ b/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
@@ -117,7 +117,6 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
       }
     });
 
-    console.log("practitionerRefsSet", practitionerRefsSet);
     const practitionerRefs = Array.from(practitionerRefsSet).map(p => ({ practitioner: p }));
 
     if (isResultPresent) {

--- a/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
+++ b/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
@@ -117,6 +117,7 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
       }
     });
 
+    console.log("practitionerRefsSet", practitionerRefsSet);
     const practitionerRefs = Array.from(practitionerRefsSet).map(p => ({ practitioner: p }));
 
     if (isResultPresent) {
@@ -138,9 +139,7 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
         const practitionerAndDateKeys = createKeysFromObjectArray({ datetime }, practitionerRefs);
         setterKeys.push(...practitionerAndDateKeys);
         getterKeys.push(...practitionerAndDateKeys);
-      }
-
-      if (practitionerRefs.length === 0) {
+      } else {
         const dateKey = JSON.stringify({ datetime });
         setterKeys.push(dateKey);
         getterKeys.push(dateKey);

--- a/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
+++ b/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
@@ -26,8 +26,6 @@ const diagnosticReportStatus = [
 ] as const;
 export type DiagnosticReportStatus = (typeof diagnosticReportStatus)[number];
 
-// import fs from "fs";
-
 const statusRanking: Record<DiagnosticReportStatus, number> = {
   "entered-in-error": 0,
   unknown: 0,


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/2533

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3080

### Description
- DiagnosticReport dedup is now dependent on the practitioner that performed it, in addition to the datetime
- Updated unit tests

### Testing

- Local
  - [x] Unit tests
  - [x] Check the effect on some larger bundles

### Release Plan
- [ ] Merge this
