### PR TITLE
fix(core): added composition dedup

### DIFF
--- a/packages/core/src/fhir-deduplication/__tests__/group-same-compositions.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-compositions.test.ts
@@ -1,0 +1,41 @@
+import { faker } from "@faker-js/faker";
+import { Composition, Extension } from "@medplum/fhirtypes";
+import { createFilePath } from "../../domain/filename";
+import { DOC_ID_EXTENSION_URL } from "../../external/fhir/shared/extensions/doc-id-extension";
+import { makeComposition } from "../../fhir-to-cda/cda-templates/components/__tests__/make-composition";
+import { groupSameCompositions } from "../resources/composition";
+
+let compositionId: string;
+let compositionId2: string;
+let composition: Composition;
+let composition2: Composition;
+let sourceExtension: Extension;
+
+beforeEach(() => {
+  compositionId = faker.string.uuid();
+  compositionId2 = faker.string.uuid();
+  sourceExtension = {
+    url: DOC_ID_EXTENSION_URL,
+    valueString: createFilePath(faker.string.uuid(), faker.string.uuid(), faker.string.uuid()),
+  };
+  composition = makeComposition(undefined, { id: compositionId, extension: [sourceExtension] });
+  composition2 = makeComposition(undefined, { id: compositionId2, extension: [sourceExtension] });
+});
+
+describe("groupSameCompositions", () => {
+  it("correctly groups duplicate compositions based on the source document", () => {
+    const { compositionsMap } = groupSameCompositions([composition, composition2]);
+    expect(compositionsMap.size).toBe(1);
+  });
+
+  it("correctly groups duplicate compositions based on the payor org ref, status, and period", () => {
+    composition2.extension = [
+      {
+        url: DOC_ID_EXTENSION_URL,
+        valueString: createFilePath(faker.string.uuid(), faker.string.uuid(), faker.string.uuid()),
+      },
+    ];
+    const { compositionsMap } = groupSameCompositions([composition, composition2]);
+    expect(compositionsMap.size).toBe(2);
+  });
+});

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -1,12 +1,14 @@
 import { Bundle, EncounterDiagnosis, Resource } from "@medplum/fhirtypes";
 import { cloneDeep } from "lodash";
 import {
-  buildBundleEntry,
   ExtractedFhirTypes,
+  buildBundleEntry,
   extractFhirTypesFromBundle,
   initExtractedFhirTypes,
 } from "../external/fhir/shared/bundle";
+import { capture } from "../util";
 import { deduplicateAllergyIntolerances } from "./resources/allergy-intolerance";
+import { deduplicateCompositions } from "./resources/composition";
 import { deduplicateConditions } from "./resources/condition";
 import { deduplicateCoverages } from "./resources/coverage";
 import { deduplicateDiagReports } from "./resources/diagnostic-report";
@@ -26,7 +28,6 @@ import { deduplicatePractitioners } from "./resources/practitioner";
 import { deduplicateProcedures } from "./resources/procedure";
 import { deduplicateRelatedPersons } from "./resources/related-person";
 import { createRef } from "./shared";
-import { capture } from "../util";
 
 const medicationRelatedTypes = [
   "MedicationStatement",
@@ -41,6 +42,9 @@ export function deduplicateFhir(
 ): Bundle<Resource> {
   const deduplicatedBundle: Bundle = cloneDeep(fhirBundle);
   let resourceArrays = extractFhirTypesFromBundle(deduplicatedBundle);
+
+  const compositionsResult = deduplicateCompositions(resourceArrays.compositions);
+  resourceArrays.compositions = compositionsResult.combinedResources;
 
   const medicationsResult = deduplicateMedications(resourceArrays.medications);
   /* WARNING we need to replace references in the following resource arrays before deduplicating them because their deduplication keys 

--- a/packages/core/src/fhir-deduplication/resources/__tests__/group-same-compositions.test.ts
+++ b/packages/core/src/fhir-deduplication/resources/__tests__/group-same-compositions.test.ts
@@ -1,9 +1,9 @@
 import { faker } from "@faker-js/faker";
 import { Composition, Extension } from "@medplum/fhirtypes";
-import { createFilePath } from "../../domain/filename";
-import { DOC_ID_EXTENSION_URL } from "../../external/fhir/shared/extensions/doc-id-extension";
-import { makeComposition } from "../../fhir-to-cda/cda-templates/components/__tests__/make-composition";
-import { groupSameCompositions } from "../resources/composition";
+import { createFilePath } from "../../../domain/filename";
+import { DOC_ID_EXTENSION_URL } from "../../../external/fhir/shared/extensions/doc-id-extension";
+import { makeComposition } from "../../../fhir-to-cda/cda-templates/components/__tests__/make-composition";
+import { groupSameCompositions } from "../../resources/composition";
 
 let compositionId: string;
 let compositionId2: string;
@@ -23,12 +23,17 @@ beforeEach(() => {
 });
 
 describe("groupSameCompositions", () => {
+  it("doesn't break on an empty array", () => {
+    const { compositionsMap } = groupSameCompositions([]);
+    expect(compositionsMap.size).toBe(0);
+  });
+
   it("correctly groups duplicate compositions based on the source document", () => {
     const { compositionsMap } = groupSameCompositions([composition, composition2]);
     expect(compositionsMap.size).toBe(1);
   });
 
-  it("correctly groups duplicate compositions based on the payor org ref, status, and period", () => {
+  it("does not group compositions that came from different documents", () => {
     composition2.extension = [
       {
         url: DOC_ID_EXTENSION_URL,

--- a/packages/core/src/fhir-deduplication/resources/composition.ts
+++ b/packages/core/src/fhir-deduplication/resources/composition.ts
@@ -1,0 +1,47 @@
+import { Composition } from "@medplum/fhirtypes";
+import { DOC_ID_EXTENSION_URL } from "../../external/fhir/shared/extensions/doc-id-extension";
+import { DeduplicationResult, combineResources, fillMaps } from "../shared";
+
+export function deduplicateCompositions(
+  compositions: Composition[]
+): DeduplicationResult<Composition> {
+  const { compositionsMap, refReplacementMap, danglingReferences } =
+    groupSameCompositions(compositions);
+  return {
+    combinedResources: combineResources({
+      combinedMaps: [compositionsMap],
+    }),
+    refReplacementMap,
+    danglingReferences,
+  };
+}
+
+export function groupSameCompositions(compositions: Composition[]): {
+  compositionsMap: Map<string, Composition>;
+  refReplacementMap: Map<string, string>;
+  danglingReferences: Set<string>;
+} {
+  const compositionsMap = new Map<string, Composition>();
+  const refReplacementMap = new Map<string, string>();
+  const danglingReferences = new Set<string>();
+
+  for (const composition of compositions) {
+    const documentName = composition.extension?.find(
+      ext => ext.url === DOC_ID_EXTENSION_URL
+    )?.valueString;
+
+    if (documentName) {
+      const key = JSON.stringify({ documentName });
+      fillMaps(compositionsMap, key, composition, refReplacementMap);
+    } else {
+      const key = JSON.stringify({ id: composition.id });
+      fillMaps(compositionsMap, key, composition, refReplacementMap);
+    }
+  }
+
+  return {
+    compositionsMap,
+    refReplacementMap,
+    danglingReferences,
+  };
+}

--- a/packages/core/src/fhir-deduplication/resources/coverage.ts
+++ b/packages/core/src/fhir-deduplication/resources/coverage.ts
@@ -1,8 +1,8 @@
 import { Coverage } from "@medplum/fhirtypes";
 import { DeduplicationResult, combineResources, createRef, fillMaps } from "../shared";
 
-export function deduplicateCoverages(medications: Coverage[]): DeduplicationResult<Coverage> {
-  const { coveragesMap, refReplacementMap, danglingReferences } = groupSameCoverages(medications);
+export function deduplicateCoverages(coverages: Coverage[]): DeduplicationResult<Coverage> {
+  const { coveragesMap, refReplacementMap, danglingReferences } = groupSameCoverages(coverages);
   return {
     combinedResources: combineResources({
       combinedMaps: [coveragesMap],
@@ -43,7 +43,7 @@ export function groupSameCoverages(coverages: Coverage[]): {
 
   return {
     coveragesMap,
-    refReplacementMap: refReplacementMap,
+    refReplacementMap,
     danglingReferences,
   };
 }


### PR DESCRIPTION
refs. metriport/metriport-internal#2502

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3101

### Description
- Added `Composition` dedup to account for the large files being split into X number of chunks, which results in X number of Compositions

### Testing

- Local
  - [x] Unit tests
  - [x] Convert a few documents locally to make sure the Compositions are being deduped as expected
- Staging
  - [ ] Convert a large document on staging to make sure the Compositions are being deduped as expected

### Release Plan
- [ ] Upstream dependencies are met/released
- [ ] Merge this
