### PR TITLE
feat(s3): adding cors to sandbox bucket

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -302,6 +302,12 @@ export class APIStack extends Stack {
           bucketName: sandboxConfig.sandboxSeedDataBucketName,
           publicReadAccess: false,
           encryption: s3.BucketEncryption.S3_MANAGED,
+          cors: [
+            {
+              allowedOrigins: ["*"],
+              allowedMethods: [s3.HttpMethods.GET],
+            },
+          ],
         });
       }
     };


### PR DESCRIPTION
Ref: #1040

### Description

- Adding CORS to sandbox documents bucket
- NOTE: Added CORS *manually* to the s3 bucket -- copied permissions from `metriport-medical-documents`

### Testing

- Local
  - [ ] N/A
- Staging
  - [ ] N/A
- Sandbox
  - [x] Docs download
- Production
  - [ ] N/A

### Release Plan

- [ ] Merge this
