### PR TITLE
PATCH RELEASE Fetch Coding attributes

### DIFF
--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -411,7 +411,7 @@ export function fetchCodingCodeOrDisplayOrSystem(
 ): string | undefined {
   const { log } = out(`fetchCodingCodeOrDisplayOrSystem - coding ${JSON.stringify(coding)}`);
   try {
-    return coding[field]?.trim().toLowerCase();
+    return coding[field]?.toString().trim().toLowerCase();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     if (error instanceof TypeError) {


### PR DESCRIPTION
Ticket: #metriport/metriport-internal/issues/799

### Description
- We got an error where we tried to trim an attribute that unexpectedly had a number instead of a string in it

### Testing

- Local
  - [x] Confirmed on [TS Playground](https://www.typescriptlang.org/play/?#code/MYewdgzgLgBKAmBLMBzGBeGBvARAgpjgFwCcArAHQDsANDkhAA4A2AhgJ7E4BiATJQAYYAZWAALRAC8QrAGaz8wKIgBu+GABFEEEACd4+XTRgAhRIxBtdmiAFsAtGRgBhXYiiHErHHQjto+LZcYlBQjEQA9BEeurbIliAo7BRizFQUeigRziAGwv4ethEAks4a9iTOALL2SKwoYCAQ2gQQOAC+ANwAUN2gkJb4FMyJABQ4AOruYjBQIMJQbqhEPnC5yCgA2ni5hAC6APwUcwtLKKMAlMdutpfHIAAyIADuhs6sEPiXF33gOsxDEbnSbTEAAV1gJ0WGxWxgQG22BBwh2uiFuVzmT1eunen2+QA) that this was the issue

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
