### PR TITLE
fix(docs): fix broken postman link

### DIFF
--- a/docs/medical-api/api-tools/postman.mdx
+++ b/docs/medical-api/api-tools/postman.mdx
@@ -12,4 +12,4 @@ You can access our Postman collection here:
 
 Additionally, you can download the `collection.json` file directly from our GitHub repository:
 
-[Metriport Postman Collection on GitHub](https://github.com/metriport/metriport/tree/develop/packages/postman)
+[Metriport Postman Collection on GitHub](https://github.com/metriport/metriport/tree/develop/postman)


### PR DESCRIPTION
refs. metriport/metriport#304

### Dependencies

n/a

### Description

fix broken postman link on docs

### Testing

n/a - just a link update

### Release Plan

- [ ] Merge this
