### PR TITLE
1040 (redo) Script to compare CQ <> Metriport orgs/facilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16594,8 +16594,8 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -27584,6 +27584,7 @@
         "dotenv": "^16.0.3",
         "express": "^4.19.2",
         "express-promise-router": "^4.1.1",
+        "fast-json-stable-stringify": "^2.1.0",
         "jsonschema": "^1.4.1",
         "langchain": "^0.3.6",
         "lodash": "^4.17.21",

--- a/packages/api/src/external/carequality/command/cq-organization/__tests__/create-or-update-cq-organization.test.ts
+++ b/packages/api/src/external/carequality/command/cq-organization/__tests__/create-or-update-cq-organization.test.ts
@@ -19,7 +19,7 @@ import { CQDirectoryEntryData } from "../../../cq-directory";
 import { buildCqOrgNameForFacility, buildCqOrgNameForOboFacility } from "../../../shared";
 import { metriportIntermediaryOid, metriportOid } from "../constants";
 import { createOrUpdateCqOrganization } from "../create-or-update-cq-organization";
-import * as getCqOrgFile from "../get-cq-organization";
+import { CqOrgLoaderImpl } from "../get-cq-organization";
 import { getOrganizationFhirTemplate } from "../organization-template";
 
 let getAddressWithCoordination: jest.SpyInstance;
@@ -53,7 +53,7 @@ beforeEach(() => {
     cwOboOid: faker.string.uuid(),
   });
   getAddressWithCoordination = jest.spyOn(getAddress, "getAddressWithCoordinates");
-  getCqOrgMock = jest.spyOn(getCqOrgFile, "getCqOrg");
+  getCqOrgMock = jest.spyOn(CqOrgLoaderImpl.prototype, "getCqOrg");
   makeCarequalityManagementAPIFhirMock = jest.spyOn(
     apiFhirFile,
     "makeCarequalityManagementAPIFhir"
@@ -62,6 +62,9 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+});
+afterAll(() => {
+  jest.restoreAllMocks();
 });
 
 function makeApiImpl(params: {
@@ -123,7 +126,7 @@ describe("createOrUpdateCqOrganization", () => {
         active: expectedCqOrg.active,
       }),
     });
-    makeCarequalityManagementAPIFhirMock.mockReturnValueOnce(apiImpl);
+    makeCarequalityManagementAPIFhirMock.mockReturnValue(apiImpl);
 
     await createOrUpdateCqOrganization({
       cxId,
@@ -200,7 +203,7 @@ describe("createOrUpdateCqOrganization", () => {
         active: expectedCqOrg.active,
       }),
     });
-    makeCarequalityManagementAPIFhirMock.mockReturnValueOnce(apiImpl);
+    makeCarequalityManagementAPIFhirMock.mockReturnValue(apiImpl);
 
     await createOrUpdateCqOrganization({
       cxId,

--- a/packages/api/src/external/carequality/command/cq-organization/cq-org-loader.ts
+++ b/packages/api/src/external/carequality/command/cq-organization/cq-org-loader.ts
@@ -1,0 +1,6 @@
+import { CQDirectoryEntryData } from "../../cq-directory";
+
+export interface CqOrgLoader {
+  getCqOrg(oid: string): Promise<CQDirectoryEntryData | undefined>;
+  getCqOrgOrFail(oid: string): Promise<CQDirectoryEntryData>;
+}

--- a/packages/api/src/external/carequality/command/cq-organization/create-or-update-cq-organization.ts
+++ b/packages/api/src/external/carequality/command/cq-organization/create-or-update-cq-organization.ts
@@ -5,7 +5,7 @@ import { errorToString } from "@metriport/shared";
 import { makeCarequalityManagementAPIFhir } from "../../api";
 import { CQDirectoryEntryData } from "../../cq-directory";
 import { CQOrgDetails, CQOrgDetailsWithUrls, getCqAddress, getCqOrgUrls } from "../../shared";
-import { getCqOrg } from "./get-cq-organization";
+import { CqOrgLoaderImpl } from "./get-cq-organization";
 import { getOrganizationFhirTemplate } from "./organization-template";
 import { parseCQOrganization } from "./parse-cq-organization";
 
@@ -25,8 +25,9 @@ export type CreateOrUpdateCqOrganizationCmd = Omit<
 export async function createOrUpdateCqOrganization(
   cmd: CreateOrUpdateCqOrganizationCmd
 ): Promise<CQDirectoryEntryData> {
+  const cqOrgLoader = new CqOrgLoaderImpl();
   const [cqOrg, orgDetailsWithUrls] = await Promise.all([
-    getCqOrg(cmd.oid),
+    cqOrgLoader.getCqOrg(cmd.oid),
     cmdToCqOrgDetails(cmd),
   ]);
   if (cqOrg) return await updateCQOrganization(orgDetailsWithUrls);
@@ -66,7 +67,7 @@ async function updateCQOrganization(
       oid: orgDetails.oid,
     });
     debug(`resp updateOrganization: `, () => JSON.stringify(resp));
-    return parseCQOrganization(resp);
+    return parseCQOrganization(resp, new CqOrgLoaderImpl());
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     const extra = {
@@ -96,7 +97,7 @@ async function createCQOrganization(
   try {
     const resp = await cq.registerOrganization(carequalityOrg);
     debug(`resp registerOrganization: `, () => JSON.stringify(resp));
-    return parseCQOrganization(resp);
+    return parseCQOrganization(resp, new CqOrgLoaderImpl());
   } catch (error) {
     const msg = `Failure while registering org @ CQ`;
     log(`${msg}. Org OID: ${orgDetails.oid}. Cause: ${errorToString(error)}`);

--- a/packages/api/src/external/carequality/command/cq-organization/get-cq-organization-cached.ts
+++ b/packages/api/src/external/carequality/command/cq-organization/get-cq-organization-cached.ts
@@ -1,0 +1,69 @@
+import { Organization } from "@medplum/fhirtypes";
+import { CarequalityManagementAPIFhir } from "@metriport/carequality-sdk";
+import { executeAsynchronously } from "@metriport/core/util";
+import { NotFoundError } from "@metriport/shared";
+import { makeCarequalityManagementAPIFhir } from "../../api";
+import { CQDirectoryEntryData } from "../../cq-directory";
+import { CqOrgLoader } from "./cq-org-loader";
+import { getParentOid } from "./get-parent-org";
+import { parseCQOrganization, parseCQOrganizationSimplified } from "./parse-cq-organization";
+
+const numberParallelRequestsToCq = 20;
+
+export class CachedCqOrgLoader implements CqOrgLoader {
+  private cache: Record<string, Organization> = {};
+  private parsedCache: Record<string, CQDirectoryEntryData> = {};
+  private readonly cq: CarequalityManagementAPIFhir;
+  constructor() {
+    this.cq = makeCarequalityManagementAPIFhir();
+  }
+
+  public async getCqOrgUnparsed(oid: string): Promise<Organization | undefined> {
+    const orgFromCq = this.cache[oid] ?? (await this.cq.getOrganization(oid));
+    if (!orgFromCq) return undefined;
+    this.cache[oid] = orgFromCq;
+    return orgFromCq;
+  }
+
+  public async getCqOrg(oid: string): Promise<CQDirectoryEntryData | undefined> {
+    const orgFromCache = await this.getCqOrgUnparsed(oid);
+    if (!orgFromCache) return undefined;
+    const parsedOrg =
+      oid === getParentOid(orgFromCache)
+        ? parseCQOrganizationSimplified(orgFromCache)
+        : await parseCQOrganization(orgFromCache, this);
+    this.parsedCache[oid] = parsedOrg;
+    return parsedOrg;
+  }
+
+  public async getCqOrgOrFail(oid: string): Promise<CQDirectoryEntryData> {
+    const org = await this.getCqOrg(oid);
+    if (!org) throw new NotFoundError("Organization not found");
+    return org;
+  }
+
+  public async getCqOrgs(oids: string[]): Promise<CQDirectoryEntryData[]> {
+    const orgs: CQDirectoryEntryData[] = [];
+    await executeAsynchronously(
+      oids,
+      async oid => {
+        const cqOrg = await this.getCqOrg(oid);
+        if (cqOrg) orgs.push(cqOrg);
+      },
+      { numberOfParallelExecutions: numberParallelRequestsToCq, minJitterMillis: 20 }
+    );
+    return orgs;
+  }
+
+  public populate(orgs: Organization[]): void {
+    orgs.forEach(org => {
+      if (!org.id) return;
+      this.cache[org.id] = org;
+    });
+  }
+
+  public clear(): void {
+    this.cache = {};
+    this.parsedCache = {};
+  }
+}

--- a/packages/api/src/external/carequality/command/cq-organization/get-cq-organization.ts
+++ b/packages/api/src/external/carequality/command/cq-organization/get-cq-organization.ts
@@ -1,34 +1,47 @@
+import { CarequalityManagementAPIFhir } from "@metriport/carequality-sdk";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import { errorToString, NotFoundError } from "@metriport/shared";
 import { makeCarequalityManagementAPIFhir } from "../../api";
 import { CQDirectoryEntryData } from "../../cq-directory";
-import { parseCQOrganization } from "./parse-cq-organization";
+import { CqOrgLoader } from "./cq-org-loader";
+import { getParentOid } from "./get-parent-org";
+import { parseCQOrganization, parseCQOrganizationSimplified } from "./parse-cq-organization";
 
-export async function getCqOrg(oid: string): Promise<CQDirectoryEntryData | undefined> {
-  const { log, debug } = out(`CQ getCqOrg - OID ${oid}`);
-  const cq = makeCarequalityManagementAPIFhir();
-
-  try {
-    const org = await cq.getOrganization(oid);
-    debug(`resp getOrganization: `, () => JSON.stringify(org));
-    return parseCQOrganization(org);
-  } catch (error) {
-    const msg = `Failure while getting Org @ CQ`;
-    log(`${msg}. Org OID: ${oid}. Cause: ${errorToString(error)}`);
-    capture.error(msg, {
-      extra: {
-        orgOid: oid,
-        context: `cq.org.get`,
-        error,
-      },
-    });
-    throw error;
+export class CqOrgLoaderImpl implements CqOrgLoader {
+  private readonly cq: CarequalityManagementAPIFhir;
+  constructor() {
+    this.cq = makeCarequalityManagementAPIFhir();
   }
-}
 
-export async function getCqOrgOrFail(oid: string): Promise<CQDirectoryEntryData> {
-  const org = await getCqOrg(oid);
-  if (!org) throw new NotFoundError("Organization not found");
-  return org;
+  public async getCqOrg(oid: string): Promise<CQDirectoryEntryData | undefined> {
+    const { log, debug } = out(`CQ getCqOrg - OID ${oid}`);
+
+    try {
+      const org = await this.cq.getOrganization(oid);
+      debug(`resp getOrganization: `, () => JSON.stringify(org));
+      const parsedOrg =
+        oid === getParentOid(org)
+          ? parseCQOrganizationSimplified(org)
+          : await parseCQOrganization(org, this);
+      return parsedOrg;
+    } catch (error) {
+      const msg = `Failure while getting Org @ CQ`;
+      log(`${msg}. Org OID: ${oid}. Cause: ${errorToString(error)}`);
+      capture.error(msg, {
+        extra: {
+          orgOid: oid,
+          context: `cq.org.get`,
+          error,
+        },
+      });
+      throw error;
+    }
+  }
+
+  public async getCqOrgOrFail(oid: string): Promise<CQDirectoryEntryData> {
+    const org = await this.getCqOrg(oid);
+    if (!org) throw new NotFoundError("Organization not found");
+    return org;
+  }
 }

--- a/packages/api/src/external/carequality/command/cq-organization/get-parent-org.ts
+++ b/packages/api/src/external/carequality/command/cq-organization/get-parent-org.ts
@@ -1,0 +1,7 @@
+import { Organization } from "@medplum/fhirtypes";
+
+export function getParentOid(org: Organization): string | undefined {
+  const parentOrg = org.partOf?.reference ?? org.partOf?.identifier?.value;
+  const parentOrgOid = parentOrg?.split("/")[1];
+  return parentOrgOid;
+}

--- a/packages/api/src/external/carequality/cq-directory.ts
+++ b/packages/api/src/external/carequality/cq-directory.ts
@@ -1,5 +1,5 @@
-import { BaseDomain, BaseDomainCreate } from "@metriport/core/domain/base-domain";
 import { Organization } from "@metriport/carequality-sdk/models/organization";
+import { BaseDomain, BaseDomainCreate } from "@metriport/core/domain/base-domain";
 
 export type CQDirectoryEntryData = {
   id: string; // Organization's OID

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -60,6 +60,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.19.2",
     "express-promise-router": "^4.1.1",
+    "fast-json-stable-stringify": "^2.1.0",
     "jsonschema": "^1.4.1",
     "langchain": "^0.3.6",
     "lodash": "^4.17.21",

--- a/packages/utils/src/carequality/compare-orgs-cq.ts
+++ b/packages/utils/src/carequality/compare-orgs-cq.ts
@@ -1,0 +1,179 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import { Organization, OrgType } from "@metriport/core/domain/organization";
+import { out } from "@metriport/core/util/log";
+import { getEnvVarOrFail, sleep } from "@metriport/shared";
+import axios from "axios";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import stringify from "fast-json-stable-stringify";
+import fs from "fs";
+import { Facility as FacilityInternal, facilitySchema } from "../internal/schemas/facility";
+import {
+  Organization as OrganizationInternal,
+  OrganizationBizType,
+  organizationSchema,
+} from "../internal/schemas/organization";
+import { elapsedTimeAsStr } from "../shared/duration";
+import { buildGetDirPathInside, getFileNameForOrg, initRunsFolder } from "../shared/folder";
+// Not happy with importing from a diff package, but it's a quick fix for now
+import { Facility } from "../../../api/src/domain/medical/facility";
+import { makeCarequalityManagementAPIFhir } from "../../../api/src/external/carequality/api";
+import { cmdToCqOrgDetails } from "../../../api/src/external/carequality/command/cq-organization/create-or-update-cq-organization";
+import { getOrganizationFhirTemplate } from "../../../api/src/external/carequality/command/cq-organization/organization-template";
+import { getCqCommand as getCqCommandForFacility } from "../../../api/src/external/carequality/command/create-or-update-facility";
+import { getCqCommand as getCqCommandForOrganization } from "../../../api/src/external/carequality/command/create-or-update-organization";
+
+dayjs.extend(duration);
+
+/**
+ * Compare Metriport generated organizations with the respective entries in the CareQuality directory.
+ *
+ * Stores both in the runs/compare-orgs-cq/run_<date>/ directory for further inspection.
+ *
+ * Note: you might need to update the files below on the API package, making the `Request` type `any`
+ * because we're importing directly from that package but ts-node doesn't recognize the @types declaration
+ * on the API's `tsconfig.json` file, even if we add that to Util's `tsconfig`:
+ * - src/routes/auth.ts
+ * - src/routes/util.ts
+ *
+ * To use it:
+ * - Set the required env vars in .env
+ *   - Also, see makeCarequalityManagementAPIFhir for required env vars.
+ * - Run with `ts-node compare-orgs-cq.ts`
+ */
+
+const apiUrl = getEnvVarOrFail("API_URL");
+const cq = makeCarequalityManagementAPIFhir();
+
+const cxIds: string[] = [];
+
+export const apiOssProxyInternal = axios.create({ baseURL: `${apiUrl}/internal` });
+
+const getFolderName = buildGetDirPathInside(`compare-orgs-cq`);
+
+export async function main() {
+  await sleep(50); // just to make sure the logs are in not mixed up with Node's and other libs'
+  const startedAt = Date.now();
+  console.log(`########################## Started at ${new Date(startedAt).toISOString()}`);
+  initRunsFolder();
+  const outputFolderName = getFolderName("run");
+  fs.mkdirSync(outputFolderName, { recursive: true });
+
+  for (const cxId of cxIds) {
+    const { org, facilities } = await getCxData(cxId);
+    const { log } = out(`${cxId} / ${org.name}`);
+
+    const inputMetriportOrg: Organization = {
+      cxId,
+      id: org.id,
+      organizationNumber: Number(org.oid.split(":")[-1]),
+      type: org.businessType,
+      data: {
+        name: org.name,
+        location: org.location,
+        type: org.type as unknown as OrgType,
+      },
+      oid: org.oid,
+      cqActive: org.cqActive ?? false,
+      cqApproved: org.cqApproved ?? false,
+      cwActive: org.cwActive ?? false,
+      cwApproved: org.cwApproved ?? false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      eTag: org.eTag ?? "",
+    };
+
+    if (org.businessType === OrganizationBizType.healthcareProvider) {
+      log(`Provider - Processing org...`);
+      if (!org.cqActive || !org.cqApproved) {
+        log(`Skipping ${org.name} because it is not active or approved in CQ`);
+        continue;
+      }
+      const cqCmd = getCqCommandForOrganization({ org: inputMetriportOrg });
+      const cqOrgDetails = await cmdToCqOrgDetails(cqCmd);
+      const metriportOrg = getOrganizationFhirTemplate(cqOrgDetails);
+      await process("org", org, metriportOrg, outputFolderName);
+    } else if (org.businessType === OrganizationBizType.healthcareITVendor) {
+      log(`IT Vendor - Processing ${facilities.length} facilities...`);
+      for (const facility of facilities) {
+        if (!facility.cqActive || !facility.cqApproved) {
+          log(`... facility ${facility.id} is not approved/active in CQ, skipping`);
+          continue;
+        }
+        const inputFacility: Facility = {
+          cxId,
+          id: facility.id,
+          oid: facility.oid,
+          facilityNumber: Number(facility.oid.split(":")[-1]),
+          data: {
+            name: facility.name,
+            address: facility.address,
+            npi: facility.npi,
+            active: facility.active == undefined ? undefined : facility.active,
+          },
+          cqType: facility.cqType,
+          cqOboOid: facility.cqOboOid,
+          cqActive: facility.cqActive ?? false,
+          cqApproved: facility.cqApproved ?? false,
+          cwActive: facility.cwActive ?? false,
+          cwApproved: facility.cwApproved ?? false,
+          cwOboOid: facility.cwOboOid,
+          cwType: facility.cwType,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          eTag: facility.eTag ?? "",
+        };
+        const cqCmd = getCqCommandForFacility({ org: inputMetriportOrg, facility: inputFacility });
+        const cqOrgDetails = await cmdToCqOrgDetails(cqCmd);
+        const metriportOrg = getOrganizationFhirTemplate(cqOrgDetails);
+        await process("fac", facility, metriportOrg, outputFolderName);
+      }
+    } else {
+      throw new Error(`Unsupported business type: ${org.businessType}`);
+    }
+    log(`Done`);
+  }
+
+  console.log(`>>> ALL Done in ${elapsedTimeAsStr(startedAt)}`);
+}
+
+async function process(
+  type: "org" | "fac",
+  org: { oid: string; name: string },
+  metriportOrg: unknown,
+  outputFolderName: string
+) {
+  const cqOrgs = await cq.listOrganizations({ oid: org.oid });
+  if (cqOrgs.length < 1) console.log(`No CQ organizations found for ${org.oid} / ${org.name}`);
+
+  if (cqOrgs.length > 1) {
+    console.log(`cqOrgs`, cqOrgs);
+    throw new Error(`Found more than one CQ organization for ${org.oid}`);
+  }
+  const cqOrg = cqOrgs[0] ?? "NOT_FOUND";
+
+  const pathAndPrefix = outputFolderName + "/" + type + "_";
+  const outputFileNameMetriport = getFileNameForOrg(org.name + "_metriport");
+  const outputFileNameCq = getFileNameForOrg(org.name + "_cq");
+
+  const outputCq = JSON.stringify(JSON.parse(stringify(cqOrg)), null, 2);
+  fs.writeFileSync(pathAndPrefix + outputFileNameCq, outputCq);
+
+  const outputMetriport = JSON.stringify(JSON.parse(stringify(metriportOrg)), null, 2);
+  fs.writeFileSync(pathAndPrefix + outputFileNameMetriport, outputMetriport);
+}
+
+async function getCxData(
+  cxId: string
+): Promise<{ org: OrganizationInternal; facilities: FacilityInternal[] }> {
+  const resp = await apiOssProxyInternal.get(`/cx-data?cxId=${cxId}`);
+  if (!resp.data) throw new Error(`Cx data not returned`);
+  return {
+    org: organizationSchema.parse(resp.data["org"]),
+    facilities: resp.data["facilities"].map(facilitySchema.parse),
+  };
+}
+
+main();

--- a/packages/utils/src/internal/schemas/address.ts
+++ b/packages/utils/src/internal/schemas/address.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { usStateSchema } from "@metriport/api-sdk/medical/models/common/us-data";
+import { defaultOptionalString, defaultZipString } from "./shared";
+
+export const addressStrictSchema = z.object({
+  addressLine1: z.string().min(1),
+  addressLine2: defaultOptionalString,
+  city: z.string().min(1),
+  state: usStateSchema,
+  zip: defaultZipString,
+  country: z.literal("USA").default("USA"),
+});

--- a/packages/utils/src/internal/schemas/base-update.ts
+++ b/packages/utils/src/internal/schemas/base-update.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const baseUpdateSchema = z.object({
+  id: z.string(),
+  eTag: z.string().optional(),
+});

--- a/packages/utils/src/internal/schemas/customer.ts
+++ b/packages/utils/src/internal/schemas/customer.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const subscriptionStatusSchema = z.enum(["disabled", "active", "overdue"]);
+export type SubscriptionStatusSchema = z.infer<typeof subscriptionStatusSchema>;
+
+export const customerSchema = z.object({
+  id: z.string(),
+  email: z.string().nullable(),
+  subscriptionStatus: subscriptionStatusSchema,
+  subscriptionCancelsAt: z.string().nullable(),
+  stripeCxId: z.string().nullable(),
+  stripeSubscriptionId: z.string().nullable(),
+  devicesStripeSubscriptionItemId: z.string().nullable(),
+  medicalStripeSubscriptionItemId: z.string().nullable(),
+  isRoot: z.boolean(),
+});
+export type Customer = z.infer<typeof customerSchema>;

--- a/packages/utils/src/internal/schemas/facility.ts
+++ b/packages/utils/src/internal/schemas/facility.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+import { addressStrictSchema } from "./address";
+import { baseUpdateSchema } from "./base-update";
+import { CqDirectoryEntryData, CwOrgData } from "./organization";
+import { PatientCoverage } from "./patient";
+import { optionalString } from "./shared";
+
+enum FacilityType {
+  initiatorAndResponder = "initiator_and_responder",
+  initiatorOnly = "initiator_only",
+}
+
+export const facilityMapiBaseSchema = z.object({
+  oid: z.string(),
+  name: z.string().min(1),
+  npi: z.string().length(10),
+  tin: optionalString(z.string()),
+  active: z.boolean().optional().nullable(),
+  address: addressStrictSchema,
+});
+export const facilityMapiCreateSchema = facilityMapiBaseSchema.omit({ oid: true });
+export type FacilityMapiCreate = z.infer<typeof facilityMapiCreateSchema>;
+
+export const facilityInternalDetailsSchema = z.object({
+  cqApproved: z.boolean().optional().nullable(),
+  cqType: z.nativeEnum(FacilityType),
+  cqActive: z.boolean().optional().nullable(),
+  cqOboOid: z.string().nullable(),
+  cwApproved: z.boolean().optional().nullable(),
+  cwType: z.nativeEnum(FacilityType),
+  cwActive: z.boolean().optional().nullable(),
+  cwOboOid: z.string().nullable(),
+});
+
+export const facilitySchema = baseUpdateSchema
+  .merge(facilityMapiBaseSchema)
+  .merge(facilityInternalDetailsSchema);
+export type Facility = z.infer<typeof facilitySchema>;
+
+export const facilityMapiSchema = baseUpdateSchema.merge(facilityMapiBaseSchema);
+export type FacilityMapi = z.infer<typeof facilityMapiSchema>;
+
+export const facilityCreateOrUpdateInternalSchema = z
+  .object({
+    id: z.string().optional(),
+    nameInMetriport: z.string(),
+    npi: z.string().length(10),
+    tin: optionalString(z.string()),
+  })
+  .merge(facilityInternalDetailsSchema)
+  .omit({
+    cqOboOid: true,
+    cwOboOid: true,
+  })
+  .merge(
+    z.object({
+      cqOboOid: z.string().optional(),
+      cwOboOid: z.string().optional(),
+    })
+  )
+  .merge(addressStrictSchema);
+export type FacilityInternalCreateOrUpdate = z.infer<typeof facilityCreateOrUpdateInternalSchema>;
+
+export const cqFacilityUpdateSchema = z.object({
+  active: z.boolean(),
+});
+export type CqFacilityUpdate = z.infer<typeof cqFacilityUpdateSchema>;
+
+export const cwFacilityUpdateSchema = z.object({
+  active: z.boolean(),
+});
+export type CwFacilityUpdate = z.infer<typeof cwFacilityUpdateSchema>;
+
+export type ExtendedFacility = {
+  facility: Facility;
+  cqFacility?: CqDirectoryEntryData | null;
+  cwFacility?: CwOrgData | null;
+  patientsWithAssessments?: PatientCoverage[];
+};

--- a/packages/utils/src/internal/schemas/organization.ts
+++ b/packages/utils/src/internal/schemas/organization.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+import { addressStrictSchema } from "./address";
+import { baseUpdateSchema } from "./base-update";
+
+export enum OrganizationBizType {
+  healthcareProvider = "healthcare_provider",
+  healthcareITVendor = "healthcare_it_vendor",
+}
+
+export enum TreatmentType {
+  acuteCare = "acuteCare",
+  ambulatory = "ambulatory",
+  hospital = "hospital",
+  labSystems = "labSystems",
+  pharmacy = "pharmacy",
+  postAcuteCare = "postAcuteCare",
+}
+
+export const orgBizTypeSchema = z.nativeEnum(OrganizationBizType);
+export const orgTypeSchema = z.nativeEnum(TreatmentType);
+
+export const organizationMapiBaseSchema = z.object({
+  oid: z.string(),
+  type: orgTypeSchema,
+  name: z.string().min(1),
+  location: addressStrictSchema,
+});
+export const organizationBizTypeSchema = z.object({
+  businessType: orgBizTypeSchema,
+});
+export const organizationCreateSchema = organizationMapiBaseSchema
+  .omit({ oid: true })
+  .merge(organizationBizTypeSchema);
+export type OrganizationCreate = z.infer<typeof organizationCreateSchema>;
+
+export const organizationInternalDetailsSchema = organizationBizTypeSchema.merge(
+  z.object({
+    cqApproved: z.boolean().optional().nullable(),
+    cqActive: z.boolean().optional().nullable(),
+    cwApproved: z.boolean().optional().nullable(),
+    cwActive: z.boolean().optional().nullable(),
+  })
+);
+
+export const organizationSchema = baseUpdateSchema
+  .merge(organizationMapiBaseSchema)
+  .merge(organizationInternalDetailsSchema);
+export type Organization = z.infer<typeof organizationSchema>;
+
+export const organizationMapiSchema = baseUpdateSchema.merge(organizationMapiBaseSchema);
+export type OrganizationMapi = z.infer<typeof organizationMapiSchema>;
+
+export const organizationCreateOrUpdateInternalSchema = z
+  .object({
+    id: z.string().optional(),
+    type: orgTypeSchema,
+    nameInMetriport: z.string(),
+  })
+  .merge(organizationBizTypeSchema)
+  .merge(organizationInternalDetailsSchema)
+  .merge(addressStrictSchema);
+export type OrganizationInternalCreateOrUpdate = z.infer<
+  typeof organizationCreateOrUpdateInternalSchema
+>;
+
+export const cqOrganitzationUpdateSchema = z.object({
+  active: z.boolean(),
+});
+export type CqOrganizationUpdate = z.infer<typeof cqOrganitzationUpdateSchema>;
+
+export const cwOrganitzationUpdateSchema = z.object({
+  active: z.boolean(),
+});
+export type CwOrganizationUpdate = z.infer<typeof cwOrganitzationUpdateSchema>;
+
+export const cqDirectoryEntryDataSchema = z.object({
+  id: z.string(), // Organization's OID
+  name: z.string().optional(),
+  urlXCPD: z.string().optional(),
+  urlDQ: z.string().optional(),
+  urlDR: z.string().optional(),
+  lat: z.number().optional(),
+  lon: z.number().optional(),
+  addressLine: z.string().optional(),
+  city: z.string().optional(),
+  state: z.string().optional(),
+  zip: z.string().optional(),
+  point: z.string().optional(),
+  managingOrganization: z.string().optional(),
+  managingOrganizationId: z.string().optional(),
+  active: z.boolean(),
+  lastUpdatedAtCQ: z.string(),
+});
+export type CqDirectoryEntryData = z.infer<typeof cqDirectoryEntryDataSchema>;
+
+export const cwOrgDataSchema = z.object({
+  oid: z.string(),
+  data: z.object({
+    name: z.string(),
+    location: addressStrictSchema,
+    type: orgTypeSchema,
+  }),
+  active: z.boolean(),
+});
+export type CwOrgData = z.infer<typeof cwOrgDataSchema>;
+
+export type ExtendedOrganization = {
+  organization: Organization | null;
+  cqOrganization?: CqDirectoryEntryData | null;
+  cwOrganization?: CwOrgData | null;
+};
+
+export type ExtendedOrganizationWithMapiOrg = {
+  organization: Organization;
+} & Pick<ExtendedOrganization, "cqOrganization" | "cwOrganization">;

--- a/packages/utils/src/internal/schemas/patient.ts
+++ b/packages/utils/src/internal/schemas/patient.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { addressStrictSchema } from "./address";
+
+const coverageAssessmentPatientSchema = z.object({
+  dob: z.string().optional(),
+  gender: z.string().optional(),
+  firstname: z.string().optional(),
+  lastname: z.string().optional(),
+  zip: z.string().optional(),
+  city: z.string().optional(),
+  state: z.string().optional(),
+  addressline1: z.string().optional(),
+  addressline2: z.string().optional(),
+  phone1: z.string().optional(),
+  phone2: z.string().optional(),
+  email1: z.string().optional(),
+  email2: z.string().optional(),
+  externalid: z.string().optional(),
+});
+
+const coverageAssessmentSchema = z.object({
+  patients: coverageAssessmentPatientSchema.array(),
+});
+export type CoverageAssessment = z.infer<typeof coverageAssessmentSchema>;
+
+const patientCoverageSchema = z.object({
+  id: z.string(),
+  firstName: z.string(),
+  lastName: z.string(),
+  dob: z.string(),
+  address: addressStrictSchema.array(),
+  downloadStatus: z.string().optional(),
+  docCount: z.number().optional(),
+  convertStatus: z.string().optional(),
+  fhirCount: z.number(),
+  fhirDetails: z.string(),
+  mrSummaryUrl: z.string().optional(),
+});
+export type PatientCoverage = z.infer<typeof patientCoverageSchema>;
+
+export const patientCoverageResponseSchema = z.object({
+  patientsWithAssessments: patientCoverageSchema.array(),
+});
+export type PatientCoverageResponse = z.infer<typeof patientCoverageResponseSchema>;

--- a/packages/utils/src/internal/schemas/shared.ts
+++ b/packages/utils/src/internal/schemas/shared.ts
@@ -1,0 +1,22 @@
+import { z, ZodString } from "zod";
+
+export const optionalString = (zodSchema: ZodString) =>
+  zodSchema.or(z.string().optional()).transform(emptyStringToUndefined);
+
+export const emptyStringToUndefined = (v: string | undefined | null) =>
+  v == null || v.length < 1 ? undefined : v;
+
+export function stripNonNumericChars(str: string): string {
+  return str.trim().replace(/\D/g, "");
+}
+
+export const defaultString = z.string().trim();
+export const defaultOptionalString = optionalString(defaultString);
+
+const zipLength = 5;
+export const defaultZipString = z.coerce
+  .string()
+  .transform(zipStr => stripNonNumericChars(zipStr))
+  .refine(zip => zip.length === zipLength, {
+    message: `Zip must be a string consisting of ${zipLength} numbers`,
+  });


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport/issues/1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/2974
- Downstream: none

### Description

[WIP]

Add script to compare CQ directory entries built with our code from the data in our DB with the ones from the actual CQ directory.

Open question: how do we want to deal with the schemas of the internal endpoints? That's related to the folder `packages/utils/src/internal/schemas`.
1. Expose on `@metriport/shared`?
2. Expose on a new package?
3. Just copy them?
4. Just work with `any` as response from the internal endpoint?

### Testing

- Local
  - [ ] Run it and analyze the output on the "runs" folder
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
