### PR TITLE
PATCH RELEASE - DQ WH Payload + other misc fixes

### DIFF
--- a/packages/api/src/command/medical/document/document-webhook.ts
+++ b/packages/api/src/command/medical/document/document-webhook.ts
@@ -87,7 +87,7 @@ export const processPatientDocumentRequest = async (
         metadata
       );
     } else {
-      log(`WH disabled. Not sending it - metadata: ${metadata}`);
+      log(`WH disabled. Not sending it - metadata: ${JSON.stringify(metadata)}`);
       await createWebhookRequest({
         cxId,
         type: whType,

--- a/packages/api/src/external/fhir/shared/hydrate-bundle.ts
+++ b/packages/api/src/external/fhir/shared/hydrate-bundle.ts
@@ -69,6 +69,9 @@ function verifyPatientReferences(resource: Resource, patientId: string) {
 function comparePatientIds(reference: Reference | undefined, patientId: string) {
   const refString = reference?.reference;
   const refId = refString?.split("Patient/")[1];
+  if (refId?.trim().length === 0) {
+    throw new BadRequestError("Missing ID in the Patient reference!");
+  }
   if (refId != patientId) {
     throw new BadRequestError("Patient reference is pointing to another patient!");
   }

--- a/packages/core/src/external/fhir/document/get-documents.ts
+++ b/packages/core/src/external/fhir/document/get-documents.ts
@@ -24,7 +24,7 @@ export async function getDocuments({
   try {
     const api = makeFhirApi(cxId, Config.getFHIRServerUrl());
     const docs: DocumentReferenceWithId[] = [];
-    const chunksDocIds = documentIds && documentIds.length > 0 ? chunk(documentIds, 150) : [[]];
+    const chunksDocIds = documentIds && documentIds.length > 0 ? chunk(documentIds, 150) : [];
 
     for (const docIds of chunksDocIds) {
       const filtersAsStr = getFilters({ patientId, documentIds: docIds, from, to });

--- a/packages/utils/src/fhir/validate/validate-all-bundles.ts
+++ b/packages/utils/src/fhir/validate/validate-all-bundles.ts
@@ -119,6 +119,7 @@ async function uploadToS3(filePath: string) {
 }
 
 async function startImportJob(): Promise<string> {
+  const clientToken = nanoid().replace(/[^a-zA-Z]/g, "");
   const startFhirImportCmd = new StartFHIRImportJobCommand({
     InputDataConfig: {
       S3Uri: `s3://${sourceBucketName}/${sourcePrefix}`,
@@ -131,7 +132,7 @@ async function startImportJob(): Promise<string> {
     },
     DatastoreId: datastoreId,
     DataAccessRoleArn: accesRoleArn,
-    ClientToken: nanoid(),
+    ClientToken: clientToken,
   });
   console.log(`Starting import job...`);
   const response = await healthlake.send(startFhirImportCmd);


### PR DESCRIPTION
refs. metriport/metriport-internal#799

### Description
- Fixing bug which caused all documents to be sent on WH for each new DQ that finds no new documents
- Fixing log that printed `[object Object]` on WH settings
- Adding more informative error feedback on missing patient references for data contributions
- Fixing a bug for a local script, where a nanoid containing `-` or `_` would cause the flow to break

### Testing

- Local
  - [x] Tested locally to verify the fixes work as intended
- Production
  - [ ] Monitor the API after release

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
