### PR TITLE
1040 Fix repo init so it installs husky/hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
         "packages/utils",
         "packages/tester-node"
       ],
+      "dependencies": {
+        "is-ci": "^3.0.1"
+      },
       "devDependencies": {
         "@commitlint/cli": "^17.4.2",
         "@commitlint/config-conventional": "^17.4.2",
@@ -15835,7 +15838,6 @@
     },
     "node_modules/ci-info": {
       "version": "3.8.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19123,7 +19125,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
       "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "dev": true,
       "dependencies": {
         "ci-info": "^3.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "1.0.0",
   "bin": {},
   "scripts": {
-    "preinstall": "npm i -g rimraf",
-    "prepare": "husky install",
+    "prepare-dev": "is-ci || husky install",
+    "preinstall": "npm i -g rimraf@5.0.10 --no-fund && npm run prepare-dev",
+    "preci": "npm run preinstall",
+    "preinstall-deps": "npm run preci",
     "init": "npm i && SCRIPT='i' npm run lambdas:no-run",
     "clean": "npm run clean --workspaces --if-present && SCRIPT='clean' npm run lambdas",
     "deepclean": "npm run deepclean --workspaces --if-present && echo 'rimraf node_modules' && rimraf node_modules && SCRIPT='deepclean' npm run lambdas",
@@ -62,6 +64,9 @@
     "commitizen": {
       "path": "@commitlint/cz-commitlint"
     }
+  },
+  "dependencies": {
+    "is-ci": "^3.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.4.2",


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- Related: https://github.com/metriport/metriport-internal/pull/2569

### Description

Currently, when someone clones the repo and runs `install-deps` it doesn't initialize Husky/Githooks. This results in commits being sent without the respective goodies/controls.

This fix repo initialization so it installs husky/hooks when first cloned.

Also
- only installs Husky on local/dev (not on CICD)
- fixes `rimraf` to a version compatible with Node 18.

### Testing

- Local
  - [x] `clean && install-deps` installs Husky
- Staging
  - [ ] CICD runs and deploys successfully
- Staging EHR App ([Athena Testing Notion](https://www.notion.so/metriport/EHR-Integrations-12fb51bb90408021850cc595b060efc7?pvs=4#12fb51bb90408020a9affff80dc98fac))
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
- [ ] Manually trigger a `Deploy - staging` from `develop`
