### PR TITLE
1040 Add .prettierignore throughout

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+runs
+vscode
+docs
+postman
+**/.DS_Store

--- a/packages/api-sdk/.prettierignore
+++ b/packages/api-sdk/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/packages/api/.prettierignore
+++ b/packages/api/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+build
+dist
+e2e-test-results

--- a/packages/carequality-cert-runner/.prettierignore
+++ b/packages/carequality-cert-runner/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/packages/carequality-sdk/.prettierignore
+++ b/packages/carequality-sdk/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/packages/commonwell-cert-runner/.prettierignore
+++ b/packages/commonwell-cert-runner/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/packages/commonwell-sdk/.prettierignore
+++ b/packages/commonwell-sdk/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/packages/core/.prettierignore
+++ b/packages/core/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/packages/ihe-gateway-sdk/.prettierignore
+++ b/packages/ihe-gateway-sdk/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/packages/infra/.prettierignore
+++ b/packages/infra/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/packages/shared/.prettierignore
+++ b/packages/shared/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/packages/terminology/.prettierignore
+++ b/packages/terminology/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/packages/utils/.prettierignore
+++ b/packages/utils/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Add `.prettierignore` in all packages. It makes it `npm run prettier-fix` much faster since it doesn't need to look into all of the now ignored folders.

- [ ] Fix requested changes
- [ ] Add bedrock and langchain files to `.prettierignore` (`packages/core/src/external/langchain/bedrock/*`)

### Testing

- Local
  - [ ] It fixes files not in the ignored folders
  - [ ] It skips files in the ignored folders
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
- [ ] Replicate this to the internal repo
