### PR TITLE
PATCH RELEASE Fixing Duplicate IDs on Consolidated Bundle

### DIFF
--- a/packages/core/src/domain/conversion/bundle-modifications/__tests__/post-process-bundle.test.ts
+++ b/packages/core/src/domain/conversion/bundle-modifications/__tests__/post-process-bundle.test.ts
@@ -9,14 +9,14 @@ import { makePatient } from "../../../../fhir-to-cda/cda-templates/components/__
 import * as bundleMods from "../modifications";
 import { postProcessBundle } from "../post-process";
 
-let replaceIdsMock: jest.SpyInstance;
 let addExtensionToConversionMock: jest.SpyInstance;
+let replaceIdsMock: jest.SpyInstance;
 let createFullBundleEntriesMock: jest.SpyInstance;
 let removePatientFromConversionMock: jest.SpyInstance;
 
 beforeAll(() => {
-  replaceIdsMock = jest.spyOn(bundleMods, "replaceIdsForResourcesWithDocExtension");
   addExtensionToConversionMock = jest.spyOn(bundleMods, "addExtensionToConversion");
+  replaceIdsMock = jest.spyOn(bundleMods, "replaceIdsForResourcesWithDocExtension");
   createFullBundleEntriesMock = jest.spyOn(bundleShared, "createFullBundleEntries");
   removePatientFromConversionMock = jest.spyOn(bundleMods, "removePatientFromConversion");
 });
@@ -201,23 +201,23 @@ describe("Checking postProcessBundle and its constituent functions", () => {
 
       postProcessBundle(bundle, patientId, documentExtension);
 
-      expect(replaceIdsMock).toHaveBeenCalled();
       expect(addExtensionToConversionMock).toHaveBeenCalled();
+      expect(replaceIdsMock).toHaveBeenCalled();
       expect(createFullBundleEntriesMock).toHaveBeenCalled();
       expect(removePatientFromConversionMock).toHaveBeenCalled();
 
       // Check relative order of execution
-      const replaceIdsOrder = replaceIdsMock.mock.invocationCallOrder[0];
       const addExtensionOrder = addExtensionToConversionMock.mock.invocationCallOrder[0];
+      const replaceIdsOrder = replaceIdsMock.mock.invocationCallOrder[0];
       const addRequestsOrder = createFullBundleEntriesMock.mock.invocationCallOrder[0];
       const removePatientOrder = removePatientFromConversionMock.mock.invocationCallOrder[0];
 
-      if (!replaceIdsOrder) throw new Error("Failed to get replaceIdsOrder");
       if (!addExtensionOrder) throw new Error("Failed to get addExtensionOrder");
+      if (!replaceIdsOrder) throw new Error("Failed to get replaceIdsOrder");
       if (!addRequestsOrder) throw new Error("Failed to get addRequestsOrder");
       if (!removePatientOrder) throw new Error("Failed to get removePatientOrder");
 
-      expect(replaceIdsOrder).toBeLessThan(addExtensionOrder);
+      expect(addExtensionOrder).toBeLessThan(replaceIdsOrder);
       expect(addExtensionOrder).toBeLessThan(addRequestsOrder);
       expect(addRequestsOrder).toBeLessThan(removePatientOrder);
     });

--- a/packages/core/src/domain/conversion/bundle-modifications/modifications.ts
+++ b/packages/core/src/domain/conversion/bundle-modifications/modifications.ts
@@ -35,6 +35,7 @@ export function replaceIdsForResourcesWithDocExtension(
     if (bundleEntry.resource.id === patientId) continue;
 
     const resource = bundleEntry.resource;
+    // TODO: 2574 - Make sure IDs are replaced for all relevant resources - not just the ones with extensions
     if ("extension" in resource) {
       const docIdExtension = resource.extension?.find(ext => ext.url === DOC_ID_EXTENSION_URL);
       const idToUse = bundleEntry.resource.id;

--- a/packages/core/src/domain/conversion/bundle-modifications/post-process.ts
+++ b/packages/core/src/domain/conversion/bundle-modifications/post-process.ts
@@ -23,6 +23,8 @@ export function postProcessBundle(
   patientId: string,
   documentExtension: FhirExtension
 ) {
+  // It'ss important to add extensions before replacing IDs b/c currently replaceIdsForResourcesWithDocExtension only replaces IDs of resources with extensions (#2574 to fix that).
+  // This current order guarantees that all resources have at least one extension
   const withExtensions = addExtensionToConversion(fhirBundle, documentExtension);
   const withNewIds = replaceIdsForResourcesWithDocExtension(withExtensions, patientId);
   const withRequests = createFullBundleEntries(withNewIds);

--- a/packages/core/src/domain/conversion/bundle-modifications/post-process.ts
+++ b/packages/core/src/domain/conversion/bundle-modifications/post-process.ts
@@ -23,9 +23,9 @@ export function postProcessBundle(
   patientId: string,
   documentExtension: FhirExtension
 ) {
-  const withNewIds = replaceIdsForResourcesWithDocExtension(fhirBundle, patientId);
-  const withExtensions = addExtensionToConversion(withNewIds, documentExtension);
-  const withRequests = createFullBundleEntries(withExtensions);
+  const withExtensions = addExtensionToConversion(fhirBundle, documentExtension);
+  const withNewIds = replaceIdsForResourcesWithDocExtension(withExtensions, patientId);
+  const withRequests = createFullBundleEntries(withNewIds);
   const withoutPatient = removePatientFromConversion(withRequests);
   return withoutPatient;
 }


### PR DESCRIPTION
refs. https://github.com/metriport/metriport-internal/issues/2574

### Description
- Once an XML is converted to FHIR, we want to add the document extension. With this extension, the `postProcess` function will make sure each resource ID is replaced with another one - eliminating the possibility of having two resources with the same ID in the collection bundle

### Testing
_[ Patch PRs ]_:
- ⚠️ [x] Run E2E tests locally

### Release Plan
- ⚠️ Pointing to `master`
- [ ] Merge this
