### PR TITLE
#2998 npm package updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33317,7 +33317,7 @@
       }
     },
     "packages/api": {
-      "version": "1.22.15-alpha.0",
+      "version": "1.22.15",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -33401,12 +33401,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "14.4.0-alpha.0",
+      "version": "14.4.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.1.12-alpha.0",
-        "@metriport/shared": "^0.14.7-alpha.0",
+        "@metriport/commonwell-sdk": "^5.1.12",
+        "@metriport/shared": "^0.14.7",
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -33462,10 +33462,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.11.12-alpha.0",
+      "version": "1.11.12",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.12.12-alpha.0",
+        "@metriport/ihe-gateway-sdk": "^0.12.12",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -33479,7 +33479,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "0.13.12-alpha.0",
+      "version": "0.13.12",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -33489,10 +33489,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.19.12-alpha.0",
+      "version": "1.19.12",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.1.12-alpha.0",
+        "@metriport/commonwell-sdk": "^5.1.12",
         "axios": "^1.4.0",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -33531,10 +33531,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.17.12-alpha.0",
+      "version": "1.17.12",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.1.12-alpha.0",
+        "@metriport/commonwell-sdk": "^5.1.12",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -33566,10 +33566,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.1.12-alpha.0",
+      "version": "5.1.12",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.14.7-alpha.0",
+        "@metriport/shared": "^0.14.7",
         "axios": "^1.4.0",
         "http-status": "^1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -33617,7 +33617,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.17.12-alpha.0",
+      "version": "1.17.12",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -34836,17 +34836,17 @@
     "packages/core/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.12.12-alpha.0",
+      "version": "0.12.12",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.14.7-alpha.0",
+        "@metriport/shared": "^0.14.7",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.15.12-alpha.0",
+      "version": "1.15.12",
       "dependencies": {
         "aws-cdk-lib": "^2.122.0",
         "constructs": "^10.2.69",
@@ -34919,7 +34919,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.14.7-alpha.0",
+      "version": "0.14.7",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -34967,7 +34967,7 @@
       }
     },
     "packages/utils": {
-      "version": "1.18.12-alpha.0",
+      "version": "1.18.12",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.658.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "14.4.0-alpha.0",
+  "version": "14.4.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.1.12-alpha.0",
-    "@metriport/shared": "^0.14.7-alpha.0",
+    "@metriport/commonwell-sdk": "^5.1.12",
+    "@metriport/shared": "^0.14.7",
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.22.15-alpha.0",
+  "version": "1.22.15",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.11.12-alpha.0",
+  "version": "1.11.12",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.12.12-alpha.0",
+    "@metriport/ihe-gateway-sdk": "^0.12.12",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "0.13.12-alpha.0",
+  "version": "0.13.12",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.19.12-alpha.0",
+  "version": "1.19.12",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.1.12-alpha.0",
+    "@metriport/commonwell-sdk": "^5.1.12",
     "axios": "^1.4.0",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.17.12-alpha.0",
+  "version": "1.17.12",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.1.12-alpha.0",
+    "@metriport/commonwell-sdk": "^5.1.12",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.1.12-alpha.0",
+  "version": "5.1.12",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.14.7-alpha.0",
+    "@metriport/shared": "^0.14.7",
     "axios": "^1.4.0",
     "http-status": "^1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.17.12-alpha.0",
+  "version": "1.17.12",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.12.12-alpha.0",
+  "version": "0.12.12",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.14.7-alpha.0",
+    "@metriport/shared": "^0.14.7",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.15.12-alpha.0",
+  "version": "1.15.12",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.14.7-alpha.0",
+  "version": "0.14.7",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.18.12-alpha.0",
+  "version": "1.18.12",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ref: #2998 

 - api@1.22.15
 - @metriport/api-sdk@14.4.0
 - @metriport/carequality-cert-runner@1.11.12
 - @metriport/carequality-sdk@0.13.12
 - @metriport/commonwell-cert-runner@1.19.12
 - @metriport/commonwell-jwt-maker@1.17.12
 - @metriport/commonwell-sdk@5.1.12
 - @metriport/core@1.17.12
 - @metriport/ihe-gateway-sdk@0.12.12
 - infrastructure@1.15.12
 - @metriport/shared@0.14.7
 - utils@1.18.12

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

- Ticket #2998 

### Dependencies

- Upstream: #3137 - Package bumps for release PR

### Testing
None

### Release Plan
- [ ] Merge this
