### PR TITLE
PATCH RELEASE 1040 Refresh patient before scheduling

### DIFF
--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -21,6 +21,7 @@ import { getCqInitiator } from "../shared";
 import { isFacilityEnabledToQueryCQ } from "../../carequality/shared";
 import { filterCqLinksByManagingOrg } from "./filter-oids-by-managing-org";
 import { processAsyncError } from "@metriport/core/util/error/shared";
+import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 
 const staleLookbackHours = 24;
 
@@ -72,7 +73,8 @@ export async function getDocumentsFromCQ({
       }),
     ]);
 
-    const patientCQData = getCQData(patient.data.externalData);
+    const currentPatient = await getPatientOrFail({ id: patientId, cxId });
+    const patientCQData = getCQData(currentPatient.data.externalData);
     const hasNoCQStatus = !patientCQData || !patientCQData.discoveryStatus;
     const isProcessing = patientCQData?.discoveryStatus === "processing";
     const updateStalePatients = await isStalePatientUpdateEnabledForCx(cxId);

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -66,6 +66,7 @@ import {
   getFileName,
 } from "./shared";
 import { validateCWEnabled } from "../shared";
+import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 
 const staleLookbackHours = 24;
 
@@ -150,7 +151,8 @@ export async function queryAndProcessDocuments({
       }),
     ]);
 
-    const patientCWData = getCWData(patientParam.data.externalData);
+    const currentPatient = await getPatientOrFail({ id: patientId, cxId });
+    const patientCWData = getCWData(currentPatient.data.externalData);
     const hasNoCWStatus = !patientCWData || !patientCWData.status;
     const isProcessing = patientCWData?.status === "processing";
     const updateStalePatients = await isStalePatientUpdateEnabledForCx(cxId);


### PR DESCRIPTION
Ref: #1040

### Description

- quick fix to refresh the patient right before deciding to schedule

### Testing

N/A

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
