### PR TITLE
feat(ehr): use home addresses from athena + check zip separate

### DIFF
--- a/packages/api/src/external/ehr/athenahealth/command/sync-patient.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/sync-patient.ts
@@ -12,7 +12,7 @@ import {
   NotFoundError,
   toTitleCase,
 } from "@metriport/shared";
-import { PatientResource } from "@metriport/shared/interface/external/athenahealth/patient";
+import { PatientResourceWithHomeAddress } from "@metriport/shared/interface/external/athenahealth/patient";
 import { getFacilityMappingOrFail } from "../../../../command/mapping/facility";
 import { findOrCreatePatientMapping, getPatientMapping } from "../../../../command/mapping/patient";
 import { queryDocumentsAcrossHIEs } from "../../../../command/medical/document/document-query";
@@ -176,7 +176,7 @@ export async function syncAthenaPatientIntoMetriport({
   return metriportPatient.id;
 }
 
-function createMetriportPatientDemos(patient: PatientResource): PatientDemoData[] {
+function createMetriportPatientDemos(patient: PatientResourceWithHomeAddress): PatientDemoData[] {
   const addressArray = createMetriportAddresses(patient);
   const contactArray = createMetriportContacts(patient);
   const names = createNames(patient);
@@ -193,7 +193,7 @@ function createMetriportPatientDemos(patient: PatientResource): PatientDemoData[
 }
 
 function createMetriportPatientCreateCmd(
-  patient: PatientResource
+  patient: PatientResourceWithHomeAddress
 ): Omit<PatientCreateCmd, "cxId" | "facilityId"> {
   const addressArray = createMetriportAddresses(patient);
   const contactArray = createMetriportContacts(patient);

--- a/packages/api/src/external/ehr/athenahealth/shared.ts
+++ b/packages/api/src/external/ehr/athenahealth/shared.ts
@@ -16,7 +16,7 @@ import {
   AthenaClientJwtTokenData,
   AthenaClientJwtTokenInfo,
 } from "@metriport/shared/interface/external/athenahealth/jwt-token";
-import { PatientResource } from "@metriport/shared/interface/external/athenahealth/patient";
+import { PatientResourceWithHomeAddress } from "@metriport/shared/interface/external/athenahealth/patient";
 import {
   findOrCreateJwtToken,
   getLatestExpiringJwtTokenBySourceAndData,
@@ -27,7 +27,7 @@ const region = Config.getAWSRegion();
 
 export const athenaClientJwtTokenSource = "athenahealth-client";
 
-export function createMetriportContacts(patient: PatientResource): Contact[] {
+export function createMetriportContacts(patient: PatientResourceWithHomeAddress): Contact[] {
   return (patient.telecom ?? []).flatMap(telecom => {
     if (telecom.system === "email") {
       return {
@@ -42,7 +42,7 @@ export function createMetriportContacts(patient: PatientResource): Contact[] {
   });
 }
 
-export function createMetriportAddresses(patient: PatientResource): Address[] {
+export function createMetriportAddresses(patient: PatientResourceWithHomeAddress): Address[] {
   return patient.address.map(address => {
     if (address.line.length === 0) {
       throw new Error("AthenaHealth patient missing at least one line in address");
@@ -58,7 +58,9 @@ export function createMetriportAddresses(patient: PatientResource): Address[] {
   });
 }
 
-export function createNames(patient: PatientResource): { firstName: string; lastName: string }[] {
+export function createNames(
+  patient: PatientResourceWithHomeAddress
+): { firstName: string; lastName: string }[] {
   const names: { firstName: string; lastName: string }[] = [];
   patient.name.map(name => {
     const lastName = name.family.trim();

--- a/packages/core/src/external/athenahealth/index.ts
+++ b/packages/core/src/external/athenahealth/index.ts
@@ -19,8 +19,9 @@ import {
   medicationCreateResponseSchema,
   MedicationReference,
   medicationReferencesGetResponseSchema,
-  PatientResource,
+  PatientResourceWithHomeAddress,
   patientResourceSchema,
+  patientResourceSchemaWithHomeAddress,
   patientSearchResourceSchema,
   ProblemCreateResponse,
   problemCreateResponseSchema,
@@ -271,7 +272,7 @@ class AthenaHealthApi {
   }: {
     cxId: string;
     patientId: string;
-  }): Promise<PatientResource | undefined> {
+  }): Promise<PatientResourceWithHomeAddress | undefined> {
     const { log, debug } = out(
       `AthenaHealth get patient - cxId ${cxId} practiceId ${this.practiceId} patientId ${patientId}`
     );
@@ -335,7 +336,7 @@ class AthenaHealthApi {
         });
         return undefined;
       }
-      return patientData;
+      return patientResourceSchemaWithHomeAddress.parse(patientData);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       if (error.response?.status === 404) return undefined;
@@ -361,7 +362,7 @@ class AthenaHealthApi {
   }: {
     cxId: string;
     patientId: string;
-  }): Promise<PatientResource | undefined> {
+  }): Promise<PatientResourceWithHomeAddress | undefined> {
     const { log, debug } = out(
       `AthenaHealth search patient - cxId ${cxId} practiceId ${this.practiceId} patientId ${patientId}`
     );
@@ -445,7 +446,7 @@ class AthenaHealthApi {
         });
         return undefined;
       }
-      return patientData;
+      return patientResourceSchemaWithHomeAddress.parse(patientData);
     } catch (error) {
       const msg = `Failure while searching patient @ AthenaHealth`;
       log(`${msg}. Cause: ${errorToString(error)}`);

--- a/packages/core/src/external/athenahealth/index.ts
+++ b/packages/core/src/external/athenahealth/index.ts
@@ -317,7 +317,25 @@ class AthenaHealthApi {
         });
         return undefined;
       }
-      return patient.data;
+      const patientData = patient.data;
+      patientData.address = patientData.address.filter(
+        a => a.postalCode !== undefined && a.use === "home"
+      );
+      if (patientData.address.length === 0) {
+        const msg = "No home address with valid zip found for patient";
+        capture.message(msg, {
+          extra: {
+            url: patientUrl,
+            cxId,
+            practiceId: this.practiceId,
+            patientId,
+            context: "athenahealth.get-patient",
+          },
+          level: "info",
+        });
+        return undefined;
+      }
+      return patientData;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       if (error.response?.status === 404) return undefined;
@@ -408,7 +426,26 @@ class AthenaHealthApi {
           additionalInfo
         );
       }
-      return entry[0]?.resource;
+      const patientData = entry[0]?.resource;
+      if (!patientData) return undefined;
+      patientData.address = patientData.address.filter(
+        a => a.postalCode !== undefined && a.use === "home"
+      );
+      if (patientData.address.length === 0) {
+        const msg = "No home address with valid zip found for patient from search set";
+        capture.message(msg, {
+          extra: {
+            url: patientSearchUrl,
+            cxId,
+            practiceId: this.practiceId,
+            patientId,
+            context: "athenahealth.get-patient",
+          },
+          level: "info",
+        });
+        return undefined;
+      }
+      return patientData;
     } catch (error) {
       const msg = `Failure while searching patient @ AthenaHealth`;
       log(`${msg}. Cause: ${errorToString(error)}`);

--- a/packages/shared/src/interface/external/athenahealth/patient.ts
+++ b/packages/shared/src/interface/external/athenahealth/patient.ts
@@ -15,6 +15,16 @@ const address = z.object({
   postalCode: z.string().optional(),
 });
 
+const homeAddress = z.object({
+  use: z.literal("home"),
+  country: z.string(),
+  period,
+  state: z.string(),
+  line: z.string().array(),
+  city: z.string(),
+  postalCode: z.string(),
+});
+
 const telecome = z.object({
   value: z.string(),
   system: z.enum(["phone", "email"]),
@@ -35,8 +45,16 @@ export const patientResourceSchema = z.object({
   telecom: telecome.array().optional(),
 });
 
-export type PatientResource = z.infer<typeof patientResourceSchema>;
+export const patientResourceSchemaWithHomeAddress = z.object({
+  gender: z.string(),
+  name: name.array(),
+  address: homeAddress.array(),
+  birthDate: z.string(),
+  telecom: telecome.array().optional(),
+});
 
+export type PatientResource = z.infer<typeof patientResourceSchema>;
+export type PatientResourceWithHomeAddress = z.infer<typeof patientResourceSchemaWithHomeAddress>;
 export const patientSearchResourceSchema = z.object({
   entry: z
     .object({

--- a/packages/shared/src/interface/external/athenahealth/patient.ts
+++ b/packages/shared/src/interface/external/athenahealth/patient.ts
@@ -12,7 +12,7 @@ const address = z.object({
   state: z.string(),
   line: z.string().array(),
   city: z.string(),
-  postalCode: z.string(),
+  postalCode: z.string().optional(),
 });
 
 const telecome = z.object({


### PR DESCRIPTION
Ref: #1040

### Description

- allow postalCode to be optional in initial zod schema
- filter addresses along missing zips and only home addresses (new zod schema)

### Testing

- Local
  - [x] ensure fetch via appointments still works
- Staging
  - [ ] ensure fetch via appointments still works
  - [ ] ensure opening the page still works
- Sandbox
  - [ ] N/A
- Production
  - [ ] ensure fetch via appointments still works
  - [ ] ensure opening the page still works

### Release Plan

- [ ] Merge this
