### PR TITLE
feat(ehr): bump token size to support 8kb

### DIFF
--- a/packages/api/src/sequelize/migrations/2025-01-15_00-alter-jwt_token-increase-token-length_3.ts
+++ b/packages/api/src/sequelize/migrations/2025-01-15_00-alter-jwt_token-increase-token-length_3.ts
@@ -1,0 +1,27 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+
+const jwtTokenTableName = "jwt_token";
+const jwtTokenColumnName = "token";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.changeColumn(
+      jwtTokenTableName,
+      jwtTokenColumnName,
+      { type: DataTypes.STRING(8192) },
+      { transaction }
+    );
+  });
+};
+
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.changeColumn(
+      jwtTokenTableName,
+      jwtTokenColumnName,
+      { type: DataTypes.STRING(4096) },
+      { transaction }
+    );
+  });
+};


### PR DESCRIPTION
Ref: #1040

### Description

- Athena breaking change https://docs.athenahealth.com/api/resources/25-03-release-introducing-json-web-tokens-for-apis recommends supporting tokens up to 8kb

### Release Plan

- :warning: This contains a DB migration
- [ ] Merge this
