### PR TITLE
fix(core): changed target region for bedrock

### DIFF
--- a/packages/core/src/command/ai-brief/create.ts
+++ b/packages/core/src/command/ai-brief/create.ts
@@ -101,7 +101,7 @@ export async function summarizeFilteredBundleWithAI(
     const llmSummary = new BedrockChat({
       model: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
       temperature: 0,
-      region: "us-east-1",
+      region: "us-west-2",
       callbacks: [
         {
           handleLLMEnd: output => {


### PR DESCRIPTION
refs. metriportmetriport-internal#799

### Description
- Updated the target region for Bedrock to `us-west-2`, which is said to have the highest input token limit - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1737378694508219)

### Testing

- Local
  - [x] Checked that the AI Brief generation still works using the local script 
- Production
  - [ ] Confirm that AI Brief generation still works on prod 

### Release Plan
- [ ] Merge this
