### PR TITLE
2553 Lighter CQ dir rebuild logic, no PK and only IDs

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory-raw-sql.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory-raw-sql.ts
@@ -19,6 +19,8 @@ export const cqDirectoryEntryBackup1 = `cq_directory_entry_backup1`;
 export const cqDirectoryEntryBackup2 = `cq_directory_entry_backup2`;
 export const cqDirectoryEntryBackup3 = `cq_directory_entry_backup3`;
 
+const pkNamePrefix = "cq_directory_entry_pkey";
+
 const keys = createKeys();
 const number_of_keys = keys.split(",").length;
 
@@ -86,16 +88,10 @@ function createKeys(): string {
   return Object.values(allKeys).join(", ");
 }
 
-export async function getCqDirectoryEntries(
-  sequelize: Sequelize,
-  ids: string[] = []
-): Promise<CQDirectoryEntryViewModel[]> {
-  const whereClause = ids.length > 0 ? `WHERE id in ('${ids.join(`','`)}')` : "";
-  const query = `SELECT * FROM ${cqDirectoryEntryTemp} ${whereClause};`;
-  const result = await sequelize.query<CQDirectoryEntryViewModel>(query, {
-    type: QueryTypes.SELECT,
-  });
-  return result;
+export async function getCqDirectoryIds(sequelize: Sequelize): Promise<string[]> {
+  const query = `SELECT id FROM ${cqDirectoryEntryTemp};`;
+  const result = await sequelize.query<{ id: string }>(query, { type: QueryTypes.SELECT });
+  return result.map(row => row.id);
 }
 
 export async function deleteCqDirectoryEntries(sequelize: Sequelize, ids: string[]): Promise<void> {
@@ -106,7 +102,9 @@ export async function deleteCqDirectoryEntries(sequelize: Sequelize, ids: string
 
 export async function createTempCqDirectoryTable(sequelize: Sequelize): Promise<void> {
   await deleteTempCqDirectoryTable(sequelize);
-  const query = `CREATE TABLE IF NOT EXISTS ${cqDirectoryEntryTemp} (LIKE ${cqDirectoryEntry} INCLUDING ALL)`;
+  // The PK is added later, on `updateCqDirectoryViewDefinition`
+  const query = `CREATE TABLE IF NOT EXISTS ${cqDirectoryEntryTemp} (LIKE ${cqDirectoryEntry} 
+                 INCLUDING DEFAULTS INCLUDING STORAGE EXCLUDING CONSTRAINTS)`;
   await sequelize.query(query, { type: QueryTypes.RAW });
 }
 
@@ -117,19 +115,27 @@ export async function deleteTempCqDirectoryTable(sequelize: Sequelize): Promise<
 
 export async function updateCqDirectoryViewDefinition(sequelize: Sequelize): Promise<void> {
   await executeOnDBTx(CQDirectoryEntryViewModel.prototype, async transaction => {
-    const dropView = `DROP VIEW IF EXISTS ${cqDirectoryEntryView};`;
-    const createView = `CREATE VIEW ${cqDirectoryEntryView} AS SELECT * FROM ${cqDirectoryEntryTemp};`;
-    const dropBackup3 = `DROP TABLE IF EXISTS ${cqDirectoryEntryBackup3};`;
-    const renameBackup2To3 = `ALTER TABLE IF EXISTS ${cqDirectoryEntryBackup2} RENAME TO ${cqDirectoryEntryBackup3};`;
-    const renameBackup1To2 = `ALTER TABLE IF EXISTS ${cqDirectoryEntryBackup1} RENAME TO ${cqDirectoryEntryBackup2};`;
-    const renameNewToBackup = `ALTER TABLE ${cqDirectoryEntry} RENAME TO ${cqDirectoryEntryBackup1};`;
-    const renameTempToNew = `ALTER TABLE ${cqDirectoryEntryTemp} RENAME TO ${cqDirectoryEntry};`;
-    await sequelize.query(dropView, { type: QueryTypes.RAW, transaction });
-    await sequelize.query(createView, { type: QueryTypes.RAW, transaction });
-    await sequelize.query(dropBackup3, { type: QueryTypes.RAW, transaction });
-    await sequelize.query(renameBackup2To3, { type: QueryTypes.RAW, transaction });
-    await sequelize.query(renameBackup1To2, { type: QueryTypes.RAW, transaction });
-    await sequelize.query(renameNewToBackup, { type: QueryTypes.RAW, transaction });
-    await sequelize.query(renameTempToNew, { type: QueryTypes.RAW, transaction });
+    async function runSql(sql: string): Promise<void> {
+      await sequelize.query(sql, { type: QueryTypes.RAW, transaction });
+    }
+    await runSql(
+      `ALTER TABLE ${cqDirectoryEntryTemp} ADD CONSTRAINT ${buildPkName()} PRIMARY KEY (id);`
+    );
+    await runSql(`DROP VIEW IF EXISTS ${cqDirectoryEntryView};`);
+    await runSql(`CREATE VIEW ${cqDirectoryEntryView} AS SELECT * FROM ${cqDirectoryEntryTemp};`);
+    await runSql(`DROP TABLE IF EXISTS ${cqDirectoryEntryBackup3};`);
+    await runSql(
+      `ALTER TABLE IF EXISTS ${cqDirectoryEntryBackup2} RENAME TO ${cqDirectoryEntryBackup3};`
+    );
+    await runSql(
+      `ALTER TABLE IF EXISTS ${cqDirectoryEntryBackup1} RENAME TO ${cqDirectoryEntryBackup2};`
+    );
+    await runSql(`ALTER TABLE ${cqDirectoryEntry} RENAME TO ${cqDirectoryEntryBackup1};`);
+    await runSql(`ALTER TABLE ${cqDirectoryEntryTemp} RENAME TO ${cqDirectoryEntry};`);
   });
+}
+
+function buildPkName(): string {
+  const timestamp = new Date().getTime();
+  return `${pkNamePrefix}_${timestamp}`;
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#2553

### Dependencies

- upstream: https://github.com/metriport/metriport/pull/3177

### Description

Lighter CQ dir rebuild logic, no PK and only IDs

### Testing

- Local
  - [ ] Rebuild dev CQ dir on local
  - [ ] Rebuild prod CQ dir on local
- Staging
  - [ ] Rebuild CQ dir
- Sandbox
  - none
- Production
  - [ ] Rebuild CQ dir

### Release Plan

- [ ] Merge this
