### PR TITLE
fix(core): updated input bundle for ai brief gen

### DIFF
--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -69,7 +69,7 @@ export async function createConsolidatedFromConversions({
   log(`isAiBriefFeatureFlagEnabled: ${isAiBriefFeatureFlagEnabled}`);
 
   if (isAiBriefFeatureFlagEnabled) {
-    const aiBriefContent = await summarizeFilteredBundleWithAI(withDups, cxId, patientId);
+    const aiBriefContent = await summarizeFilteredBundleWithAI(deduped, cxId, patientId);
     const aiBriefFhirResource = generateAiBriefFhirResource(aiBriefContent);
     if (aiBriefFhirResource) {
       deduped.entry?.push(buildBundleEntry(aiBriefFhirResource));


### PR DESCRIPTION
refs. metriportmetriport-internal#799

### Description
- Using the deduped bundle as input for AI Brief generation

### Testing

- Local
  - [x] Make an AI Brief using a deduped bundle locally
- Production
  - [ ] Monitor usage

### Release Plan
- [ ] Merge this
