### PR TITLE
feat(bundle): bumping lambda size + deleting tmp files

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1356,7 +1356,7 @@ export class APIStack extends Stack {
         lambdaLayers.chromium,
         lambdaLayers.puppeteer,
       ],
-      memory: 4096,
+      memory: 8192,
       timeout: lambdaTimeout,
       isEnableInsights: true,
       vpc,

--- a/packages/lambdas/src/fhir-to-medical-record.ts
+++ b/packages/lambdas/src/fhir-to-medical-record.ts
@@ -222,6 +222,9 @@ const convertStoreAndReturnPdfUrl = async ({
     }
   }
 
+  fs.rmSync(htmlFilepath, { force: true });
+  fs.rmSync(pdfFilepath, { force: true });
+
   // Logs "shutdown" statement
   console.log("generate-pdf -> shutdown");
   const urlPdf = await getSignedUrl(fileName);


### PR DESCRIPTION
Ref: #1040

### Description

- delete temp html / pdf files saved to generate PDFs
- bump fhir to MR lambda memory

### Testing

- Local
  - [ ] N/A
- Staging
  - [ ] Validate JSON, HTML, and PDF MR generation is working
- Sandbox
  - [ ] Validate JSON, HTML, and PDF MR generation is working
- Production
  - [ ] Validate JSON, HTML, and PDF MR generation is working

### Release Plan

- [ ] Merge this
