### PR TITLE
feat(bundle): remove storing html locally

### DIFF
--- a/packages/lambdas/src/fhir-to-medical-record.ts
+++ b/packages/lambdas/src/fhir-to-medical-record.ts
@@ -161,10 +161,6 @@ const convertStoreAndReturnPdfUrl = async ({
 }) => {
   const tmpFileName = uuid.v4();
 
-  const htmlFilepath = `/tmp/${tmpFileName}`;
-
-  fs.writeFileSync(htmlFilepath, html);
-
   // Defines filename + path for downloaded HTML file
   const tmpPDFFileName = tmpFileName.concat(".pdf");
   const pdfFilepath = `/tmp/${tmpPDFFileName}`;
@@ -222,7 +218,6 @@ const convertStoreAndReturnPdfUrl = async ({
     }
   }
 
-  fs.rmSync(htmlFilepath, { force: true });
   fs.rmSync(pdfFilepath, { force: true });
 
   // Logs "shutdown" statement


### PR DESCRIPTION
Ref: #1040

### Description

- remove storing html locally when generating a pdf as it doesn't appear to have any purpose

### Testing

- Local
  - [ ] N/A
- Staging
  - [ ] Ensure JSON, PDF, and HTML generation works
- Sandbox
  - [ ] Ensure JSON, PDF, and HTML generation works
- Production
  - [ ] Ensure JSON, PDF, and HTML generation works

### Release Plan

- [ ] Merge this
