### PR TITLE
fix(core): adding permissions for converter lambda to access app config

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -551,6 +551,7 @@ export class APIStack extends Stack {
       queue: fhirConverterQueue,
       resource: apiService.service.taskDefinition.taskRole,
     });
+
     const fhirConverterLambda = fhirConverterConnector.createLambda({
       envType: props.config.environmentType,
       stack: this,
@@ -564,6 +565,11 @@ export class APIStack extends Stack {
       termServerUrl: props.config.termServerUrl,
       apiServiceDnsAddress: apiDirectUrl,
       alarmSnsAction: slackNotification?.alarmAction,
+      appConfigEnvVars: {
+        appId: appConfigAppId,
+        configId: appConfigConfigId,
+      },
+      fargateService: apiService,
     });
 
     // Add ENV after the API service is created

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -590,7 +590,7 @@ export class APIStack extends Stack {
 
     AppConfigUtils.allowReadConfig({
       scope: this,
-      resourceName: "FhirToMrLambda",
+      resourceName: "FhirConverterLambda",
       resourceRole: fhirConverterLambda.role,
       appConfigResources: ["*"],
     });

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -569,7 +569,6 @@ export class APIStack extends Stack {
         appId: appConfigAppId,
         configId: appConfigConfigId,
       },
-      fargateService: apiService,
     });
 
     // Add ENV after the API service is created
@@ -588,6 +587,13 @@ export class APIStack extends Stack {
     medicalDocumentsBucket.grantReadWrite(apiService.taskDefinition.taskRole);
     medicalDocumentsBucket.grantReadWrite(documentDownloaderLambda);
     fhirConverterLambda && medicalDocumentsBucket.grantRead(fhirConverterLambda);
+
+    AppConfigUtils.allowReadConfig({
+      scope: this,
+      resourceName: "FhirToMrLambda",
+      resourceRole: fhirConverterLambda.role,
+      appConfigResources: ["*"],
+    });
 
     createDocQueryChecker({
       lambdaLayers,


### PR DESCRIPTION
refs. metriportmetriport-internal#2563

### Description
- Added AppConfig env vars and permissions to FHIR Converter lambda 

### Testing

- Staging
  - [ ] Make sure this fixes the issue on Staging
- Production
  - [ ] Make sure this works on Prod

### Release Plan
- [ ] Merge this
