### PR TITLE
1040 Add URL expiration time to docs

### DIFF
--- a/docs/medical-api/api-reference/document/get-document.mdx
+++ b/docs/medical-api/api-reference/document/get-document.mdx
@@ -4,7 +4,9 @@ description: "Gets a downloadable URL for downloading the specified document."
 api: "GET /medical/v1/document/download-url"
 ---
 
-This endpoint returns a URL which you can use to download the specified document and/or convert using the file name provided from the [List Documents endpoint](/medical-api/api-reference/document/list-documents), or from the `meta.source` field of the FHIR resource you are interested in.
+This endpoint returns a URL which you can use to download the specified document and/orconvert
+using the file name provided from the [List Documents endpoint](/medical-api/api-reference/document/list-documents),
+or from the `meta.source` field of the FHIR resource you are interested in.
 
 <Info>The URL will only be valid for 60 seconds before you need to request a new one.</Info>
 
@@ -29,7 +31,9 @@ A JSON object containing the URL will be returned.
 </ResponseField>
 
 <Tip>
-  For patients with a large volume documents, you can use the [Bulk Get Document URL](/medical-api/api-reference/document/download-url-bulk to get all download URLs, instead of doing it one at a time.
+  For patients with a large volume documents, you can use the
+  [Bulk Get Document URL](/medical-api/api-reference/document/download-url-bulk)
+  to get all download URLs, instead of doing it one at a time.
 </Tip>
 
 <ResponseExample>

--- a/docs/medical-api/api-reference/document/get-document.mdx
+++ b/docs/medical-api/api-reference/document/get-document.mdx
@@ -4,7 +4,7 @@ description: "Gets a downloadable URL for downloading the specified document."
 api: "GET /medical/v1/document/download-url"
 ---
 
-This endpoint returns a URL which you can use to download the specified document and/orconvert
+This endpoint returns a URL which you can use to download the specified document and/or convert
 using the file name provided from the [List Documents endpoint](/medical-api/api-reference/document/list-documents),
 or from the `meta.source` field of the FHIR resource you are interested in.
 
@@ -31,8 +31,8 @@ A JSON object containing the URL will be returned.
 </ResponseField>
 
 <Tip>
-  For patients with a large volume documents, you can use the
-  [Bulk Get Document URL](/medical-api/api-reference/document/download-url-bulk)
+  For patients with a large volume of documents, you can use the
+  [Bulk Get Document URL endpoint](/medical-api/api-reference/document/download-url-bulk)
   to get all download URLs, instead of doing it one at a time.
 </Tip>
 

--- a/docs/medical-api/handling-data/webhooks.mdx
+++ b/docs/medical-api/handling-data/webhooks.mdx
@@ -382,7 +382,15 @@ being the main difference between each:
 - `completed`: the bulk create is completed;
 - `failed`: the bulk create failed (likely due to an uploaded file with invalid format).
 
-Here is an example payload:
+<Info>
+  If the Medical Record doesn't contain any information, the
+  `Bundle` will be empty (the `entry` array will have no
+  elements).
+</Info>
+
+<Info>The URL will only be valid for 180 seconds (3 minutes).</Info>
+
+Example payload:
 
 ```json
 {
@@ -470,6 +478,8 @@ An example of a result file can be accessed
 
 If you want to download all of a patient's documents, especially when they have a large volume of documents, you can start a [Bulk Get Document URL query](/medical-api/api-reference/document/download-url-bulk). We’ll send a webhook message with all the downloadable URLs for all the patient's documents.
 You can use the value of the `url` property in the returned `documents` objects to download the files.
+
+<Info>The URLs will only be valid for 600 seconds (10 minutes).</Info>
 
 Here is an example payload:
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Updates to docs:
- Add URL expiration time
- Fix link on `Get Document URL`

New expiration info

![image](https://github.com/user-attachments/assets/bd5898e5-f85b-44ae-8a6f-c94ed1c8e7a6)

![image](https://github.com/user-attachments/assets/6db9a6f6-22f6-4d0a-acfa-3c0d72842093)

Bug...

![image](https://github.com/user-attachments/assets/4f746ccf-2e0f-4014-b855-73c0d229d41a)

...fix

![image](https://github.com/user-attachments/assets/a451e781-1d72-499b-9ab6-3a5254a8e004)

### Testing

- Local
  - [ ] Docs load and updates work
- Staging
  - none
- Sandbox
  - none
- Production
  - [ ] Docs load and updates work

### Release Plan

- [ ] Merge this
