### PR TITLE
chore(release): publish new versions of packages needed for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33317,7 +33317,7 @@
       }
     },
     "packages/api": {
-      "version": "1.22.18-alpha.0",
+      "version": "1.22.18",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -33401,12 +33401,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "14.7.0-alpha.0",
+      "version": "14.7.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.3.1-alpha.0",
-        "@metriport/shared": "^0.17.0-alpha.0",
+        "@metriport/commonwell-sdk": "^5.3.1",
+        "@metriport/shared": "^0.17.0",
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -33462,10 +33462,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.13.1-alpha.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.14.1-alpha.0",
+        "@metriport/ihe-gateway-sdk": "^0.14.1",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -33479,7 +33479,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.1.1-alpha.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -33503,10 +33503,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.21.1-alpha.0",
+      "version": "1.21.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.3.1-alpha.0",
+        "@metriport/commonwell-sdk": "^5.3.1",
         "axios": "^1.4.0",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -33545,10 +33545,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.19.1-alpha.0",
+      "version": "1.19.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.3.1-alpha.0",
+        "@metriport/commonwell-sdk": "^5.3.1",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -33580,10 +33580,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.3.1-alpha.0",
+      "version": "5.3.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.17.0-alpha.0",
+        "@metriport/shared": "^0.17.0",
         "axios": "^1.4.0",
         "http-status": "^1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -33631,7 +33631,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.19.1-alpha.0",
+      "version": "1.19.1",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -34850,17 +34850,17 @@
     "packages/core/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.14.1-alpha.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.17.0-alpha.0",
+        "@metriport/shared": "^0.17.0",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.17.1-alpha.0",
+      "version": "1.17.1",
       "dependencies": {
         "@metriport/shared": "file:packages/shared",
         "aws-cdk-lib": "^2.122.0",
@@ -34939,7 +34939,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.17.0-alpha.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -34987,7 +34987,7 @@
       }
     },
     "packages/utils": {
-      "version": "1.20.1-alpha.0",
+      "version": "1.20.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.658.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -77,5 +77,5 @@
     "ts-jest": "29.1.1",
     "typescript": "^4.9.5"
   },
-  "gitHead": "c9fec5e64fcf51b647d8a5bb3099a1841bb70c89"
+  "gitHead": "209fd9ebe5c2ab348cfa7e448f1c5cb5f5136a92"
 }

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "14.7.0-alpha.0",
+  "version": "14.7.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.3.1-alpha.0",
-    "@metriport/shared": "^0.17.0-alpha.0",
+    "@metriport/commonwell-sdk": "^5.3.1",
+    "@metriport/shared": "^0.17.0",
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.22.18-alpha.0",
+  "version": "1.22.18",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -43,5 +43,6 @@
   "dependencies": {
     "@metriport/ihe-gateway-sdk": "^0.14.1",
     "@metriport/shared": "^0.8.0"
-  }
+  },
+  "gitHead": "209fd9ebe5c2ab348cfa7e448f1c5cb5f5136a92"
 }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.13.1-alpha.0",
+  "version": "1.13.1",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.14.1-alpha.0",
+    "@metriport/ihe-gateway-sdk": "^0.14.1",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -78,5 +78,6 @@
     "ts-essentials": "^9.3.1",
     "ts-jest": "29.1.1",
     "typescript": "^4.9.5"
-  }
+  },
+  "gitHead": "209fd9ebe5c2ab348cfa7e448f1c5cb5f5136a92"
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.1.1-alpha.0",
+  "version": "1.1.1",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.21.1-alpha.0",
+  "version": "1.21.1",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.3.1-alpha.0",
+    "@metriport/commonwell-sdk": "^5.3.1",
     "axios": "^1.4.0",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -62,5 +62,6 @@
     "nodemon": "^2.0.20",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
-  }
+  },
+  "gitHead": "209fd9ebe5c2ab348cfa7e448f1c5cb5f5136a92"
 }

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.19.1-alpha.0",
+  "version": "1.19.1",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.3.1-alpha.0",
+    "@metriport/commonwell-sdk": "^5.3.1",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -54,5 +54,6 @@
     "nodemon": "^2.0.20",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
-  }
+  },
+  "gitHead": "209fd9ebe5c2ab348cfa7e448f1c5cb5f5136a92"
 }

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.3.1-alpha.0",
+  "version": "5.3.1",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.17.0-alpha.0",
+    "@metriport/shared": "^0.17.0",
     "axios": "^1.4.0",
     "http-status": "^1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -77,5 +77,6 @@
     "eslint-config-prettier": "^8.6.0",
     "prettier": "^2.8.3",
     "typescript": "^4.9.5"
-  }
+  },
+  "gitHead": "209fd9ebe5c2ab348cfa7e448f1c5cb5f5136a92"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.19.1-alpha.0",
+  "version": "1.19.1",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -56,5 +56,6 @@
     "@metriport/shared": "^0.17.0",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
-  }
+  },
+  "gitHead": "209fd9ebe5c2ab348cfa7e448f1c5cb5f5136a92"
 }

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.14.1-alpha.0",
+  "version": "0.14.1",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.17.0-alpha.0",
+    "@metriport/shared": "^0.17.0",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.17.1-alpha.0",
+  "version": "1.17.1",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.17.0-alpha.0",
+  "version": "0.17.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -92,5 +92,6 @@
     "ts-essentials": "^9.3.1",
     "ts-jest": "29.1.1",
     "typescript": "^4.9.5"
-  }
+  },
+  "gitHead": "209fd9ebe5c2ab348cfa7e448f1c5cb5f5136a92"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.20.1-alpha.0",
+  "version": "1.20.1",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ref: #000

 - api@1.22.19
 - @metriport/api-sdk@14.7.0
 - @metriport/carequality-cert-runner@1.13.1
 - @metriport/carequality-sdk@1.1.1
 - @metriport/commonwell-cert-runner@1.21.1
 - @metriport/commonwell-jwt-maker@1.19.1
 - @metriport/commonwell-sdk@5.3.1
 - @metriport/core@1.19.1
 - @metriport/ihe-gateway-sdk@0.14.1
 - infrastructure@1.17.1
 - @metriport/shared@0.17.0
 - utils@1.20.1

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>
