### PR TITLE
PATCH RELEASE Fixing inbound XCPD schema

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/process/schema.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/process/schema.ts
@@ -35,11 +35,11 @@ export const QueryByParameterSchema = z.object({
         _value: z.string(),
       }),
     }),
-    livingSubjectId: z
-      .object({
+    livingSubjectId: schemaOrArray(
+      z.object({
         value: schemaOrArrayOrEmpty(idSchema).optional(),
       })
-      .optional(),
+    ).optional(),
     livingSubjectName: schemaOrArray(
       z.object({
         value: nameSchema,

--- a/packages/terminology/src/operations/codeLookup.ts
+++ b/packages/terminology/src/operations/codeLookup.ts
@@ -222,10 +222,7 @@ export async function lookupCoding(
   const params = [codeSystem.id, coding.code];
   const result = await dbClient.select(query, params);
 
-  if (result.length === 0) {
-    console.log(`Code not found: system=${codeSystem.url}, code=${coding.code}`);
-    return [notFound];
-  }
+  if (result.length === 0) return [notFound];
 
   const resolved = result[0];
   const output: CodeSystemLookupOutput = {


### PR DESCRIPTION
refs. metriportmetriport-internal#799

### Description
- Adjusting the inbound XCPD schema / Added a Sentry alert for parsing
- Adjusting how the resulting object is handled
- Small tweak to remove a log from the Term Server

### Testing

_[Patch PRs:]_

- [x] :warning: Run E2E tests locally

- Local
  - [x] Test with a handful of different inbound requests to make sure all versions are being parsed with no errors
- Production
  - [ ] Monitor in prod

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
