### PR TITLE
fix(core): createMRSummaryFileName accepts json again

### DIFF
--- a/packages/core/src/domain/__tests__/medical-record-summary.test.ts
+++ b/packages/core/src/domain/__tests__/medical-record-summary.test.ts
@@ -1,8 +1,30 @@
 import { faker } from "@faker-js/faker";
+import { consolidationConversionType } from "../conversion/fhir-to-medical-record";
 import { createMRSummaryFileName } from "../medical-record-summary";
 
 describe("medical-record-summary", () => {
   describe("createMRSummaryFileName", () => {
+    describe("loop through all extensions", () => {
+      for (const extension of consolidationConversionType) {
+        it(`simply adds ${extension} extension`, async () => {
+          const cxId = faker.string.uuid();
+          const patientId = faker.string.uuid();
+          const result = createMRSummaryFileName(cxId, patientId, extension);
+          expect(result).toBeTruthy();
+          // eslint-disable-next-line
+          expect(result).toEqual(expect.stringMatching(new RegExp(`.+\.${extension}`)));
+        });
+      }
+    });
+
+    it(`builds pathname with HTML extension`, async () => {
+      const cxId = faker.string.uuid();
+      const patientId = faker.string.uuid();
+      const result = createMRSummaryFileName(cxId, patientId, "json");
+      expect(result).toBeTruthy();
+      expect(result).toEqual(`${cxId}/${patientId}/${cxId}_${patientId}_MR.json`);
+    });
+
     it(`builds pathname with HTML extension`, async () => {
       const cxId = faker.string.uuid();
       const patientId = faker.string.uuid();
@@ -11,12 +33,20 @@ describe("medical-record-summary", () => {
       expect(result).toEqual(`${cxId}/${patientId}/${cxId}_${patientId}_MR.html`);
     });
 
-    it(`builds pathname with PDF extension`, async () => {
+    it(`builds pathname with PDF extension including .html`, async () => {
       const cxId = faker.string.uuid();
       const patientId = faker.string.uuid();
       const result = createMRSummaryFileName(cxId, patientId, "pdf");
       expect(result).toBeTruthy();
       expect(result).toEqual(`${cxId}/${patientId}/${cxId}_${patientId}_MR.html.pdf`);
+    });
+
+    it(`builds pathname with JSON extension when dedupEnabled is false`, async () => {
+      const cxId = faker.string.uuid();
+      const patientId = faker.string.uuid();
+      const result = createMRSummaryFileName(cxId, patientId, "json", false);
+      expect(result).toBeTruthy();
+      expect(result).toEqual(`${cxId}/${patientId}/${cxId}_${patientId}_MR.json`);
     });
 
     it(`builds pathname with HTML extension when dedupEnabled is false`, async () => {
@@ -33,6 +63,14 @@ describe("medical-record-summary", () => {
       const result = createMRSummaryFileName(cxId, patientId, "pdf", false);
       expect(result).toBeTruthy();
       expect(result).toEqual(`${cxId}/${patientId}/${cxId}_${patientId}_MR.html.pdf`);
+    });
+
+    it(`builds pathname with JSON extension when dedupEnabled is true`, async () => {
+      const cxId = faker.string.uuid();
+      const patientId = faker.string.uuid();
+      const result = createMRSummaryFileName(cxId, patientId, "json", true);
+      expect(result).toBeTruthy();
+      expect(result).toEqual(`${cxId}/${patientId}/${cxId}_${patientId}_MR_deduped.json`);
     });
 
     it(`builds pathname with HTML extension when dedupEnabled is true`, async () => {

--- a/packages/core/src/domain/medical-record-summary.ts
+++ b/packages/core/src/domain/medical-record-summary.ts
@@ -10,9 +10,9 @@ export const createMRSummaryFileName = (
   dedupEnabled?: boolean
 ): string => {
   const fileSuffixBeforeExtension = createFileSuffixBeforeExtension(dedupEnabled);
-  const fileSuffix = `${fileSuffixBeforeExtension}.html`;
+  const fileExtension = extension === "pdf" ? "html.pdf" : extension;
+  const fileSuffix = `${fileSuffixBeforeExtension}.${fileExtension}`;
   const filePath = createFilePath(cxId, patientId, fileSuffix);
-  if (extension === "pdf") return `${filePath}.pdf`;
   return filePath;
 };
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1672

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3071
- Downstream: none

### Description

Fix `createMRSummaryFileName()` so it accepts JSON extension again.

### Testing

See upstream

### Release Plan

- [ ] Merge this
