### PR TITLE
1672 wkhtmltopdf defaults to using background

### DIFF
--- a/packages/core/src/external/wk-html-to-pdf/types.ts
+++ b/packages/core/src/external/wk-html-to-pdf/types.ts
@@ -59,6 +59,6 @@ export interface WkOptions {
   marginLeft?: number;
   /** Defaults to true */
   grayscale?: boolean;
-  /** Defaults to true */
+  /** Defaults to fase */
   removeBackground?: boolean;
 }

--- a/packages/core/src/external/wk-html-to-pdf/wk-html-to-pdf.ts
+++ b/packages/core/src/external/wk-html-to-pdf/wk-html-to-pdf.ts
@@ -23,7 +23,7 @@ export function wkHtmlToPdf(
   input: string | Stream,
   log?: typeof console.log | undefined
 ): Promise<Buffer> {
-  const { removeBackground = true, grayscale = true } = props;
+  const { removeBackground = false, grayscale = true } = props;
   return new Promise<Buffer>((resolve, reject) => {
     let wkhtmltopdfPath = "/opt/bin/wkhtmltopdf";
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1672

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3215
- Downstream: none

### Description

WkHtmlToPdf defaults to using background

### Testing

See upstream

### Release Plan

- [ ] Merge this
