### PR TITLE
1040 Repo init install is-ci globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {},
   "scripts": {
     "prepare-dev": "is-ci || husky install",
-    "preinstall": "npm i -g rimraf@5.0.10 --no-fund && npm run prepare-dev",
+    "preinstall": "npm i -g rimraf@5.0.10 is-ci@3.0.1 --no-fund && npm run prepare-dev",
     "preci": "npm run preinstall",
     "preinstall-deps": "npm run preci",
     "init": "npm i && SCRIPT='i' npm run lambdas:no-run",
@@ -64,9 +64,6 @@
     "commitizen": {
       "path": "@commitlint/cz-commitlint"
     }
-  },
-  "dependencies": {
-    "is-ci": "^3.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.4.2",


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3143
- Downstream: none

### Description

Repo init install is-ci globally - [context](https://github.com/metriport/metriport/actions/runs/13057010072/job/36430485450?pr=3226).

### Testing

- Local
  - [x] `husky uninstall && npm run deepclean && npm run install-deps && npm run build && npm run test` works
- Staging
  - [ ] CICD checks and deployment work
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
