### PR TITLE
feat(core): added concept and coding normalization

### DIFF
--- a/packages/core/src/command/consolidated/consolidated-shared.ts
+++ b/packages/core/src/command/consolidated/consolidated-shared.ts
@@ -1,6 +1,6 @@
 import { Config } from "../../util/config";
 
-export type ConsolidatedFileType = "original" | "dedup" | "invalid";
+export type ConsolidatedFileType = "original" | "dedup" | "invalid" | "normalized";
 
 export function getConsolidatedLocation() {
   return Config.getMedicalDocumentsBucketName();

--- a/packages/core/src/command/consolidated/get-snapshot-local.ts
+++ b/packages/core/src/command/consolidated/get-snapshot-local.ts
@@ -12,7 +12,9 @@ import { isConsolidatedFromS3Enabled } from "../../external/aws/app-config";
 import { checkBundle } from "../../external/fhir/bundle/qa";
 import { getConsolidatedFhirBundle as getConsolidatedFromFhirServer } from "../../external/fhir/consolidated/consolidated";
 import { deduplicate } from "../../external/fhir/consolidated/deduplicate";
+import { normalize } from "../../external/fhir/consolidated/normalize";
 import { toFHIR as patientToFhir } from "../../external/fhir/patient/conversion";
+import { isPatient } from "../../external/fhir/shared";
 import { buildBundleEntry } from "../../external/fhir/shared/bundle";
 import { capture, out } from "../../util";
 import { getConsolidatedFromS3 } from "./consolidated-filter";
@@ -23,7 +25,6 @@ import {
   ConsolidatedSnapshotResponse,
 } from "./get-snapshot";
 import { uploadConsolidatedSnapshotToS3 } from "./snapshot-on-s3";
-import { isPatient } from "../../external/fhir/shared";
 
 const MAX_API_NOTIFICATION_ATTEMPTS = 5;
 
@@ -54,8 +55,14 @@ export class ConsolidatedSnapshotConnectorLocal implements ConsolidatedSnapshotC
       bundle: originalBundleWithoutContainedPatients,
     });
 
+    const normalizedBundle = await normalize({
+      cxId,
+      patientId,
+      bundle: dedupedBundle,
+    });
+
     try {
-      checkBundle(dedupedBundle, cxId, patientId);
+      checkBundle(normalizedBundle, cxId, patientId);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       const msg = "Bundle contains invalid data";
@@ -87,6 +94,12 @@ export class ConsolidatedSnapshotConnectorLocal implements ConsolidatedSnapshotC
         s3BucketName: this.bucketName,
         bundle: dedupedBundle,
         type: "dedup",
+      }),
+      uploadConsolidatedSnapshotToS3({
+        ...params,
+        s3BucketName: this.bucketName,
+        bundle: normalizedBundle,
+        type: "normalized",
       }),
     ]);
 

--- a/packages/core/src/domain/consolidated/filename.ts
+++ b/packages/core/src/domain/consolidated/filename.ts
@@ -32,6 +32,8 @@ function getSuffixForType(type?: ConsolidatedFileType): string {
       return "";
     case "dedup":
       return "_deduped";
+    case "normalized":
+      return "_normalized";
     case "invalid":
       return "_invalid";
   }

--- a/packages/core/src/external/fhir/codeable-concept.ts
+++ b/packages/core/src/external/fhir/codeable-concept.ts
@@ -1,4 +1,8 @@
-import { CodeableConcept, Resource } from "@medplum/fhirtypes";
+import { CodeableConcept, Coding, Resource } from "@medplum/fhirtypes";
+import { isUnknownCoding } from "../../fhir-deduplication/shared";
+import { knownSystemUrls } from "../../util/constants";
+
+export const unknownValues = ["unknown", "unk", "no known"];
 
 /**
  * Returns the code attribute from each resource based on its spec
@@ -24,4 +28,20 @@ export function getCodesFromResource(res: Resource): CodeableConcept[] {
     return res.type ? [res.type] : [];
   }
   return [];
+}
+
+export function isValidCoding(coding: Coding): boolean {
+  if (coding.display && !isUselessDisplay(coding.display)) return true;
+  if (isUnknownCoding(coding)) return false;
+  if (coding.system && knownSystemUrls.includes(coding.system)) return true;
+  return false;
+}
+
+export function isUselessDisplay(text: string) {
+  const normalizedText = text.toLowerCase().trim();
+  return (
+    normalizedText.length === 0 ||
+    unknownValues.includes(normalizedText) ||
+    normalizedText.includes("no data available")
+  );
 }

--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-coding.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-coding.test.ts
@@ -43,6 +43,19 @@ describe("normalizeCodeableConcept", () => {
     expect(normalized.text).toBe("Cpt Term");
   });
 
+  it("should remove the coding from a known system if its code is UNK", () => {
+    const concept: CodeableConcept = {
+      coding: [
+        { system: SNOMED_URL, code: "123", display: "Snomed Term" },
+        { system: CPT_URL, code: "UNK" },
+      ],
+    };
+
+    const normalized = normalizeCodeableConcept(concept);
+    expect(normalized.coding?.length).toEqual(1);
+    expect(normalized.text).toBe("Snomed Term");
+  });
+
   it("should not set text if highest priority coding has no display", () => {
     const concept: CodeableConcept = {
       coding: [

--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-coding.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-coding.test.ts
@@ -1,0 +1,114 @@
+import { CodeableConcept } from "@medplum/fhirtypes";
+import { CPT_URL, ICD_10_URL, LOINC_URL, RXNORM_URL, SNOMED_URL } from "../../../../util/constants";
+import { normalizeCodeableConcept } from "../coding";
+
+describe("normalizeCodeableConcept", () => {
+  it("should return concept unchanged when no coding array present", () => {
+    const concept: CodeableConcept = {
+      text: "Some text",
+    };
+    expect(normalizeCodeableConcept(concept)).toEqual(concept);
+  });
+
+  it("should sort codings based on system priority", () => {
+    const concept: CodeableConcept = {
+      coding: [
+        { system: SNOMED_URL, code: "123", display: "Snomed Term" },
+        { system: RXNORM_URL, code: "456", display: "Rxnorm Term" },
+        { system: LOINC_URL, code: "789", display: "Loinc Term" },
+      ],
+    };
+
+    const normalized = normalizeCodeableConcept(concept);
+    expect(normalized.coding).toBeDefined();
+    expect(normalized.coding?.length).toEqual(3);
+
+    expect(normalized.coding?.[0]).toBeDefined();
+    expect(normalized.coding?.[0]?.system).toBe(RXNORM_URL);
+    expect(normalized.coding?.[1]).toBeDefined();
+    expect(normalized.coding?.[1]?.system).toBe(LOINC_URL);
+    expect(normalized.coding?.[2]).toBeDefined();
+    expect(normalized.coding?.[2]?.system).toBe(SNOMED_URL);
+  });
+
+  it("should set text to highest priority coding display if no text exists", () => {
+    const concept: CodeableConcept = {
+      coding: [
+        { system: SNOMED_URL, code: "123", display: "Snomed Term" },
+        { system: CPT_URL, code: "456", display: "Cpt Term" },
+      ],
+    };
+
+    const normalized = normalizeCodeableConcept(concept);
+    expect(normalized.text).toBe("Cpt Term");
+  });
+
+  it("should not set text if highest priority coding has no display", () => {
+    const concept: CodeableConcept = {
+      coding: [
+        { system: SNOMED_URL, code: "123", display: "Snomed Term" },
+        { system: CPT_URL, code: "456" },
+      ],
+    };
+
+    const normalized = normalizeCodeableConcept(concept);
+    expect(normalized.text).toEqual("Snomed Term");
+  });
+
+  it("should filter out invalid codings when multiple codings exist", () => {
+    const concept: CodeableConcept = {
+      coding: [
+        { system: SNOMED_URL, code: "123", display: "Snomed Term" },
+        { system: ICD_10_URL },
+        { system: CPT_URL, code: "456", display: "Cpt Term" },
+      ],
+    };
+
+    const normalized = normalizeCodeableConcept(concept);
+    expect(normalized.coding).toHaveLength(2);
+    expect(normalized.coding?.map(c => c.system)).toEqual([CPT_URL, SNOMED_URL]);
+  });
+
+  it("should not filter codings when only one coding exists", () => {
+    const concept: CodeableConcept = {
+      coding: [{ system: ICD_10_URL }],
+    };
+
+    const normalized = normalizeCodeableConcept(concept);
+    expect(normalized.coding).toHaveLength(1);
+    expect(normalized.coding?.[0]?.system).toBeDefined();
+    expect(normalized.coding?.[0]?.system as string).toBe(ICD_10_URL);
+  });
+
+  it("Picks the first useful display to replace the text field", () => {
+    const concept: CodeableConcept = {
+      coding: [
+        { system: CPT_URL, code: "456", display: "Unknown" },
+        { system: SNOMED_URL, code: "123", display: "Snomed Term" },
+      ],
+    };
+
+    const normalized = normalizeCodeableConcept(concept);
+    expect(normalized.text).toEqual("Snomed Term");
+  });
+
+  it("Keeps the existing text if there's nothing better to replace it with", () => {
+    const concept: CodeableConcept = {
+      text: "Something intelligent",
+      coding: [{ system: CPT_URL, code: "456", display: "Unknown" }],
+    };
+
+    const normalized = normalizeCodeableConcept(concept);
+    expect(normalized.text).toEqual("Something intelligent");
+  });
+
+  it("Keeps the existing text if there's nothing better to replace it with", () => {
+    const concept: CodeableConcept = {
+      text: "Something intelligent",
+      coding: [{ system: CPT_URL, code: "456", display: "Something more intelligent" }],
+    };
+
+    const normalized = normalizeCodeableConcept(concept);
+    expect(normalized.text).toEqual("Something more intelligent");
+  });
+});

--- a/packages/core/src/external/fhir/normalization/coding.ts
+++ b/packages/core/src/external/fhir/normalization/coding.ts
@@ -1,0 +1,91 @@
+import { Bundle, CodeableConcept, Coding, Resource } from "@medplum/fhirtypes";
+import { cloneDeep } from "lodash";
+import {
+  CPT_URL,
+  CVX_URL,
+  ICD_10_URL,
+  ICD_9_URL,
+  LOINC_URL,
+  NDC_URL,
+  RXNORM_URL,
+  SNOMED_URL,
+} from "../../../util/constants";
+import { isUselessDisplay, isValidCoding } from "../codeable-concept";
+
+export function sortCodings(bundle: Bundle<Resource>): Bundle<Resource> {
+  const updatedBundle = cloneDeep(bundle);
+  updatedBundle.entry?.forEach(entry => {
+    if (entry.resource) {
+      normalizeResource(entry.resource);
+    }
+  });
+
+  return updatedBundle;
+}
+
+function normalizeResource(resource: Resource): void {
+  if (!resource) return;
+  for (const [key, value] of Object.entries(resource)) {
+    if (!value) continue;
+
+    if (isCodeableConcept(value)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (resource as any)[key] = normalizeCodeableConcept(value);
+    } else if (Array.isArray(value)) {
+      value.forEach((item, idx) => {
+        if (isCodeableConcept(item)) {
+          value[idx] = normalizeCodeableConcept(item);
+        }
+      });
+    }
+  }
+}
+
+function isCodeableConcept(value: unknown): value is CodeableConcept {
+  return typeof value === "object" && value !== null && "coding" in value;
+}
+
+export function normalizeCodeableConcept(concept: CodeableConcept): CodeableConcept {
+  if (!concept.coding) return concept;
+  const codings = concept.coding;
+  const filteredCodings = codings.length > 1 ? codings.filter(isValidCoding) : codings;
+  const sortedCodings = [...filteredCodings].sort((a, b) => rankCoding(a) - rankCoding(b));
+  const replacementText = sortedCodings.find(
+    c => c.display && !isUselessDisplay(c.display)
+  )?.display;
+
+  return {
+    ...concept,
+    ...(replacementText && !isUselessDisplay(replacementText)
+      ? { text: replacementText }
+      : undefined),
+    coding: sortedCodings,
+  };
+}
+
+// TODO: 2626 - Improve sorting for codes from the same system
+function rankCoding(coding: Coding): number {
+  const system = coding.system;
+  if (!system) return 99;
+
+  switch (system) {
+    case RXNORM_URL:
+      return 1;
+    case NDC_URL:
+      return 2;
+    case CPT_URL:
+      return 1;
+    case CVX_URL:
+      return 1;
+    case ICD_10_URL:
+      return 1;
+    case ICD_9_URL:
+      return 2;
+    case LOINC_URL:
+      return 3;
+    case SNOMED_URL:
+      return 4;
+    default:
+      return 99;
+  }
+}

--- a/packages/core/src/external/fhir/normalization/normalize-fhir.ts
+++ b/packages/core/src/external/fhir/normalization/normalize-fhir.ts
@@ -3,6 +3,7 @@ import { cloneDeep } from "lodash";
 import { buildCompleteBundleEntry, extractFhirTypesFromBundle } from "../shared/bundle";
 import { normalizeCoverages } from "./resources/coverage";
 import { normalizeObservations } from "./resources/observation";
+import { sortCodings } from "./coding";
 
 export function normalizeFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> {
   const normalizedBundle: Bundle = cloneDeep(fhirBundle);
@@ -18,5 +19,5 @@ export function normalizeFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> {
     return entriesArray.flatMap(v => buildCompleteBundleEntry(v, normalizedBundle.type) || []);
   });
 
-  return normalizedBundle;
+  return sortCodings(normalizedBundle);
 }

--- a/packages/core/src/external/fhir/shared/__tests__/is-useless-display.test.ts
+++ b/packages/core/src/external/fhir/shared/__tests__/is-useless-display.test.ts
@@ -1,0 +1,23 @@
+import { isUselessDisplay } from "../../codeable-concept";
+
+describe("isUselessDisplay", () => {
+  it("correctly recognizes unknown as a useless display", () => {
+    const result = isUselessDisplay("Unknown");
+    expect(result).toEqual(true);
+  });
+
+  it("correctly recognizes unknown as a useless display", () => {
+    const result = isUselessDisplay("No data available for this section");
+    expect(result).toEqual(true);
+  });
+
+  it("correctly recognizes a useful description as something useful", () => {
+    const result = isUselessDisplay("Some useful description");
+    expect(result).toEqual(false);
+  });
+
+  it("correctly recognizes a useful description as something useful", () => {
+    const result = isUselessDisplay("");
+    expect(result).toEqual(true);
+  });
+});

--- a/packages/core/src/external/fhir/shared/__tests__/is-valid-coding.test.ts
+++ b/packages/core/src/external/fhir/shared/__tests__/is-valid-coding.test.ts
@@ -1,0 +1,65 @@
+import { isValidCoding } from "../../codeable-concept";
+import { knownSystemUrls } from "../../../../util/constants";
+
+describe("isValidCoding", () => {
+  it("should return true for coding with only a valid display", () => {
+    const result = isValidCoding({ display: "Some display" });
+    expect(result).toBe(true);
+  });
+
+  it("should return false for coding with useless display", () => {
+    const result = isValidCoding({ display: "Unknown" });
+    expect(result).toBe(false);
+  });
+
+  it("should return true for coding with a known system even if display is missing", () => {
+    expect(knownSystemUrls.length).toBeGreaterThan(0);
+    expect(knownSystemUrls[0]).toBeDefined();
+
+    const result = isValidCoding({
+      system: knownSystemUrls[0] as string,
+      code: "123",
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false for an uninformative coding without known system", () => {
+    const result = isValidCoding({
+      system: "http://some-other-system.org",
+      code: "456",
+      display: "Unknown",
+    });
+    expect(result).toBe(false);
+  });
+
+  it("should return true for an informative coding without known system", () => {
+    const result = isValidCoding({
+      system: "http://some-other-system.org",
+      code: "456",
+      display: "Some valid descriptor",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("should return false for valid coding without known system", () => {
+    const result = isValidCoding({
+      system: "http://some-other-system.org",
+      code: "456",
+    });
+    expect(result).toBe(false);
+  });
+
+  it("should return false for unknown coding", () => {
+    const result = isValidCoding({
+      system: "http://unknown-system.org",
+      code: "UNK",
+    });
+    expect(result).toBe(false);
+  });
+
+  it("should return false for empty coding", () => {
+    const result = isValidCoding({});
+    expect(result).toBe(false);
+  });
+});

--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -4,6 +4,7 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import _, { cloneDeep } from "lodash";
 import { v4 as uuidv4 } from "uuid";
+import { unknownValues } from "../external/fhir/codeable-concept";
 import { capture, out } from "../util";
 
 dayjs.extend(utc);
@@ -67,7 +68,6 @@ export function combineTwoResources<T extends Resource>(
 
 // TODO: Might be a good idea to include a check to see if all resources refer to the same patient
 const conditionKeysToIgnore = ["id", "resourceType", "subject"];
-const unknownValues = ["unknown", "unk", "no known"];
 
 //eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function deepMerge(target: any, source: any, isExtensionIncluded: boolean): any {
@@ -390,6 +390,11 @@ export function isUnknownCoding(coding: Coding, text?: string | undefined): bool
       (!text || text === unknownCode.text.toLowerCase() || text.includes("no data"))
     );
   }
+}
+
+export function isUselessDisplay(text: string) {
+  const normalizedText = text.toLowerCase().trim();
+  return unknownValues.includes(normalizedText) || normalizedText.includes("no data available");
 }
 
 export type DeduplicationResult<T extends Resource> = {

--- a/packages/core/src/util/constants.ts
+++ b/packages/core/src/util/constants.ts
@@ -13,12 +13,14 @@ export const ICD_10_URL = "http://hl7.org/fhir/sid/icd-10-cm";
 export const ICD_10_OID = "2.16.840.1.113883.6.90";
 
 export const ICD_9_CODE = "icd-9";
+export const ICD_9_URL = "http://terminology.hl7.org/CodeSystem/ICD-9CM-diagnosiscodes9";
 
 export const RXNORM_CODE = "rxnorm";
 export const RXNORM_URL = "http://www.nlm.nih.gov/research/umls/rxnorm";
 export const RXNORM_OID = "2.16.840.1.113883.6.88";
 
 export const NDC_CODE = "ndc";
+export const NDC_URL = "http://hl7.org/fhir/sid/ndc";
 export const NDC_OID = "2.16.840.1.113883.6.69";
 
 export const CVX_CODE = "cvx";
@@ -28,3 +30,22 @@ export const CVX_OID = "2.16.840.1.113883.12.292";
 export const CPT_CODE = "cpt";
 export const CPT_URL = "http://www.ama-assn.org/go/cpt";
 export const CPT_OID = "2.16.840.1.113883.6.12";
+
+export const NDDF_URL = "http://terminology.hl7.org/CodeSystem/nddf";
+
+export const HL7_ACT_URL = "http://terminology.hl7.org/CodeSystem/v3-ActCode";
+
+export const EPIC_PARTIAL_URN = "1.2.840.114350.1.13";
+export const HL7_PARTIAL_URN = "2.16.840.1.113883";
+
+export const knownSystemUrls = [
+  RXNORM_URL,
+  NDC_URL,
+  CPT_URL,
+  CVX_URL,
+  ICD_10_URL,
+  ICD_9_URL,
+  LOINC_URL,
+  SNOMED_URL,
+  HL7_ACT_URL,
+];

--- a/packages/utils/src/fhir-normalization/normalize-files-local.ts
+++ b/packages/utils/src/fhir-normalization/normalize-files-local.ts
@@ -36,7 +36,7 @@ async function main() {
 
     const cxId = uuidv4();
     const patientId = uuidv4();
-    const resultingBundle = normalize({ cxId, patientId, bundle });
+    const resultingBundle = await normalize({ cxId, patientId, bundle });
 
     console.log(`normalized bundle in ${elapsedTimeFromNow(startedAt)} ms.`);
 


### PR DESCRIPTION
refs. metriportmetriport-internal#2625

### Description
- Removing unknown / useless Codings wherever possible (leaving them in, if they're the only element in the coding array)
- Leaving Codings from known systems if they have a non-UNK code, even if missing display
- Leaving Codings from unknown systems as long as they have a non-Unknown display
- Sorting remaining Codings based on their relevance
- Replacing the CodeableConcept.text field with an informative display 

### Testing

- Local
  - [x] Unit tests
  - [x] Test with a few bundles 
- Production
  - [ ] Reprocess a few patients known to have problems and validate the improvement

### Release Plan
- [ ] Merge this
