### PR TITLE
1040 Publish non-alpha packages for Binary type on filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,6 @@
         "packages/utils",
         "packages/tester-node"
       ],
-      "dependencies": {
-        "is-ci": "^3.0.1"
-      },
       "devDependencies": {
         "@commitlint/cli": "^17.4.2",
         "@commitlint/config-conventional": "^17.4.2",
@@ -17112,6 +17109,7 @@
     },
     "node_modules/ci-info": {
       "version": "3.8.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -21834,6 +21832,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
       "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
       "dependencies": {
         "ci-info": "^3.2.0"
       },
@@ -33327,7 +33326,7 @@
       }
     },
     "packages/api": {
-      "version": "1.23.0-alpha.0",
+      "version": "1.24.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -33411,12 +33410,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "14.9.0-alpha.0",
+      "version": "14.10.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.4.0-alpha.0",
-        "@metriport/shared": "^0.18.0-alpha.0",
+        "@metriport/commonwell-sdk": "^5.5.0",
+        "@metriport/shared": "^0.19.0",
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -33472,10 +33471,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.14.0-alpha.0",
+      "version": "1.15.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.15.0-alpha.0",
+        "@metriport/ihe-gateway-sdk": "^0.16.0",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -33489,7 +33488,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.2.0-alpha.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -33513,10 +33512,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.22.0-alpha.0",
+      "version": "1.23.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.4.0-alpha.0",
+        "@metriport/commonwell-sdk": "^5.5.0",
         "axios": "^1.4.0",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -33555,10 +33554,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.20.0-alpha.0",
+      "version": "1.21.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.4.0-alpha.0",
+        "@metriport/commonwell-sdk": "^5.5.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -33590,10 +33589,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.4.0-alpha.0",
+      "version": "5.5.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.18.0-alpha.0",
+        "@metriport/shared": "^0.19.0",
         "axios": "^1.4.0",
         "http-status": "^1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -33641,7 +33640,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.20.0-alpha.0",
+      "version": "1.21.0",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -34861,17 +34860,17 @@
     "packages/core/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.15.0-alpha.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.18.0-alpha.0",
+        "@metriport/shared": "^0.19.0",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.18.0-alpha.0",
+      "version": "1.19.0",
       "dependencies": {
         "@metriport/shared": "file:packages/shared",
         "aws-cdk-lib": "^2.122.0",
@@ -34950,7 +34949,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.18.0-alpha.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -34998,7 +34997,7 @@
       }
     },
     "packages/utils": {
-      "version": "1.21.0-alpha.0",
+      "version": "1.22.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.658.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "14.9.0-alpha.0",
+  "version": "14.10.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.4.0-alpha.0",
-    "@metriport/shared": "^0.18.0-alpha.0",
+    "@metriport/commonwell-sdk": "^5.5.0",
+    "@metriport/shared": "^0.19.0",
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.23.0-alpha.0",
+  "version": "1.24.0",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.14.0-alpha.0",
+  "version": "1.15.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.15.0-alpha.0",
+    "@metriport/ihe-gateway-sdk": "^0.16.0",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.2.0-alpha.0",
+  "version": "1.3.0",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.22.0-alpha.0",
+  "version": "1.23.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.4.0-alpha.0",
+    "@metriport/commonwell-sdk": "^5.5.0",
     "axios": "^1.4.0",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.20.0-alpha.0",
+  "version": "1.21.0",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.4.0-alpha.0",
+    "@metriport/commonwell-sdk": "^5.5.0",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.4.0-alpha.0",
+  "version": "5.5.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.18.0-alpha.0",
+    "@metriport/shared": "^0.19.0",
     "axios": "^1.4.0",
     "http-status": "^1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.20.0-alpha.0",
+  "version": "1.21.0",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.15.0-alpha.0",
+  "version": "0.16.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.18.0-alpha.0",
+    "@metriport/shared": "^0.19.0",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.18.0-alpha.0",
+  "version": "1.19.0",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.18.0-alpha.0",
+  "version": "0.19.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.21.0-alpha.0",
+  "version": "1.22.0",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3223
- Downstream: none

### Description

chore(release): publish

 - api@1.24.0
 - @metriport/api-sdk@14.10.0
 - @metriport/carequality-cert-runner@1.15.0
 - @metriport/carequality-sdk@1.3.0
 - @metriport/commonwell-cert-runner@1.23.0
 - @metriport/commonwell-jwt-maker@1.21.0
 - @metriport/commonwell-sdk@5.5.0
 - @metriport/core@1.21.0
 - @metriport/ihe-gateway-sdk@0.16.0
 - infrastructure@1.19.0
 - @metriport/shared@0.19.0
 - utils@1.22.0

### Testing

none

### Release Plan

- [ ] Merge this
