### PR TITLE
fix(api): use 2 letter state code incl. puerto rico

### DIFF
--- a/docs/_snippets/list-network-entries-response.mdx
+++ b/docs/_snippets/list-network-entries-response.mdx
@@ -11,7 +11,7 @@
 </ResponseField>
 
 <ResponseField name="state" type="string">
-  The full state name, for example: `New Jersey`.
+  The 2 letter state acronym, for example: `CA`.
 </ResponseField>
 
 <ResponseField name="rootOrganization" type="string">

--- a/packages/api/src/domain/medical/network-entry.ts
+++ b/packages/api/src/domain/medical/network-entry.ts
@@ -1,9 +1,11 @@
+import { USStateForAddress } from "@metriport/shared";
+
 export interface NetworkEntry {
   id: string;
   oid: string;
   name: string;
   zipCode?: string;
-  state?: string;
+  state?: USStateForAddress;
   managingOrgOid?: string;
   rootOrganization?: string;
 }

--- a/packages/api/src/routes/medical/dtos/network-entry-dto.ts
+++ b/packages/api/src/routes/medical/dtos/network-entry-dto.ts
@@ -1,3 +1,4 @@
+import { normalizeUSStateForAddress } from "@metriport/shared";
 import { NetworkEntry } from "../../../domain/medical/network-entry";
 import { HieDirectoryEntry } from "../../../external/hie/domain/hie-directory-entry";
 
@@ -8,7 +9,7 @@ export function dtoFromHieDirectoryEntry(networkEntry: HieDirectoryEntry): Netwo
     name: networkEntry.name,
     oid: networkEntry.oid,
     zipCode: networkEntry.zipCode,
-    state: networkEntry.state,
+    state: normalizeUSStateForAddress(networkEntry.state ?? ""),
     rootOrganization: networkEntry.rootOrganization,
     managingOrgOid: networkEntry.managingOrganizationId,
   };


### PR DESCRIPTION
refs. metriport/metriport-internal#1772

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

Ticket: #1772

### Dependencies
Needs to ship with https://github.com/metriport/metriport/pull/3233

### Description

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/f36716d2-fdc6-452e-8cce-110253e48151" />

### Testing
- Local
  - [x] Verify that CW states are appearing as 2 letter codes
- Staging
  - [ ] Verify that CW states are appearing as 2 letter codes
- Sandbox
  - [ ] Verify that CW states are appearing as 2 letter codes


### Release Plan
See https://github.com/metriport/metriport/pull/3222