### PR TITLE
PATCH 1772 - Update packages to release version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33329,7 +33329,7 @@
       }
     },
     "packages/api": {
-      "version": "1.24.1-alpha.0",
+      "version": "1.24.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -33413,12 +33413,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "14.11.0-alpha.0",
+      "version": "14.11.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.5.1-alpha.0",
-        "@metriport/shared": "^0.19.1-alpha.0",
+        "@metriport/commonwell-sdk": "^5.5.1",
+        "@metriport/shared": "^0.19.1",
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -33474,10 +33474,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.15.1-alpha.0",
+      "version": "1.15.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.16.1-alpha.0",
+        "@metriport/ihe-gateway-sdk": "^0.16.1",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -33491,7 +33491,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.3.1-alpha.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -33515,10 +33515,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.23.1-alpha.0",
+      "version": "1.23.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.5.1-alpha.0",
+        "@metriport/commonwell-sdk": "^5.5.1",
         "axios": "^1.4.0",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -33557,10 +33557,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.21.1-alpha.0",
+      "version": "1.21.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.5.1-alpha.0",
+        "@metriport/commonwell-sdk": "^5.5.1",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -33592,10 +33592,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.5.1-alpha.0",
+      "version": "5.5.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.19.1-alpha.0",
+        "@metriport/shared": "^0.19.1",
         "axios": "^1.4.0",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -33643,7 +33643,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.21.1-alpha.0",
+      "version": "1.21.1",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -34865,17 +34865,17 @@
     "packages/core/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.16.1-alpha.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.19.1-alpha.0",
+        "@metriport/shared": "^0.19.1",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.19.1-alpha.0",
+      "version": "1.19.1",
       "dependencies": {
         "@metriport/shared": "file:packages/shared",
         "aws-cdk-lib": "^2.122.0",
@@ -34954,7 +34954,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.19.1-alpha.0",
+      "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -35002,7 +35002,7 @@
       }
     },
     "packages/utils": {
-      "version": "1.22.1-alpha.0",
+      "version": "1.22.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.658.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "14.11.0-alpha.0",
+  "version": "14.11.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.5.1-alpha.0",
-    "@metriport/shared": "^0.19.1-alpha.0",
+    "@metriport/commonwell-sdk": "^5.5.1",
+    "@metriport/shared": "^0.19.1",
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.24.1-alpha.0",
+  "version": "1.24.1",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.15.1-alpha.0",
+  "version": "1.15.1",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.16.1-alpha.0",
+    "@metriport/ihe-gateway-sdk": "^0.16.1",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.3.1-alpha.0",
+  "version": "1.3.1",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.23.1-alpha.0",
+  "version": "1.23.1",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.5.1-alpha.0",
+    "@metriport/commonwell-sdk": "^5.5.1",
     "axios": "^1.4.0",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.21.1-alpha.0",
+  "version": "1.21.1",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.5.1-alpha.0",
+    "@metriport/commonwell-sdk": "^5.5.1",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.5.1-alpha.0",
+  "version": "5.5.1",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.19.1-alpha.0",
+    "@metriport/shared": "^0.19.1",
     "axios": "^1.4.0",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.21.1-alpha.0",
+  "version": "1.21.1",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.16.1-alpha.0",
+  "version": "0.16.1",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.19.1-alpha.0",
+    "@metriport/shared": "^0.19.1",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.19.1-alpha.0",
+  "version": "1.19.1",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.19.1-alpha.0",
+  "version": "0.19.1",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.22.1-alpha.0",
+  "version": "1.22.1",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
refs. metriport/metriport-internal#1772

### Description
- Bump released package off the alpha version

### Testing
None

### Release Plan
- :warning: Points to `master`
- [ ] Merge this
- [ ] Backmerge into develop
