### PR TITLE
PATCH RELEASE Update docs with Binary resource on consolidated

### DIFF
--- a/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
+++ b/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
@@ -45,7 +45,8 @@ that will contain a URL to retrieve the data from.
 <ParamField query="resources" type="string" optional>
   A comma separated, case sensitive list of resources to be returned. If none are provided all
   resources will be included. Metriport will automatically hydrate the initially filtered resources
-  with referenced ones to create bundle consistency.
+  with referenced ones to create bundle consistency. The list of accepted resources can be accessed
+  [here](/medical-api/api-reference/fhir/consolidated-data-query-post#available-fhir-resources).
 </ParamField>
 
 <ParamField query="dateFrom" type="string" optional>
@@ -68,11 +69,6 @@ Otherwise, the data will be returned in JSON format in the Webhook payload (defa
   <Info>Providing `pdf` or `html` results in a
   [Medical Record Summary](/medical-api/handling-data/webhooks#medical-record) being sent.</Info>
 </ParamField>
-
-<Info>
-  You can scroll to the bottom of the page to view all [available
-  resources](/medical-api/api-reference/fhir/get-patient-consolidated#available-fhir-resources).
-</Info>
 
 ## Body
 
@@ -113,6 +109,7 @@ See [limits and throttling](/medical-api/more-info/limits#rate-limits)
 This is the list of all available [FHIR resources](/medical-api/fhir/resources) you can query for:
 
 - [AllergyIntolerance](/medical-api/fhir/resources/allergyintolerance)
+- [Binary](/medical-api/fhir/resources/binary)
 - [Communication](/medical-api/fhir/resources/communication)
 - [Composition](/medical-api/fhir/resources/composition)
 - [Condition](/medical-api/fhir/resources/condition)

--- a/docs/medical-api/fhir/overview.mdx
+++ b/docs/medical-api/fhir/overview.mdx
@@ -107,8 +107,8 @@ In JSON, an Observation Resource would look like this, for example:
 }
 ```
 
-You're able to query for a Patient's FHIR Resources using the [Get Patient's Consolidated Data
-Endpoint](/medical-api/api-reference/fhir/get-patient-consolidated).
+You're able to query for a Patient's FHIR Resources using the [Consolidated Data Query
+Endpoint](/medical-api/api-reference/fhir/consolidated-data-query-post).
 
 Additionally, to meet data contribution requirements, you're able to provide new data about a
 Patient using the [Add Patient Data endpoint](/medical-api/api-reference/fhir/add-patient-data).

--- a/docs/medical-api/more-info/ai-brief.mdx
+++ b/docs/medical-api/more-info/ai-brief.mdx
@@ -4,22 +4,39 @@ description: "How to use the AI Brief feature"
 ---
 
 <Warning>
-  The AI Brief feature is currently in Beta. While we strive for accuracy, these summaries should
-  not be used as the sole source of truth for medical decision-making. We welcome your feedback to
-  help us improve this feature.
+  The AI Brief feature is currently in Beta. While we strive
+  for accuracy, these summaries should not be used as the
+  sole source of truth for medical decision-making. We
+  welcome your feedback to help us improve this feature.
 </Warning>
 
-The AI Brief feature summarizes your lengthiest patient records into one cohesive paragraph consisting of the most relevant medical history you need to know about your patient.
+The AI Brief feature summarizes your lengthiest patient records into one cohesive paragraph consisting
+of the most relevant medical history you need to know about your patient.
 
 ## API
 
-When using the API, you can access the AI brief by triggering a [Consolidated Data Query](/medical-api/api-reference/fhir/consolidated-data-query-post) request. Depending on the `conversionType` you choose, the AI brief will be included in the response in a different format.
+When using the API, you can access the AI brief by triggering a
+[Consolidated Data Query](/medical-api/api-reference/fhir/consolidated-data-query-post) request.
+Depending on the `conversionType` you choose, the AI brief will be included in the response in a
+different format (see [FHIR Bundle](/medical-api/more-info/ai-brief#fhir-bundle) or
+[Medical Record Summary](/medical-api/more-info/ai-brief#medical-record-summary) below).
+
+<Tip>
+  If you add a resource type filter to the `Consolidated
+  Data Query`, make sure to include `Binary` as well in
+  order to get the AI Brief in the results.
+</Tip>
 
 ### FHIR Bundle
 
-When triggering a consolidated query via the API with the `conversionType` query param set to `json`, the AI brief will be included in the response under a [Binary resource](/medical-api/fhir/resources/binary) with the following format:
+When triggering a consolidated query via the API with the `conversionType` query param set to `json`,
+the AI brief will be included in the response under a
+[Binary resource](/medical-api/fhir/resources/binary) with the following format:
 
-<Info>The `data` field is a Base64 encoded string containing the AI brief text.</Info>
+<Info>
+  The `data` field is a Base64 encoded string containing the
+  AI brief text.
+</Info>
 
 ```json
 {
@@ -31,13 +48,25 @@ When triggering a consolidated query via the API with the `conversionType` query
     "source": "metriport:ai-generated-brief"
   },
   "contentType": "text/plain",
-  "data": "VGhlIHBhdGllbnQgaXMgYSA0Mi15ZWFyLW9sZCBtYWxlIHdobyBpcyBjdXJyZW50bHkgb24gbXVsdGlwbGUgbWVkaWNhdGlvbnMgdG8gbWFuYWdlCnZhcmlvdXMgY29uZGl0aW9ucy4gSGlzIG1lZGljYXRpb24gcmVnaW1lbiBpbmNsdWRlcyB6b2xwaWRlbSAxMCBtZyBmb3Igc2xlZXAsIHNpbXZhc3RhdGluCjIwIG1nIGZvciBjaG9sZXN0ZXJvbCBtYW5hZ2VtZW50LCBsZXZvdGh5cm94aW5lIHNvZGl1bSAwLjA3NSBtZyAoU3ludGhyb2lkKSBmb3IgdGh5cm9pZApyZXBsYWNlbWVudCB0aGVyYXB5LCBhbmQgemFmaXJsdWthc3QgMjAgbWcgKEFjY29sYXRlKSBmb3IgYXN0aG1hIG1hbmFnZW1lbnQuIFRoZQpjb21iaW5hdGlvbiBvZiB0aGVzZSBtZWRpY2F0aW9ucyBzdWdnZXN0cyB0aGUgcGF0aWVudCBoYXMgY29uY3VycmVudCBjb25kaXRpb25zCmluY2x1ZGluZyBzbGVlcCBkaXN0dXJiYW5jZSwgaHlwZXJjaG9sZXN0ZXJvbGVtaWEsIGh5cG90aHlyb2lkaXNtLCBhbmQgYXN0aG1hIG9yIG90aGVyCnJlc3BpcmF0b3J5IGlzc3VlcyByZXF1aXJpbmcgYSBsZXVrb3RyaWVuZSBtb2RpZmllci4="
+  "data": "VGhlIHBhdGllbnQgaXMgYSA0Mi15ZWFyLW9sZCBtYWxlIHdobyBpcyBjdXJyZW50bHkgb24g
+           bXVsdGlwbGUgbWVkaWNhdGlvbnMgdG8gbWFuYWdlCnZhcmlvdXMgY29uZGl0aW9ucy4gSGlz
+           IG1lZGljYXRpb24gcmVnaW1lbiBpbmNsdWRlcyB6b2xwaWRlbSAxMCBtZyBmb3Igc2xlZXAs
+           IHNpbXZhc3RhdGluCjIwIG1nIGZvciBjaG9sZXN0ZXJvbCBtYW5hZ2VtZW50LCBsZXZvdGh5
+           cm94aW5lIHNvZGl1bSAwLjA3NSBtZyAoU3ludGhyb2lkKSBmb3IgdGh5cm9pZApyZXBsYWNl
+           bWVudCB0aGVyYXB5LCBhbmQgemFmaXJsdWthc3QgMjAgbWcgKEFjY29sYXRlKSBmb3IgYXN0
+           aG1hIG1hbmFnZW1lbnQuIFRoZQpjb21iaW5hdGlvbiBvZiB0aGVzZSBtZWRpY2F0aW9ucyBz
+           dWdnZXN0cyB0aGUgcGF0aWVudCBoYXMgY29uY3VycmVudCBjb25kaXRpb25zCmluY2x1ZGlu
+           ZyBzbGVlcCBkaXN0dXJiYW5jZSwgaHlwZXJjaG9sZXN0ZXJvbGVtaWEsIGh5cG90aHlyb2lk
+           aXNtLCBhbmQgYXN0aG1hIG9yIG90aGVyCnJlc3BpcmF0b3J5IGlzc3VlcyByZXF1aXJpbmcg
+           YSBsZXVrb3RyaWVuZSBtb2RpZmllci4="
 }
 ```
 
 ### Medical Record Summary
 
-When triggering a consolidated query via the API with the `conversionType` query param set to `html` or `pdf`, the AI brief appears at the top of the Medical Record Summary document.
+When triggering a consolidated query via the API with the `conversionType` query param set to
+`html` or `pdf`, the AI brief appears
+at the top of the Medical Record Summary document.
 
 <Frame>
   <img src="/images/ai-brief-pdf.png" alt="AI Brief" />
@@ -45,8 +74,12 @@ When triggering a consolidated query via the API with the `conversionType` query
 
 ## Dashboard
 
-Once a patient's data is loaded in the Metriport dashboard, you can view their AI brief at the top of their medical record history.
+Once a patient's data is loaded in the Metriport dashboard, you can view their AI brief at the
+top of their medical record history.
 
 <Frame>
-  <img src="/images/ai-brief-dash.png" alt="AI Brief in Dashboard" />
+  <img
+    src="/images/ai-brief-dash.png"
+    alt="AI Brief in Dashboard"
+  />
 </Frame>


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3226
- Downstream: none

### Description

Add `Binary` resource type to the list of accepted resource types on Start Consolidated Data Query docs - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1738282640546209?thread_ts=1738181709.284669&cid=C0616FCPAKZ).

#### Start Consolidated Data Query

![image](https://github.com/user-attachments/assets/939e5f0a-8a31-4db1-97d1-8d64c2dfcbca)

...

![image](https://github.com/user-attachments/assets/1c90dd27-74e8-4c60-98ad-6950a2fdcedf)


#### FHIR overview

![image](https://github.com/user-attachments/assets/59bea222-a455-4cec-b831-b2c6ef8ecc5b)

#### AI Brief

![image](https://github.com/user-attachments/assets/521d09c6-1784-4b7b-b8c5-af3c82ab94b0)

...

![image](https://github.com/user-attachments/assets/39de7e98-2e01-4b18-bcb4-f9f09e70c1d6)


### Testing

- Local
  - [x] Docs render correctly the updates
- Production
  - [ ] Docs render correctly the updates

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
- [ ] Rebase master into develop
