### PR TITLE
2572 condensed resources

### DIFF
--- a/packages/core/src/command/ai-brief/create.ts
+++ b/packages/core/src/command/ai-brief/create.ts
@@ -417,8 +417,8 @@ function replaceReferencesWithData(
           return [];
         })
         .join(", ");
-
-      updRes.reference = { ...updRes.reference, practitioner };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      updRes.reference = { ...updRes.reference, practitioner } as any;
     }
   }
 
@@ -477,7 +477,8 @@ function replaceReferencesWithData(
     updRes.reference = {
       ...updRes.reference,
       reasons: Array.from(reasonsSet).join(", "),
-    };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
     delete updRes.reasonReference;
   }
 

--- a/packages/core/src/command/ai-brief/create.ts
+++ b/packages/core/src/command/ai-brief/create.ts
@@ -1,13 +1,12 @@
 import * as dotenv from "dotenv";
 dotenv.config();
 // keep that ^ on top
-// import { PromptTemplate } from "@langchain/core/prompts";
-// import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
+import { PromptTemplate } from "@langchain/core/prompts";
+import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 import { Bundle, Medication, Observation, Patient, Resource } from "@medplum/fhirtypes";
 import { errorToString, toArray } from "@metriport/shared";
-import { ISO_DATE, buildDayjs } from "@metriport/shared/common/date";
-// import { ISO_DATE, buildDayjs, elapsedTimeFromNow } from "@metriport/shared/common/date";
-// import { LLMChain, MapReduceDocumentsChain, StuffDocumentsChain } from "langchain/chains";
+import { ISO_DATE, buildDayjs, elapsedTimeFromNow } from "@metriport/shared/common/date";
+import { LLMChain, MapReduceDocumentsChain, StuffDocumentsChain } from "langchain/chains";
 import { cloneDeep } from "lodash";
 import {
   SlimCondition,
@@ -17,24 +16,24 @@ import {
   applyResourceSpecificFilters,
   getSlimPatient,
 } from "../../domain/ai-brief/modify-resources";
-// import { EventTypes, analytics } from "../../external/analytics/posthog";
+import { EventTypes, analytics } from "../../external/analytics/posthog";
 import {
   findDiagnosticReportResources,
   findPatientResource,
 } from "../../external/fhir/shared/index";
-// import { BedrockChat } from "../../external/langchain/bedrock";
+import { BedrockChat } from "../../external/langchain/bedrock";
 import { capture, out } from "../../util";
 import { uuidv7 } from "../../util/uuid-v7";
 import { filterBundleByDate } from "../consolidated/consolidated-filter-by-date";
 import { getDatesFromEffectiveDateTimeOrPeriod } from "../consolidated/consolidated-filter-shared";
 
-// const CHUNK_SIZE = 100_000;
-// const CHUNK_OVERLAP = 1000;
+const CHUNK_SIZE = 100_000;
+const CHUNK_OVERLAP = 1000;
 
 const NUM_HISTORICAL_YEARS = 1;
 const MAX_REPORTS_PER_GROUP = 3;
-// const SONNET_COST_PER_INPUT_TOKEN = 0.0015 / 1000;
-// const SONNET_COST_PER_OUTPUT_TOKEN = 0.0075 / 1000;
+const SONNET_COST_PER_INPUT_TOKEN = 0.0015 / 1000;
+const SONNET_COST_PER_OUTPUT_TOKEN = 0.0075 / 1000;
 
 const relevantResources = [
   "AllergyIntolerance",
@@ -54,9 +53,8 @@ const relevantResources = [
 
 const referenceResources = ["Practitioner", "Organization", "Observation", "Location"];
 
-// const documentVariableName = "text";
+const documentVariableName = "text";
 
-import fs from "fs";
 import { condenseBundle } from "../../domain/ai-brief/condense-bundle";
 //--------------------------------
 // AI-based brief generation
@@ -67,7 +65,7 @@ export async function summarizeFilteredBundleWithAI(
   patientId: string
 ): Promise<string | undefined> {
   const requestId = uuidv7();
-  // const startedAt = new Date();
+  const startedAt = new Date();
   const { log } = out(`summarizeFilteredBundleWithAI - cxId ${cxId}, patientId ${patientId}`);
   // filter out historical data
   log(`Starting with requestId ${requestId}, and bundle length ${bundle.entry?.length}`);
@@ -82,128 +80,127 @@ export async function summarizeFilteredBundleWithAI(
     const dateFrom = initialDate.subtract(NUM_HISTORICAL_YEARS, "year").format(ISO_DATE);
     const filteredBundle = filterBundleByDate(bundle, dateFrom);
     const slimPayloadBundle = buildSlimmerPayload(filteredBundle);
-    // const inputString = JSON.stringify(slimPayloadBundle);
-    fs.writeFileSync("slimBundle.json", JSON.stringify(slimPayloadBundle, null, 2));
+    const inputString = JSON.stringify(slimPayloadBundle);
+
     // TODO: #2510 - experiment with different splitters
-    // const textSplitter = new RecursiveCharacterTextSplitter({
-    //   chunkSize: CHUNK_SIZE,
-    //   chunkOverlap: CHUNK_OVERLAP,
-    // });
-    // const docs = await textSplitter.createDocuments([inputString ?? ""]);
-    // const totalTokensUsed = {
-    //   input: 0,
-    //   output: 0,
-    // };
+    const textSplitter = new RecursiveCharacterTextSplitter({
+      chunkSize: CHUNK_SIZE,
+      chunkOverlap: CHUNK_OVERLAP,
+    });
+    const docs = await textSplitter.createDocuments([inputString ?? ""]);
+    const totalTokensUsed = {
+      input: 0,
+      output: 0,
+    };
 
-    // const llmSummary = new BedrockChat({
-    //   model: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
-    //   temperature: 0,
-    //   region: "us-west-2",
-    //   callbacks: [
-    //     {
-    //       handleLLMEnd: output => {
-    //         const usage = output.llmOutput?.usage;
-    //         if (usage) {
-    //           totalTokensUsed.input += usage.input_tokens;
-    //           totalTokensUsed.output += usage.output_tokens;
-    //         }
-    //       },
-    //     },
-    //   ],
-    // });
+    const llmSummary = new BedrockChat({
+      model: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+      temperature: 0,
+      region: "us-west-2",
+      callbacks: [
+        {
+          handleLLMEnd: output => {
+            const usage = output.llmOutput?.usage;
+            if (usage) {
+              totalTokensUsed.input += usage.input_tokens;
+              totalTokensUsed.output += usage.output_tokens;
+            }
+          },
+        },
+      ],
+    });
 
-    // const todaysDate = new Date().toISOString().split("T")[0];
-    // const systemPrompt = "You are an expert primary care doctor.";
+    const todaysDate = new Date().toISOString().split("T")[0];
+    const systemPrompt = "You are an expert primary care doctor.";
 
-    // const summaryTemplate = `
-    // ${systemPrompt}
+    const summaryTemplate = `
+    ${systemPrompt}
 
-    // Today's date is ${todaysDate}.
-    // Your goal is to write a summary of the patient's most recent medical history, so that another doctor can understand the patient's medical history to be able to treat them effectively.
-    // Here is a portion of the patient's medical history:
-    // --------
-    // {${documentVariableName}}
-    // --------
+    Today's date is ${todaysDate}.
+    Your goal is to write a summary of the patient's most recent medical history, so that another doctor can understand the patient's medical history to be able to treat them effectively.
+    Here is a portion of the patient's medical history:
+    --------
+    {${documentVariableName}}
+    --------
 
-    // Write a summary of the patient's most recent medical history, considering the following goals:
-    // 1. Specify whether a DNR or POLST form has been completed.
-    // 2. Include a summary of the patient's most recent hospitalization, including the location of the hospitalization, the date of the hospitalization, the reason for the hospitalization, and the results of the hospitalization.
-    // 3. Include a summary of the patient's current chronic conditions, allergies, and any previous surgeries.
-    // 4. Include a summary of the patient's current medications, including dosages and frequency - do not include instructions on how to take the medications. Include any history of medication allergies or adverse reactions.
-    // 5. Include any other relevant information about the patient's health.
+    Write a summary of the patient's most recent medical history, considering the following goals:
+    1. Specify whether a DNR or POLST form has been completed.
+    2. Include a summary of the patient's most recent hospitalization, including the location of the hospitalization, the date of the hospitalization, the reason for the hospitalization, and the results of the hospitalization.
+    3. Include a summary of the patient's current chronic conditions, allergies, and any previous surgeries.
+    4. Include a summary of the patient's current medications, including dosages and frequency - do not include instructions on how to take the medications. Include any history of medication allergies or adverse reactions.
+    5. Include any other relevant information about the patient's health.
 
-    // If any of the above information is not present, do not include it in the summary.
-    // Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided.
+    If any of the above information is not present, do not include it in the summary.
+    Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided.
 
-    // SUMMARY:
-    // `;
-    // const SUMMARY_PROMPT = PromptTemplate.fromTemplate(summaryTemplate);
-    // const summaryChain = new LLMChain({
-    //   llm: llmSummary as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    //   prompt: SUMMARY_PROMPT as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    // });
+    SUMMARY:
+    `;
+    const SUMMARY_PROMPT = PromptTemplate.fromTemplate(summaryTemplate);
+    const summaryChain = new LLMChain({
+      llm: llmSummary as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      prompt: SUMMARY_PROMPT as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    });
 
-    // const summaryTemplateRefined = `
-    // ${systemPrompt}
+    const summaryTemplateRefined = `
+    ${systemPrompt}
 
-    // Today's date is ${todaysDate}.
-    // Your goal is to write a summary of the patient's most recent medical history, so that another doctor can understand the patient's medical history to be able to treat them effectively.
-    // Here are the previous summaries written by you of sections of the patient's medical history:
-    // --------
-    // {${documentVariableName}}
-    // --------
+    Today's date is ${todaysDate}.
+    Your goal is to write a summary of the patient's most recent medical history, so that another doctor can understand the patient's medical history to be able to treat them effectively.
+    Here are the previous summaries written by you of sections of the patient's medical history:
+    --------
+    {${documentVariableName}}
+    --------
 
-    // Combine these summaries into a single, comprehensive summary of the patient's most recent medical history in a single paragraph.
+    Combine these summaries into a single, comprehensive summary of the patient's most recent medical history in a single paragraph.
 
-    // Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided.
+    Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided.
 
-    // SUMMARY:
-    // `;
-    // const SUMMARY_PROMPT_REFINED = PromptTemplate.fromTemplate(summaryTemplateRefined);
-    // const summaryChainRefined = new StuffDocumentsChain({
-    //   llmChain: new LLMChain({
-    //     llm: llmSummary as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    //     prompt: SUMMARY_PROMPT_REFINED as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    //   }),
-    //   documentVariableName,
-    // });
+    SUMMARY:
+    `;
+    const SUMMARY_PROMPT_REFINED = PromptTemplate.fromTemplate(summaryTemplateRefined);
+    const summaryChainRefined = new StuffDocumentsChain({
+      llmChain: new LLMChain({
+        llm: llmSummary as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        prompt: SUMMARY_PROMPT_REFINED as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      }),
+      documentVariableName,
+    });
 
-    // const mapReduce = new MapReduceDocumentsChain({
-    //   llmChain: summaryChain,
-    //   combineDocumentChain: summaryChainRefined,
-    //   documentVariableName,
-    //   verbose: false,
-    // });
+    const mapReduce = new MapReduceDocumentsChain({
+      llmChain: summaryChain,
+      combineDocumentChain: summaryChainRefined,
+      documentVariableName,
+      verbose: false,
+    });
 
-    // const summary = (await mapReduce.invoke({
-    //   input_documents: docs,
-    // })) as { text: string };
+    const summary = (await mapReduce.invoke({
+      input_documents: docs,
+    })) as { text: string };
 
-    // const costs = calculateCostsBasedOnTokens(totalTokensUsed);
+    const costs = calculateCostsBasedOnTokens(totalTokensUsed);
 
-    // const duration = elapsedTimeFromNow(startedAt);
-    // log(
-    //   `Done. Finished in ${duration} ms. Total tokens used: ${JSON.stringify(
-    //     totalTokensUsed
-    //   )}. Input cost: ${costs.input}, output cost: ${costs.output}. Total cost: ${costs.total}`
-    // );
+    const duration = elapsedTimeFromNow(startedAt);
+    log(
+      `Done. Finished in ${duration} ms. Total tokens used: ${JSON.stringify(
+        totalTokensUsed
+      )}. Input cost: ${costs.input}, output cost: ${costs.output}. Total cost: ${costs.total}`
+    );
 
-    // analytics({
-    //   distinctId: cxId,
-    //   event: EventTypes.aiBriefGeneration,
-    //   properties: {
-    //     requestId,
-    //     patientId,
-    //     startBundleSize: bundle.entry?.length,
-    //     endBundleSize: slimPayloadBundle?.length,
-    //     duration,
-    //     totalTokensUsed,
-    //     costs,
-    //   },
-    // });
-    // if (!summary.text) return undefined;
-    // return summary.text;
-    return "asd";
+    analytics({
+      distinctId: cxId,
+      event: EventTypes.aiBriefGeneration,
+      properties: {
+        requestId,
+        patientId,
+        startBundleSize: bundle.entry?.length,
+        endBundleSize: slimPayloadBundle?.length,
+        duration,
+        totalTokensUsed,
+        costs,
+      },
+    });
+    if (!summary.text) return undefined;
+    return summary.text;
   } catch (err) {
     const msg = `AI brief generation failure`;
     log(`${msg} - ${errorToString(err)}`);
@@ -262,8 +259,7 @@ function buildSlimmerPayload(bundle: Bundle): SlimResource[] | undefined {
     patient
   );
 
-  const dedupedBundle = condenseBundle(slimBundle);
-  return dedupedBundle;
+  return condenseBundle(slimBundle);
 }
 
 function buildSlimmerBundle(originalBundle: Bundle<Resource>) {
@@ -417,8 +413,7 @@ function replaceReferencesWithData(
           return [];
         })
         .join(", ");
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      updRes.reference = { ...updRes.reference, practitioner } as any;
+      updRes.reference = { ...updRes.reference, practitioner };
     }
   }
 
@@ -477,8 +472,7 @@ function replaceReferencesWithData(
     updRes.reference = {
       ...updRes.reference,
       reasons: Array.from(reasonsSet).join(", "),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any;
+    };
     delete updRes.reasonReference;
   }
 
@@ -676,14 +670,14 @@ function removeReferencesAndLeftOverResources(
   return cleanPayload;
 }
 
-// function calculateCostsBasedOnTokens(totalTokens: { input: number; output: number }): {
-//   input: number;
-//   output: number;
-//   total: number;
-// } {
-//   const input = totalTokens.input * SONNET_COST_PER_INPUT_TOKEN;
-//   const output = totalTokens.output * SONNET_COST_PER_OUTPUT_TOKEN;
-//   const total = input + output;
+function calculateCostsBasedOnTokens(totalTokens: { input: number; output: number }): {
+  input: number;
+  output: number;
+  total: number;
+} {
+  const input = totalTokens.input * SONNET_COST_PER_INPUT_TOKEN;
+  const output = totalTokens.output * SONNET_COST_PER_OUTPUT_TOKEN;
+  const total = input + output;
 
-//   return { input, output, total };
-// }
+  return { input, output, total };
+}

--- a/packages/core/src/domain/ai-brief/condense-bundle.ts
+++ b/packages/core/src/domain/ai-brief/condense-bundle.ts
@@ -1,0 +1,104 @@
+import { SlimCondition, SlimProcedure, SlimResource } from "./modify-resources";
+import { uniqWith, isEqual } from "lodash";
+import fs from "fs";
+
+export function condenseBundle(bundle: SlimResource[]): SlimResource[] {
+  // Split bundle into conditions, procedures, and remaining resources
+  const [conditions, procedures, remainingBundle] = bundle.reduce(
+    (acc, resource) => {
+      const [conditions, procedures, remaining] = acc;
+      if (resource.resourceType === "Condition") {
+        conditions.push(resource);
+      } else if (resource.resourceType === "Procedure") {
+        procedures.push(resource);
+      } else {
+        remaining.push(resource);
+      }
+      return acc;
+    },
+    [[], [], []] as [SlimCondition[], SlimProcedure[], SlimResource[]]
+  );
+
+  const condensedConditions = condenseConditions(conditions);
+  const condensedProcedures = condenseProcedures(procedures);
+
+  fs.writeFileSync("condensedConditions.json", JSON.stringify(condensedConditions, null, 2));
+  fs.writeFileSync("condensedProcedures.json", JSON.stringify(condensedProcedures, null, 2));
+
+  return [...remainingBundle, ...condensedConditions, ...condensedProcedures];
+}
+
+function condenseConditions(conditions: SlimCondition[]) {
+  const conditionsMap = new Map<string, SlimCondition>();
+  conditions.forEach(c => {
+    const name = c.name;
+    if (!name) return;
+
+    const existing = conditionsMap.get(name);
+
+    if (!existing) {
+      conditionsMap.set(name, reconstructCondition(c, c));
+    } else {
+      conditionsMap.set(name, reconstructCondition(existing, c));
+    }
+  });
+  return [...conditionsMap.values()];
+}
+
+function reconstructCondition(master: SlimCondition, additional?: SlimCondition) {
+  const reference = {
+    ...(master.reference ?? {}),
+    ...(additional?.reference ?? {}),
+  };
+
+  const instances = uniqWith(
+    [...(master.instances ?? []), ...(additional?.instances ?? [])],
+    isEqual
+  );
+
+  const fullCondition: SlimCondition = {
+    ...master,
+    reference,
+    instances,
+  };
+  delete fullCondition.onsetPeriod;
+
+  return fullCondition;
+}
+
+function condenseProcedures(procedures: SlimProcedure[]) {
+  const proceduresMap = new Map<string, SlimProcedure>();
+  procedures.forEach(p => {
+    const name = p.name;
+    if (!name) return;
+
+    const existing = proceduresMap.get(name);
+
+    if (!existing) {
+      proceduresMap.set(name, reconstructProcedure(p, p));
+    } else {
+      proceduresMap.set(name, reconstructProcedure(existing, p));
+    }
+  });
+  return [...proceduresMap.values()];
+}
+
+function reconstructProcedure(master: SlimProcedure, additional?: SlimProcedure) {
+  const reference = {
+    ...(master.reference ?? {}),
+    ...(additional?.reference ?? {}),
+  };
+
+  const instances = uniqWith(
+    [...(master.instances ?? []), ...(additional?.instances ?? [])],
+    isEqual
+  );
+
+  const fullProcedure: SlimProcedure = {
+    ...master,
+    reference,
+    instances,
+  };
+
+  return fullProcedure;
+}

--- a/packages/core/src/domain/ai-brief/condense-bundle.ts
+++ b/packages/core/src/domain/ai-brief/condense-bundle.ts
@@ -1,48 +1,73 @@
-import { SlimCondition, SlimProcedure, SlimResource } from "./modify-resources";
-import { uniqWith, isEqual } from "lodash";
+import { Period } from "@medplum/fhirtypes";
 import fs from "fs";
+import { isEqual, uniqWith } from "lodash";
+import {
+  SlimCondition,
+  SlimMedicationStatement,
+  SlimProcedure,
+  SlimResource,
+} from "./modify-resources";
 
 export function condenseBundle(bundle: SlimResource[]): SlimResource[] {
-  // Split bundle into conditions, procedures, and remaining resources
-  const [conditions, procedures, remainingBundle] = bundle.reduce(
+  // Split bundle into conditions, procedures, medications, and remaining resources
+  const [conditions, procedures, medStatements, remainingBundle] = bundle.reduce(
     (acc, resource) => {
-      const [conditions, procedures, remaining] = acc;
+      const [conditions, procedures, medStatements, remaining] = acc;
       if (resource.resourceType === "Condition") {
         conditions.push(resource);
       } else if (resource.resourceType === "Procedure") {
         procedures.push(resource);
+      } else if (resource.resourceType === "MedicationStatement") {
+        medStatements.push(resource);
       } else {
         remaining.push(resource);
       }
       return acc;
     },
-    [[], [], []] as [SlimCondition[], SlimProcedure[], SlimResource[]]
+    [[], [], [], []] as [
+      SlimCondition[],
+      SlimProcedure[],
+      SlimMedicationStatement[],
+      SlimResource[]
+    ]
   );
 
-  const condensedConditions = condenseConditions(conditions);
-  const condensedProcedures = condenseProcedures(procedures);
+  const condensedConditions = condenseSlimResources(conditions, c => c.name, reconstructCondition);
+  const condensedProcedures = condenseSlimResources(procedures, p => p.name, reconstructProcedure);
+  const condensedMedStmnts = condenseSlimResources(
+    medStatements,
+    s => JSON.stringify(s.reference),
+    reconstructMedStatement
+  );
 
   fs.writeFileSync("condensedConditions.json", JSON.stringify(condensedConditions, null, 2));
   fs.writeFileSync("condensedProcedures.json", JSON.stringify(condensedProcedures, null, 2));
+  fs.writeFileSync("condensedMedStmnts.json", JSON.stringify(condensedMedStmnts, null, 2));
 
-  return [...remainingBundle, ...condensedConditions, ...condensedProcedures];
+  return [
+    ...remainingBundle,
+    ...condensedConditions,
+    ...condensedProcedures,
+    ...condensedMedStmnts,
+  ];
 }
 
-function condenseConditions(conditions: SlimCondition[]) {
-  const conditionsMap = new Map<string, SlimCondition>();
-  conditions.forEach(c => {
-    const name = c.name;
-    if (!name) return;
+function condenseSlimResources<T>(
+  items: T[],
+  getKey: (item: T) => string | undefined,
+  merge: (existing: T, incoming: T) => T
+): T[] {
+  const map = new Map<string, T>();
 
-    const existing = conditionsMap.get(name);
+  items.forEach(item => {
+    const key = getKey(item);
+    if (!key) return;
 
-    if (!existing) {
-      conditionsMap.set(name, reconstructCondition(c, c));
-    } else {
-      conditionsMap.set(name, reconstructCondition(existing, c));
-    }
+    const existing = map.get(key);
+    map.set(key, existing ? merge(existing, item) : merge(item, item));
   });
-  return [...conditionsMap.values()];
+
+  return [...map.values()];
 }
 
 function reconstructCondition(master: SlimCondition, additional?: SlimCondition) {
@@ -51,8 +76,9 @@ function reconstructCondition(master: SlimCondition, additional?: SlimCondition)
     ...(additional?.reference ?? {}),
   };
 
+  const newInstance = createInstanceFromCondition(additional?.onsetPeriod);
   const instances = uniqWith(
-    [...(master.instances ?? []), ...(additional?.instances ?? [])],
+    [master.instances, newInstance].flatMap(i => i ?? []),
     isEqual
   );
 
@@ -66,39 +92,57 @@ function reconstructCondition(master: SlimCondition, additional?: SlimCondition)
   return fullCondition;
 }
 
-function condenseProcedures(procedures: SlimProcedure[]) {
-  const proceduresMap = new Map<string, SlimProcedure>();
-  procedures.forEach(p => {
-    const name = p.name;
-    if (!name) return;
-
-    const existing = proceduresMap.get(name);
-
-    if (!existing) {
-      proceduresMap.set(name, reconstructProcedure(p, p));
-    } else {
-      proceduresMap.set(name, reconstructProcedure(existing, p));
-    }
-  });
-  return [...proceduresMap.values()];
+function createInstanceFromCondition(period: Period | undefined) {
+  if (!period) return undefined;
+  return { onsetPeriod: period };
 }
 
 function reconstructProcedure(master: SlimProcedure, additional?: SlimProcedure) {
-  const reference = {
-    ...(master.reference ?? {}),
-    ...(additional?.reference ?? {}),
-  };
+  const references = uniqWith(
+    [master.reference, additional?.reference].flatMap(r => r ?? []),
+    isEqual
+  );
 
   const instances = uniqWith(
-    [...(master.instances ?? []), ...(additional?.instances ?? [])],
+    [master.instances, additional?.instances].flatMap(i => i ?? []),
     isEqual
   );
 
   const fullProcedure: SlimProcedure = {
     ...master,
-    reference,
+    reference: references,
     instances,
   };
 
   return fullProcedure;
+}
+
+function reconstructMedStatement(
+  master: SlimMedicationStatement,
+  additional?: SlimMedicationStatement
+) {
+  const reference = {
+    ...(master.reference ?? {}),
+    ...(additional?.reference ?? {}),
+  };
+
+  const newInstance = {
+    dosages: additional?.dosages,
+    date: additional?.effectivePeriod,
+  };
+
+  const instances = uniqWith(
+    [master.instances, newInstance].flatMap(i => i ?? []),
+    isEqual
+  );
+
+  const fullMedication: SlimMedicationStatement = {
+    ...master,
+    reference,
+    instances,
+  };
+  delete fullMedication.effectivePeriod;
+  delete fullMedication.dosages;
+
+  return fullMedication;
 }

--- a/packages/core/src/domain/ai-brief/modify-resources.ts
+++ b/packages/core/src/domain/ai-brief/modify-resources.ts
@@ -82,7 +82,7 @@ export type SlimProcedure = Omit<
   name?: string | undefined;
   status?: string | undefined;
   bodySite?: string | undefined;
-  reference?: Record<string, string | object>;
+  reference?: Record<string, string | object>[];
   instances?: Array<{
     performedDateTime?: string | undefined;
     performedPeriod?: Period | undefined;
@@ -458,15 +458,19 @@ function getSlimMedicationRequest(res: MedicationRequest): SlimMedicationRequest
   };
 }
 
+type Dosage = {
+  dose: string | undefined;
+  route: string | undefined;
+};
+
 export type SlimMedicationStatement = Omit<MedicationStatement, "dosage" | "status"> & {
   dosages?: Dosage[] | undefined;
   reference?: Record<string, Partial<SlimMedication>>;
   status?: string | undefined;
-};
-
-type Dosage = {
-  dose: string | undefined;
-  route: string | undefined;
+  instances?: Array<{
+    date?: Period | undefined;
+    dosages?: Dosage[] | undefined;
+  }>;
 };
 
 function getSlimMedicationStatement(res: MedicationStatement): SlimMedicationStatement {

--- a/packages/core/src/domain/ai-brief/modify-resources.ts
+++ b/packages/core/src/domain/ai-brief/modify-resources.ts
@@ -219,7 +219,7 @@ export type SlimImmunization = Omit<Immunization, "vaccineCode" | "site" | "rout
   vaccineCode?: string | undefined;
   site?: string | undefined;
   route?: string | undefined;
-  reference?: Record<string, Partial<SlimOrganization>>;
+  reference?: Record<string, string | Partial<SlimOrganization>>;
 };
 
 function getSlimImmunization(res: Immunization): SlimImmunization | undefined {
@@ -362,7 +362,7 @@ function getSlimDiagnosticReport(res: DiagnosticReport): SlimDiagnosticReport | 
     return undefined;
   }
 
-  const category = updRes.category
+  const category = toArray(updRes.category)
     ?.map(cat => cat.coding?.flatMap(coding => coding.display || []))
     .join(", ");
 
@@ -429,6 +429,8 @@ function getSlimObservation(res: Observation): SlimObservation {
 export type SlimMedication = Omit<Medication, "name"> & {
   name?: string | undefined;
   reference?: Record<string, string>;
+  sideNote?: string;
+  names?: string[];
 };
 
 function getSlimMedication(res: Medication): SlimMedication {


### PR DESCRIPTION
Ticket: metriport/metriport-internal#2572

### Description
- Condense the bundle by deduplicating the following resources:
  - Condition
  - Procedure
  - MedicationStatement
  - Medication

I call it "condense" and not "deduplicate" because we're turning certain properties into arrays, while keeping other fields untouched. This allows us to group these resources together to avoid listing the same thing over and over for every single one of them. 

From the tests on a few bundles, we're getting around ~25% smaller bundles with these changes, while preserving all of the same information. 

### Testing

- Local
  - [x] Run on a few different bundles and ensure good results (AI brief still creates, makes sense, and bundles get smaller)
- Production
  - [ ] Run for a few patients and make sure the AI briefs look good

### Release Plan
- [ ] Merge this
