### PR TITLE
1040 Store `conversionType` on WH table

### DIFF
--- a/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
+++ b/docs/medical-api/api-reference/fhir/consolidated-data-query-post.mdx
@@ -22,10 +22,11 @@ the new query will be ignored and you'll get the status and request ID of the pr
 
 You can check the status of the data query by calling [get consolidated data query](/medical-api/api-reference/fhir/consolidated-data-query-get).
 
-This endpoint also provides the ability to render a [Medical Record Summary](/medical-api/handling-data/medical-record-summary)
-from the FHIR bundle as a PDF or HTML document. This will be returned [via a webhook](/medical-api/handling-data/webhooks#medical-record)
-as a FHIR bundle with a [DocumentReference](/medical-api/fhir/resources/documentreference) resource
-that will contain a URL to retrieve the data from.
+This endpoint also provides the ability to render a 
+[Medical Record Summary](/medical-api/handling-data/medical-record-summary) from the FHIR bundle 
+as a PDF or HTML document. This will be returned via webhook with a URL to download it
+inside a [DocumentReference](/medical-api/fhir/resources/documentreference) resource - for more
+details, see [the respective webhook section](/medical-api/handling-data/webhooks#medical-record).
 
 ## Path Params
 
@@ -36,27 +37,33 @@ that will contain a URL to retrieve the data from.
 ## Query Params
 
 <Tip>
-  You can optionally filter resources by date, using the `dateFrom` and `dateTo` query params. Note
-  that not all resources will support this filter - see the [FHIR R4
-  docs](https://www.hl7.org/fhir/R4/searchparameter-registry.html#clinical-date) for a list of
-  supported resources.
+  You can optionally filter resources by date, using the
+  `dateFrom` and `dateTo` query params. Note that not all
+  resources will support this filter - see the [FHIR R4
+  docs](https://www.hl7.org/fhir/R4/searchparameter-registry.html#clinical-date)
+  for a list of supported resources.
 </Tip>
 
 <ParamField query="resources" type="string" optional>
-  A comma separated, case sensitive list of resources to be returned. If none are provided all
-  resources will be included. Metriport will automatically hydrate the initially filtered resources
-  with referenced ones to create bundle consistency. The list of accepted resources can be accessed
+  A comma separated, case sensitive list of resources to be
+  returned. If none are provided all resources will be
+  included. Metriport will automatically hydrate the
+  initially filtered resources with referenced ones to
+  create bundle consistency. The list of accepted resources
+  can be accessed
   [here](/medical-api/api-reference/fhir/consolidated-data-query-post#available-fhir-resources).
 </ParamField>
 
 <ParamField query="dateFrom" type="string" optional>
-  The start date (inclusive) for which to filter returned resources - formatted `YYYY-MM-DD` as per
-  ISO 8601. If not provided, no start date filter will be applied.
+  The start date (inclusive) for which to filter returned
+  resources - formatted `YYYY-MM-DD` as per ISO 8601. If not
+  provided, no start date filter will be applied.
 </ParamField>
 
 <ParamField query="dateTo" type="string" optional>
-  The end date (inclusive) for which to filter returned resources - formatted `YYYY-MM-DD` as per
-  ISO 8601. If not provided, no end date filter will be applied.
+  The end date (inclusive) for which to filter returned
+  resources - formatted `YYYY-MM-DD` as per ISO 8601. If not
+  provided, no end date filter will be applied.
 </ParamField>
 
 <ParamField query="conversionType" type="string" optional>
@@ -134,6 +141,12 @@ This is the list of all available [FHIR resources](/medical-api/fhir/resources) 
 - [ServiceRequest](/medical-api/fhir/resources/servicerequest)
 
 <Tip>
-  Other resources referenced in the bundle will be automatically added to the bundle.
-  This could include resources like [Location](/medical-api/fhir/resources/location), [Organization](/medical-api/fhir/resources/organization), [Practitioner](/medical-api/fhir/resources/practitioner), [Medication](/medical-api/fhir/resources/medication), and others.
+  Other resources referenced in the bundle will be
+  automatically added to the bundle. This could include
+  resources like
+  [Location](/medical-api/fhir/resources/location),
+  [Organization](/medical-api/fhir/resources/organization),
+  [Practitioner](/medical-api/fhir/resources/practitioner),
+  [Medication](/medical-api/fhir/resources/medication), and
+  others.
 </Tip>

--- a/docs/medical-api/handling-data/medical-record-summary.mdx
+++ b/docs/medical-api/handling-data/medical-record-summary.mdx
@@ -4,20 +4,30 @@ icon: "clipboard-list"
 description: "Consolidate Medical Records Into a Single Document"
 ---
 
-This guide will teach you how to generate a Medical Record Summary, which condenses all of patients' medical records into a single document.
+This guide will teach you how to generate a Medical Record Summary, which condenses all of
+patients' medical records into a single document.
 
-To do this, Metriport extracts FHIR resources across all available C-CDA documents for a patient and de-duplicates them, resulting in a set of unique medical records. These are then rendered as HTML or PDF files, making them extremely easy to navigate.
+To do this, Metriport extracts FHIR resources across all available C-CDA documents for a patient
+and de-duplicates them, resulting in a set of unique medical records. These are then rendered as
+HTML or PDF files, making them extremely easy to navigate.
 
 Here's the title page of an example Medical Record Summary:
 
-<img className="h-100" src="/images/example-medical-record.png" />
+<img
+  className="h-100"
+  src="/images/example-medical-record.png"
+/>
 
 ## Generate using the API
 
 To generate a Medical Record Summary using Metriport API:
 
-1. Start a [Consolidated Data Query](/medical-api/api-reference/fhir/consolidated-data-query-post). This endpoint allows you to optionally choose [FHIR resources](/medical-api/fhir/overview), date range, and rendering (`pdf` or `html`) for your Medical Record Summary.
-1. When the file is rendered, a [webhook message with a downloadable URL](/medical-api/handling-data/webhooks#medical-record) will be sent to you.
+1. Start a [Consolidated Data Query](/medical-api/api-reference/fhir/consolidated-data-query-post).
+   This endpoint allows you to optionally choose [FHIR resources](/medical-api/fhir/overview), date
+   range, and rendering (`pdf` or `html`) for your Medical Record Summary.
+1. When the file is rendered, a
+   [webhook message with a downloadable URL](/medical-api/handling-data/webhooks#medical-record)
+   will be sent to you.
 
 ## Generate using the Dashboard
 
@@ -25,22 +35,33 @@ To generate a Medical Record Summary from the dashboard:
 
 1. Navigate to the patient's page by selecting a patient from the list:
 
-<img className="h-100" src="/images/dashboard-patients.png" />
+<img
+  className="h-100"
+  src="/images/dashboard-patients.png"
+/>
 
 2. Click on the "Generate Medical Record" button to view the Medical Record Summary modal:
 
-<img className="h-100" src="/images/dashboard-patient.png" />
+<img
+  className="h-100"
+  src="/images/dashboard-patient.png"
+/>
 
 3. Select whether you want to download a new or a previously-generated (if such is available) Medical Record Summary.
 4. (Optional) Choose the date range for the Medical Record Summary.
 5. Click the button with the desired format to initiate the download.
 
 <Warning>
-  For patients with a large number of documents, this may take a few minutes to complete.
+  For patients with a large number of documents, this may
+  take a few minutes to complete.
 </Warning>
 
-<img className="h-100" src="/images/dashboard-patient-mr.png" />
+<img
+  className="h-100"
+  src="/images/dashboard-patient-mr.png"
+/>
 
 <Warning>
-  Make sure to enable pop-ups on the website to allow download once the document is ready.
+  Make sure to enable pop-ups on the website to allow
+  download once the document is ready.
 </Warning>

--- a/docs/medical-api/handling-data/webhooks.mdx
+++ b/docs/medical-api/handling-data/webhooks.mdx
@@ -23,8 +23,9 @@ To enable this integration approach with Metriport, and for some prerequesite re
 how the Webhook flow works, see [our Webhooks guide](/medical-api/getting-started/webhooks).
 
 <Warning>
-  When you receive a webhook message, you should respond with a `200` status code within 4 seconds.
-  We recommend processing the webhook request asynchronously.
+  When you receive a webhook message, you should respond
+  with a `200` status code within 4 seconds. We recommend
+  processing the webhook request asynchronously.
 </Warning>
 
 ### Types of Messages
@@ -124,8 +125,8 @@ These are messages you can expect to receive in the following scenarios:
    in FHIR-compliant format.
 
 <Tip>
-  Note that the webhooks will only contain updates for new data fetched in the current document
-  query.
+  Note that the webhooks will only contain updates for new
+  data fetched in the current document query.
 </Tip>
 
 ```json
@@ -397,6 +398,12 @@ that represents the resulting FHIR bundle.
 
 Inside the `Bundle` you'll find a `DocumentReference` resource with the first item in the `content` array containing
 an attachment with a `url` which can be used to download the rendered medical record.
+
+<Info>
+  If the Medical Record doesn't contain any information, the
+  `Bundle` will be empty (the `entry` array will have no
+  elements).
+</Info>
 
 Example payload:
 

--- a/packages/api/src/command/medical/patient/consolidated-get.ts
+++ b/packages/api/src/command/medical/patient/consolidated-get.ts
@@ -255,6 +255,7 @@ export async function getConsolidated({
     resources: resources ? resources.join(", ") : undefined,
     dateFrom,
     dateTo,
+    conversionType,
   };
   try {
     if (!bundle) {


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

none

### Description

Store `conversionType` on WH table, and add info to doc about empty MR WH when no content - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1738370386312109?thread_ts=1738354495.517799&cid=C0616FCPAKZ)

#### Relevant sections on docs

No change (need to click on webhook message with a downloadable URL to get to second img and see the note)

![image](https://github.com/user-attachments/assets/11a535bb-95c8-4cf5-b0ed-972b56b4b2f5)

updated

![image](https://github.com/user-attachments/assets/d15e7ee2-72c0-4a33-90c9-7c650c9c7f4c)

updated

![image](https://github.com/user-attachments/assets/ec8f1181-9b7d-457f-a593-7ba7c396cf37)


### Testing

- Local
  - [ ] `conversionType` gets stored on the WH table
  - [ ] docs are updated accordingly
- Staging
  - [ ] `conversionType` gets stored on the WH table
  - [ ] docs are updated accordingly
- Sandbox
  - none
- Production
  - [ ] monitor for a few minutes and check that `conversionType` gets stored on the WH table
  - [ ] docs are updated accordingly

### Release Plan

- [ ] Merge this
