### PR TITLE
PATCH - fix(api): ensure generated column for CQ search_criteria is kept when rebuilding the CQ directory

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory-raw-sql.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory-raw-sql.ts
@@ -104,7 +104,7 @@ export async function createTempCqDirectoryTable(sequelize: Sequelize): Promise<
   await deleteTempCqDirectoryTable(sequelize);
   // The PK is added later, on `updateCqDirectoryViewDefinition`
   const query = `CREATE TABLE IF NOT EXISTS ${cqDirectoryEntryTemp} (LIKE ${cqDirectoryEntry} 
-                 INCLUDING DEFAULTS INCLUDING STORAGE EXCLUDING CONSTRAINTS)`;
+                 INCLUDING DEFAULTS INCLUDING STORAGE INCLUDING GENERATED EXCLUDING CONSTRAINTS)`;
   await sequelize.query(query, { type: QueryTypes.RAW });
 }
 

--- a/packages/api/src/sequelize/migrations/2025-02-01_00_alter-cq-directory-entry-new_recreate-search-criteria.ts
+++ b/packages/api/src/sequelize/migrations/2025-02-01_00_alter-cq-directory-entry-new_recreate-search-criteria.ts
@@ -1,0 +1,70 @@
+import { QueryTypes } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "cq_directory_entry_new";
+const hieViewName = "hie_directory_view";
+const cqViewName = "cq_directory_entry_view";
+const columnName = "search_criteria";
+
+const dropHieViewSql = `DROP VIEW IF EXISTS ${hieViewName};`;
+const dropCqViewSql = `DROP VIEW IF EXISTS ${cqViewName};`;
+
+const alterSearchCriteriaColumnSql = `
+ALTER TABLE ${tableName} 
+DROP COLUMN ${columnName},
+ADD COLUMN ${columnName} tsvector
+GENERATED ALWAYS AS (
+  to_tsvector('english', coalesce(id, '')) || ' ' ||
+  to_tsvector('english', coalesce(name, '')) || ' ' ||
+  to_tsvector('english', coalesce(root_organization, '')) || ' ' ||
+  to_tsvector('english', coalesce(address_line, '')) || ' ' ||
+  to_tsvector('english', coalesce(city, '')) || ' ' ||
+  to_tsvector('english', coalesce(state, '')) || ' ' ||
+  to_tsvector('english', coalesce(zip, ''))
+) STORED;
+`;
+
+const createCqViewSql = `CREATE VIEW ${cqViewName} AS SELECT * from ${tableName};`;
+const createHieViewSql = `CREATE VIEW ${hieViewName} AS SELECT * from ${cqViewName};`;
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  for (const sql of [
+    dropHieViewSql,
+    dropCqViewSql,
+    alterSearchCriteriaColumnSql,
+    createCqViewSql,
+    createHieViewSql,
+  ]) {
+    await queryInterface.sequelize.query(sql, {
+      type: QueryTypes.RAW,
+    });
+  }
+};
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  const restorePreviousDefinitionSql = `
+  ALTER TABLE ${tableName} 
+  DROP COLUMN ${columnName},
+  ADD COLUMN ${columnName} tsvector
+  GENERATED ALWAYS AS (
+    to_tsvector('english', id::text) || ' ' ||
+    to_tsvector('english', coalesce(organization_id, '')) || ' ' ||
+    to_tsvector('english', coalesce(organization_name, '')) || ' ' ||
+    to_tsvector('english', 'Commonwell') || ' ' ||
+    to_tsvector('english', coalesce(state, '')) || ' ' ||
+    to_tsvector('english', coalesce(zip_code, ''))
+  ) STORED;
+  `;
+
+  for (const sql of [
+    dropHieViewSql,
+    dropCqViewSql,
+    restorePreviousDefinitionSql,
+    createCqViewSql,
+    createHieViewSql,
+  ]) {
+    await queryInterface.sequelize.query(sql, {
+      type: QueryTypes.RAW,
+    });
+  }
+};

--- a/packages/api/src/sequelize/migrations/2025-02-01_00_alter-cq-directory-entry-new_recreate-search-criteria.ts
+++ b/packages/api/src/sequelize/migrations/2025-02-01_00_alter-cq-directory-entry-new_recreate-search-criteria.ts
@@ -41,30 +41,8 @@ export const up: Migration = async ({ context: queryInterface }) => {
   }
 };
 
-export const down: Migration = async ({ context: queryInterface }) => {
-  const restorePreviousDefinitionSql = `
-  ALTER TABLE ${tableName} 
-  DROP COLUMN ${columnName},
-  ADD COLUMN ${columnName} tsvector
-  GENERATED ALWAYS AS (
-    to_tsvector('english', id::text) || ' ' ||
-    to_tsvector('english', coalesce(organization_id, '')) || ' ' ||
-    to_tsvector('english', coalesce(organization_name, '')) || ' ' ||
-    to_tsvector('english', 'Commonwell') || ' ' ||
-    to_tsvector('english', coalesce(state, '')) || ' ' ||
-    to_tsvector('english', coalesce(zip_code, ''))
-  ) STORED;
-  `;
-
-  for (const sql of [
-    dropHieViewSql,
-    dropCqViewSql,
-    restorePreviousDefinitionSql,
-    createCqViewSql,
-    createHieViewSql,
-  ]) {
-    await queryInterface.sequelize.query(sql, {
-      type: QueryTypes.RAW,
-    });
-  }
+export const down: Migration = async () => {
+  console.log(
+    "No down migration for 2025-02-01_00_alter-cq-directory-entry-new_recreate-search-criteria"
+  );
 };


### PR DESCRIPTION
refs. metriport/metriport-internal#1772

### Description
- Fixes an issue where the generated 'search_criteria' column used for FTS has its definition wiped when rebuilding the CQ directory.

### Testing

#### Local
✅ Test this 👇  
(1) Check `cq_directory_entry_new` table has incorrect 'search_criteria' generation definition. 
(2) Run migrations 
(3) Ensure generation definition is correct. 
(4) Run CQ directory rebuild 
(5) Ensure generation definition has not returned to NULL

#### Prod
[ ] Test this 👇 
(3) Ensure generation definition is correct. 
(4) Run CQ directory rebuild 
(5) Ensure generation definition has not returned to NULL

### Release Plan
- :warning: Points to `master`
- [ ] Merge this
- [ ] Backmerge into develop
