### PR TITLE
PATCH 1772 - fix(api): fix hie directory view in migrations

### DIFF
--- a/packages/api/src/sequelize/migrations/2025-02-01_01_recreate-hie-directory-view.ts
+++ b/packages/api/src/sequelize/migrations/2025-02-01_01_recreate-hie-directory-view.ts
@@ -29,12 +29,12 @@ SELECT
   organization_id as oid,
   zip_code,
   state,
-  'Commonwell' as root_organization,
+  'CommonWell' as root_organization,
   '2.16.840.1.113883.3.3330' as managing_organization_id,
   search_criteria,
   'COMMONWELL' as network
 FROM ${cwTableName} cw
--- No duplicates! Exclude orgs that already exist in the CareQuality view
+-- No duplicates! Exclude orgs that already exist in the Carequality view
 WHERE NOT EXISTS (
   SELECT 1 
   FROM ${cqViewName} cq 

--- a/packages/api/src/sequelize/migrations/2025-02-01_01_recreate-hie-directory-view.ts
+++ b/packages/api/src/sequelize/migrations/2025-02-01_01_recreate-hie-directory-view.ts
@@ -1,0 +1,57 @@
+import { QueryTypes } from "sequelize";
+import type { Migration } from "..";
+
+const hieViewName = "hie_directory_view";
+const cqViewName = "cq_directory_entry_view";
+const cwTableName = "cw_directory_entry";
+
+const dropHieViewSql = `DROP VIEW IF EXISTS ${hieViewName};`;
+
+const createHieViewSql = `
+CREATE VIEW ${hieViewName} AS 
+SELECT 
+  name,
+  id,
+  id as oid,
+  zip as zip_code,
+  state,
+  root_organization,
+  managing_organization_id,
+  search_criteria,
+  'CAREQUALITY' as network
+FROM ${cqViewName} cq
+
+UNION ALL
+
+SELECT 
+  organization_name as name,
+  organization_id as id,
+  organization_id as oid,
+  zip_code,
+  state,
+  'Commonwell' as root_organization,
+  '2.16.840.1.113883.3.3330' as managing_organization_id,
+  search_criteria,
+  'COMMONWELL' as network
+FROM ${cwTableName} cw
+-- No duplicates! Exclude orgs that already exist in the CareQuality view
+WHERE NOT EXISTS (
+  SELECT 1 
+  FROM ${cqViewName} cq 
+  WHERE cq.id = cw.organization_id
+)
+;`;
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  for (const sql of [dropHieViewSql, createHieViewSql]) {
+    await queryInterface.sequelize.query(sql, {
+      type: QueryTypes.RAW,
+    });
+  }
+};
+
+export const down: Migration = async () => {
+  console.log(
+    "No down migration for 2025-02-01_00_alter-cq-directory-entry-new_recreate-search-criteria"
+  );
+};


### PR DESCRIPTION
refs. metriport/metriport-internal#1772

### Description
- Fixes an issue zip and oid columns are not properly loading in production

### Testing

#### Local
- [x] Check that null values in the network-entries table just get rendered as empty values

#### BEFORE
<img width="1225" alt="image" src="https://github.com/user-attachments/assets/a128ed4e-9302-4faf-a847-f22a0aaa12af" />

#### AFTER 
<img width="1225" alt="image" src="https://github.com/user-attachments/assets/6a5faf40-9c98-4614-945b-dde86611a973" />

#### Prod
- [ ] Check that null values in the network-entries table just get rendered as empty values

### Release Plan
- :warning: Points to `master`
- [ ] Merge this
- [ ] Backmerge into develop
