### PR TITLE
PATCH 1772 fix invalid us state or territory error

### DIFF
--- a/docs/_snippets/list-network-entries-response.mdx
+++ b/docs/_snippets/list-network-entries-response.mdx
@@ -6,19 +6,19 @@
   The name of this Network Entry.
 </ResponseField>
 
-<ResponseField name="zip" type="string">
+<ResponseField name="zip" type="string | undefined">
   The zipcode this Network Entry resides in.
 </ResponseField>
 
-<ResponseField name="state" type="string">
-  The 2 letter state acronym, for example: `CA`.
+<ResponseField name="state" type="string | undefined">
+  The 2 letter state or territory acronym, for example: `CA`.
 </ResponseField>
 
-<ResponseField name="rootOrganization" type="string">
+<ResponseField name="rootOrganization" type="string | undefined">
   The name of the top level organization responsible for
   both this entry and the managing organization.
 </ResponseField>
 
-<ResponseField name="managingOrgId" type="string">
+<ResponseField name="managingOrgId" type="string | undefined">
   The ID of the organization that is the direct parent.
 </ResponseField>

--- a/packages/api-sdk/src/medical/models/network-entry.ts
+++ b/packages/api-sdk/src/medical/models/network-entry.ts
@@ -1,10 +1,10 @@
-import { USState } from "@metriport/shared/dist/domain/address/state";
+import { USStateForAddress } from "@metriport/shared/dist/domain/address";
 
 export interface NetworkEntry {
   name: string;
   oid: string;
-  zip?: string;
-  state?: USState;
-  rootOrganization?: string;
-  managingOrgOid?: string;
+  zip: string | undefined;
+  state: USStateForAddress | undefined;
+  rootOrganization: string | undefined;
+  managingOrgOid: string | undefined;
 }

--- a/packages/api/src/domain/medical/network-entry.ts
+++ b/packages/api/src/domain/medical/network-entry.ts
@@ -4,8 +4,8 @@ export interface NetworkEntry {
   id: string;
   oid: string;
   name: string;
-  zipCode?: string;
-  state?: USStateForAddress;
-  managingOrgOid?: string;
-  rootOrganization?: string;
+  state: USStateForAddress | undefined;
+  zipCode: string | undefined;
+  managingOrgOid: string | undefined;
+  rootOrganization: string | undefined;
 }

--- a/packages/api/src/external/hie/models/hie-directory-view.ts
+++ b/packages/api/src/external/hie/models/hie-directory-view.ts
@@ -42,6 +42,10 @@ export class HIEDirectoryEntryViewModel extends BaseModel<HIEDirectoryEntryViewM
           type: DataTypes.STRING,
           field: "managing_organization_id",
         },
+        addressLine: {
+          type: DataTypes.STRING,
+          field: "address_line",
+        },
         state: {
           type: DataTypes.STRING,
         },

--- a/packages/api/src/routes/medical/dtos/network-entry-dto.ts
+++ b/packages/api/src/routes/medical/dtos/network-entry-dto.ts
@@ -1,4 +1,4 @@
-import { normalizeUSStateForAddress } from "@metriport/shared";
+import { normalizeUSStateForAddressSafe } from "@metriport/shared";
 import { NetworkEntry } from "../../../domain/medical/network-entry";
 import { HieDirectoryEntry } from "../../../external/hie/domain/hie-directory-entry";
 
@@ -9,7 +9,7 @@ export function dtoFromHieDirectoryEntry(networkEntry: HieDirectoryEntry): Netwo
     name: networkEntry.name,
     oid: networkEntry.oid,
     zipCode: networkEntry.zipCode,
-    state: normalizeUSStateForAddress(networkEntry.state ?? ""),
+    state: normalizeUSStateForAddressSafe(networkEntry.state ?? ""),
     rootOrganization: networkEntry.rootOrganization,
     managingOrgOid: networkEntry.managingOrganizationId,
   };


### PR DESCRIPTION
refs. metriport/metriport-internal#1772

### Description
- Fixes an issue where null or invalid state codes would break the network-entries table

### Testing

#### Local
- [x] Check that null values in the network-entries table just get rendered as empty values
![image](https://github.com/user-attachments/assets/4307e601-60e7-4bce-b0bf-185a5808423b)

#### Prod
- [ ] Check that null values in the network-entries table just get rendered as empty values

### Release Plan
- :warning: Points to `master`
- [ ] Merge this
- [ ] Backmerge into develop
