### PR TITLE
fix(api): fix invalid us state code

### DIFF
--- a/packages/api/src/domain/medical/network-entry.ts
+++ b/packages/api/src/domain/medical/network-entry.ts
@@ -5,7 +5,7 @@ export interface NetworkEntry {
   oid: string;
   name: string;
   zipCode?: string;
-  state?: USStateForAddress;
+  state?: USStateForAddress | undefined;
   managingOrgOid?: string;
   rootOrganization?: string;
 }

--- a/packages/api/src/routes/medical/dtos/network-entry-dto.ts
+++ b/packages/api/src/routes/medical/dtos/network-entry-dto.ts
@@ -1,4 +1,4 @@
-import { normalizeUSStateForAddress } from "@metriport/shared";
+import { normalizeUSStateForAddressSafe } from "@metriport/shared";
 import { NetworkEntry } from "../../../domain/medical/network-entry";
 import { HieDirectoryEntry } from "../../../external/hie/domain/hie-directory-entry";
 
@@ -9,7 +9,7 @@ export function dtoFromHieDirectoryEntry(networkEntry: HieDirectoryEntry): Netwo
     name: networkEntry.name,
     oid: networkEntry.oid,
     zipCode: networkEntry.zipCode,
-    state: normalizeUSStateForAddress(networkEntry.state ?? ""),
+    state: normalizeUSStateForAddressSafe(networkEntry.state ?? ""),
     rootOrganization: networkEntry.rootOrganization,
     managingOrgOid: networkEntry.managingOrganizationId,
   };


### PR DESCRIPTION
refs. metriport/metriport-internal#1772

### Description
- Fixes an issue where null or invalid state codes would break the network-entries table

### Testing

#### Local
- [x] Check that null values in the network-entries table just get rendered as empty values
![image](https://github.com/user-attachments/assets/4307e601-60e7-4bce-b0bf-185a5808423b)

#### Prod
- [ ] Check that null values in the network-entries table just get rendered as empty values

### Release Plan
- [x] Merge this to stage
- [ ] Verify in stage
- [ ] Merge to master
- [ ] Verify in master
