### PR TITLE
fix(core): xml cleanup escape chars in code

### DIFF
--- a/packages/core/src/domain/conversion/__tests__/cleanup.test.ts
+++ b/packages/core/src/domain/conversion/__tests__/cleanup.test.ts
@@ -1,0 +1,27 @@
+import fs from "fs";
+import path from "path";
+import { cleanUpTranslationCode, xmlTranslationCodeRegex } from "../cleanup";
+
+describe("cleanUpTranslationCode", () => {
+  it("regex correctly gets the translation code", () => {
+    const xmlFilePath = path.join(__dirname, "example.xml");
+    const xmlContent = fs.readFileSync(xmlFilePath, "utf-8");
+    const matches = xmlContent.match(xmlTranslationCodeRegex);
+    const match = matches?.[0];
+
+    expect(match).toBeDefined();
+    expect(match).toEqual(`<translation code="272.4\\272.4"`);
+  });
+
+  it("correctly replaces the junk code with something legible", () => {
+    const xmlFilePath = path.join(__dirname, "example.xml");
+    const xmlContent = fs.readFileSync(xmlFilePath, "utf-8");
+    const result = cleanUpTranslationCode(xmlContent);
+    const matches = result.match(xmlTranslationCodeRegex);
+    const translationCodeMatch = matches?.[0];
+
+    expect(result).not.toContain(`<translation code="272.4\\272.4"`);
+    expect(translationCodeMatch).toBeDefined();
+    expect(translationCodeMatch).toEqual(`<translation code="272.4"`);
+  });
+});

--- a/packages/core/src/domain/conversion/__tests__/example.xml
+++ b/packages/core/src/domain/conversion/__tests__/example.xml
@@ -1,0 +1,3 @@
+<ClinicalDocument>
+	<translation code="272.4\272.4" displayName="Hyperlipidemia" codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD9CM" />
+</ClinicalDocument>

--- a/packages/core/src/domain/conversion/cleanup.ts
+++ b/packages/core/src/domain/conversion/cleanup.ts
@@ -1,7 +1,8 @@
 export function cleanUpPayload(payloadRaw: string): string {
   const payloadNoCdUnk = replaceCdUnkString(payloadRaw);
   const payloadNoNullFlavor = replaceNullFlavor(payloadNoCdUnk);
-  return payloadNoNullFlavor;
+  const payloadCleanedCode = cleanUpTranslationCode(payloadNoNullFlavor);
+  return payloadCleanedCode;
 }
 
 function replaceCdUnkString(payloadRaw: string): string {
@@ -14,4 +15,12 @@ function replaceNullFlavor(payloadRaw: string): string {
   const stringToReplace = /<id\s*nullFlavor\s*=\s*".*?"\s*\/>/g;
   const replacement = `<id extension="1" root="1"/>`;
   return payloadRaw.replace(stringToReplace, replacement);
+}
+
+export const xmlTranslationCodeRegex = /(<translation[^>]*\scode=")([^"]*?)(")/g;
+export function cleanUpTranslationCode(payloadRaw: string): string {
+  return payloadRaw.replace(xmlTranslationCodeRegex, (_, prefix, code, suffix) => {
+    const cleanedCode = code.split("\\")[0].trim();
+    return `${prefix}${cleanedCode}${suffix}`;
+  });
 }

--- a/packages/core/src/domain/conversion/cleanup.ts
+++ b/packages/core/src/domain/conversion/cleanup.ts
@@ -1,6 +1,9 @@
+export const xmlTranslationCodeRegex = /(<translation[^>]*\scode=")([^"]*?)(")/g;
+
 export function cleanUpPayload(payloadRaw: string): string {
   const payloadNoCdUnk = replaceCdUnkString(payloadRaw);
-  const payloadNoNullFlavor = replaceNullFlavor(payloadNoCdUnk);
+  const payloadNoAmpersand = replaceAmpersand(payloadNoCdUnk);
+  const payloadNoNullFlavor = replaceNullFlavor(payloadNoAmpersand);
   const payloadCleanedCode = cleanUpTranslationCode(payloadNoNullFlavor);
   return payloadCleanedCode;
 }
@@ -17,7 +20,12 @@ function replaceNullFlavor(payloadRaw: string): string {
   return payloadRaw.replace(stringToReplace, replacement);
 }
 
-export const xmlTranslationCodeRegex = /(<translation[^>]*\scode=")([^"]*?)(")/g;
+function replaceAmpersand(payloadRaw: string): string {
+  const stringToReplace = /\s&\s/g;
+  const replacement = " &amp; ";
+  return payloadRaw.replace(stringToReplace, replacement);
+}
+
 export function cleanUpTranslationCode(payloadRaw: string): string {
   return payloadRaw.replace(xmlTranslationCodeRegex, (_, prefix, code, suffix) => {
     const cleanedCode = code.split("\\")[0].trim();

--- a/packages/lambdas/src/cda-to-visualization.ts
+++ b/packages/lambdas/src/cda-to-visualization.ts
@@ -1,4 +1,5 @@
 import { Input, Output } from "@metriport/core/domain/conversion/cda-to-html-pdf";
+import { cleanUpPayload } from "@metriport/core/domain/conversion/cleanup";
 import { MetriportError } from "@metriport/core/util/error/metriport-error";
 import * as Sentry from "@sentry/serverless";
 import chromium from "@sparticuz/chromium";
@@ -42,7 +43,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(
       });
     }
 
-    const document = normalizeDocument(originalDocument);
+    const document = cleanUpPayload(originalDocument);
 
     if (conversionType === "html") {
       const url = await convertStoreAndReturnHtmlDocUrl({ fileName, document, bucketName });
@@ -62,11 +63,6 @@ export const handler = Sentry.AWSLambda.wrapHandler(
     });
   }
 );
-
-function normalizeDocument(document: string): string {
-  const normalizedDocument = document.replace(/\s&\s/g, " &amp; ");
-  return normalizedDocument;
-}
 
 const downloadDocumentFromS3 = async ({
   fileName,

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -262,7 +262,13 @@ export async function handler(event: SQSEvent) {
             const msg = "Failed to hydrate the converted bundle";
             log(`${msg}: ${errorToString(error)}`);
             capture.message(msg, {
-              extra: { error, cxId, patientId, context: lambdaName },
+              extra: {
+                error,
+                cxId,
+                patientId,
+                context: lambdaName,
+                s3FileName,
+              },
               level: "warning",
             });
           }

--- a/packages/utils/src/fhir-converter/convert.ts
+++ b/packages/utils/src/fhir-converter/convert.ts
@@ -1,5 +1,6 @@
 import { Bundle, Resource } from "@medplum/fhirtypes";
 import { postProcessBundle } from "@metriport/core/domain/conversion/bundle-modifications/post-process";
+import { cleanUpPayload } from "@metriport/core/domain/conversion/cleanup";
 import { partitionPayload } from "@metriport/core/external/cda/partition-payload";
 import { removeBase64PdfEntries } from "@metriport/core/external/cda/remove-b64";
 import { hydrate } from "@metriport/core/external/fhir/consolidated/hydrate";
@@ -68,7 +69,8 @@ export async function convert(
     throw new Error(`File has nonXMLBody`);
   }
 
-  const { documentContents: noB64FileContents } = removeBase64PdfEntries(fileContents);
+  const payloadClean = cleanUpPayload(fileContents);
+  const { documentContents: noB64FileContents } = removeBase64PdfEntries(payloadClean);
   const payloads = partitionPayload(noB64FileContents);
 
   const unusedSegments = false;
@@ -85,7 +87,6 @@ export async function convert(
   const params = { patientId, fileName, unusedSegments, invalidAccess };
   for (let index = 0; index < payloads.length; index++) {
     const payload = payloads[index];
-
     const res = await api.post(url, payload, {
       params,
       headers: { "Content-Type": "text/plain" },


### PR DESCRIPTION
refs. metriport/metriport-internal#2638

### Description
- Cleaning up translation.code elements in XMLs during parsing, prior to conversion
- Cleaning up the ampersands 
- Added the cleanup to the visualization lambda
- Updating the fhir integration test to also cleanup the payload

### Testing

- Local
  - [x] Unit tests
  - [x] Run the new flow on the problematic file to make sure it works
- Staging
  - [ ] Convert some docs in staging and make sure the payloads are as expected
- Production
  - [ ] Rerun conversion on the file that failed in prod

### Release Plan
- [ ] Merge this
