### PR TITLE
fix(terminology): updated readme with existing route and supported systems

### DIFF
--- a/packages/core/src/external/term-server/index.ts
+++ b/packages/core/src/external/term-server/index.ts
@@ -21,7 +21,7 @@ export type CodeSystemLookupOutput = {
 };
 
 export const termServerUrl = Config.getTermServerUrl();
-const bulkLookupUrl = "terminology/code-system/lookup/bulk";
+const bulkLookupUrl = "code-system/lookup/bulk";
 
 export const supportedSystems = [ICD_10_URL, SNOMED_URL, LOINC_URL, RXNORM_URL, CPT_URL, CVX_URL];
 

--- a/packages/terminology/README.md
+++ b/packages/terminology/README.md
@@ -42,6 +42,54 @@ docker-compose build
 docker-compose up -d
 ```
 
+## Supported Systems
+
+Currently, the Term Server supports the following systems:
+
+| System     | URL                                         |
+| ---------- | ------------------------------------------- |
+| SNOMED     | http://snomed.info/sct                      |
+| LOINC      | http://loinc.org                            |
+| RXNORM     | http://www.nlm.nih.gov/research/umls/rxnorm |
+| CPT        | http://www.ama-assn.org/go/cpt              |
+| CVX        | http://hl7.org/fhir/sid/cvx                 |
+| ICD-10-PCS | http://hl7.org/fhir/sid/icd-10-pcs          |
+| ICD-10-CM  | http://hl7.org/fhir/sid/icd-10-cm           |
+
+## APIs
+
+### POST /code-system/lookup/bulk
+
+Send a `POST` request to this route to look up an array of codes from the supported systems, and receive results containing displays for those codes.
+
+#### Body
+
+A JSON payload, containing an array of FHIR Parameters objects with required `id` and `parameter` fields.
+
+```
+[
+  {
+    "resourceType": "Parameters",
+    "id": "abcd1234-abcd-1234-efgh-abcd1234efgh",
+    "parameter": [
+      {
+        "name": "system",
+        "valueUri": "http://hl7.org/fhir/sid/icd-10-cm"
+      },
+      {
+        "name": "code",
+        "valueCode": "T21.30"
+      }
+    ]
+  }
+]
+
+```
+
+### More routes coming soon 🚀
+
+In the near future, we are planning to add a route to do bulk crosswalks between systems. Stay tuned!
+
 ```
             ,▄,
           ▄▓███▌

--- a/packages/terminology/README.md
+++ b/packages/terminology/README.md
@@ -3,6 +3,7 @@
 ## Overview
 
 This project provides a term server for lookups in SNOMED, ICD, LOINC, and RXNORM, CPT, and CVX and crosswalks between SNOMED and ICD.
+Currently, this is mostly intended for internal use.
 
 ## Download Metathesaurus
 
@@ -14,7 +15,12 @@ You can download the Metathesaurus from the following link:
 
 ### Start the Term Server Locally
 
-To start the term server, run the following command:
+Set up the `.env` with the following variables:
+
+- AWS_REGION=<staging-region>
+- TERMINOLOGY_BUCKET=<umls-bucket>
+
+To download the terminology database to your local environment and initiate the service, run this command:
 
 ```bash
 npm run start

--- a/packages/terminology/src/app.ts
+++ b/packages/terminology/src/app.ts
@@ -36,7 +36,7 @@ async function main() {
 
   await initTermServer();
 
-  app.use("/terminology/", fhirRouter);
+  app.use("/", fhirRouter);
 
   const PORT = process.env.PORT || 8080;
 


### PR DESCRIPTION
refs. metriport/metriport-internal#2599

### Description
- Adding some API info for the Term Server
- Removing the `terminology/` from the routes 

### Testing
- Local
  - [x] Preview readme 
  - [x] Make sure the hydration still works 
- Staging
  - [ ] Make sure hydration doesn't fail

### Screenshots
<img width="896" alt="Screenshot 2025-02-03 at 8 41 17 AM" src="https://github.com/user-attachments/assets/977a36cd-053e-4fab-8e8b-562f1b41e8c4" />

<img width="863" alt="Screenshot 2025-02-03 at 8 41 43 AM" src="https://github.com/user-attachments/assets/92b5fa02-b1bb-43ca-a987-2a6568a7ee38" />

### Release Plan
- [ ] Merge this
- [ ] Update Postman collection - [link](https://metriport.postman.co/workspace/Team-Workspace~d17be5cc-10ed-49ad-8ad9-09d04d0c0d88/request/30695411-ba3cd09a-7c83-463d-b954-3add17288639)
