### PR TITLE
PATCH RELEASE: FF for MR Summary without logo

### DIFF
--- a/packages/core/src/external/aws/app-config.ts
+++ b/packages/core/src/external/aws/app-config.ts
@@ -37,7 +37,7 @@ export const cxBasedFFsSchema = z.object({
   cxsWithCQDirectFeatureFlag: ffStringValuesSchema,
   cxsWithCWFeatureFlag: ffStringValuesSchema,
   cxsWithADHDMRFeatureFlag: ffStringValuesSchema,
-  cxsWithNoLogoMrFeatureFlag: ffStringValuesSchema,
+  cxsWithNoMrLogoFeatureFlag: ffStringValuesSchema,
   cxsWithBmiMrFeatureFlag: ffStringValuesSchema,
   cxsWithDermMrFeatureFlag: ffStringValuesSchema,
   cxsWithAiBriefFeatureFlag: ffStringValuesSchema,

--- a/packages/core/src/external/aws/app-config.ts
+++ b/packages/core/src/external/aws/app-config.ts
@@ -37,6 +37,7 @@ export const cxBasedFFsSchema = z.object({
   cxsWithCQDirectFeatureFlag: ffStringValuesSchema,
   cxsWithCWFeatureFlag: ffStringValuesSchema,
   cxsWithADHDMRFeatureFlag: ffStringValuesSchema,
+  cxsWithNoLogoMrFeatureFlag: ffStringValuesSchema,
   cxsWithBmiMrFeatureFlag: ffStringValuesSchema,
   cxsWithDermMrFeatureFlag: ffStringValuesSchema,
   cxsWithAiBriefFeatureFlag: ffStringValuesSchema,

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -479,16 +479,14 @@ function extractFhirTypesFromBundle(bundle: Bundle): {
   };
 }
 
+const metriportLogo = `<div class='logo-container'>
+<img src="https://raw.githubusercontent.com/metriport/metriport/develop/assets/logo-black.png" alt="Logo">
+</div>`;
+
 function createMRHeader(patient: Patient, isLogoDisabled: boolean) {
   return `
     <div id="mr-header">
-    ${
-      isLogoDisabled
-        ? ""
-        : ` <div class='logo-container'>
-        <img src="https://raw.githubusercontent.com/metriport/metriport/develop/assets/logo-black.png" alt="Logo">
-      </div>`
-    }
+    ${isLogoDisabled ? "" : metriportLogo}
       <h1 class="title">
         Medical Record Summary (${formatDateForDisplay(new Date())})
       </h1>

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -45,7 +45,7 @@ const CPT_CODE = "cpt";
 const UNK_CODE = "UNK";
 const UNKNOWN_DISPLAY = "unknown";
 
-export function bundleToHtml(fhirBundle: Bundle, brief?: Brief, isLogoDisabled = false): string {
+export function bundleToHtml(fhirBundle: Bundle, brief?: Brief, isLogoEnabled = true): string {
   const {
     patient,
     practitioners,
@@ -317,7 +317,7 @@ export function bundleToHtml(fhirBundle: Bundle, brief?: Brief, isLogoDisabled =
       </head>
 
       <body>
-        ${createMRHeader(patient, isLogoDisabled)}
+        ${createMRHeader(patient, isLogoEnabled)}
         ${createBrief(brief)}
         <div class="divider"></div>
         <div id="mr-sections">
@@ -483,10 +483,10 @@ const metriportLogo = `<div class='logo-container'>
 <img src="https://raw.githubusercontent.com/metriport/metriport/develop/assets/logo-black.png" alt="Logo">
 </div>`;
 
-function createMRHeader(patient: Patient, isLogoDisabled: boolean) {
+function createMRHeader(patient: Patient, isLogoEnabled: boolean) {
   return `
     <div id="mr-header">
-    ${isLogoDisabled ? "" : metriportLogo}
+    ${isLogoEnabled ? metriportLogo : ""}
       <h1 class="title">
         Medical Record Summary (${formatDateForDisplay(new Date())})
       </h1>

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -45,7 +45,7 @@ const CPT_CODE = "cpt";
 const UNK_CODE = "UNK";
 const UNKNOWN_DISPLAY = "unknown";
 
-export function bundleToHtml(fhirBundle: Bundle, brief?: Brief): string {
+export function bundleToHtml(fhirBundle: Bundle, brief?: Brief, isLogoDisabled = false): string {
   const {
     patient,
     practitioners,
@@ -317,7 +317,7 @@ export function bundleToHtml(fhirBundle: Bundle, brief?: Brief): string {
       </head>
 
       <body>
-        ${createMRHeader(patient)}
+        ${createMRHeader(patient, isLogoDisabled)}
         ${createBrief(brief)}
         <div class="divider"></div>
         <div id="mr-sections">
@@ -479,12 +479,16 @@ function extractFhirTypesFromBundle(bundle: Bundle): {
   };
 }
 
-function createMRHeader(patient: Patient) {
+function createMRHeader(patient: Patient, isLogoDisabled: boolean) {
   return `
     <div id="mr-header">
-      <div class='logo-container'>
+    ${
+      isLogoDisabled
+        ? ""
+        : ` <div class='logo-container'>
         <img src="https://raw.githubusercontent.com/metriport/metriport/develop/assets/logo-black.png" alt="Logo">
-      </div>
+      </div>`
+    }
       <h1 class="title">
         Medical Record Summary (${formatDateForDisplay(new Date())})
       </h1>

--- a/packages/lambdas/src/fhir-to-medical-record.ts
+++ b/packages/lambdas/src/fhir-to-medical-record.ts
@@ -72,6 +72,8 @@ export async function handler({
   try {
     const cxsWithADHDFeatureFlagValue = await getCxsWithADHDFeatureFlagValue();
     const isADHDFeatureFlagEnabled = cxsWithADHDFeatureFlagValue.includes(cxId);
+    const cxsWithNoMrLogoFeatureFlagValue = await getCxsWithNoMrLogoFeatureFlagValue();
+    const isLogoEnabled = !cxsWithNoMrLogoFeatureFlagValue.includes(cxId);
     const cxsWithBmiFeatureFlagValue = await getCxsWithBmiFeatureFlagValue();
     const isBmiFeatureFlagEnabled = cxsWithBmiFeatureFlagValue.includes(cxId);
     const cxsWithDermFeatureFlagValue = await getCxsWithDermFeatureFlagValue();
@@ -98,7 +100,7 @@ export async function handler({
       ? bundleToHtmlBmi(bundle, aiBrief)
       : isDermFeatureFlagEnabled
       ? bundleToHtmlDerm(bundle, aiBrief)
-      : bundleToHtml(bundle, aiBrief);
+      : bundleToHtml(bundle, aiBrief, isLogoEnabled);
     await cloudWatchUtils.reportMemoryUsage({ metricName: "memPostHtml" });
     metrics.htmlConversion = {
       duration: Date.now() - htmlStartedAt,
@@ -278,6 +280,20 @@ async function convertAndStorePdf({
   fs.rmSync(pdfFilepath, { force: true });
 
   console.log("generate-pdf -> shutdown");
+}
+
+async function getCxsWithNoMrLogoFeatureFlagValue(): Promise<string[]> {
+  const featureFlag = await getFeatureFlagValueStringArray(
+    region,
+    appConfigAppId,
+    appConfigConfigId,
+    getEnvType(),
+    "cxsWithNoMrLogoFeatureFlag"
+  );
+
+  if (featureFlag?.enabled && featureFlag?.values) return featureFlag.values;
+
+  return [];
 }
 
 async function getCxsWithADHDFeatureFlagValue(): Promise<string[]> {

--- a/packages/lambdas/src/fhir-to-medical-record2.ts
+++ b/packages/lambdas/src/fhir-to-medical-record2.ts
@@ -74,6 +74,8 @@ export async function handler({
   try {
     const cxsWithADHDFeatureFlagValue = await getCxsWithADHDFeatureFlagValue();
     const isADHDFeatureFlagEnabled = cxsWithADHDFeatureFlagValue.includes(cxId);
+    const cxsWithNoLogoFeatureFlagValue = await getCxsWithNoLogoFeatureFlagValue();
+    const isNoLogoFeatureFlagEnabled = cxsWithNoLogoFeatureFlagValue.includes(cxId);
     const cxsWithBmiFeatureFlagValue = await getCxsWithBmiFeatureFlagValue();
     const isBmiFeatureFlagEnabled = cxsWithBmiFeatureFlagValue.includes(cxId);
     const cxsWithDermFeatureFlagValue = await getCxsWithDermFeatureFlagValue();
@@ -100,7 +102,7 @@ export async function handler({
       ? bundleToHtmlBmi(bundle, aiBrief)
       : isDermFeatureFlagEnabled
       ? bundleToHtmlDerm(bundle, aiBrief)
-      : bundleToHtml(bundle, aiBrief);
+      : bundleToHtml(bundle, aiBrief, isNoLogoFeatureFlagEnabled);
     await cloudWatchUtils.reportMemoryUsage({ metricName: "memPostHtml" });
     metrics.htmlConversion = {
       duration: Date.now() - htmlStartedAt,
@@ -264,6 +266,20 @@ async function getCxsWithBmiFeatureFlagValue(): Promise<string[]> {
     appConfigConfigId,
     getEnvType(),
     "cxsWithBmiMrFeatureFlag"
+  );
+
+  if (featureFlag?.enabled && featureFlag?.values) return featureFlag.values;
+
+  return [];
+}
+
+async function getCxsWithNoLogoFeatureFlagValue(): Promise<string[]> {
+  const featureFlag = await getFeatureFlagValueStringArray(
+    region,
+    appConfigAppId,
+    appConfigConfigId,
+    getEnvType(),
+    "cxsWithNoLogoMrFeatureFlag"
   );
 
   if (featureFlag?.enabled && featureFlag?.values) return featureFlag.values;

--- a/packages/lambdas/src/fhir-to-medical-record2.ts
+++ b/packages/lambdas/src/fhir-to-medical-record2.ts
@@ -75,7 +75,7 @@ export async function handler({
     const cxsWithADHDFeatureFlagValue = await getCxsWithADHDFeatureFlagValue();
     const isADHDFeatureFlagEnabled = cxsWithADHDFeatureFlagValue.includes(cxId);
     const cxsWithNoMrLogoFeatureFlagValue = await getCxsWithNoMrLogoFeatureFlagValue();
-    const isNoMrLogoFeatureFlagEnabled = cxsWithNoMrLogoFeatureFlagValue.includes(cxId);
+    const isLogoDisabled = cxsWithNoMrLogoFeatureFlagValue.includes(cxId);
     const cxsWithBmiFeatureFlagValue = await getCxsWithBmiFeatureFlagValue();
     const isBmiFeatureFlagEnabled = cxsWithBmiFeatureFlagValue.includes(cxId);
     const cxsWithDermFeatureFlagValue = await getCxsWithDermFeatureFlagValue();
@@ -102,7 +102,7 @@ export async function handler({
       ? bundleToHtmlBmi(bundle, aiBrief)
       : isDermFeatureFlagEnabled
       ? bundleToHtmlDerm(bundle, aiBrief)
-      : bundleToHtml(bundle, aiBrief, isNoMrLogoFeatureFlagEnabled);
+      : bundleToHtml(bundle, aiBrief, isLogoDisabled);
     await cloudWatchUtils.reportMemoryUsage({ metricName: "memPostHtml" });
     metrics.htmlConversion = {
       duration: Date.now() - htmlStartedAt,

--- a/packages/lambdas/src/fhir-to-medical-record2.ts
+++ b/packages/lambdas/src/fhir-to-medical-record2.ts
@@ -75,7 +75,7 @@ export async function handler({
     const cxsWithADHDFeatureFlagValue = await getCxsWithADHDFeatureFlagValue();
     const isADHDFeatureFlagEnabled = cxsWithADHDFeatureFlagValue.includes(cxId);
     const cxsWithNoMrLogoFeatureFlagValue = await getCxsWithNoMrLogoFeatureFlagValue();
-    const isNoLogoFeatureFlagEnabled = cxsWithNoMrLogoFeatureFlagValue.includes(cxId);
+    const isNoMrLogoFeatureFlagEnabled = cxsWithNoMrLogoFeatureFlagValue.includes(cxId);
     const cxsWithBmiFeatureFlagValue = await getCxsWithBmiFeatureFlagValue();
     const isBmiFeatureFlagEnabled = cxsWithBmiFeatureFlagValue.includes(cxId);
     const cxsWithDermFeatureFlagValue = await getCxsWithDermFeatureFlagValue();
@@ -102,7 +102,7 @@ export async function handler({
       ? bundleToHtmlBmi(bundle, aiBrief)
       : isDermFeatureFlagEnabled
       ? bundleToHtmlDerm(bundle, aiBrief)
-      : bundleToHtml(bundle, aiBrief, isNoLogoFeatureFlagEnabled);
+      : bundleToHtml(bundle, aiBrief, isNoMrLogoFeatureFlagEnabled);
     await cloudWatchUtils.reportMemoryUsage({ metricName: "memPostHtml" });
     metrics.htmlConversion = {
       duration: Date.now() - htmlStartedAt,

--- a/packages/lambdas/src/fhir-to-medical-record2.ts
+++ b/packages/lambdas/src/fhir-to-medical-record2.ts
@@ -75,7 +75,7 @@ export async function handler({
     const cxsWithADHDFeatureFlagValue = await getCxsWithADHDFeatureFlagValue();
     const isADHDFeatureFlagEnabled = cxsWithADHDFeatureFlagValue.includes(cxId);
     const cxsWithNoMrLogoFeatureFlagValue = await getCxsWithNoMrLogoFeatureFlagValue();
-    const isLogoDisabled = cxsWithNoMrLogoFeatureFlagValue.includes(cxId);
+    const isLogoEnabled = !cxsWithNoMrLogoFeatureFlagValue.includes(cxId);
     const cxsWithBmiFeatureFlagValue = await getCxsWithBmiFeatureFlagValue();
     const isBmiFeatureFlagEnabled = cxsWithBmiFeatureFlagValue.includes(cxId);
     const cxsWithDermFeatureFlagValue = await getCxsWithDermFeatureFlagValue();
@@ -102,7 +102,7 @@ export async function handler({
       ? bundleToHtmlBmi(bundle, aiBrief)
       : isDermFeatureFlagEnabled
       ? bundleToHtmlDerm(bundle, aiBrief)
-      : bundleToHtml(bundle, aiBrief, isLogoDisabled);
+      : bundleToHtml(bundle, aiBrief, isLogoEnabled);
     await cloudWatchUtils.reportMemoryUsage({ metricName: "memPostHtml" });
     metrics.htmlConversion = {
       duration: Date.now() - htmlStartedAt,

--- a/packages/lambdas/src/fhir-to-medical-record2.ts
+++ b/packages/lambdas/src/fhir-to-medical-record2.ts
@@ -74,8 +74,8 @@ export async function handler({
   try {
     const cxsWithADHDFeatureFlagValue = await getCxsWithADHDFeatureFlagValue();
     const isADHDFeatureFlagEnabled = cxsWithADHDFeatureFlagValue.includes(cxId);
-    const cxsWithNoLogoFeatureFlagValue = await getCxsWithNoLogoFeatureFlagValue();
-    const isNoLogoFeatureFlagEnabled = cxsWithNoLogoFeatureFlagValue.includes(cxId);
+    const cxsWithNoMrLogoFeatureFlagValue = await getCxsWithNoMrLogoFeatureFlagValue();
+    const isNoLogoFeatureFlagEnabled = cxsWithNoMrLogoFeatureFlagValue.includes(cxId);
     const cxsWithBmiFeatureFlagValue = await getCxsWithBmiFeatureFlagValue();
     const isBmiFeatureFlagEnabled = cxsWithBmiFeatureFlagValue.includes(cxId);
     const cxsWithDermFeatureFlagValue = await getCxsWithDermFeatureFlagValue();
@@ -273,13 +273,13 @@ async function getCxsWithBmiFeatureFlagValue(): Promise<string[]> {
   return [];
 }
 
-async function getCxsWithNoLogoFeatureFlagValue(): Promise<string[]> {
+async function getCxsWithNoMrLogoFeatureFlagValue(): Promise<string[]> {
   const featureFlag = await getFeatureFlagValueStringArray(
     region,
     appConfigAppId,
     appConfigConfigId,
     getEnvType(),
-    "cxsWithNoLogoMrFeatureFlag"
+    "cxsWithNoMrLogoFeatureFlag"
   );
 
   if (featureFlag?.enabled && featureFlag?.values) return featureFlag.values;


### PR DESCRIPTION
refs. metriport/metriport-internal#799

### Description
- Adding FF to turn off adding Metriport logo to MR summary header

### Testing

_[Patch PRs:]_

- :warning: [ ] Run E2E tests locally

- Local
  - [x] Generate an MR locally to make sure the MR summary turns out as expected
- Production
  - [ ] Generate an MR summary for a patient and validate the result


### Release Plan

- :warning: Points to `master`
- [ ] FFs have been set in Staging, Production, and Sandbox
- [ ] Merge this
