### PR TITLE
PATCH RELEASE: upd whitespace format for mr logo

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -480,13 +480,13 @@ function extractFhirTypesFromBundle(bundle: Bundle): {
 }
 
 const metriportLogo = `<div class='logo-container'>
-<img src="https://raw.githubusercontent.com/metriport/metriport/develop/assets/logo-black.png" alt="Logo">
-</div>`;
+        <img src="https://raw.githubusercontent.com/metriport/metriport/develop/assets/logo-black.png" alt="Logo">
+      </div>`;
 
 function createMRHeader(patient: Patient, isLogoEnabled: boolean) {
   return `
     <div id="mr-header">
-    ${isLogoEnabled ? metriportLogo : ""}
+      ${isLogoEnabled ? metriportLogo : ""}
       <h1 class="title">
         Medical Record Summary (${formatDateForDisplay(new Date())})
       </h1>


### PR DESCRIPTION
refs. metriport/metriport-internal#799

### Description
- Added whitespaces to keep the expected format

### Testing
- Local
  - [x] Generate MR and make sure it looks like the expected format
- Staging
  - [ ] Make sure e2e pass after backmerge

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
