### PR TITLE
1040 Make build failures more obvious

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prep-deploy-staging": "npm run install-deps && npm run build:staging && npm run test && npm run prep-lambdas",
     "package": "npm run prep-deploy",
     "install-deps": "npm ci --ignore-scripts --no-fund && SCRIPT='ci --ignore-scripts --no-fund' npm run lambdas:no-run",
-    "build": "npm run build --workspaces && SCRIPT='build' npm run lambdas",
+    "build": "if npm run build --workspaces && SCRIPT='build' npm run lambdas; then echo '\n\\033[1;32mBuild successful\\033[0m'; else echo '\n\\033[1;31m>>> Build failed <<<\\033[0m' && exit 1; fi",
     "build:cloud": "npm run build:cloud --workspaces && SCRIPT='build:cloud' npm run lambdas",
     "build:staging": "ENV_TYPE='staging' npm run build:cloud --workspaces && SCRIPT='build:cloud' npm run lambdas",
     "typecheck": "npm run typecheck --workspaces --if-present && SCRIPT='typecheck' npm run lambdas",


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Make build failures more obvious

this

![image](https://github.com/user-attachments/assets/46303da1-f8e2-4711-a2d8-d72f29083df3)

...and

![image](https://github.com/user-attachments/assets/1cfd9fe5-f911-42c2-b80f-245284c75523)

instead of this

![image](https://github.com/user-attachments/assets/29b5f0c2-e009-46d8-a3da-5685ed48dcb1)

...

![image](https://github.com/user-attachments/assets/52e5c454-3eda-4adf-b74e-b5a758ccad25)


### Testing

- Local
  - [x] `npm run build && npm run test` run successfully when build works
  - [x] `npm run build && npm run test` stops after `build` when it fails
- Staging
  - [ ] CICD works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
