### PR TITLE
feat(fhir-converter): more thorough date mapping for medication request

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Resources/MedicationRequest.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/MedicationRequest.hbs
@@ -43,6 +43,10 @@
             "authoredOn": "{{formatAsDateTime medicationRequest.effectiveTime.low.value}}",
         {{else if medicationRequest.author.time}}
             "authoredOn": "{{formatAsDateTime medicationRequest.author.time}}",
+        {{else if date.low.value}}
+            "authoredOn": "{{formatAsDateTime date.low.value}}",
+        {{else if date.high.value}}
+            "authoredOn": "{{formatAsDateTime date.high.value}}",
         {{else if @encounterTimePeriod.low}}
             "authoredOn": "{{formatAsDateTime @encounterTimePeriod.low.value}}",
         {{else if @encounterTimePeriod.high}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Medication.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Medication.hbs
@@ -39,8 +39,8 @@
                         
                         {{>References/MedicationStatement/medicationReference.hbs ID=(generateUUID (toJsonString medEntry.substanceAdministration)) REF=(concat 'Medication/' (generateUUID (toJsonString medEntry.substanceAdministration.consumable.manufacturedProduct.manufacturedMaterial)))}},
                         {{#each (toArray medEntry.substanceAdministration.entryRelationship) as |medReq|}}
-                            {{#if medReq.supply}}
-                                {{>Resources/MedicationRequest.hbs medicationRequest=medReq.supply ID=(generateUUID (toJsonString medReq.supply))}},
+                            {{#if medReq.supply}}   
+                                {{>Resources/MedicationRequest.hbs medicationRequest=medReq.supply date=medEntry.substanceAdministration.effectiveTime ID=(generateUUID (toJsonString medReq.supply))}},
                                 {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
                                 	{{>References/MedicationRequest/subject.hbs ID=(generateUUID (toJsonString medReq.supply)) REF=(concat 'Patient/' patientId.Id)}},
                                 {{/with}}


### PR DESCRIPTION
refs. metriport/metriport-internal#2128

### Description
- Added a backup date mapping for the MedicationRequest from its parent XML element

### Testing

- Local
  - [x] FHIR test suite 
  - [x] Check that the improved mapping actually applies as expected

### Release Plan
- [ ] Merge this
