### PR TITLE
2330 Don't require optional params on bulk import parse lambda

### DIFF
--- a/packages/lambdas/src/patient-import-create.ts
+++ b/packages/lambdas/src/patient-import-create.ts
@@ -10,10 +10,10 @@ import { getEnvOrFail } from "./shared/env";
 import { prefixedLog } from "./shared/log";
 import {
   parseCxIdAndJob,
-  parseDisableWebhooks,
+  parseDisableWebhooksOrFail,
   parseFacilityId,
-  parseRerunPdOnNewDemos,
-  parseTriggerConsolidated,
+  parseRerunPdOnNewDemosOrFail,
+  parseTriggerConsolidatedOrFail,
 } from "./shared/patient-import";
 import { getSingleMessageOrFail } from "./shared/sqs";
 
@@ -104,21 +104,21 @@ function parseBody(body?: unknown): ProcessPatientCreateRequest {
 
   const { cxIdRaw, jobIdRaw } = parseCxIdAndJob(bodyAsJson);
   const { facilityIdRaw } = parseFacilityId(bodyAsJson);
-  const { triggerConsolidatedRaw } = parseTriggerConsolidated(bodyAsJson);
-  const { disableWebhooksRaw } = parseDisableWebhooks(bodyAsJson);
-  const { rerunPdOnNewDemographicsRaw } = parseRerunPdOnNewDemos(bodyAsJson);
+  const { triggerConsolidatedRaw } = parseTriggerConsolidatedOrFail(bodyAsJson);
+  const { disableWebhooksRaw } = parseDisableWebhooksOrFail(bodyAsJson);
+  const { rerunPdOnNewDemographicsRaw } = parseRerunPdOnNewDemosOrFail(bodyAsJson);
 
   const patientPayloadRaw = bodyAsJson.patientPayload;
   if (!patientPayloadRaw) throw new Error(`Missing patientPayload`);
   if (typeof patientPayloadRaw !== "object") throw new Error(`Invalid patientPayload`);
 
-  const cxId = cxIdRaw as string;
-  const facilityId = facilityIdRaw as string;
-  const jobId = jobIdRaw as string;
+  const cxId = cxIdRaw;
+  const facilityId = facilityIdRaw;
+  const jobId = jobIdRaw;
   const patientPayload = patientPayloadRaw as PatientPayload;
-  const triggerConsolidated = triggerConsolidatedRaw as boolean;
-  const disableWebhooks = disableWebhooksRaw as boolean;
-  const rerunPdOnNewDemographics = rerunPdOnNewDemographicsRaw as boolean;
+  const triggerConsolidated = triggerConsolidatedRaw;
+  const disableWebhooks = disableWebhooksRaw;
+  const rerunPdOnNewDemographics = rerunPdOnNewDemographicsRaw;
 
   return {
     cxId,

--- a/packages/lambdas/src/patient-import-parse.ts
+++ b/packages/lambdas/src/patient-import-parse.ts
@@ -96,13 +96,13 @@ function parseBody(body?: unknown): StartPatientImportRequest {
   if (dryRunRaw === undefined) throw new Error(`Missing dryRun`);
   if (typeof dryRunRaw !== "boolean") throw new Error(`Invalid dryRun`);
 
-  const cxId = cxIdRaw as string;
-  const facilityId = facilityIdRaw as string;
-  const jobId = jobIdRaw as string;
-  const triggerConsolidated = triggerConsolidatedRaw as boolean;
-  const disableWebhooks = disableWebhooksRaw as boolean;
-  const rerunPdOnNewDemographics = rerunPdOnNewDemographicsRaw as boolean;
-  const dryRun = dryRunRaw as boolean;
+  const cxId = cxIdRaw;
+  const facilityId = facilityIdRaw;
+  const jobId = jobIdRaw;
+  const triggerConsolidated = triggerConsolidatedRaw;
+  const disableWebhooks = disableWebhooksRaw;
+  const rerunPdOnNewDemographics = rerunPdOnNewDemographicsRaw;
+  const dryRun = dryRunRaw;
 
   return {
     cxId,

--- a/packages/lambdas/src/patient-import-query.ts
+++ b/packages/lambdas/src/patient-import-query.ts
@@ -7,9 +7,9 @@ import { getEnvOrFail } from "./shared/env";
 import { prefixedLog } from "./shared/log";
 import {
   parseCxIdAndJob,
-  parseDisableWebhooks,
-  parseRerunPdOnNewDemos,
-  parseTriggerConsolidated,
+  parseDisableWebhooksOrFail,
+  parseRerunPdOnNewDemosOrFail,
+  parseTriggerConsolidatedOrFail,
 } from "./shared/patient-import";
 import { getSingleMessageOrFail } from "./shared/sqs";
 
@@ -95,20 +95,20 @@ function parseBody(body?: unknown): ProcessPatientQueryRequest {
   const bodyAsJson = JSON.parse(bodyString);
 
   const { cxIdRaw, jobIdRaw } = parseCxIdAndJob(bodyAsJson);
-  const { triggerConsolidatedRaw } = parseTriggerConsolidated(bodyAsJson);
-  const { disableWebhooksRaw } = parseDisableWebhooks(bodyAsJson);
-  const { rerunPdOnNewDemographicsRaw } = parseRerunPdOnNewDemos(bodyAsJson);
+  const { triggerConsolidatedRaw } = parseTriggerConsolidatedOrFail(bodyAsJson);
+  const { disableWebhooksRaw } = parseDisableWebhooksOrFail(bodyAsJson);
+  const { rerunPdOnNewDemographicsRaw } = parseRerunPdOnNewDemosOrFail(bodyAsJson);
 
   const patientIdRaw = bodyAsJson.patientId;
   if (!patientIdRaw) throw new Error(`Missing patientId`);
   if (typeof patientIdRaw !== "string") throw new Error(`Invalid patientId`);
 
-  const cxId = cxIdRaw as string;
-  const jobId = jobIdRaw as string;
-  const patientId = patientIdRaw as string;
-  const triggerConsolidated = triggerConsolidatedRaw as boolean;
-  const disableWebhooks = disableWebhooksRaw as boolean;
-  const rerunPdOnNewDemographics = rerunPdOnNewDemographicsRaw as boolean;
+  const cxId = cxIdRaw;
+  const jobId = jobIdRaw;
+  const patientId = patientIdRaw;
+  const triggerConsolidated = triggerConsolidatedRaw;
+  const disableWebhooks = disableWebhooksRaw;
+  const rerunPdOnNewDemographics = rerunPdOnNewDemographicsRaw;
 
   return {
     cxId,

--- a/packages/lambdas/src/shared/patient-import.ts
+++ b/packages/lambdas/src/shared/patient-import.ts
@@ -12,15 +12,6 @@ export function parseCxIdAndJob(bodyAsJson: any) {
 }
 
 //eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function parseJobStartedAt(bodyAsJson: any) {
-  const jobStartedAtRaw = bodyAsJson.jobStartedAt;
-  if (!jobStartedAtRaw) throw new Error(`Missing jobStartedAt`);
-  if (typeof jobStartedAtRaw !== "string") throw new Error(`Invalid jobStartedAt`);
-
-  return { jobStartedAtRaw };
-}
-
-//eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseFacilityId(bodyAsJson: any) {
   const facilityIdRaw = bodyAsJson.facilityId;
   if (!facilityIdRaw) throw new Error(`Missing cxId`);
@@ -32,28 +23,40 @@ export function parseFacilityId(bodyAsJson: any) {
 //eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseTriggerConsolidated(bodyAsJson: any) {
   const triggerConsolidatedRaw = bodyAsJson.triggerConsolidated;
-  if (triggerConsolidatedRaw === undefined) throw new Error(`Missing triggerConsolidated`);
+  if (triggerConsolidatedRaw === undefined) return {};
   if (typeof triggerConsolidatedRaw !== "boolean") throw new Error(`Invalid triggerConsolidated`);
-
+  return { triggerConsolidatedRaw };
+}
+export function parseTriggerConsolidatedOrFail(bodyAsJson: unknown) {
+  const { triggerConsolidatedRaw } = parseTriggerConsolidated(bodyAsJson);
+  if (!triggerConsolidatedRaw) throw new Error(`Missing triggerConsolidated`);
   return { triggerConsolidatedRaw };
 }
 
 //eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseDisableWebhooks(bodyAsJson: any) {
   const disableWebhooksRaw = bodyAsJson.disableWebhooks;
-  if (disableWebhooksRaw === undefined) throw new Error(`Missing disableWebhooks`);
+  if (disableWebhooksRaw === undefined) return {};
   if (typeof disableWebhooksRaw !== "boolean") throw new Error(`Invalid disableWebhooks`);
-
+  return { disableWebhooksRaw };
+}
+export function parseDisableWebhooksOrFail(bodyAsJson: unknown) {
+  const { disableWebhooksRaw } = parseDisableWebhooks(bodyAsJson);
+  if (!disableWebhooksRaw) throw new Error(`Missing disableWebhooks`);
   return { disableWebhooksRaw };
 }
 
 //eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseRerunPdOnNewDemos(bodyAsJson: any) {
   const rerunPdOnNewDemographicsRaw = bodyAsJson.rerunPdOnNewDemographics;
-  if (rerunPdOnNewDemographicsRaw === undefined)
-    throw new Error(`Missing rerunPdOnNewDemographics`);
-  if (typeof rerunPdOnNewDemographicsRaw !== "boolean")
+  if (rerunPdOnNewDemographicsRaw === undefined) return {};
+  if (typeof rerunPdOnNewDemographicsRaw !== "boolean") {
     throw new Error(`Invalid rerunPdOnNewDemographics`);
-
+  }
+  return { rerunPdOnNewDemographicsRaw };
+}
+export function parseRerunPdOnNewDemosOrFail(bodyAsJson: unknown) {
+  const { rerunPdOnNewDemographicsRaw } = parseRerunPdOnNewDemos(bodyAsJson);
+  if (!rerunPdOnNewDemographicsRaw) throw new Error(`Missing rerunPdOnNewDemographics`);
   return { rerunPdOnNewDemographicsRaw };
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#2330

### Dependencies

- Upstream: none
- Downstream: none

### Description

Don't require optional params on bulk import parse lambda.

### Testing

- Local
  - none
- Staging
  - [ ] Bulk import w/o `disableWebhook` param works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
