### PR TITLE
fix(lambda): adding bedrock permissions for multiple regions

### DIFF
--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -138,6 +138,7 @@ type EnvConfigBase = {
     modelId: string;
     region: string;
     anthropicVersion: string;
+    activeRegions?: string[];
   };
   openSearch: OpenSearchConnectorConfig;
   carequality?: {

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -138,7 +138,6 @@ type EnvConfigBase = {
     modelId: string;
     region: string;
     anthropicVersion: string;
-    activeRegions?: string[];
   };
   openSearch: OpenSearchConnectorConfig;
   carequality?: {

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -449,9 +449,7 @@ export class LambdasNestedStack extends NestedStack {
     alarmAction: SnsAction | undefined;
     appId: string;
     configId: string;
-    bedrock:
-      | { modelId: string; region: string; anthropicVersion: string; activeRegions?: string[] }
-      | undefined;
+    bedrock: { modelId: string; region: string; anthropicVersion: string } | undefined;
   }): Lambda {
     const lambdaTimeout = MAXIMUM_LAMBDA_TIMEOUT.minus(Duration.seconds(5));
 
@@ -495,16 +493,16 @@ export class LambdasNestedStack extends NestedStack {
       appConfigResources: ["*"],
     });
 
-    if (bedrock?.activeRegions) {
-      const bedrockPolicyStatement = new iam.PolicyStatement({
-        actions: ["bedrock:InvokeModel"],
-        resources: bedrock.activeRegions.flatMap(region => [
-          `arn:aws:bedrock:${region}:${this.account}:foundation-model/*`,
-          `arn:aws:bedrock:${region}:${this.account}:inference-profile/*`,
-        ]),
-      });
-      fhirToBundleLambda.addToRolePolicy(bedrockPolicyStatement);
-    }
+    const bedrockPolicyStatement = new iam.PolicyStatement({
+      actions: ["bedrock:InvokeModel"],
+      resources: [
+        `arn:aws:bedrock:*:*:foundation-model/*`,
+        `arn:aws:bedrock:*:*:inference-profile/*`,
+        `arn:aws:bedrock:*:*:application-inference-profile/*`,
+      ],
+    });
+
+    fhirToBundleLambda.addToRolePolicy(bedrockPolicyStatement);
 
     return fhirToBundleLambda;
   }

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -499,7 +499,7 @@ export class LambdasNestedStack extends NestedStack {
       const bedrockPolicyStatement = new iam.PolicyStatement({
         actions: ["bedrock:InvokeModel"],
         resources: bedrock.activeRegions.flatMap(region => [
-          `arn:aws:bedrock:${region}:${this.account}:model/*`,
+          `arn:aws:bedrock:${region}:${this.account}:foundation-model/*`,
           `arn:aws:bedrock:${region}:${this.account}:inference-profile/*`,
         ]),
       });


### PR DESCRIPTION
refs. metriport/metriport-internal#2664

### Dependencies
- Upstream: https://github.com/metriport/metriport-internal/pull/2665

### Description
- Adding permissions to the FhirToBundle lambda to invoke Bedrock models in an array of active regions
- Supporting docs:
  - https://aws.amazon.com/blogs/machine-learning/getting-started-with-cross-region-inference-in-amazon-bedrock/?utm_source=chatgpt.com#:~:text=your%20CloudWatch%20dashboard.-,Identity%20and%20Access%20Management,-AWS%20Identity%20and
  - https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-prereq.html  

### Testing

- Staging
  - [x] Branch to staging, make sure the AI Brief still gets generated as expected
- Production
  - [ ] Validate with the patient whose AI Brief gen failed

### Release Plan

- [x] Upstream dependencies are met/released
- [ ] Merge this
