### PR TITLE
fix(fhir-converter): improved reason code mapping for encounters

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Sections/Encounters.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Encounters.hbs
@@ -30,12 +30,7 @@
                 {{#with (multipleToArray this.[2_16_840_1_113883_10_20_22_2_22_1].entry this.[2_16_840_1_113883_10_20_22_2_22].entry) as |encounterEntries|}}
                     {{#each encounterEntries as |encounterEntry|}}
                         {{#if encounterEntry.encounter}}
-                            {{!-- only pass reason codes if there is one encounter and so we know the reason for visit applies to it --}}
-                            {{#if (eq (length encounterEntries) 1)}}
-                                {{>Resources/Encounter.hbs encounter=encounterEntry.encounter reasonCodes=reasonCodes ID=(generateUUID (toJsonString encounterEntry))}},
-                            {{else}}
-                                {{>Resources/Encounter.hbs encounter=encounterEntry.encounter ID=(generateUUID (toJsonString encounterEntry))}},
-                            {{/if}}
+                            {{>Resources/Encounter.hbs encounter=encounterEntry.encounter reasonCodes=reasonCodes ID=(generateUUID (toJsonString encounterEntry))}},
 
                             {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
                                 {{>References/Encounter/subject.hbs ID=(generateUUID (toJsonString encounterEntry)) REF=(concat 'Patient/' patientId.Id)}},

--- a/packages/utils/src/consolidated/create-consolidate-local.ts
+++ b/packages/utils/src/consolidated/create-consolidate-local.ts
@@ -1,0 +1,77 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import {
+  buildConsolidatedBundle,
+  merge,
+} from "@metriport/core/command/consolidated/consolidated-create";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
+import { getFileContents } from "@metriport/core/util/fs";
+import { sleep } from "@metriport/shared";
+import { Command } from "commander";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import fs from "fs";
+import { initPatientIdRepository } from "../bulk-insert-patients";
+import { getFileNames } from "../shared/fs";
+import { parseFhirBundle } from "@metriport/shared/medical";
+
+dayjs.extend(duration);
+
+/**
+ * Creates a consolidated bundle from a collection of converted JSONs locally. Requires a folder with FHIR JSON files.
+ */
+
+const bundlesLocation = ``;
+
+let startedAt = Date.now();
+const outputFolderName = `${bundlesLocation}/consolidated`;
+
+const program = new Command();
+program
+  .name("consolidate-create")
+  .description("Creates a Consolidated Bundle from local conversions")
+  .parse()
+  .showHelpAfterError();
+
+export async function main() {
+  initPatientIdRepository(outputFolderName);
+  await sleep(100);
+  startedAt = Date.now();
+
+  console.log(`Creating consolidated bundle - started at ${new Date().toISOString()}`);
+
+  const jsonFileNames = getFileNames({
+    folder: bundlesLocation,
+    recursive: true,
+    extension: "json",
+  });
+  console.log(`Found ${jsonFileNames.length} JSON files.`);
+
+  const mergedBundle = buildConsolidatedBundle();
+  await executeAsynchronously(
+    jsonFileNames,
+    async filePath => {
+      const contents = getFileContents(filePath);
+      const singleConversion = parseFhirBundle(contents);
+      if (!singleConversion) {
+        console.log(`No valid bundle found in ${filePath}, skipping`);
+        return;
+      }
+      merge(singleConversion).into(mergedBundle);
+    },
+    { numberOfParallelExecutions: 10 }
+  );
+
+  const duration = Date.now() - startedAt;
+  const durationMin = dayjs.duration(duration).asMinutes();
+  console.log(`Total time: ${duration} ms / ${durationMin} min`);
+
+  console.log(`File Location: ${outputFolderName}`);
+  fs.writeFileSync(`${outputFolderName}/consolidated.json`, JSON.stringify(mergedBundle, null, 2));
+  return;
+}
+
+main().then(() => {
+  process.exit(0);
+});


### PR DESCRIPTION
refs. metriport/metriport-internal#2357

### Description
- Encounter.reasonCode mapping improvements. Previously, we thought that the array of reasonCode was generated from multiple different previous encounters. That assumption was wrong. The `Reasons for Visit` section might contain multiple entries, but they are not in conflict to each other. 
- Some examples:
  - Cough
  - Runny nose
  - Difficulty breathing

- Added a local script to generate a consolidated bundle to allow better local testing for FHIR converter changes / dashboard changes


### Testing

- Local
  - [x] Run on ~1k files and review the results 
    - I printed the `reasonCode` from each file into one document, and looked over most of it to make sure nothing crazy is being inserted there
  
  - [x] Run FHIR test suite
    - [x] ...with inserts


### Release Plan

- [ ] Merge this
