### PR TITLE
feat(core): b64 attachments from xmls undergo mimetype detection

### DIFF
--- a/packages/core/src/domain/document/upload.ts
+++ b/packages/core/src/domain/document/upload.ts
@@ -30,5 +30,6 @@ export function createAttachmentUploadFilePath({
   mimeType: string | undefined;
 }): string {
   const extension = getFileExtension(mimeType);
-  return `${filePath}_${attachmentId}${extension}`;
+  const finalExtension = extension === "" ? ".unknown" : extension;
+  return `${filePath}_${attachmentId}${finalExtension}`;
 }

--- a/packages/core/src/external/cda/process-attachments.ts
+++ b/packages/core/src/external/cda/process-attachments.ts
@@ -171,19 +171,13 @@ async function handleS3Upload(
   s3Utils: S3Utils,
   log: typeof console.log
 ): Promise<void> {
-  uploadDetails.forEach(d => {
-    log(
-      `Attachment upload details: ${JSON.stringify({
-        bucket: d.bucket,
-        key: d.key,
-        contentType: d.contentType,
-        metadata: d.metadata,
-      })}`
-    );
-  });
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const detailsToLog = uploadDetails.map(({ file, ...d }) => d);
+  log(`[handleS3Upload] Upload details: ${JSON.stringify(detailsToLog)}`);
   await executeAsynchronously(uploadDetails, async (uploadParams: UploadParams) => {
     await s3Utils.uploadFile(uploadParams);
   });
+  log(`[handleS3Upload] Done`);
 }
 
 function buildDocumentReferenceDraft(

--- a/packages/utils/src/fhir-converter/integration-test.ts
+++ b/packages/utils/src/fhir-converter/integration-test.ts
@@ -85,6 +85,7 @@ type Params = {
 const options: ProcessingOptions = {
   hydrate: false,
   normalize: false,
+  processAttachments: false,
 };
 
 const program = new Command();


### PR DESCRIPTION
refs. metriport/metriport-internal#2683

### Description

- Added mimetype detection for b64 attachments from xmls 

### Testing

- Local
  - [x] Test the mimetype detection logic for a bunch of different XMLs that contain B64 attachments
- Production
  - [ ] Make sure the mimetypes are present in the patient that had the issue

### Release Plan
- [ ] Merge this
