### PR TITLE
2687 fix incorrect "document not found in S3" error log

### DIFF
--- a/packages/lambdas/src/cda-to-visualization.ts
+++ b/packages/lambdas/src/cda-to-visualization.ts
@@ -37,8 +37,14 @@ export const handler = Sentry.AWSLambda.wrapHandler(
     console.log(`Running with conversionType: ${conversionType}, fileName: ${fileName}`);
 
     const originalDocument = await downloadDocumentFromS3({ fileName, bucketName });
-    if (!originalDocument) {
+    if (originalDocument === undefined) {
       throw new MetriportError(`Document not found in S3`, undefined, {
+        fileName,
+      });
+    }
+
+    if (originalDocument === "") {
+      throw new MetriportError(`Document body is empty`, undefined, {
         fileName,
       });
     }


### PR DESCRIPTION
refs. metriport/metriport-internal#2687

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

None

### Description

This PR fixes an [error message](https://metriport.slack.com/archives/C04T256DQPQ/p1736948806370619) that claims that a file is not found, when it's actually just that the body of the file is empty. 

### Testing

None, other then ensuring type inference looks good

### Release Plan

- [ ] Merge this
