### PR TITLE
1040 Fine tune FHIR converter

### DIFF
--- a/packages/core/src/external/cda/remove-b64.ts
+++ b/packages/core/src/external/cda/remove-b64.ts
@@ -87,7 +87,7 @@ export function removeBase64PdfEntries(payloadRaw: string): {
     });
   }
 
-  if (b64Attachments.total === 0) {
+  if (b64Attachments.total < 1) {
     return {
       documentContents: payloadRaw,
       b64Attachments: undefined,

--- a/packages/infra/lib/api-stack/fhir-converter-service.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-service.ts
@@ -26,8 +26,8 @@ export function settings() {
     cpuAmount,
     cpu: cpuAmount * vCPU,
     memoryLimitMiB: prod ? 8192 : 4096,
-    taskCountMin: prod ? 8 : 1,
-    taskCountMax: prod ? 30 : 10,
+    taskCountMin: prod ? 16 : 1,
+    taskCountMax: prod ? 32 : 4,
     // How long this service can run for
     maxExecutionTimeout: MAXIMUM_LAMBDA_TIMEOUT,
   };

--- a/packages/infra/lib/patient-import-nested-stack.ts
+++ b/packages/infra/lib/patient-import-nested-stack.ts
@@ -36,7 +36,7 @@ function settings() {
       reportBatchItemFailures: true,
     },
     queue: {
-      alarmMaxAgeOfOldestMessage: patientCreateLambdaTimeout.minus(Duration.seconds(10)),
+      alarmMaxAgeOfOldestMessage: Duration.days(2),
       maxMessageCountAlarmThreshold: 5_000,
       maxReceiveCount: 3,
       visibilityTimeout: Duration.seconds(patientCreateLambdaTimeout.toSeconds() * 2 + 1),
@@ -56,7 +56,7 @@ function settings() {
       reportBatchItemFailures: true,
     },
     queue: {
-      alarmMaxAgeOfOldestMessage: patientQueryLambdaTimeout.minus(Duration.seconds(10)),
+      alarmMaxAgeOfOldestMessage: Duration.minutes(5),
       maxReceiveCount: 3,
       visibilityTimeout: Duration.seconds(patientQueryLambdaTimeout.toSeconds() * 2 + 1),
       createRetryLambda: false,

--- a/packages/infra/lib/patient-import-nested-stack.ts
+++ b/packages/infra/lib/patient-import-nested-stack.ts
@@ -13,7 +13,7 @@ import { createLambda } from "./shared/lambda";
 import { LambdaLayers } from "./shared/lambda-layers";
 import { createQueue } from "./shared/sqs";
 
-const waitTimePatientCreate = Duration.seconds(15);
+const waitTimePatientCreate = Duration.seconds(6); // 10 patients/min
 const waitTimePatientQuery = Duration.seconds(0);
 
 function settings() {

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -126,7 +126,6 @@ export async function handler(event: SQSEvent) {
         const { s3BucketName, s3FileName, documentExtension } = parseBody(message.body);
         const metrics: Metrics = {};
 
-        await cloudWatchUtils.reportMemoryUsage();
         log(`Getting contents from bucket ${s3BucketName}, key ${s3FileName}`);
         const downloadStart = Date.now();
         const payloadRaw = await s3Utils.getFileContentsAsString(s3BucketName, s3FileName);
@@ -169,7 +168,6 @@ export async function handler(event: SQSEvent) {
           continue;
         }
 
-        await cloudWatchUtils.reportMemoryUsage();
         const conversionStart = Date.now();
 
         const converterUrl = attrib.serverUrl?.stringValue;
@@ -198,8 +196,6 @@ export async function handler(event: SQSEvent) {
         });
 
         const partitionedPayloads = partitionPayload(payloadClean);
-
-        await cloudWatchUtils.reportMemoryUsage();
 
         const [conversionResult] = await Promise.all([
           convertPayloadToFHIR({
@@ -234,8 +230,6 @@ export async function handler(event: SQSEvent) {
           lambdaParams,
           log,
         });
-
-        await cloudWatchUtils.reportMemoryUsage();
 
         let hydratedBundle = conversionResult;
         // TODO: 2563 - Remove this after prod testing is done
@@ -279,8 +273,6 @@ export async function handler(event: SQSEvent) {
           }
         }
 
-        await cloudWatchUtils.reportMemoryUsage();
-
         const normalizedBundle = await normalize({
           cxId,
           patientId,
@@ -296,8 +288,6 @@ export async function handler(event: SQSEvent) {
           lambdaParams,
           log,
         });
-
-        await cloudWatchUtils.reportMemoryUsage();
 
         const postProcessStart = Date.now();
         const updatedConversionResult = postProcessBundle(
@@ -321,7 +311,6 @@ export async function handler(event: SQSEvent) {
           log,
         });
 
-        await cloudWatchUtils.reportMemoryUsage();
         await cloudWatchUtils.reportMetrics(metrics);
       } catch (error) {
         await ossApi.internal.notifyApi({ ...lambdaParams, status: "failed" }, log);


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

none

### Description

(each change has its own commit to help reviewing)

- fewer lambdas than ECS cores - [context](https://metriport.slack.com/archives/C04DBBJSKGB/p1739719790818809?thread_ts=1739665734.719219&cid=C04DBBJSKGB)
- deal w/ attachments (store on FHIR server and S3) while waiting for (CDA to) FHIR Conversion
- scale out FHIR Converter - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1739721142186769?thread_ts=1739646397.447249&cid=C04T256DQPQ)
   - the one linked was 4x b/c of the situation we were were in, this PR 2x so we can process bursts and imports
-  update bulk pt import lambdas's max age thresholds - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1739715092014349?thread_ts=1739666724.121709&cid=C04T256DQPQ)
- stop reporting intermediate mem info on fhirconverter lambda - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1739722149440979?thread_ts=1739721972.067319&cid=C04T256DQPQ)
   - we don't use it and it becomes noise on scaling out events

### Testing

- Local
  - none
- Staging
  - [ ] FHIR conversion w/ attachment is successful
- Sandbox
  - none
- Production
  - [ ] FHIR Converter infra scaled out
  - [ ] alert to import patient create lambda updated

### Release Plan

- [ ] Merge this
