### PR TITLE
1040 Fix missing awaits

### DIFF
--- a/packages/api/src/command/medical/document/document-conversion-status.ts
+++ b/packages/api/src/command/medical/document/document-conversion-status.ts
@@ -7,6 +7,7 @@ import {
 import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
 import { isMedicalDataSource, MedicalDataSource } from "@metriport/core/external/index";
 import { out } from "@metriport/core/util/log";
+import { emptyFunction } from "@metriport/shared";
 import { elapsedTimeFromNow } from "@metriport/shared/common/date";
 import { getCQData } from "../../../external/carequality/patient";
 import { getCWData } from "../../../external/commonwell/patient";
@@ -111,13 +112,13 @@ export async function calculateDocumentConversionStatus({
         patient: updatedPatient,
         conversionType: "pdf",
         context: `Post-DQ getConsolidated ${source}`,
-      });
+      }).catch(emptyFunction);
     } else if (isGlobalConversionCompleted) {
       // intentionally async
       recreateConsolidated({
         patient: updatedPatient,
         context: "Post-DQ getConsolidated GLOBAL",
-      });
+      }).catch(emptyFunction);
     }
   } else {
     const expectedPatient = await updateConversionProgress({
@@ -134,14 +135,14 @@ export async function calculateDocumentConversionStatus({
     if (isConversionCompleted) {
       // we want to await here to ensure the consolidated bundle is created before we send the webhook
       await recreateConsolidated({ patient, context: "calculate-no-source" });
-
+      // intentionally async
       processPatientDocumentRequest(
         cxId,
         patientId,
         "medical.document-conversion",
         MAPIWebhookStatus.completed,
         ""
-      );
+      ).catch(emptyFunction);
     }
   }
 }

--- a/packages/api/src/command/medical/document/document-webhook.ts
+++ b/packages/api/src/command/medical/document/document-webhook.ts
@@ -1,6 +1,7 @@
 import { PatientData } from "@metriport/core/domain/patient";
 import { out } from "@metriport/core/util";
 import { capture } from "@metriport/core/util/notifications";
+import { errorToString } from "@metriport/shared";
 import { WebhookMetadata } from "@metriport/shared/medical";
 import { Product } from "../../../domain/product";
 import { MAPIWebhookType } from "../../../domain/webhook";
@@ -120,10 +121,11 @@ export const processPatientDocumentRequest = async (
     if (shouldReportUsage) {
       reportUsageCmd({ cxId, entityId: patientId, product: Product.medical, docQuery: true });
     }
-  } catch (err) {
-    log(`Error on processPatientDocumentRequest: ${err}`);
-    capture.error(err, {
-      extra: { patientId, context: `webhook.processPatientDocumentRequest`, err },
+  } catch (error) {
+    const msg = `Error on processPatientDocumentRequest`;
+    log(`${msg}: ${errorToString(error)}`);
+    capture.error(msg, {
+      extra: { patientId, context: `webhook.processPatientDocumentRequest`, error },
     });
   }
 };

--- a/packages/api/src/command/medical/patient/data-contribution/handle-data-contributions.ts
+++ b/packages/api/src/command/medical/patient/data-contribution/handle-data-contributions.ts
@@ -5,6 +5,7 @@ import { toFHIR as toFhirPatient } from "@metriport/core/external/fhir/patient/c
 import { uploadCdaDocuments, uploadFhirBundleToS3 } from "@metriport/core/fhir-to-cda/upload";
 import { out } from "@metriport/core/util/log";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
+import { emptyFunction } from "@metriport/shared";
 import { processCcdRequest } from "../../../../external/cda/process-ccd-request";
 import { hydrateBundle } from "../../../../external/fhir/shared/hydrate-bundle";
 import { validateFhirEntries } from "../../../../external/fhir/shared/json-validator";
@@ -67,7 +68,9 @@ export async function handleDataContribution({
       cdaBundles: converted,
       organization: fhirOrganization,
       docId: requestId,
-    }).then(() => log(`${Date.now() - cdaConversionStartedAt}ms to convert to CDA`));
+    })
+      .then(() => log(`${Date.now() - cdaConversionStartedAt}ms to convert to CDA`))
+      .catch(emptyFunction);
   }
 
   const storeStartedAt = Date.now();
@@ -81,7 +84,7 @@ export async function handleDataContribution({
 
   if (!Config.isSandbox()) {
     // intentionally async
-    processCcdRequest({ patient, organization, requestId });
+    processCcdRequest({ patient, organization, requestId }).catch(emptyFunction);
   }
 
   return consolidatedDataUploadResults;

--- a/packages/api/src/command/usage/report-usage.ts
+++ b/packages/api/src/command/usage/report-usage.ts
@@ -1,8 +1,10 @@
+import { capture } from "@metriport/core/util";
+import { out } from "@metriport/core/util/log";
+import { errorToString } from "@metriport/shared";
 import Axios from "axios";
 import stringify from "json-stringify-safe";
 import { Product } from "../../domain/product";
 import { Config } from "../../shared/config";
-import { capture } from "../../shared/notifications";
 
 const axios = Axios.create({ timeout: 20_000 });
 
@@ -13,14 +15,14 @@ export type ReportUsageCommand = {
   docQuery?: boolean;
 };
 
-export const reportUsage = ({ cxId, entityId, product, docQuery }: ReportUsageCommand): void => {
+export function reportUsage({ cxId, entityId, product, docQuery }: ReportUsageCommand): void {
   const url = Config.getUsageUrl();
   if (!url) return;
   const payload = { cxId, entityId, apiType: product, docQuery };
-
+  const { log } = out(`reportUsage cxId ${cxId}`);
   // intentionally asynchronous
-  axios.post(`${url}`, payload).catch(err => {
-    console.log(`Failed to report usage (${stringify(payload)}) to server ${url}: `, err.message);
-    capture.error(err, { extra: { payload, err } });
+  axios.post(`${url}`, payload).catch(error => {
+    log(`Failed to report usage (${stringify(payload)}) to server ${url}: ${errorToString(error)}`);
+    capture.error("Failed to report usage", { extra: { payload, error } });
   });
-};
+}

--- a/packages/api/src/routes/medical/internal-docs.ts
+++ b/packages/api/src/routes/medical/internal-docs.ts
@@ -7,6 +7,7 @@ import { S3Utils } from "@metriport/core/external/aws/s3";
 import { toFHIR as toFhirOrganization } from "@metriport/core/external/fhir/organization/conversion";
 import { isMedicalDataSource } from "@metriport/core/external/index";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
+import { emptyFunction } from "@metriport/shared";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import httpStatus from "http-status";
@@ -40,8 +41,8 @@ import { documentQueryProgressSchema } from "../schemas/internal";
 import { getUUIDFrom } from "../schemas/uuid";
 import { asyncHandler, getFrom, getFromQueryAsArray, getFromQueryAsBoolean } from "../util";
 import { getFromQueryOrFail } from "./../util";
-import { cxRequestMetadataSchema } from "./schemas/request-metadata";
 import { toDTO } from "./dtos/document-bulk-downloadDTO";
+import { cxRequestMetadataSchema } from "./schemas/request-metadata";
 
 const router = Router();
 const upload = multer();
@@ -406,7 +407,7 @@ router.post(
       requestId: requestId,
     });
 
-    // trigger the webhook
+    // intentionally async - trigger the webhook
     processPatientDocumentRequest(
       cxId,
       patientId,
@@ -414,7 +415,7 @@ router.post(
       status as MAPIWebhookStatus,
       requestId,
       toDTO(docs)
-    );
+    ).catch(emptyFunction);
 
     return res.status(httpStatus.OK).json(updatedPatient.data.bulkGetDocumentsUrlProgress);
   })

--- a/packages/core/src/command/ai-brief/create.ts
+++ b/packages/core/src/command/ai-brief/create.ts
@@ -201,7 +201,6 @@ export async function summarizeFilteredBundleWithAI(
   } catch (err) {
     const msg = `AI brief generation failure`;
     log(`${msg} - ${errorToString(err)}`);
-    // Intentionally not throwing the error to avoid breaking the MR Summary generation flow
     throw err;
   }
 }

--- a/packages/core/src/external/aws/document-signing/document-bulk-signer-lambda.ts
+++ b/packages/core/src/external/aws/document-signing/document-bulk-signer-lambda.ts
@@ -10,27 +10,20 @@ export class DocumentBulkSignerLambda extends DocumentBulkSigner {
     this.lambdaClient = makeLambdaClient(this.region);
   }
 
-  async sign({ patientId, cxId, requestId }: DocumentBulkSignerRequest) {
+  async sign({ patientId, cxId, requestId }: DocumentBulkSignerRequest): Promise<void> {
     const payload: DocumentBulkSignerRequest = {
       patientId: patientId,
       cxId: cxId,
       requestId: requestId,
     };
 
-    this.lambdaClient
+    await this.lambdaClient
       .invoke({
         FunctionName: this.lambdaName,
-        InvocationType: "RequestResponse",
+        InvocationType: "Event", // async
         Payload: JSON.stringify(payload),
       })
       .promise()
-      .then(
-        defaultLambdaInvocationResponseHandler({
-          lambdaName: this.lambdaName,
-        })
-      )
-      .catch(error => {
-        throw error;
-      });
+      .then(defaultLambdaInvocationResponseHandler({ lambdaName: this.lambdaName }));
   }
 }

--- a/packages/core/src/external/commonwell/document/document-downloader-lambda.ts
+++ b/packages/core/src/external/commonwell/document/document-downloader-lambda.ts
@@ -1,3 +1,4 @@
+import { out } from "../../../util";
 import { getLambdaResultPayload, makeLambdaClient } from "../../aws/lambda";
 import {
   Document,
@@ -45,6 +46,7 @@ export class DocumentDownloaderLambda extends DocumentDownloader {
     fileInfo: FileInfo;
     cxId: string;
   }): Promise<DownloadResult> {
+    const { log } = out(`DocumentDownloaderLambda.download cxId ${cxId}`);
     const payload: DocumentDownloaderLambdaRequest = {
       document,
       fileInfo,
@@ -67,9 +69,7 @@ export class DocumentDownloaderLambda extends DocumentDownloader {
       lambdaName: this.lambdaName,
     });
 
-    console.log(
-      `Response from the downloader lambda: ${lambdaResult.StatusCode} / ${resultPayload}`
-    );
+    log(`Response from the downloader lambda: ${lambdaResult.StatusCode} / ${resultPayload}`);
     return JSON.parse(resultPayload.toString());
   }
 }


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

none

### Description

- Fix bulk download url signer, so it awaits on lambda invocation
- Apply standards to some code w/o changing logic 

### Testing

...WIP

- Local
  - [ ] _[Indicate how you tested this, on local or staging]_
  - [ ] ...
- Staging
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Sandbox
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Production
  - [ ] _testing step 1_
  - [ ] _testing step 2_

### Release Plan

...WIP

_[How does the changes on this PR impact/interact with the existing environment (database, configs, secrets, FFs, api contracts, etc.)?
Consider creating 2+ PRs if we need to ship those changes in a staged way]_

_[This is the release plan for production]_

_[You should execute the exact same steps when releasing to staging to validate it works]_

_[Add and remove items below accordingly]_

- :warning: Points to `master`
- :warning: This contains a DB migration
- [ ] Maintenance window scheduled/created at Checkly (if needed)
- [ ] Execute this on <env1>, <env2>
  - [ ] _step1_
  - [ ] _step2_
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (deprecates a feature that needs to be communicated with customers)
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (introduce a feature that would be useful customers)
- [ ] Upstream dependencies are met/released
- [ ] Release NPM packages
- [ ] Fern Definition Updated
- [ ] Release Fern SDKs
- [ ] FFs have been set in Staging, Production, and Sandbox
- [ ] No dependencies between API and Infra that will cause errors during deployment
- [ ] _[action n-1]_
- [ ] _[action n]_
- [ ] Merge this
