### PR TITLE
fix(core): smaller partitioning chunks

### DIFF
--- a/packages/core/src/domain/conversion/upload-conversion-steps.ts
+++ b/packages/core/src/domain/conversion/upload-conversion-steps.ts
@@ -63,9 +63,11 @@ export async function storePartitionedPayloadsInS3({
 }): Promise<void> {
   const fileNames: string[] = [];
 
+  const payloadsWithIndices = partitionedPayloads.map((payload, index) => ({ payload, index }));
+
   const results = await executeAsynchronously(
-    partitionedPayloads,
-    async (payload, index) => {
+    payloadsWithIndices,
+    async ({ payload, index }) => {
       const nameWithPartNumber = buildDocumentNameForPartialConversions(
         preConversionFilename,
         index

--- a/packages/core/src/external/cda/partition-payload.ts
+++ b/packages/core/src/external/cda/partition-payload.ts
@@ -3,7 +3,7 @@ import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { sizeInBytes } from "../../util/string";
 import { XMLBuilder } from "fast-xml-parser";
 
-export const MAX_CHUNK_SIZE_IN_BYTES = 10_000_000;
+export const MAX_CHUNK_SIZE_IN_BYTES = 5_000_000;
 const builder = new XMLBuilder({
   format: false,
   ignoreAttributes: false,


### PR DESCRIPTION
refs. metriport/metriport-internal#2343

### Description
- Smaller chunks for large CDA partitioning - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1739823991376319?thread_ts=1739720279.850789&cid=C04DMKE9DME)
- Fixing the issue where the parts indices were incorrectly implemented, resulting in chunks overwriting one another on s3

### Testing

- Local
  - [x] Partition a large file and make sure that `storePartitionedPayloadsInS3` prints correct indices for each chunk
- Production
  - [ ] Validate this is working as expected in prod with a large file 


### Release Plan

- [ ] Merge this
