### PR TITLE
feat(core): replace less than with html code 

### DIFF
--- a/packages/core/src/domain/conversion/__tests__/cleanup.test.ts
+++ b/packages/core/src/domain/conversion/__tests__/cleanup.test.ts
@@ -1,6 +1,11 @@
 import fs from "fs";
 import path from "path";
-import { cleanUpTranslationCode, xmlTranslationCodeRegex } from "../cleanup";
+import {
+  LESS_THAN,
+  cleanUpTranslationCode,
+  replaceLessThanChar,
+  xmlTranslationCodeRegex,
+} from "../cleanup";
 
 describe("cleanUpTranslationCode", () => {
   it("regex correctly gets the translation code", () => {
@@ -23,5 +28,35 @@ describe("cleanUpTranslationCode", () => {
     expect(result).not.toContain(`<translation code="272.4\\272.4"`);
     expect(translationCodeMatch).toBeDefined();
     expect(translationCodeMatch).toEqual(`<translation code="272.4"`);
+  });
+});
+
+describe("replaceLessThanChar", () => {
+  test("should replace '<' with spaces around it", () => {
+    expect(replaceLessThanChar("A < B")).toBe(`A ${LESS_THAN} B`);
+  });
+
+  test("should replace '<' before a digit", () => {
+    expect(replaceLessThanChar("A < 5")).toBe(`A ${LESS_THAN} 5`);
+  });
+
+  test("should replace '<' without a space before it", () => {
+    expect(replaceLessThanChar("A<5")).toBe(`A ${LESS_THAN} 5`);
+  });
+
+  test("should replace '<' with a space after it", () => {
+    expect(replaceLessThanChar("A< 5")).toBe(`A ${LESS_THAN} 5`);
+  });
+
+  test("should not replace '<' before a letter", () => {
+    expect(replaceLessThanChar("A<B")).toBe("A<B");
+  });
+
+  test("should not change text with no '<'", () => {
+    expect(replaceLessThanChar("No changes needed")).toBe("No changes needed");
+  });
+
+  test("should not replace '<' if it's part of an HTML tag", () => {
+    expect(replaceLessThanChar("<div>")).toBe("<div>");
   });
 });

--- a/packages/core/src/domain/conversion/cleanup.ts
+++ b/packages/core/src/domain/conversion/cleanup.ts
@@ -1,12 +1,12 @@
 export const xmlTranslationCodeRegex = /(<translation[^>]*\scode=")([^"]*?)(")/g;
 
-const LESS_THAN = "&lt;";
+export const LESS_THAN = "&lt;";
 const AMPERSAND = "&amp;";
 
 export function cleanUpPayload(payloadRaw: string): string {
   const payloadNoCdUnk = replaceCdUnkString(payloadRaw);
   const payloadNoAmpersand = replaceAmpersand(payloadNoCdUnk);
-  const payloadNoLessThan = replaceLessThanAndMoreThan(payloadNoAmpersand);
+  const payloadNoLessThan = replaceLessThanChar(payloadNoAmpersand);
   const payloadNoNullFlavor = replaceNullFlavor(payloadNoLessThan);
   const payloadCleanedCode = cleanUpTranslationCode(payloadNoNullFlavor);
   return payloadCleanedCode;
@@ -35,13 +35,9 @@ function replaceAmpersand(payloadRaw: string): string {
  *
  * Not replacing `>X` and `> X` because those might happen naturally, i.e. in lists `<td>1.`, etc.
  */
-function replaceLessThanAndMoreThan(payloadRaw: string): string {
-  const lessWithSpaces = /\s<\s/g; // Matches ` < `
-  const lessWithDigit = /<\s*(\d)/g; // Matches `<X` and `< X`
-
-  return payloadRaw
-    .replace(lessWithSpaces, ` ${LESS_THAN} `)
-    .replace(lessWithDigit, (_, digit) => `${LESS_THAN} ${digit}`);
+export function replaceLessThanChar(payloadRaw: string): string {
+  const lessPattern = /\s<\s|\s*<\s*(?=\d)/g;
+  return payloadRaw.replace(lessPattern, ` ${LESS_THAN} `);
 }
 
 export function cleanUpTranslationCode(payloadRaw: string): string {


### PR DESCRIPTION
refs. metriport/metriport-internal#2107

### Description
- Replacing some instances of the `<` char to avoid CDA>FHIR conversion failures

### Testing

- Local
  - [x] Test conversion flow on a problematic file from prod
  - [x] Run the FHIR test suite
- Production
  - [ ] Reconvert the problematic file and ensure we count more FHIR resources as a result

### Release Plan
- [ ] Merge this
