### PR TITLE
feat(api): moving dq wh to send after consolidated generation

### DIFF
--- a/packages/api/src/command/medical/document/__tests__/process-doc-query-webhook.test.ts
+++ b/packages/api/src/command/medical/document/__tests__/process-doc-query-webhook.test.ts
@@ -122,7 +122,6 @@ describe("processDocQueryProgressWebhook", () => {
           },
         },
         requestId,
-        isConsolidatedComplete: true,
       });
 
       expect(processPatientDocumentRequest).toHaveBeenCalledWith(
@@ -172,7 +171,6 @@ describe("processDocQueryProgressWebhook", () => {
           },
         },
         requestId,
-        isConsolidatedComplete: true,
       });
 
       expect(processPatientDocumentRequest).toHaveBeenCalledWith(

--- a/packages/api/src/command/medical/document/__tests__/process-doc-query-webhook.test.ts
+++ b/packages/api/src/command/medical/document/__tests__/process-doc-query-webhook.test.ts
@@ -52,9 +52,14 @@ describe("processDocQueryProgressWebhook", () => {
       const downloadProgress = { status: "processing" as const };
 
       await processDocQueryWebhook.processDocQueryProgressWebhook({
-        patient,
+        patient: {
+          ...patient,
+          data: {
+            ...patient.data,
+            documentQueryProgress: { download: downloadProgress },
+          },
+        },
         requestId,
-        documentQueryProgress: { download: downloadProgress },
       });
 
       expect(processPatientDocumentRequest).not.toHaveBeenCalled();
@@ -64,9 +69,14 @@ describe("processDocQueryProgressWebhook", () => {
       const convertProgress = { status: "processing" as const };
 
       await processDocQueryWebhook.processDocQueryProgressWebhook({
-        patient,
+        patient: {
+          ...patient,
+          data: {
+            ...patient.data,
+            documentQueryProgress: { convert: convertProgress },
+          },
+        },
         requestId,
-        documentQueryProgress: { convert: convertProgress },
       });
 
       expect(processPatientDocumentRequest).not.toHaveBeenCalled();
@@ -77,9 +87,16 @@ describe("processDocQueryProgressWebhook", () => {
       composeDocRefPayload.mockResolvedValueOnce(webhookPayload);
 
       await processDocQueryWebhook.processDocQueryProgressWebhook({
-        patient: { id: patient.id, cxId: patient.cxId },
+        patient: {
+          ...patient,
+          id: patient.id,
+          cxId: patient.cxId,
+          data: {
+            ...patient.data,
+            documentQueryProgress: { download: downloadProgress },
+          },
+        },
         requestId,
-        documentQueryProgress: { download: downloadProgress },
       });
 
       expect(processPatientDocumentRequest).toHaveBeenCalledWith(
@@ -97,9 +114,15 @@ describe("processDocQueryProgressWebhook", () => {
       composeDocRefPayload.mockResolvedValueOnce(webhookPayload);
 
       await processDocQueryWebhook.processDocQueryProgressWebhook({
-        patient,
+        patient: {
+          ...patient,
+          data: {
+            ...patient.data,
+            documentQueryProgress: { convert: convertProgress },
+          },
+        },
         requestId,
-        documentQueryProgress: { convert: convertProgress },
+        isConsolidatedComplete: true,
       });
 
       expect(processPatientDocumentRequest).toHaveBeenCalledWith(
@@ -116,9 +139,14 @@ describe("processDocQueryProgressWebhook", () => {
       composeDocRefPayload.mockResolvedValueOnce(webhookPayload);
 
       await processDocQueryWebhook.processDocQueryProgressWebhook({
-        patient,
+        patient: {
+          ...patient,
+          data: {
+            ...patient.data,
+            documentQueryProgress: { download: downloadProgress },
+          },
+        },
         requestId,
-        documentQueryProgress: { download: downloadProgress },
       });
 
       expect(processPatientDocumentRequest).toHaveBeenCalledWith(
@@ -136,9 +164,15 @@ describe("processDocQueryProgressWebhook", () => {
       composeDocRefPayload.mockResolvedValueOnce(webhookPayload);
 
       await processDocQueryWebhook.processDocQueryProgressWebhook({
-        patient,
+        patient: {
+          ...patient,
+          data: {
+            ...patient.data,
+            documentQueryProgress: { convert: convertProgress },
+          },
+        },
         requestId,
-        documentQueryProgress: { convert: convertProgress },
+        isConsolidatedComplete: true,
       });
 
       expect(processPatientDocumentRequest).toHaveBeenCalledWith(
@@ -155,9 +189,14 @@ describe("processDocQueryProgressWebhook", () => {
       composeDocRefPayload.mockResolvedValueOnce(webhookPayload);
 
       await processDocQueryWebhook.processDocQueryProgressWebhook({
-        patient,
+        patient: {
+          ...patient,
+          data: {
+            ...patient.data,
+            documentQueryProgress: { download: downloadProgress },
+          },
+        },
         requestId,
-        documentQueryProgress: { download: downloadProgress },
       });
 
       expect(processPatientDocumentRequest).not.toHaveBeenCalled();
@@ -167,9 +206,14 @@ describe("processDocQueryProgressWebhook", () => {
       const downloadProgress = { status: "completed" as const, webhookSent: true as const };
 
       await processDocQueryWebhook.processDocQueryProgressWebhook({
-        patient,
+        patient: {
+          ...patient,
+          data: {
+            ...patient.data,
+            documentQueryProgress: { download: downloadProgress },
+          },
+        },
         requestId,
-        documentQueryProgress: { convert: downloadProgress },
       });
 
       expect(processPatientDocumentRequest).not.toHaveBeenCalled();

--- a/packages/api/src/command/medical/document/document-conversion-status.ts
+++ b/packages/api/src/command/medical/document/document-conversion-status.ts
@@ -107,7 +107,7 @@ export async function calculateDocumentConversionStatus({
     const dqWhParams: ProcessDocQueryProgressWebhookParams | undefined = {
       patient: updatedPatient,
       requestId,
-      progressType: "convert",
+      progressType: "consolidated",
     };
 
     if (

--- a/packages/api/src/command/medical/document/document-webhook.ts
+++ b/packages/api/src/command/medical/document/document-webhook.ts
@@ -156,5 +156,5 @@ export async function createConsolidatedAndProcessWebhook(
 ) {
   await recreateConsolidated(recreateParams);
   log(`Sending DQ WH in createConsolidatedAndProcessWebhook...`);
-  await processDocQueryProgressWebhook({ ...whParams, isConsolidatedComplete: true });
+  await processDocQueryProgressWebhook(whParams);
 }

--- a/packages/api/src/command/medical/document/document-webhook.ts
+++ b/packages/api/src/command/medical/document/document-webhook.ts
@@ -12,8 +12,14 @@ import { reportUsage as reportUsageCmd } from "../../usage/report-usage";
 import { isWebhookDisabled, processRequest } from "../../webhook/webhook";
 import { createWebhookRequest } from "../../webhook/webhook-request";
 import { updateProgressWebhookSent } from "../patient/append-doc-query-progress";
+import { RecreateConsolidatedParams, recreateConsolidated } from "../patient/consolidated-recreate";
 import { getPatientOrFail } from "../patient/get-patient";
-import { CONVERSION_WEBHOOK_TYPE, DOWNLOAD_WEBHOOK_TYPE } from "./process-doc-query-webhook";
+import {
+  CONVERSION_WEBHOOK_TYPE,
+  DOWNLOAD_WEBHOOK_TYPE,
+  ProcessDocQueryProgressWebhookParams,
+  processDocQueryProgressWebhook,
+} from "./process-doc-query-webhook";
 
 export enum MAPIWebhookStatus {
   completed = "completed",
@@ -137,5 +143,18 @@ function getMetadata(whType: MAPIWebhookType, patientData: PatientData) {
     return patientData.cxDownloadRequestMetadata;
   } else {
     return undefined;
+  }
+}
+
+export async function createConsolidatedAndProcessWebhook(
+  recreateParams: RecreateConsolidatedParams,
+  whParams: ProcessDocQueryProgressWebhookParams,
+  log: typeof console.log
+) {
+  await recreateConsolidated(recreateParams);
+  const dqProgress = whParams.documentQueryProgress;
+  if (dqProgress) {
+    log(`Sending DQ WH in recreateConsolidated...`);
+    await processDocQueryProgressWebhook({ ...whParams, documentQueryProgress: dqProgress });
   }
 }

--- a/packages/api/src/command/medical/document/document-webhook.ts
+++ b/packages/api/src/command/medical/document/document-webhook.ts
@@ -155,9 +155,6 @@ export async function createConsolidatedAndProcessWebhook(
   log: typeof console.log
 ) {
   await recreateConsolidated(recreateParams);
-  const dqProgress = whParams.documentQueryProgress;
-  if (dqProgress) {
-    log(`Sending DQ WH in recreateConsolidated...`);
-    await processDocQueryProgressWebhook({ ...whParams, documentQueryProgress: dqProgress });
-  }
+  log(`Sending DQ WH in createConsolidatedAndProcessWebhook...`);
+  await processDocQueryProgressWebhook({ ...whParams, isConsolidatedComplete: true });
 }

--- a/packages/api/src/command/medical/document/process-doc-query-webhook.ts
+++ b/packages/api/src/command/medical/document/process-doc-query-webhook.ts
@@ -27,12 +27,10 @@ export type ProcessDocQueryProgressWebhookParams = {
 export const processDocQueryProgressWebhook = async ({
   patient,
   requestId,
-  isConsolidatedComplete = true,
   progressType,
 }: {
   patient: Pick<Patient, "id" | "cxId" | "externalId" | "data">;
   requestId: string;
-  isConsolidatedComplete?: boolean;
   progressType?: ProgressType;
 }): Promise<void> => {
   const { id: patientId } = patient;
@@ -41,9 +39,7 @@ export const processDocQueryProgressWebhook = async ({
   try {
     if (documentQueryProgress) {
       await handleDownloadWebhook(patient, requestId, documentQueryProgress, progressType);
-      if (isConsolidatedComplete) {
-        await handleConversionWebhook(patient, requestId, documentQueryProgress, progressType);
-      }
+      await handleConversionWebhook(patient, requestId, documentQueryProgress, progressType);
     }
   } catch (error) {
     const msg = `Error on processDocQueryProgressWebhook`;
@@ -102,9 +98,9 @@ const handleConversionWebhook = async (
 
   const convertStatus = documentQueryProgress.convert?.status;
   const isConvertFinished = convertStatus === "completed" || convertStatus === "failed";
-  const isTypeConversion = progressType ? progressType === "convert" : true;
+  const isTypeConsolidated = progressType ? progressType === "consolidated" : true;
 
-  const canProcessRequest = isConvertFinished && isTypeConversion && !webhookSent;
+  const canProcessRequest = isConvertFinished && isTypeConsolidated && !webhookSent;
 
   if (canProcessRequest) {
     const convertIsCompleted = convertStatus === "completed";

--- a/packages/api/src/command/medical/document/process-doc-query-webhook.ts
+++ b/packages/api/src/command/medical/document/process-doc-query-webhook.ts
@@ -14,6 +14,13 @@ const isSandbox = Config.isSandbox();
 export const DOWNLOAD_WEBHOOK_TYPE = "medical.document-download";
 export const CONVERSION_WEBHOOK_TYPE = "medical.document-conversion";
 
+export type ProcessDocQueryProgressWebhookParams = {
+  patient: Pick<Patient, "id" | "cxId" | "externalId">;
+  documentQueryProgress: DocumentQueryProgress | undefined;
+  requestId: string;
+  progressType?: ProgressType;
+};
+
 /**
  * Processes the document query progress to determine if when to send the document download and conversion webhooks
  */
@@ -55,7 +62,7 @@ const handleDownloadWebhook = async (
   documentQueryProgress: DocumentQueryProgress,
   progressType?: ProgressType
 ): Promise<void> => {
-  const webhookSent = documentQueryProgress?.download?.webhookSent ?? false;
+  const webhookSent = documentQueryProgress.download?.webhookSent ?? false;
 
   const downloadStatus = documentQueryProgress.download?.status;
   const isDownloadFinished = downloadStatus === "completed" || downloadStatus === "failed";

--- a/packages/api/src/command/medical/document/process-doc-query-webhook.ts
+++ b/packages/api/src/command/medical/document/process-doc-query-webhook.ts
@@ -27,7 +27,7 @@ export type ProcessDocQueryProgressWebhookParams = {
 export const processDocQueryProgressWebhook = async ({
   patient,
   requestId,
-  isConsolidatedComplete = false,
+  isConsolidatedComplete = true,
   progressType,
 }: {
   patient: Pick<Patient, "id" | "cxId" | "externalId" | "data">;

--- a/packages/api/src/external/hie/reset-doc-query-progress.ts
+++ b/packages/api/src/external/hie/reset-doc-query-progress.ts
@@ -74,11 +74,7 @@ export async function resetDocQueryProgress({
   });
 
   if (requestId && patient.data.documentQueryProgress) {
-    await processDocQueryProgressWebhook({
-      patient,
-      requestId,
-      isConsolidatedComplete: false,
-    });
+    await processDocQueryProgressWebhook({ patient, requestId });
   }
 }
 

--- a/packages/api/src/external/hie/reset-doc-query-progress.ts
+++ b/packages/api/src/external/hie/reset-doc-query-progress.ts
@@ -76,7 +76,6 @@ export async function resetDocQueryProgress({
   if (requestId && patient.data.documentQueryProgress) {
     await processDocQueryProgressWebhook({
       patient,
-      documentQueryProgress: patient.data.documentQueryProgress,
       requestId,
     });
   }

--- a/packages/api/src/external/hie/reset-doc-query-progress.ts
+++ b/packages/api/src/external/hie/reset-doc-query-progress.ts
@@ -77,6 +77,7 @@ export async function resetDocQueryProgress({
     await processDocQueryProgressWebhook({
       patient,
       requestId,
+      isConsolidatedComplete: false,
     });
   }
 }

--- a/packages/api/src/external/hie/set-doc-query-progress.ts
+++ b/packages/api/src/external/hie/set-doc-query-progress.ts
@@ -1,22 +1,26 @@
-import { Progress, DocumentQueryProgress } from "@metriport/core/domain/document-query";
-import { MedicalDataSource } from "@metriport/core/external/index";
 import { PatientExternalData } from "@metriport/core/domain//patient";
-import { progressTypes, ProgressType } from "@metriport/core/domain/document-query";
-import { DocumentQueryStatus } from "@metriport/core/domain/document-query";
+import {
+  DocumentQueryProgress,
+  DocumentQueryStatus,
+  Progress,
+  ProgressType,
+} from "@metriport/core/domain/document-query";
 import { Patient } from "@metriport/core/domain/patient";
-import { PatientModel } from "../../models/medical/patient";
-import { executeOnDBTx } from "../../models/transaction-wrapper";
+import { MedicalDataSource } from "@metriport/core/external/index";
+import { processDocQueryProgressWebhook } from "../../command/medical/document/process-doc-query-webhook";
 import {
   SetDocQueryProgressBase,
   aggregateDocQueryProgress,
 } from "../../command/medical/patient/append-doc-query-progress";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
-import { getCWData } from "../commonwell/patient";
+import { PatientModel } from "../../models/medical/patient";
+import { executeOnDBTx } from "../../models/transaction-wrapper";
 import { getCQData } from "../carequality/patient";
-import { processDocQueryProgressWebhook } from "../../command/medical/document/process-doc-query-webhook";
+import { getCWData } from "../commonwell/patient";
 
 type StaticProgress = Pick<Progress, "status" | "total">;
 type RequiredProgress = Required<Omit<Progress, "webhookSent">>;
+type ProgressTracking = Exclude<ProgressType, "consolidated">;
 
 export type SetDocQueryProgress = {
   source: MedicalDataSource;
@@ -89,7 +93,6 @@ export async function setDocQueryProgress({
   await processDocQueryProgressWebhook({
     patient,
     requestId,
-    isConsolidatedComplete: false,
   });
 
   return patient;
@@ -169,45 +172,48 @@ export function aggregateDocProgress(
   download?: RequiredProgress;
   convert?: RequiredProgress;
 } {
-  const statuses: { [key in ProgressType]: DocumentQueryStatus[] } = {
+  const statuses: Record<ProgressTracking, DocumentQueryStatus[]> = {
     download: [],
     convert: [],
   };
 
-  const tallyResults = hieDocProgresses.reduce(
-    (acc: { download?: RequiredProgress; convert?: RequiredProgress }, progress) => {
-      for (const type of progressTypes) {
-        const progressType = progress[type];
-        const existingProgressType = existingPatientDocProgress[type];
+  type TallyAccumulator = {
+    download?: RequiredProgress;
+    convert?: RequiredProgress;
+  };
 
-        if (!progressType && !existingProgressType) continue;
+  const relevantTypes: ProgressTracking[] = ["download", "convert"];
+  const tallyResults = hieDocProgresses.reduce((acc: TallyAccumulator, progress) => {
+    for (const type of relevantTypes) {
+      const progressType = progress[type];
+      const existingProgressType = existingPatientDocProgress[type];
 
-        const currTotal = progressType?.total ?? 0;
-        const currErrors = progressType?.errors ?? 0;
-        const currSuccessful = progressType?.successful ?? 0;
-        const accType = acc[type];
+      if (!progressType && !existingProgressType) continue;
 
-        statuses[type].push(progressType?.status ?? "completed");
+      const currTotal = progressType?.total ?? 0;
+      const currErrors = progressType?.errors ?? 0;
+      const currSuccessful = progressType?.successful ?? 0;
+      const accType = acc[type];
 
-        if (accType) {
-          accType.total += currTotal;
-          accType.errors += currErrors;
-          accType.successful += currSuccessful;
-          accType.status = aggregateStatus(statuses[type]);
-        } else {
-          acc[type] = {
-            total: currTotal,
-            errors: currErrors,
-            successful: currSuccessful,
-            status: progressType?.status ?? "completed",
-          };
-        }
+      statuses[type].push(progressType?.status ?? "completed");
+
+      if (accType) {
+        accType.total += currTotal;
+        accType.errors += currErrors;
+        accType.successful += currSuccessful;
+        accType.status = aggregateStatus(statuses[type]);
+      } else {
+        acc[type] = {
+          total: currTotal,
+          errors: currErrors,
+          successful: currSuccessful,
+          status: progressType?.status ?? "completed",
+        };
       }
+    }
 
-      return acc;
-    },
-    {}
-  );
+    return acc;
+  }, {});
 
   return tallyResults;
 }

--- a/packages/api/src/external/hie/set-doc-query-progress.ts
+++ b/packages/api/src/external/hie/set-doc-query-progress.ts
@@ -88,7 +88,6 @@ export async function setDocQueryProgress({
 
   await processDocQueryProgressWebhook({
     patient,
-    documentQueryProgress: patient.data.documentQueryProgress,
     requestId,
   });
 

--- a/packages/api/src/external/hie/set-doc-query-progress.ts
+++ b/packages/api/src/external/hie/set-doc-query-progress.ts
@@ -89,6 +89,7 @@ export async function setDocQueryProgress({
   await processDocQueryProgressWebhook({
     patient,
     requestId,
+    isConsolidatedComplete: false,
   });
 
   return patient;

--- a/packages/api/src/external/hie/tally-doc-query-progress.ts
+++ b/packages/api/src/external/hie/tally-doc-query-progress.ts
@@ -74,7 +74,6 @@ export async function tallyDocQueryProgress({
     patient,
     requestId,
     progressType: type,
-    isConsolidatedComplete: false,
   });
 
   return patient;

--- a/packages/api/src/external/hie/tally-doc-query-progress.ts
+++ b/packages/api/src/external/hie/tally-doc-query-progress.ts
@@ -1,13 +1,15 @@
-import { DocumentQueryProgress, Progress } from "@metriport/core/domain/document-query";
-import { getStatusFromProgress } from "@metriport/core/domain/document-query";
-import { MedicalDataSource } from "@metriport/core/external/index";
 import { PatientExternalData } from "@metriport/core/domain//patient";
-import { ProgressType } from "@metriport/core/domain/document-query";
+import {
+  DocumentQueryProgress,
+  Progress,
+  ProgressType,
+  getStatusFromProgress,
+} from "@metriport/core/domain/document-query";
 import { Patient } from "@metriport/core/domain/patient";
+import { MedicalDataSource } from "@metriport/core/external/index";
+import { getPatientOrFail } from "../../command/medical/patient/get-patient";
 import { PatientModel } from "../../models/medical/patient";
 import { executeOnDBTx } from "../../models/transaction-wrapper";
-import { getPatientOrFail } from "../../command/medical/patient/get-patient";
-import { processDocQueryProgressWebhook } from "../../command/medical/document/process-doc-query-webhook";
 import { aggregateAndSetHIEProgresses } from "./set-doc-query-progress";
 
 type DynamicProgress = Pick<Progress, "successful" | "errors">;
@@ -72,13 +74,6 @@ export async function tallyDocQueryProgress({
     });
 
     return updatedPatient;
-  });
-
-  await processDocQueryProgressWebhook({
-    patient: result,
-    documentQueryProgress: result.data.documentQueryProgress,
-    requestId,
-    progressType: type,
   });
 
   return result;

--- a/packages/api/src/external/hie/tally-doc-query-progress.ts
+++ b/packages/api/src/external/hie/tally-doc-query-progress.ts
@@ -7,6 +7,7 @@ import {
 } from "@metriport/core/domain/document-query";
 import { Patient } from "@metriport/core/domain/patient";
 import { MedicalDataSource } from "@metriport/core/external/index";
+import { processDocQueryProgressWebhook } from "../../command/medical/document/process-doc-query-webhook";
 import { getPatientOrFail } from "../../command/medical/patient/get-patient";
 import { PatientModel } from "../../models/medical/patient";
 import { executeOnDBTx } from "../../models/transaction-wrapper";
@@ -67,6 +68,13 @@ export async function tallyDocQueryProgress({
     await PatientModel.update(updatedPatient, { where: patientFilter, transaction });
 
     return updatedPatient;
+  });
+
+  await processDocQueryProgressWebhook({
+    patient,
+    requestId,
+    progressType: type,
+    isConsolidatedComplete: false,
   });
 
   return patient;

--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -21,6 +21,7 @@ dayjs.extend(duration);
 
 const AI_BRIEF_TIMEOUT = dayjs.duration(1.5, "minutes");
 const s3Utils = new S3Utils(Config.getAWSRegion());
+const TIMED_OUT = Symbol("TIMED_OUT");
 
 export const conversionBundleSuffix = ".xml.json";
 const numberOfParallelExecutions = 10;
@@ -37,8 +38,6 @@ export type ConsolidatePatientDataCommand = {
 };
 
 type BundleLocation = { bucket: string; key: string };
-
-const TIMED_OUT = Symbol("TIMED_OUT");
 
 /**
  * Create a consolidated bundle from the existing conversion bundles.

--- a/packages/core/src/domain/document-query.ts
+++ b/packages/core/src/domain/document-query.ts
@@ -11,7 +11,7 @@ export type Progress = {
 
 export type ProgressIntKeys = keyof Omit<Progress, "status">;
 
-export const progressTypes = ["convert", "download"] as const;
+export const progressTypes = ["convert", "download", "consolidated"] as const;
 export type ProgressType = (typeof progressTypes)[number];
 
 export type DocumentQueryProgress = Partial<

--- a/packages/core/src/util/race-control.ts
+++ b/packages/core/src/util/race-control.ts
@@ -20,7 +20,7 @@ export async function checkIfRaceIsComplete(
   return "";
 }
 
-export async function controlDuration(durationMS: number, msg: string): Promise<string> {
+export async function controlDuration<T>(durationMS: number, response: T): Promise<T> {
   await sleep(durationMS);
-  return msg;
+  return response;
 }


### PR DESCRIPTION
refs. metriport/metriport-internal#2711

### Description
- Moving the `medical.document-conversion` WH to be sent after the Consolidated Bundle and AI Brief are generated 
- Added a race condition for the AI Brief generation to make sure a failure in its creation doesn't undermine the whole flow

### Testing

- Local
  - [x] N/A 
- Staging
  - [ ] Trigger DQ for a patient, generate the Consolidated Bundle and make sure AI Brief is present in the output
- Production
  - [ ] Monitor the DQs for a bit after the release

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an additional progress stage during document processing.
  - Introduced a timeout mechanism for AI brief generation to ensure timely responses.

- **Refactor**
  - Streamlined progress tracking by consolidating related data into a unified structure.
  - Simplified webhook handling and parameter management for improved processing reliability.
  - Enhanced organization and clarity across document conversion and progress aggregation workflows.
  - Improved type handling and control flow for document query progress processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->