### PR TITLE
feat(lambdas): update all lambdas to use setExtra and wrapHandler()

### DIFF
--- a/packages/lambdas/src/fhir-to-bundle.ts
+++ b/packages/lambdas/src/fhir-to-bundle.ts
@@ -5,8 +5,10 @@ import {
 } from "@metriport/core/command/consolidated/get-snapshot";
 import { ConsolidatedSnapshotConnectorLocal } from "@metriport/core/command/consolidated/get-snapshot-local";
 import { out } from "@metriport/core/util/log";
+import * as Sentry from "@sentry/serverless";
 import { capture } from "./shared/capture";
 import { getEnvOrFail } from "./shared/env";
+import { MetriportError } from "../../shared/dist";
 
 // Keep this as early on the file as possible
 capture.init();
@@ -15,29 +17,37 @@ capture.init();
 const apiUrl = getEnvOrFail("API_URL");
 const bucketName = getEnvOrFail("BUCKET_NAME");
 
-export async function handler(
-  params: ConsolidatedSnapshotRequestSync | ConsolidatedSnapshotRequestAsync
-): Promise<ConsolidatedSnapshotResponse | void> {
-  const { patient, requestId, resources, dateFrom, dateTo } = params;
-  const conversionType = params.isAsync ? params.conversionType : undefined;
-  const { log } = out(`cx ${patient.cxId}, patient ${patient.id}, req ${requestId}`);
-  try {
-    log(
-      `Running with dateFrom: ${dateFrom}, dateTo: ${dateTo}, conversionType: ${conversionType}` +
-        `, resources: ${resources}}`
-    );
-    const conn = new ConsolidatedSnapshotConnectorLocal(bucketName, apiUrl);
-    const result = await conn.execute(params);
-    return result;
-  } catch (error) {
-    const msg = "Failed to get FHIR resources";
-    const filters = {
-      conversionType,
-      resources,
-      dateFrom,
-      dateTo,
-    };
-    log(`${msg}: ${JSON.stringify(filters)}`);
-    throw error;
+export const handler = Sentry.AWSLambda.wrapHandler(
+  async (
+    params: ConsolidatedSnapshotRequestSync | ConsolidatedSnapshotRequestAsync
+  ): Promise<ConsolidatedSnapshotResponse | void> => {
+    const { patient, requestId, resources, dateFrom, dateTo } = params;
+    const conversionType = params.isAsync ? params.conversionType : undefined;
+    const { log } = out(`cx ${patient.cxId}, patient ${patient.id}, req ${requestId}`);
+    try {
+      log(
+        `Running with dateFrom: ${dateFrom}, dateTo: ${dateTo}, conversionType: ${conversionType}` +
+          `, resources: ${resources}}`
+      );
+      const conn = new ConsolidatedSnapshotConnectorLocal(bucketName, apiUrl);
+      const result = await conn.execute(params);
+      return result;
+    } catch (error) {
+      const msg = "Failed to get FHIR resources";
+      const filters = {
+        conversionType,
+        resources,
+        dateFrom,
+        dateTo,
+      };
+      log(`${msg}: ${JSON.stringify(filters)}`);
+      capture.setExtra({
+        conversionType,
+        resources,
+        dateFrom,
+        dateTo,
+      });
+      throw new MetriportError(msg, error);
+    }
   }
-}
+);

--- a/packages/lambdas/src/fhir-to-medical-record2.ts
+++ b/packages/lambdas/src/fhir-to-medical-record2.ts
@@ -25,6 +25,7 @@ import { capture } from "./shared/capture";
 import { CloudWatchUtils, Metrics } from "./shared/cloudwatch";
 import { getEnvOrFail } from "./shared/env";
 import { apiClient } from "./shared/oss-api";
+import * as Sentry from "@sentry/serverless";
 
 // Keep this as early on the file as possible
 capture.init();
@@ -54,133 +55,133 @@ const pdfOptions: WkOptions = {
 };
 
 // Don't use Sentry's default error handler b/c we want to use our own and send more context-aware data
-export async function handler({
-  fileName: fhirFileName,
-  patientId,
-  cxId,
-  dateFrom,
-  dateTo,
-  conversionType,
-  resultFileNameSuffix,
-}: Input): Promise<Output> {
-  const { log } = out(`cx ${cxId}, patient ${patientId}`);
-  const startedAt = Date.now();
-  const metrics: Metrics = {};
-  await cloudWatchUtils.reportMemoryUsage({ metricName: "memPreSetup" });
-  log(
-    `Running with conversionType: ${conversionType}, dateFrom: ${dateFrom}, ` +
-      `dateTo: ${dateTo}, fileName: ${fhirFileName}, bucket: ${bucketName}}`
-  );
-  try {
-    const cxsWithADHDFeatureFlagValue = await getCxsWithADHDFeatureFlagValue();
-    const isADHDFeatureFlagEnabled = cxsWithADHDFeatureFlagValue.includes(cxId);
-    const cxsWithNoMrLogoFeatureFlagValue = await getCxsWithNoMrLogoFeatureFlagValue();
-    const isLogoEnabled = !cxsWithNoMrLogoFeatureFlagValue.includes(cxId);
-    const cxsWithBmiFeatureFlagValue = await getCxsWithBmiFeatureFlagValue();
-    const isBmiFeatureFlagEnabled = cxsWithBmiFeatureFlagValue.includes(cxId);
-    const cxsWithDermFeatureFlagValue = await getCxsWithDermFeatureFlagValue();
-    const isDermFeatureFlagEnabled = cxsWithDermFeatureFlagValue.includes(cxId);
-    const fileNameSuffix =
-      resultFileNameSuffix && resultFileNameSuffix.trim().length > 0
-        ? resultFileNameSuffix.trim()
-        : undefined;
+export const handler = Sentry.AWSLambda.wrapHandler(
+  async ({
+    fileName: fhirFileName,
+    patientId,
+    cxId,
+    dateFrom,
+    dateTo,
+    conversionType,
+    resultFileNameSuffix,
+  }: Input): Promise<Output> => {
+    const { log } = out(`cx ${cxId}, patient ${patientId}`);
+    const startedAt = Date.now();
+    const metrics: Metrics = {};
+    await cloudWatchUtils.reportMemoryUsage({ metricName: "memPreSetup" });
+    log(
+      `Running with conversionType: ${conversionType}, dateFrom: ${dateFrom}, ` +
+        `dateTo: ${dateTo}, fileName: ${fhirFileName}, bucket: ${bucketName}}`
+    );
+    try {
+      const cxsWithADHDFeatureFlagValue = await getCxsWithADHDFeatureFlagValue();
+      const isADHDFeatureFlagEnabled = cxsWithADHDFeatureFlagValue.includes(cxId);
+      const cxsWithNoMrLogoFeatureFlagValue = await getCxsWithNoMrLogoFeatureFlagValue();
+      const isLogoEnabled = !cxsWithNoMrLogoFeatureFlagValue.includes(cxId);
+      const cxsWithBmiFeatureFlagValue = await getCxsWithBmiFeatureFlagValue();
+      const isBmiFeatureFlagEnabled = cxsWithBmiFeatureFlagValue.includes(cxId);
+      const cxsWithDermFeatureFlagValue = await getCxsWithDermFeatureFlagValue();
+      const isDermFeatureFlagEnabled = cxsWithDermFeatureFlagValue.includes(cxId);
+      const fileNameSuffix =
+        resultFileNameSuffix && resultFileNameSuffix.trim().length > 0
+          ? resultFileNameSuffix.trim()
+          : undefined;
 
-    const bundle = await getBundleFromS3(fhirFileName);
+      const bundle = await getBundleFromS3(fhirFileName);
 
-    const aiBriefContent = getAiBriefContentFromBundle(bundle);
-    const aiBrief = convertStringToBrief({ aiBrief: aiBriefContent, dashUrl });
-    metrics.setup = {
-      duration: Date.now() - startedAt,
-      timestamp: new Date(),
-    };
-    await cloudWatchUtils.reportMemoryUsage({ metricName: "memPostSetup" });
+      const aiBriefContent = getAiBriefContentFromBundle(bundle);
+      const aiBrief = convertStringToBrief({ aiBrief: aiBriefContent, dashUrl });
+      metrics.setup = {
+        duration: Date.now() - startedAt,
+        timestamp: new Date(),
+      };
+      await cloudWatchUtils.reportMemoryUsage({ metricName: "memPostSetup" });
 
-    const htmlStartedAt = Date.now();
-    const html = isADHDFeatureFlagEnabled
-      ? bundleToHtmlADHD(bundle, aiBrief)
-      : isBmiFeatureFlagEnabled
-      ? bundleToHtmlBmi(bundle, aiBrief)
-      : isDermFeatureFlagEnabled
-      ? bundleToHtmlDerm(bundle, aiBrief)
-      : bundleToHtml(bundle, aiBrief, isLogoEnabled);
-    await cloudWatchUtils.reportMemoryUsage({ metricName: "memPostHtml" });
-    metrics.htmlConversion = {
-      duration: Date.now() - htmlStartedAt,
-      timestamp: new Date(),
-    };
+      const htmlStartedAt = Date.now();
+      const html = isADHDFeatureFlagEnabled
+        ? bundleToHtmlADHD(bundle, aiBrief)
+        : isBmiFeatureFlagEnabled
+        ? bundleToHtmlBmi(bundle, aiBrief)
+        : isDermFeatureFlagEnabled
+        ? bundleToHtmlDerm(bundle, aiBrief)
+        : bundleToHtml(bundle, aiBrief, isLogoEnabled);
+      await cloudWatchUtils.reportMemoryUsage({ metricName: "memPostHtml" });
+      metrics.htmlConversion = {
+        duration: Date.now() - htmlStartedAt,
+        timestamp: new Date(),
+      };
 
-    const hasContents = doesMrSummaryHaveContents(html);
-    log(`MR Summary has contents: ${hasContents}`);
-    const tmpHtmlFileName = createMRSummaryFileName(cxId, patientId, "html");
-    const htmlFileName = fileNameSuffix
-      ? `${tmpHtmlFileName}${fileNameSuffix}.html`
-      : tmpHtmlFileName;
+      const hasContents = doesMrSummaryHaveContents(html);
+      log(`MR Summary has contents: ${hasContents}`);
+      const tmpHtmlFileName = createMRSummaryFileName(cxId, patientId, "html");
+      const htmlFileName = fileNameSuffix
+        ? `${tmpHtmlFileName}${fileNameSuffix}.html`
+        : tmpHtmlFileName;
 
-    // TODO 1672 rename it w/o brief
-    const mrS3Info = await storeMrSummaryAndBriefInS3({
-      bucketName,
-      htmlFileName,
-      html,
-      log,
-    });
-
-    const getSignedUrlPromise = async () => {
-      if (conversionType === "pdf") {
-        const tmpPdfFileName = createMRSummaryFileName(cxId, patientId, "pdf");
-        const pdfFileName = fileNameSuffix
-          ? `${tmpPdfFileName}${fileNameSuffix}.pdf`
-          : tmpPdfFileName;
-        await convertAndStorePdf({
-          fileName: pdfFileName,
-          html,
-          bucketName,
-          metrics,
-        });
-        return await getSignedUrl(pdfFileName);
-      }
-      return await getSignedUrl(htmlFileName);
-    };
-
-    const createFeedbackForBriefPromise = async () => {
-      await createFeedbackForBrief({
-        cxId,
-        patientId,
-        aiBrief,
-        mrVersion: mrS3Info.version,
-        mrLocation: mrS3Info.location,
+      // TODO 1672 rename it w/o brief
+      const mrS3Info = await storeMrSummaryAndBriefInS3({
+        bucketName,
+        htmlFileName,
+        html,
+        log,
       });
-    };
 
-    const [urlResp] = await Promise.allSettled([
-      getSignedUrlPromise(),
-      createFeedbackForBriefPromise(),
-    ]);
-    if (urlResp.status === "rejected") throw new Error(urlResp.reason);
-    const url = urlResp.value;
+      const getSignedUrlPromise = async () => {
+        if (conversionType === "pdf") {
+          const tmpPdfFileName = createMRSummaryFileName(cxId, patientId, "pdf");
+          const pdfFileName = fileNameSuffix
+            ? `${tmpPdfFileName}${fileNameSuffix}.pdf`
+            : tmpPdfFileName;
+          await convertAndStorePdf({
+            fileName: pdfFileName,
+            html,
+            bucketName,
+            metrics,
+          });
+          return await getSignedUrl(pdfFileName);
+        }
+        return await getSignedUrl(htmlFileName);
+      };
 
-    metrics.total = {
-      duration: Date.now() - startedAt,
-      timestamp: new Date(),
-    };
-    await cloudWatchUtils.reportMetrics(metrics);
+      const createFeedbackForBriefPromise = async () => {
+        await createFeedbackForBrief({
+          cxId,
+          patientId,
+          aiBrief,
+          mrVersion: mrS3Info.version,
+          mrLocation: mrS3Info.location,
+        });
+      };
 
-    return { url, hasContents };
-  } catch (error) {
-    const msg = `Error converting FHIR to MR Summary`;
-    log(`${msg} - error: ${errorToString(error)}`);
-    capture.error(msg, {
-      extra: {
+      const [urlResp] = await Promise.allSettled([
+        getSignedUrlPromise(),
+        createFeedbackForBriefPromise(),
+      ]);
+      if (urlResp.status === "rejected") throw new Error(urlResp.reason);
+      const url = urlResp.value;
+
+      metrics.total = {
+        duration: Date.now() - startedAt,
+        timestamp: new Date(),
+      };
+      await cloudWatchUtils.reportMetrics(metrics);
+
+      return { url, hasContents };
+    } catch (error) {
+      const msg = `Error converting FHIR to MR Summary`;
+      log(`${msg} - error: ${errorToString(error)}`);
+      capture.setExtra({
         patientId,
         dateFrom,
         dateTo,
         conversionType,
         context: lambdaName,
         error,
-      },
-    });
-    throw error;
+      });
+      throw new MetriportError(msg, error);
+    }
   }
-}
+);
 
 async function getSignedUrl(fileName: string) {
   return coreGetSignedUrl({ fileName, bucketName, awsRegion: region });
@@ -380,11 +381,10 @@ async function createFeedbackForBrief({
     const extra = { cxId, patientId, aiBriefId: aiBrief.id };
     const { log } = out("createFeedbackForBrief");
     log(`${msg} - error: ${errorToString(error)}, extra: ${JSON.stringify(extra)}`);
-    capture.error(msg, {
-      extra: {
-        ...extra,
-        error,
-      },
+    capture.setExtra({
+      ...extra,
+      error,
     });
+    throw new MetriportError(msg, error);
   }
 }

--- a/packages/lambdas/src/ihe-gateway-v2-inbound-patient-discovery.ts
+++ b/packages/lambdas/src/ihe-gateway-v2-inbound-patient-discovery.ts
@@ -1,17 +1,18 @@
-import { APIGatewayProxyEventV2 } from "aws-lambda";
+import { analyticsAsync, EventTypes } from "@metriport/core/external/analytics/posthog";
+import { getSecretValue } from "@metriport/core/external/aws/secret-manager";
+import { createInboundXcpdResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/inbound/xcpd/create/xcpd-response";
+import { processInboundXcpdRequest } from "@metriport/core/external/carequality/ihe-gateway-v2/inbound/xcpd/process/xcpd-request";
+import { processInboundXcpd } from "@metriport/core/external/carequality/pd/process-inbound-pd";
+import { InboundMpiMetriportApi } from "@metriport/core/mpi/inbound-patient-mpi-metriport-api";
+import { getEnvVar, getEnvVarOrFail } from "@metriport/core/util/env-var";
+import { out } from "@metriport/core/util/log";
 import {
   InboundPatientDiscoveryReq,
   InboundPatientDiscoveryResp,
 } from "@metriport/ihe-gateway-sdk";
 import { errorToString } from "@metriport/shared";
-import { processInboundXcpdRequest } from "@metriport/core/external/carequality/ihe-gateway-v2/inbound/xcpd/process/xcpd-request";
-import { processInboundXcpd } from "@metriport/core/external/carequality/pd/process-inbound-pd";
-import { createInboundXcpdResponse } from "@metriport/core/external/carequality/ihe-gateway-v2/inbound/xcpd/create/xcpd-response";
-import { InboundMpiMetriportApi } from "@metriport/core/mpi/inbound-patient-mpi-metriport-api";
-import { getEnvVarOrFail, getEnvVar } from "@metriport/core/util/env-var";
-import { getSecretValue } from "@metriport/core/external/aws/secret-manager";
-import { analyticsAsync, EventTypes } from "@metriport/core/external/analytics/posthog";
-import { out } from "@metriport/core/util/log";
+import * as Sentry from "@sentry/serverless";
+import { APIGatewayProxyEventV2 } from "aws-lambda";
 import { getEnvOrFail } from "./shared/env";
 
 const apiUrl = getEnvVarOrFail("API_URL");
@@ -23,7 +24,7 @@ const lambdaName = getEnvOrFail("AWS_LAMBDA_FUNCTION_NAME");
 const mpi = new InboundMpiMetriportApi(apiUrl);
 const { log } = out(`ihe-gateway-v2-inbound-patient-discovery`);
 
-export async function handler(event: APIGatewayProxyEventV2) {
+export const handler = Sentry.AWSLambda.wrapHandler(async (event: APIGatewayProxyEventV2) => {
   try {
     if (!event.body) return buildResponse(400, { message: "The request body is empty" });
 
@@ -67,7 +68,7 @@ export async function handler(event: APIGatewayProxyEventV2) {
     log(`${msg}: ${errorToString(error)}`);
     return buildResponse(500, "Internal Server Error");
   }
-}
+});
 
 function buildResponse(status: number, body: unknown) {
   return {

--- a/packages/lambdas/src/patient-import-query.ts
+++ b/packages/lambdas/src/patient-import-query.ts
@@ -1,6 +1,7 @@
 import { ProcessPatientQueryRequest } from "@metriport/core/command/patient-import/steps/query/patient-import-query";
 import { PatientImportQueryHandlerLocal } from "@metriport/core/command/patient-import/steps/query/patient-import-query-local";
 import { errorToString, MetriportError } from "@metriport/shared";
+import * as Sentry from "@sentry/serverless";
 import { SQSEvent } from "aws-lambda";
 import { capture } from "./shared/capture";
 import { getEnvOrFail } from "./shared/env";
@@ -24,7 +25,7 @@ const waitTimeInMillisRaw = getEnvOrFail("WAIT_TIME_IN_MILLIS");
 const waitTimeInMillis = parseInt(waitTimeInMillisRaw);
 
 // Don't use Sentry's default error handler b/c we want to use our own and send more context-aware data
-export async function handler(event: SQSEvent) {
+export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent) => {
   let errorHandled = false;
   const errorMsg = "Error processing event on " + lambdaName;
   const startedAt = new Date().getTime();
@@ -71,20 +72,24 @@ export async function handler(event: SQSEvent) {
     } catch (error) {
       errorHandled = true;
       console.log(`${errorMsg}: ${errorToString(error)}`);
-      capture.error(errorMsg, {
-        extra: { event, context: lambdaName, error },
+      capture.setExtra({
+        event,
+        context: lambdaName,
+        error,
       });
       throw new MetriportError(errorMsg, error, { ...parsedBody });
     }
   } catch (error) {
     if (errorHandled) throw error;
     console.log(`${errorMsg}: ${errorToString(error)}`);
-    capture.error(errorMsg, {
-      extra: { event, context: lambdaName, error },
+    capture.setExtra({
+      event,
+      context: lambdaName,
+      error,
     });
     throw new MetriportError(errorMsg, error);
   }
-}
+});
 
 function parseBody(body?: unknown): ProcessPatientQueryRequest {
   if (!body) throw new Error(`Missing message body`);


### PR DESCRIPTION
refs. metriport/metriport-internal#2720

### Dependencies

None

### Description
**Problem**
Lambdas will spin up, and stay live for a few minutes, handling many requests if needed before shutting down. This is why we generally want to set up e.g. db connections and other clients outside of the handler.

This also means that unless instrumented to do otherwise, Sentry will lump all the logs coming from a single lambda into one trace, so you can end up with logs from different executions of the lambda intertwined.

Here is an example of the document query lambda with intertwined logs. You can see multiple 200s and 500s in the log output: [DQ example](https://metriport-inc.sentry.io/issues/5504414208/events/4473abe626c54beb95949b432761a017/?environment=production&project=4505252341153792&query=&referrer=next-event)

**The Fix**
This PR wraps each lambda handler invocation in its own Sentry scope, fixing this problem. Ideally we'd call `Sentry.AWSLambda.wrapHandler` because it does the same thing, but it also retriggers sentry alerts that we're logging with capture.error() calls (see [here](https://github.com/metriport/metriport/blob/ebcf17cfa701833e6343227ae3cbc0489cc54ba5/packages/lambdas/src/cw-doc-contribution.ts#L70)). I'm pretty sure we should just be able to call capture.setExtra() and then rethrow the error, but as of now it's really tricky to test changes to lambda infra so I'm going with the safe change.

Unscoped lambdas
```
document-uploader.ts
fhir-to-bundle.ts
fhir-to-medical-record.ts
fhir-to-medical-record2.ts
ihe-gateway-v2-inbound-document-query.ts
ihe-gateway-v2-inbound-document-retrieval.ts
ihe-gateway-v2-inbound-patient-discovery.ts
patient-import-create.ts
patient-import-parse.ts
patient-import-query.ts
patient-import-upload-notification.ts
sqs-to-converter.ts
sqs-to-opensearch-xml.ts
```

### Testing

- ✅ Verify locally using `sam local` sending messages to staging that the Additional Information section remains the same.
https://metriport-inc.sentry.io/issues/6322359880/?project=4505252341153792&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=0
- Watch production instances of [HTTP/SSL Failure Sending Signed DQ SAML Request 2](https://metriport-inc.sentry.io/issues/5504414208/?referrer=slack&notification_uuid=399cd910-b73d-40b3-b298-68c5df29ef62&environment=production&alert_rule_id=14442454&alert_type=issue) and similar and see if its a single log in each.

### Release
- [ ] Merge this