### PR TITLE
Reintroduce "Add URL expiration time to docs"

### DIFF
--- a/docs/medical-api/api-reference/document/get-document.mdx
+++ b/docs/medical-api/api-reference/document/get-document.mdx
@@ -33,7 +33,7 @@ A JSON object containing the URL will be returned.
 <Tip>
   For patients with a large volume of documents, you can use the
   [Bulk Get Document URL endpoint](/medical-api/api-reference/document/download-url-bulk)
-  to get all download URLs, instead of doing it one at a time.
+  to get all download URLs instead of doing it one at a time.
 </Tip>
 
 <ResponseExample>

--- a/docs/medical-api/api-reference/document/get-document.mdx
+++ b/docs/medical-api/api-reference/document/get-document.mdx
@@ -4,7 +4,9 @@ description: "Gets a downloadable URL for downloading the specified document."
 api: "GET /medical/v1/document/download-url"
 ---
 
-This endpoint returns a URL which you can use to download the specified document and/or convert using the file name provided from the [List Documents endpoint](/medical-api/api-reference/document/list-documents), or from the `meta.source` field of the FHIR resource you are interested in.
+This endpoint returns a URL which you can use to download the specified document and/or convert
+using the file name provided from the [List Documents endpoint](/medical-api/api-reference/document/list-documents),
+or from the `meta.source` field of the FHIR resource you are interested in.
 
 <Info>The URL will only be valid for 60 seconds before you need to request a new one.</Info>
 
@@ -29,7 +31,9 @@ A JSON object containing the URL will be returned.
 </ResponseField>
 
 <Tip>
-  For patients with a large volume documents, you can use the [Bulk Get Document URL](/medical-api/api-reference/document/download-url-bulk to get all download URLs, instead of doing it one at a time.
+  For patients with a large volume of documents, you can use the
+  [Bulk Get Document URL endpoint](/medical-api/api-reference/document/download-url-bulk)
+  to get all download URLs, instead of doing it one at a time.
 </Tip>
 
 <ResponseExample>

--- a/docs/medical-api/handling-data/webhooks.mdx
+++ b/docs/medical-api/handling-data/webhooks.mdx
@@ -388,7 +388,15 @@ being the main difference between each:
 - `completed`: the bulk create is completed;
 - `failed`: the bulk create failed (likely due to an uploaded file with invalid format).
 
-Here is an example payload:
+<Info>
+  If the Medical Record doesn't contain any information, the
+  `Bundle` will be empty (the `entry` array will have no
+  elements).
+</Info>
+
+<Info>The URL will only be valid for 180 seconds (3 minutes).</Info>
+
+Example payload:
 
 ```json
 {
@@ -476,6 +484,8 @@ An example of a result file can be accessed
 
 If you want to download all of a patient's documents, especially when they have a large volume of documents, you can start a [Bulk Get Document URL query](/medical-api/api-reference/document/download-url-bulk). We’ll send a webhook message with all the downloadable URLs for all the patient's documents.
 You can use the value of the `url` property in the returned `documents` objects to download the files.
+
+<Info>The URLs will only be valid for 600 seconds (10 minutes).</Info>
 
 Here is an example payload:
 


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3194
- Downstream: none

### Description

This reintroduces https://github.com/metriport/metriport/pull/3194, which was rolled-back as part of the patch https://github.com/metriport/metriport/pull/3368.

### Testing

See https://github.com/metriport/metriport/pull/3194

### Release Plan

- [ ] Merge this
