### PR TITLE
fix(infra): adding secret read access to lambdas

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -564,6 +564,7 @@ export class APIStack extends Stack {
       stack: this,
       lambdaLayers,
       vpc: this.vpc,
+      secrets,
       sourceQueue: fhirConverterQueue,
       dlq: fhirConverterDLQ,
       fhirConverterBucket,

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -135,6 +135,7 @@ export class LambdasNestedStack extends NestedStack {
       bundleBucket: props.medicalDocumentsBucket,
       conversionsBucket: this.fhirConverterConnector.bucket,
       envType: props.config.environmentType,
+      secrets: props.secrets,
       sentryDsn: props.config.lambdasSentryDSN,
       alarmAction: props.alarmAction,
       appId: props.appConfigEnvVars.appId,
@@ -435,6 +436,7 @@ export class LambdasNestedStack extends NestedStack {
     conversionsBucket,
     sentryDsn,
     envType,
+    secrets,
     alarmAction,
     appId,
     configId,
@@ -447,6 +449,7 @@ export class LambdasNestedStack extends NestedStack {
     bundleBucket: s3.IBucket;
     conversionsBucket: s3.IBucket;
     envType: EnvType;
+    secrets: Secrets;
     sentryDsn: string | undefined;
     alarmAction: SnsAction | undefined;
     appId: string;
@@ -491,6 +494,9 @@ export class LambdasNestedStack extends NestedStack {
 
     bundleBucket.grantReadWrite(fhirToBundleLambda);
     conversionsBucket.grantRead(fhirToBundleLambda);
+    if (posthogSecretName) {
+      secrets[posthogSecretName]?.grantRead(fhirToBundleLambda);
+    }
 
     AppConfigUtils.allowReadConfig({
       scope: this,


### PR DESCRIPTION
refs. metriport/metriport-internal#2600

### Description

- Read access to secrets for the lambdas that need it

### Testing

- Staging
  - [ ] Make sure the whole Data Pipeline completes and the analytics are reported to Posthog
- Production
  - [ ] Make sure the whole Data Pipeline completes and the analytics are reported to Posthog

### Release Plan

- [ ] Merge this
