### PR TITLE
fix(infra): Posthog secrets permitted on lambdas

### DIFF
--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -143,7 +143,7 @@ export function createLambda({
     maxConcurrency,
     axiosTimeout,
   } = settings();
-  const posthogSecretKeyName = config.analyticsSecretNames?.POST_HOG_API_KEY_SECRET;
+  const posthogSecretName = config.analyticsSecretNames?.POST_HOG_API_KEY_SECRET;
 
   const conversionLambda = defaultCreateLambda({
     stack,
@@ -166,8 +166,8 @@ export function createLambda({
       CONVERSION_RESULT_BUCKET_NAME: fhirConverterBucket.bucketName,
       APPCONFIG_APPLICATION_ID: appConfigEnvVars.appId,
       APPCONFIG_CONFIGURATION_ID: appConfigEnvVars.configId,
-      ...(posthogSecretKeyName && {
-        POST_HOG_API_KEY_SECRET: posthogSecretKeyName,
+      ...(posthogSecretName && {
+        POST_HOG_API_KEY_SECRET: posthogSecretName,
       }),
     },
     timeout: lambdaTimeout,
@@ -176,8 +176,8 @@ export function createLambda({
 
   fhirConverterBucket.grantReadWrite(conversionLambda);
   medicalDocumentsBucket.grantReadWrite(conversionLambda);
-  if (posthogSecretKeyName) {
-    secrets[posthogSecretKeyName]?.grantRead(conversionLambda);
+  if (posthogSecretName) {
+    secrets[posthogSecretName]?.grantRead(conversionLambda);
   }
 
   conversionLambda.addEventSource(

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -492,18 +492,19 @@ export class LambdasNestedStack extends NestedStack {
       alarmSnsAction: alarmAction,
     });
 
-    bundleBucket.grantReadWrite(fhirToBundleLambda);
-    conversionsBucket.grantRead(fhirToBundleLambda);
-    if (posthogSecretName) {
-      secrets[posthogSecretName]?.grantRead(fhirToBundleLambda);
-    }
-
     AppConfigUtils.allowReadConfig({
       scope: this,
       resourceName: "FhirToBundleLambda",
       resourceRole: fhirToBundleLambda.role,
       appConfigResources: ["*"],
     });
+
+    bundleBucket.grantReadWrite(fhirToBundleLambda);
+    conversionsBucket.grantRead(fhirToBundleLambda);
+
+    if (posthogSecretName) {
+      secrets[posthogSecretName]?.grantRead(fhirToBundleLambda);
+    }
 
     const bedrockPolicyStatement = new iam.PolicyStatement({
       actions: ["bedrock:InvokeModel"],


### PR DESCRIPTION
refs. metriport/metriport-internal#2600

### Description
- Placing Config read permission prior to actually accessing it

### Testing
- Staging
  - [ ] Check this fixes the issue in staging
- Production
  - [ ] Make sure things work in prod

### Release Plan

- [ ] Merge this
