### PR TITLE
feat(ehr): patch athena no sub

### DIFF
--- a/packages/core/src/external/athenahealth/index.ts
+++ b/packages/core/src/external/athenahealth/index.ts
@@ -753,7 +753,11 @@ class AthenaHealthApi {
       return bookedAppointments.map(a => bookedAppointmentSchema.parse(a));
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
-      if (error.response?.status === 403) {
+      if (
+        error.message?.includes(
+          "Changed messages require setup (subscription) that has not been done."
+        )
+      ) {
         // 403 indicates no existing subscription so we create one
         log(`Subscribing to appointment event for cxId ${cxId}`);
         await this.subscribeToEvent({


### PR DESCRIPTION
Ref: #1040

### Description

- hooking into message not status code as handler converts to metriport error

### Testing

- Local
  - [x] delete our own sub and re-subscribed with new code, worked 👍 
- Staging
  - [ ] N/A
- Sandbox
  - [ ] N/A
- Production
  - [ ] CX unblocked

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
