### PR TITLE
1040 Send notif to security channel about MAPI access

### DIFF
--- a/packages/api/src/command/medical/mapi-access.ts
+++ b/packages/api/src/command/medical/mapi-access.ts
@@ -1,10 +1,19 @@
+import { sendSecurityNotification } from "@metriport/core/external/slack/index";
+import { emptyFunction } from "@metriport/shared";
 import NotFoundError from "../../errors/not-found";
 import { MAPIAccess } from "../../models/medical/mapi-access";
 
 export async function allowMapiAccess(cxId: string): Promise<"new" | "existing"> {
   const existing = await MAPIAccess.findByPk(cxId);
   if (existing) return "existing";
+
   await MAPIAccess.create({ id: cxId });
+
+  // intentionally async
+  sendSecurityNotification({ subject: `🔑 MAPI access granted to customer: ${cxId}` }).catch(
+    emptyFunction
+  );
+
   return "new";
 }
 

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -41,6 +41,9 @@ export class Config {
   static getSlackSensitiveDataChannelUrl(): string | undefined {
     return getEnvVar("SLACK_SENSITIVE_DATA_URL");
   }
+  static getSlackSecurityNotificationUrl(): string | undefined {
+    return getEnvVar("SLACK_SECURITY_NOTIFICATION_URL");
+  }
 
   static getAWSRegion(): string {
     return getEnvVarOrFail("AWS_REGION");

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -212,6 +212,7 @@ type EnvConfigBase = {
   slack?: {
     SLACK_ALERT_URL?: string;
     SLACK_NOTIFICATION_URL?: string;
+    SLACK_SECURITY_NOTIFICATION_URL?: string;
     SLACK_SENSITIVE_DATA_URL?: string;
     workspaceId: string;
     alertsChannelId: string;


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Send notification to security channel about MAPI access.

### Testing

...WIP

- Local
  - [ ] _[Indicate how you tested this, on local or staging]_
  - [ ] ...
- Staging
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Sandbox
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Production
  - [ ] _testing step 1_
  - [ ] _testing step 2_

_[Release PRs:]_

Check each PR.

### Release Plan

_[How does the changes on this PR impact/interact with the existing environment (database, configs, secrets, FFs, api contracts, etc.)?
Consider creating 2+ PRs if we need to ship those changes in a staged way]_

_[This is the release plan for production]_

_[You should execute the exact same steps when releasing to staging to validate it works]_

_[Add and remove items below accordingly]_

- :warning: Points to `master`
- :warning: This contains a DB migration
- [ ] Maintenance window scheduled/created at Checkly (if needed)
- [ ] Execute this on <env1>, <env2>
  - [ ] _step1_
  - [ ] _step2_
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (deprecates a feature that needs to be communicated with customers)
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (introduce a feature that would be useful customers)
- [ ] Upstream dependencies are met/released
- [ ] Release NPM packages
- [ ] Fern Definition Updated
- [ ] Release Fern SDKs
- [ ] FFs have been set in Staging, Production, and Sandbox
- [ ] No dependencies between API and Infra that will cause errors during deployment
- [ ] _[action n-1]_
- [ ] _[action n]_
- [ ] Merge this
