### PR TITLE
fix(core): fix for mimetype detection on b64 attachemnts

### DIFF
--- a/packages/core/src/fhir-to-cda/cda-types/shared-types.ts
+++ b/packages/core/src/fhir-to-cda/cda-types/shared-types.ts
@@ -153,6 +153,7 @@ export type CdaValueEd = {
   reference?: {
     _value: string;
   };
+  "#text"?: string;
 };
 
 // Cd (CD) stands for Concept Descriptor


### PR DESCRIPTION
refs. metriport/metriport-internal#2683

### Description
- Fixing mimetype detection

### Testing

- Local
  - [x] Ran on b64-containing files to make sure the extension is identified correctly
    - [x] txt/rtf
    - [x] application/pdf
- Production
  - [ ] _testing step 1_
  - [ ] _testing step 2_

### Release Plan
- [ ] Merge this
