### PR TITLE
1040 add country normalization

### DIFF
--- a/packages/api/src/domain/medical/patient-demographics.ts
+++ b/packages/api/src/domain/medical/patient-demographics.ts
@@ -295,7 +295,7 @@ export function normalizeAddress({
     city: city?.trim().toLowerCase() ?? "",
     state: normalizeUSStateForAddressSafe(state ?? "")?.toLowerCase() ?? "",
     zip: normalizeZipCodeNewSafe(zip ?? "") ?? "",
-    country: normalizeCountrySafe(country ?? "") ?? normalizedCountryUsa,
+    country: normalizeCountrySafe(country ?? "") ?? normalizedCountryUsa.toLowerCase(),
   };
 }
 

--- a/packages/api/src/domain/medical/patient-demographics.ts
+++ b/packages/api/src/domain/medical/patient-demographics.ts
@@ -295,7 +295,7 @@ export function normalizeAddress({
     city: city?.trim().toLowerCase() ?? "",
     state: normalizeUSStateForAddressSafe(state ?? "")?.toLowerCase() ?? "",
     zip: normalizeZipCodeNewSafe(zip ?? "") ?? "",
-    country: normalizeCountrySafe(country ?? "") ?? normalizedCountryUsa.toLowerCase(),
+    country: (normalizeCountrySafe(country ?? "") ?? normalizedCountryUsa).toLowerCase(),
   };
 }
 

--- a/packages/api/src/domain/medical/patient-demographics.ts
+++ b/packages/api/src/domain/medical/patient-demographics.ts
@@ -20,6 +20,8 @@ import {
   normalizePhoneNumberSafe,
   normalizeUSStateForAddressSafe,
   normalizeZipCodeNewSafe,
+  normalizeCountrySafe,
+  normalizedCountryUsa,
   USState,
 } from "@metriport/shared";
 import { normalizeSsn as normalizeSsnFromShared } from "@metriport/shared/domain/patient/ssn";
@@ -293,14 +295,7 @@ export function normalizeAddress({
     city: city?.trim().toLowerCase() ?? "",
     state: normalizeUSStateForAddressSafe(state ?? "")?.toLowerCase() ?? "",
     zip: normalizeZipCodeNewSafe(zip ?? "") ?? "",
-    country:
-      country
-        ?.trim()
-        .toLowerCase()
-        .replaceAll("us", "usa")
-        .replaceAll("united states", "usa")
-        .replaceAll("united", "usa")
-        .slice(0, 3) ?? "usa",
+    country: normalizeCountrySafe(country ?? "") ?? normalizedCountryUsa,
   };
 }
 

--- a/packages/api/src/external/ehr/shared-fhir.ts
+++ b/packages/api/src/external/ehr/shared-fhir.ts
@@ -10,6 +10,7 @@ import {
   normalizePhoneNumberSafe,
   normalizeUSStateForAddressSafe,
   normalizeZipCodeNewSafe,
+  normalizeCountrySafe,
   toTitleCase,
 } from "@metriport/shared";
 import { Patient } from "@metriport/shared/interface/external/shared/ehr/patient";
@@ -45,8 +46,8 @@ export function createAddressesFromFhir(patient: Patient): Address[] {
     const city = address.city.trim();
     if (city === "") return [];
     if (!address.country) return [];
-    const country = address.country.trim();
-    if (country === "") return [];
+    const country = normalizeCountrySafe(address.country);
+    if (!country) return [];
     if (!address.state) return [];
     const state = normalizeUSStateForAddressSafe(address.state);
     if (!state) return [];

--- a/packages/api/src/external/ehr/shared-fhir.ts
+++ b/packages/api/src/external/ehr/shared-fhir.ts
@@ -11,6 +11,7 @@ import {
   normalizeUSStateForAddressSafe,
   normalizeZipCodeNewSafe,
   normalizeCountrySafe,
+  normalizedCountryUsa,
   toTitleCase,
 } from "@metriport/shared";
 import { Patient } from "@metriport/shared/interface/external/shared/ehr/patient";
@@ -46,8 +47,7 @@ export function createAddressesFromFhir(patient: Patient): Address[] {
     const city = address.city.trim();
     if (city === "") return [];
     if (!address.country) return [];
-    const country = normalizeCountrySafe(address.country);
-    if (!country) return [];
+    const country = normalizeCountrySafe(address.country) ?? normalizedCountryUsa;
     if (!address.state) return [];
     const state = normalizeUSStateForAddressSafe(address.state);
     if (!state) return [];

--- a/packages/shared/src/common/string.ts
+++ b/packages/shared/src/common/string.ts
@@ -14,3 +14,7 @@ export function limitStringLength<T extends string | undefined>(
 export function stripNonNumericChars(str: string): string {
   return str.trim().replace(/\D/g, "");
 }
+
+export function stripPeriods(str: string): string {
+  return str.trim().replace(/\./g, "");
+}

--- a/packages/shared/src/domain/address/__tests__/country.test.ts
+++ b/packages/shared/src/domain/address/__tests__/country.test.ts
@@ -1,0 +1,54 @@
+import { normalizeCountrySafe, normalizedCountryUsa } from "../country";
+
+describe("country", () => {
+  describe("normalizeCountrySafe", () => {
+    it("should return undefined when it gets empty string", () => {
+      const input = "";
+      expect(normalizeCountrySafe(input)).toBeUndefined();
+    });
+
+    it("should return undefined when it gets space", () => {
+      const input = " ";
+      expect(normalizeCountrySafe(input)).toBeUndefined();
+    });
+
+    const countries = [
+      normalizedCountryUsa,
+      "US",
+      "U.S",
+      "U.S.",
+      "U.S.A",
+      "UNITED STATES",
+      "UNITED STATES OF AMERICA",
+    ];
+    for (const country of countries) {
+      it(`valid - ${country}`, () => {
+        const result = normalizeCountrySafe(country);
+        expect(result).toBe(normalizedCountryUsa);
+      });
+    }
+    for (const country of countries.map(c => c.toLowerCase())) {
+      it(`valid - ${country}`, () => {
+        const result = normalizeCountrySafe(country);
+        expect(result).toBe(normalizedCountryUsa);
+      });
+    }
+
+    it("should trim input prefix", () => {
+      const expectedOutput = normalizedCountryUsa;
+      const input = " " + expectedOutput;
+      expect(normalizeCountrySafe(input)).toBe(expectedOutput);
+    });
+
+    it("should trim input suffix", () => {
+      const expectedOutput = normalizedCountryUsa;
+      const input = expectedOutput + " ";
+      expect(normalizeCountrySafe(input)).toBe(expectedOutput);
+    });
+
+    it("should return undefined when it gets invalid country", () => {
+      const input = "germany";
+      expect(normalizeCountrySafe(input)).toBeUndefined();
+    });
+  });
+});

--- a/packages/shared/src/domain/address/country.ts
+++ b/packages/shared/src/domain/address/country.ts
@@ -1,0 +1,32 @@
+import { stripPeriods } from "../../common/string";
+import { BadRequestError } from "../../error/bad-request";
+
+const validCountryStrings = ["US", "USA", "UNITED STATES", "UNITED STATES OF AMERICA"];
+
+export const normalizedCountryUsa = "USA";
+
+function isValidCountry(country: string) {
+  if (!validCountryStrings.includes(country)) return false;
+  return true;
+}
+
+function noramlizeCountryBase(country: string): string {
+  return stripPeriods(country.trim().toUpperCase());
+}
+
+export function normalizeCountrySafe(
+  country: string,
+  normalizeBase: (country: string) => string = noramlizeCountryBase
+): string | undefined {
+  const baseCountry = normalizeBase(country);
+  if (!isValidCountry(baseCountry)) return undefined;
+  return normalizedCountryUsa;
+}
+
+export function normalizeCountry(country: string): string {
+  const countryOrUndefined = normalizeCountrySafe(country);
+  if (!countryOrUndefined) {
+    throw new BadRequestError("Invalid country", undefined, { country });
+  }
+  return countryOrUndefined;
+}

--- a/packages/shared/src/domain/address/country.ts
+++ b/packages/shared/src/domain/address/country.ts
@@ -10,13 +10,13 @@ function isValidCountry(country: string) {
   return true;
 }
 
-function noramlizeCountryBase(country: string): string {
+function normalizeCountryBase(country: string): string {
   return stripPeriods(country.trim().toUpperCase());
 }
 
 export function normalizeCountrySafe(
   country: string,
-  normalizeBase: (country: string) => string = noramlizeCountryBase
+  normalizeBase: (country: string) => string = normalizeCountryBase
 ): string | undefined {
   const baseCountry = normalizeBase(country);
   if (!isValidCountry(baseCountry)) return undefined;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,6 +16,7 @@ export { toTitleCase } from "./common/title-case";
 export { AtLeastOne, stringToBoolean } from "./common/types";
 export { validateNPI } from "./common/validate-npi";
 export * from "./domain/address/index";
+export * from "./domain/address/country";
 export * from "./domain/address/state";
 export * from "./domain/address/territory";
 export * from "./domain/address/zip";


### PR DESCRIPTION
Ticket: #1040

### Description

- adding country normalization for patient demographics and ehr parsing

### Testing

- Local
  - [x] unit tests
- Staging
   - [x] unit tests
- Sandbox
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Production
  - [ ] re-run patient that failed

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced address handling with consistent normalization of country data, ensuring reliable and uniform address information across the system.
	- Introduced a new function for stripping periods from strings to improve text cleanup routines.
	- Added functionality for validating and normalizing country names, specifically focusing on various representations of the United States.
	- Expanded module exports to include new country normalization functionalities.
- **Tests**
	- Added comprehensive validation tests for the new country normalization functionality to ensure accurate handling of various input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->