### PR TITLE
2759 gracefully destroy tcp conns

### DIFF
--- a/.github/workflows/_deploy-mllp-server.yml
+++ b/.github/workflows/_deploy-mllp-server.yml
@@ -1,4 +1,4 @@
-name: Reusable Deploy workflow for API
+name: Reusable Deploy workflow for MLLP Server
 
 on:
   workflow_call:

--- a/package-lock.json
+++ b/package-lock.json
@@ -27260,6 +27260,14 @@
         }
       }
     },
+    "node_modules/node-graceful-shutdown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/node-graceful-shutdown/-/node-graceful-shutdown-1.1.5.tgz",
+      "integrity": "sha512-tlz8XpPr+pqrEGWFNLtMwd0HdFsCAKp5NCmMvwcTZTA0hyrVd7gkKbivDcSM5uYB1331/cEjNTtmVtqKy8OSBw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/node-gyp": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
@@ -35449,7 +35457,8 @@
         "@metriport/shared": "file:packages/shared",
         "@sentry/cli": "^2.42.1",
         "dotenv": "^16.4.5",
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "node-graceful-shutdown": "^1.1.5"
       },
       "devDependencies": {
         "@sentry/node": "^9.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "packages/commonwell-cert-runner",
         "packages/commonwell-jwt-maker",
         "packages/carequality-cert-runner",
-        "packages/mllp-server",
         "packages/api",
+        "packages/mllp-server",
         "packages/infra",
         "packages/utils",
         "packages/tester-node"

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -33,7 +33,8 @@
     "@metriport/shared": "file:packages/shared",
     "@sentry/cli": "^2.42.1",
     "dotenv": "^16.4.5",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "node-graceful-shutdown": "^1.1.5"
   },
   "devDependencies": {
     "@sentry/node": "^9.1.0",

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -1,8 +1,9 @@
 import { Hl7Server } from "@medplum/hl7";
 import type { Logger } from "@metriport/core/util/log";
 import { out } from "@metriport/core/util/log";
-import * as dotenv from "dotenv";
 import * as Sentry from "@sentry/node";
+import * as dotenv from "dotenv";
+import { setGracefulShutdownHandler } from "./graceful-shutdown-handler";
 import { initSentry } from "./sentry";
 
 dotenv.config();
@@ -44,7 +45,13 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
 async function main() {
   const logger = out("MLLP Server");
   const server = await createHl7Server(logger);
+
   server.start(MLLP_DEFAULT_PORT);
+  if (!server.server) {
+    throw new Error("Error starting server");
+  }
+
+  setGracefulShutdownHandler(server.server);
 }
 
 main();

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -14,7 +14,8 @@ const MLLP_DEFAULT_PORT = 2575;
 
 async function createHl7Server(logger: Logger): Promise<Hl7Server> {
   const server = new Hl7Server(connection => {
-    logger.log("Connection received");
+    const clientId = `${connection.socket.remoteAddress}:${connection.socket.remotePort}`;
+    logger.log(`Connection received from ${clientId}`);
 
     connection.addEventListener("message", ({ message }) => {
       logger.log(
@@ -27,15 +28,15 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
 
     connection.addEventListener("error", error => {
       if (error instanceof Error) {
-        logger.log("Connection error:", error);
+        logger.log(`Connection error from ${clientId}:`, error);
         Sentry.captureException(error);
       } else {
-        logger.log("Connection terminated by client");
+        logger.log(`Connection terminated by client ${clientId}`);
       }
     });
 
     connection.addEventListener("close", () => {
-      logger.log("Connection closed");
+      logger.log(`Connection closed by ${clientId}`);
     });
   });
 
@@ -44,8 +45,9 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
 
 async function main() {
   const logger = out("MLLP Server");
-  const server = await createHl7Server(logger);
+  logger.log(`[bootup] Starting server on port ${MLLP_DEFAULT_PORT}`);
 
+  const server = await createHl7Server(logger);
   server.start(MLLP_DEFAULT_PORT);
   if (!server.server) {
     throw new Error("Error starting server");

--- a/packages/mllp-server/src/graceful-shutdown-handler.ts
+++ b/packages/mllp-server/src/graceful-shutdown-handler.ts
@@ -1,0 +1,98 @@
+import { Server, Socket } from "net";
+import { onShutdown } from "node-graceful-shutdown";
+
+interface GracefulShutdownOptions {
+  /**
+   * Force shutdown after timeout milliseconds
+   * @default 30000
+   */
+  timeout?: number;
+  onShutdown?: () => void;
+}
+
+interface ShutdownController {
+  getConnections: () => number;
+  isShuttingDown: () => boolean;
+}
+
+/**
+ * Adds graceful shutdown capability to a TCP server
+ * @param server - The TCP server instance
+ * @param options - Configuration options
+ * @returns Control methods for the shutdown process
+ */
+export function setGracefulShutdownHandler(
+  server: Server,
+  options: GracefulShutdownOptions = {}
+): ShutdownController {
+  // Default options
+  const config = {
+    timeout: options.timeout || 30000,
+    onShutdown:
+      options.onShutdown ||
+      function noop() {
+        return;
+      },
+  };
+
+  // Track all active connections
+  const connections = new Set<Socket>();
+  let isShuttingDown = false;
+
+  server.on("connection", (connection: Socket) => {
+    connections.add(connection);
+    connection.on("close", () => {
+      connections.delete(connection);
+    });
+
+    if (isShuttingDown) {
+      connection.end();
+    }
+  });
+
+  const createServerClosedPromise = (): Promise<void> => {
+    return new Promise<void>(resolve => {
+      server.close(() => resolve());
+    });
+  };
+
+  const waitForConnectionsToClose = async (timeout: number): Promise<void> => {
+    const waitUntil = Date.now() + timeout;
+    while (connections.size > 0 && Date.now() < waitUntil) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      console.log(`[shutdown] Waiting, ${connections.size} connections remain`);
+    }
+  };
+
+  const forceCloseRemainingConnections = (): void => {
+    if (connections.size > 0) {
+      console.log(`[shutdown] Forcing shutdown of ${connections.size} connections remain`);
+      for (const connection of connections) {
+        connection.destroy();
+      }
+    }
+  };
+
+  const handleOnShutdown = async (): Promise<void> => {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
+
+    console.log(`[shutdown] Graceful shutdown initiated, ${connections.size} connections open`);
+
+    const serverClosedPromise = createServerClosedPromise();
+    await waitForConnectionsToClose(config.timeout);
+    forceCloseRemainingConnections();
+
+    await serverClosedPromise;
+    await config.onShutdown();
+
+    console.log("[shutdown] Graceful shutdown completed");
+  };
+
+  onShutdown(handleOnShutdown);
+
+  return {
+    getConnections: () => connections.size,
+    isShuttingDown: () => isShuttingDown,
+  };
+}


### PR DESCRIPTION
Ticket: #2759

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3372

### Description

Sparked by @leite08 's comment [here](https://github.com/metriport/metriport/pull/3372#discussion_r1981631483) in upstream. Basically we don't want to turn off the thread and leave tcp conns hanging, could result in weird state.

Medplum's graceful shutdown uses an library designed for http connection shutdown, which doesn't work for mllp, so I took a similar lib and added this myself.

### Testing

I generated with claude and ran a test script that creates 120 'responsive' tcp conns and 80 'unresponsive' connections that need to be destroyed. Ran it against the MLLP server. Server shut down nicely. Feel free to skim logs here.

See gists of test output:
[TCP conn "client" output](https://gist.github.com/lucasdellabella/57e7f286e1e3387c959aa58c5781e73e)
[MLLP server output](https://gist.github.com/lucasdellabella/851aa4ef882e07b480ca0097173dffb6)

### Release Plan
- [ ] Merge this
