### PR TITLE
fix(workflows): just run generic ci and build commands in gh actions

### DIFF
--- a/.github/workflows/_deploy-hl7-notification-cdk.yml
+++ b/.github/workflows/_deploy-hl7-notification-cdk.yml
@@ -104,18 +104,12 @@ jobs:
       # INSTALL DEPENDENCIES
       - name: Install dependencies for relevant packages
         run: |
-          npm ci --ignore-scripts --no-fund --workspace=packages/shared \
-                                            --workspace=packages/core \
-                                            --workspace=packages/mllp-server \
-                                            --workspace=packages/infra
+          npm ci --ignore-scripts --no-fund
         working-directory: "metriport/"
 
       - name: Build relevant packages
         run: |
-          npm run build:cloud --workspace=packages/shared
-          npm run build:cloud --workspace=packages/core
-          npm run build:cloud --workspace=packages/mllp-server
-          npm run build:cloud --workspace=packages/infra
+          npm run build:cloud 
         working-directory: "metriport/"
 
       # TESTS


### PR DESCRIPTION
refs. metriport/metriport-internal#2706

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

None

### Description

CI runs for MLLP Server deployment are clogging due to trying to be clever and only install + build the "needed" deps. This just uses our standard install + build commands.

See CI run [here](https://github.com/metriport/metriport/actions/runs/13725013062/job/38390997276)

### Testing

Ran commands locally w/ out change, they fail.
Ran commands locally w/ change, they succeed.

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined dependency installation and build processes in the deployment workflow, resulting in a more efficient system. These updates enhance the overall performance and reliability of backend operations without altering any visible product features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->