### PR TITLE
fix(workflows): only use master branch when deploying to production for configs

### DIFF
--- a/.github/workflows/_deploy-cdk.yml
+++ b/.github/workflows/_deploy-cdk.yml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ inputs.is-branch-to-staging == false }}
         with:
           repository: metriport/metriport-internal
-          ref: ${{ (inputs.deploy_env == 'production' || inputs.deploy_env == 'sandbox') && 'master' || 'develop' }}
+          ref: ${{ ((inputs.deploy_env == 'production' || inputs.deploy_env == 'sandbox') && 'master') || 'develop' }}
           token: ${{ secrets.SERVICE_PAT }} # secret token from user 'metriport-service'
           path: metriport-internal
           sparse-checkout: |

--- a/.github/workflows/_deploy-hl7-notification-cdk.yml
+++ b/.github/workflows/_deploy-hl7-notification-cdk.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: metriport/metriport-internal
-          ref: ${{ (inputs.deploy_env == 'production') && 'master' || 'develop' }}
+          ref: ${{ ((inputs.deploy_env == 'production') && 'master') || 'develop' }}
           token: ${{ secrets.SERVICE_PAT }} # secret token from user 'metriport-service'
           path: metriport-internal
           sparse-checkout: |

--- a/.github/workflows/_deploy-hl7-notification-cdk.yml
+++ b/.github/workflows/_deploy-hl7-notification-cdk.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: metriport/metriport-internal
-          ref: ${{ 'master' || 'develop' }}
+          ref: ${{ (inputs.deploy_env == 'production') && 'master' || 'develop' }}
           token: ${{ secrets.SERVICE_PAT }} # secret token from user 'metriport-service'
           path: metriport-internal
           sparse-checkout: |


### PR DESCRIPTION
refs. metriport/metriport-internal#2706

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

- Downstream: https://github.com/metriport/metriport/pull/3372

### Description

Deployment of the MLLP server is failing on staging because CI is not checking out staging configs due to an error in the gha workflow. This PR fixes that.

### Testing

None, we test GHA workflows by running code through them.

This is visually verifiable.

### Release Plan
- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the deployment automation process to dynamically select the appropriate branch based on the environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->