### PR TITLE
fix(workflows): add prep-deploy lambda step

### DIFF
--- a/.github/workflows/_deploy-hl7-notification-cdk.yml
+++ b/.github/workflows/_deploy-hl7-notification-cdk.yml
@@ -107,6 +107,10 @@ jobs:
           npm ci --ignore-scripts --no-fund
         working-directory: "metriport/"
 
+      - name: Build lambdas shared layer
+        run: npm run prep-deploy
+        working-directory: "metriport/packages/lambdas/"
+
       - name: Build relevant packages
         run: |
           npm run build:cloud 


### PR DESCRIPTION
refs. metriport/metriport-internal#2706

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

- Downstream: https://github.com/metriport/metriport/pull/3372

### Description

Deployment of the MLLP server is failing on staging because lambdas are failing to build. This PR fixes that.

### Testing

None, we test GHA workflows by running code through them.

This is visually verifiable.

### Release Plan
- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the deployment pipeline by adding an extra preparatory stage, which enhances build reliability and contributes to a smoother service rollout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->