### PR TITLE
1040 Add Lucas to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Goncharo @leite08 @Orta21 @RamilGaripov @jonahkaye @thomasyopes
+* @Goncharo @leite08 @Orta21 @RamilGaripov @thomasyopes @lucasdellabella


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- related: https://github.com/metriport/metriport-internal/pull/2778

### Description

Add @lucasdellabella to codeowners 🎉 

### Testing

- [x] great contributions :)

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal team management assignments to support streamlined review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->