### PR TITLE
PATCH: Deceased status family 

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-adhd.ts
@@ -32,6 +32,7 @@ import {
   ISO_DATE,
   MISSING_DATE_KEY,
   MISSING_DATE_TEXT,
+  getDeceasedStatus,
 } from "./bundle-to-html-shared";
 
 const RX_NORM_CODE = "rxnorm";
@@ -2172,16 +2173,12 @@ function createFamilyHistorySection(familyMemberHistories: FamilyMemberHistory[]
             SNOMED_CODE,
           ]);
 
-          const deceasedFamilyMember = familyMemberHistory.condition?.find(condition => {
-            return condition.contributedToDeath === true;
-          });
-
           return `
             <tr>
               <td>${getValidCode(familyMemberHistory.relationship?.coding)[0]?.display ?? ""}</td>
               <td>${renderAdministrativeGender(familyMemberHistory) ?? ""}</td>
               <td>${renderFamilyHistoryConditions(familyMemberHistory)?.join(", ") ?? ""}</td>
-              <td>${deceasedFamilyMember ? "yes" : "no"}</td>
+              <td>${getDeceasedStatus(familyMemberHistory)}</td>
               <td>${code ?? ""}</td>
             </tr>
           `;

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-derm.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-derm.ts
@@ -33,6 +33,7 @@ import {
   ISO_DATE,
   MISSING_DATE_KEY,
   MISSING_DATE_TEXT,
+  getDeceasedStatus,
 } from "./bundle-to-html-shared";
 
 const RX_NORM_CODE = "rxnorm";
@@ -2081,16 +2082,12 @@ function createFamilyHistorySection(familyMemberHistories: FamilyMemberHistory[]
             SNOMED_CODE,
           ]);
 
-          const deceasedFamilyMember = familyMemberHistory.condition?.find(condition => {
-            return condition.contributedToDeath === true;
-          });
-
           return `
             <tr>
               <td>${getValidCode(familyMemberHistory.relationship?.coding)[0]?.display ?? ""}</td>
               <td>${renderAdministrativeGender(familyMemberHistory) ?? ""}</td>
               <td>${renderFamilyHistoryConditions(familyMemberHistory)?.join(", ") ?? ""}</td>
-              <td>${deceasedFamilyMember ? "yes" : "no"}</td>
+              <td>${getDeceasedStatus(familyMemberHistory)}</td>
               <td>${code ?? ""}</td>
             </tr>
           `;

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
@@ -137,16 +137,23 @@ export function createSection(title: string, tableContents: string, id?: string)
   `;
 }
 
-export const getDeceasedStatus = (familyMemberHistory: FamilyMemberHistory): string => {
-  const deceasedBoolean = familyMemberHistory.deceasedBoolean;
-  const conditionContributedToDeath = familyMemberHistory.condition?.find(condition => {
-    return condition.contributedToDeath;
-  });
+function asYesNo(value: boolean): "yes" | "no" {
+  return value ? ("yes" as const) : ("no" as const);
+}
 
+export const getDeceasedStatus = (familyMemberHistory: FamilyMemberHistory): "yes" | "no" | "" => {
+  const deceasedBoolean = familyMemberHistory.deceasedBoolean;
   if (deceasedBoolean !== undefined) {
-    return deceasedBoolean ? "yes" : "no";
-  } else if (conditionContributedToDeath?.contributedToDeath !== undefined) {
-    return conditionContributedToDeath?.contributedToDeath ? "yes" : "no";
+    return asYesNo(deceasedBoolean);
   }
+
+  const conditionContributedToDeath = familyMemberHistory.condition?.find(
+    condition => condition.contributedToDeath
+  );
+
+  if (conditionContributedToDeath?.contributedToDeath !== undefined) {
+    return asYesNo(conditionContributedToDeath.contributedToDeath);
+  }
+
   return "";
 };

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
@@ -139,14 +139,14 @@ export function createSection(title: string, tableContents: string, id?: string)
 
 export const getDeceasedStatus = (familyMemberHistory: FamilyMemberHistory): string => {
   const deceasedBoolean = familyMemberHistory.deceasedBoolean;
-  const contributedToDeath = familyMemberHistory.condition?.find(condition => {
+  const conditionContributedToDeath = familyMemberHistory.condition?.find(condition => {
     return condition.contributedToDeath;
   });
 
   if (deceasedBoolean !== undefined) {
     return deceasedBoolean ? "yes" : "no";
-  } else if (contributedToDeath !== undefined) {
-    return contributedToDeath ? "yes" : "no";
+  } else if (conditionContributedToDeath?.contributedToDeath !== undefined) {
+    return conditionContributedToDeath?.contributedToDeath ? "yes" : "no";
   }
   return "";
 };

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
@@ -1,4 +1,4 @@
-import { DiagnosticReport } from "@medplum/fhirtypes";
+import { DiagnosticReport, FamilyMemberHistory } from "@medplum/fhirtypes";
 import dayjs from "dayjs";
 import { Brief } from "../../../command/ai-brief/brief";
 
@@ -136,3 +136,17 @@ export function createSection(title: string, tableContents: string, id?: string)
     </div>
   `;
 }
+
+export const getDeceasedStatus = (familyMemberHistory: FamilyMemberHistory): string => {
+  const deceasedBoolean = familyMemberHistory.deceasedBoolean;
+  const contributedToDeath = familyMemberHistory.condition?.find(condition => {
+    return condition.contributedToDeath;
+  });
+
+  if (deceasedBoolean !== undefined) {
+    return deceasedBoolean ? "yes" : "no";
+  } else if (contributedToDeath !== undefined) {
+    return contributedToDeath ? "yes" : "no";
+  }
+  return "";
+};

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -33,6 +33,7 @@ import {
   ISO_DATE,
   MISSING_DATE_KEY,
   MISSING_DATE_TEXT,
+  getDeceasedStatus,
 } from "./bundle-to-html-shared";
 
 const RX_NORM_CODE = "rxnorm";
@@ -1930,16 +1931,14 @@ function createFamilyHistorySection(familyMemberHistories: FamilyMemberHistory[]
             SNOMED_CODE,
           ]);
 
-          const deceasedFamilyMember = familyMemberHistory.condition?.find(condition => {
-            return condition.contributedToDeath === true;
-          });
+          const deceasedStatus = getDeceasedStatus(familyMemberHistory);
 
           return `
             <tr>
               <td>${getValidCode(familyMemberHistory.relationship?.coding)[0]?.display ?? ""}</td>
               <td>${renderAdministrativeGender(familyMemberHistory) ?? ""}</td>
               <td>${renderFamilyHistoryConditions(familyMemberHistory)?.join(", ") ?? ""}</td>
-              <td>${deceasedFamilyMember ? "yes" : "no"}</td>
+              <td>${deceasedStatus}</td>
               <td>${code ?? ""}</td>
             </tr>
           `;


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ticket: #_[ticket-number]_

### Dependencies

- Upstream: _[this PR points to another PR or depends on its release]_
- Downstream: _[PRs that depend on this one, either point to this or can only be released after this one is released]_

### Description

- We currently default to no even if we dont have a deceased status.

- Local
  - [ ] Renders status correctly
- Production
  - [ ] Renders status correctly

_[Release PRs:]_

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined the logic for determining deceased status in family history sections, centralizing the process to enhance clarity and maintainability while keeping the display results consistent for users.
	- Introduced a new function to determine deceased status, improving code modularity without altering the output format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->