### PR TITLE
feat(ehr): patch develop so that we only use the queues once the env …

### DIFF
--- a/packages/api/src/external/ehr/athenahealth/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/process-patients-from-appointments.ts
@@ -1,6 +1,6 @@
 import { isAthenaCustomFieldsEnabledForCx } from "@metriport/core/external/aws/app-config";
 import AthenaHealthApi from "@metriport/core/external/ehr/athenahealth/index";
-import { buildEhrSyncPatientHandler } from "@metriport/core/external/ehr/sync-patient/ehr-sync-patient-factory";
+//import { buildEhrSyncPatientHandler } from "@metriport/core/external/ehr/sync-patient/ehr-sync-patient-factory";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
@@ -22,7 +22,10 @@ import {
   parallelPractices,
 } from "../../shared";
 import { LookupMode, LookupModes, createAthenaClient } from "../shared";
-import { SyncAthenaPatientIntoMetriportParams } from "./sync-patient";
+import {
+  SyncAthenaPatientIntoMetriportParams,
+  syncAthenaPatientIntoMetriport,
+} from "./sync-patient";
 
 dayjs.extend(duration);
 
@@ -185,6 +188,13 @@ async function syncPatient({
   athenaPracticeId,
   athenaPatientId,
 }: Omit<SyncAthenaPatientIntoMetriportParams, "api" | "triggerDq">): Promise<void> {
+  await syncAthenaPatientIntoMetriport({
+    cxId,
+    athenaPracticeId,
+    athenaPatientId,
+    triggerDq: true,
+  });
+  /*
   const handler = buildEhrSyncPatientHandler();
   await handler.processSyncPatient({
     ehr: EhrSources.athena,
@@ -193,4 +203,5 @@ async function syncPatient({
     patientId: athenaPatientId,
     triggerDq: true,
   });
+  */
 }

--- a/packages/api/src/external/ehr/canvas/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/canvas/command/process-patients-from-appointments.ts
@@ -1,4 +1,4 @@
-import { buildEhrSyncPatientHandler } from "@metriport/core/external/ehr/sync-patient/ehr-sync-patient-factory";
+//import { buildEhrSyncPatientHandler } from "@metriport/core/external/ehr/sync-patient/ehr-sync-patient-factory";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
@@ -17,7 +17,10 @@ import {
   parallelPractices,
 } from "../../shared";
 import { createCanvasClient } from "../shared";
-import { SyncCanvasPatientIntoMetriportParams } from "./sync-patient";
+import {
+  SyncCanvasPatientIntoMetriportParams,
+  syncCanvasPatientIntoMetriport,
+} from "./sync-patient";
 
 dayjs.extend(duration);
 
@@ -118,6 +121,13 @@ async function syncPatient({
   canvasPracticeId,
   canvasPatientId,
 }: Omit<SyncCanvasPatientIntoMetriportParams, "api" | "triggerDq">): Promise<void> {
+  await syncCanvasPatientIntoMetriport({
+    cxId,
+    canvasPracticeId,
+    canvasPatientId,
+    triggerDq: true,
+  });
+  /*
   const handler = buildEhrSyncPatientHandler();
   await handler.processSyncPatient({
     ehr: EhrSources.canvas,
@@ -126,4 +136,5 @@ async function syncPatient({
     patientId: canvasPatientId,
     triggerDq: true,
   });
+  */
 }

--- a/packages/api/src/external/ehr/elation/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/elation/command/process-patients-from-appointments.ts
@@ -1,4 +1,4 @@
-import { buildEhrSyncPatientHandler } from "@metriport/core/external/ehr/sync-patient/ehr-sync-patient-factory";
+//import { buildEhrSyncPatientHandler } from "@metriport/core/external/ehr/sync-patient/ehr-sync-patient-factory";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
@@ -17,7 +17,10 @@ import {
   parallelPractices,
 } from "../../shared";
 import { createElationClient } from "../shared";
-import { SyncElationPatientIntoMetriportParams } from "./sync-patient";
+import {
+  SyncElationPatientIntoMetriportParams,
+  syncElationPatientIntoMetriport,
+} from "./sync-patient";
 
 dayjs.extend(duration);
 
@@ -118,6 +121,13 @@ async function syncPatient({
   elationPracticeId,
   elationPatientId,
 }: Omit<SyncElationPatientIntoMetriportParams, "api" | "triggerDq">): Promise<void> {
+  await syncElationPatientIntoMetriport({
+    cxId,
+    elationPracticeId,
+    elationPatientId,
+    triggerDq: true,
+  });
+  /*
   const handler = buildEhrSyncPatientHandler();
   await handler.processSyncPatient({
     ehr: EhrSources.elation,
@@ -126,4 +136,5 @@ async function syncPatient({
     patientId: elationPatientId,
     triggerDq: true,
   });
+  */
 }


### PR DESCRIPTION
Ref: #1040


### Description

- patch API to use the old synchronous version so that we can deploy the infra at the same time as the API
- revert once production is deployed and the infra is ready to go

### Testing

- Local
  - [ ] sync patient still gets called
- Staging
  - [ ] sync patient still gets called
- Sandbox
  - [ ] N/A
- Production
  - [ ] sync patient still gets called

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the patient record synchronization process across multiple external EHR integrations.
  - Replaced the previous indirect, handler-based approach with a direct synchronization call using preset parameters, enhancing consistency in processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->