### PR TITLE
feat(ehr): disabled appointments collection in background

### DIFF
--- a/packages/api/src/external/ehr/athenahealth/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/process-patients-from-appointments.ts
@@ -49,13 +49,18 @@ export async function processPatientsFromAppointments({ lookupMode }: { lookupMo
 
   const allAppointments: Appointment[] = [];
   const getAppointmentsErrors: { error: unknown; cxId: string; practiceId: string }[] = [];
-  const getAppointmentsArgs: GetAppointmentsParams[] = cxMappings.map(mapping => {
-    return {
-      cxId: mapping.cxId,
-      practiceId: mapping.externalId,
-      departmentIds: mapping.secondaryMappings?.departmentIds,
-      lookupMode,
-    };
+  const getAppointmentsArgs: GetAppointmentsParams[] = cxMappings.flatMap(mapping => {
+    if (mapping.secondaryMappings?.backgroundAppointmentsDisabled) {
+      return [];
+    }
+    return [
+      {
+        cxId: mapping.cxId,
+        practiceId: mapping.externalId,
+        departmentIds: mapping.secondaryMappings?.departmentIds,
+        lookupMode,
+      },
+    ];
   });
 
   await executeAsynchronously(

--- a/packages/api/src/routes/ehr/canvas/patient-webhook.ts
+++ b/packages/api/src/routes/ehr/canvas/patient-webhook.ts
@@ -14,7 +14,7 @@ const router = Router();
  *
  * Tries to retrieve the matching Metriport patient on appointment created
  * @param req.params.id The ID of Canvas Patient.
- * @returns Metriport Patient if found.
+ * @returns HTTP 200 OK on successful processing.
  */
 router.post(
   "/:id/appointment-created",

--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -24,7 +24,7 @@ export type FHIRConverterConnector = {
  * than the FHIR Converter can process in parallel, which would mean using it's worker thread's internal queue.
  * See more here: https://metriport.slack.com/archives/C04DBBJSKGB/p1739719790818809?thread_ts=1739665734.719219&cid=C04DBBJSKGB
  */
-const multiplier = 0.8;
+const multiplier = 0.4;
 
 function settings() {
   const {

--- a/packages/infra/lib/api-stack/fhir-converter-service.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-service.ts
@@ -26,8 +26,8 @@ export function settings() {
     cpuAmount,
     cpu: cpuAmount * vCPU,
     memoryLimitMiB: prod ? 8192 : 4096,
-    taskCountMin: prod ? 16 : 1,
-    taskCountMax: prod ? 32 : 4,
+    taskCountMin: prod ? 32 : 1,
+    taskCountMax: prod ? 64 : 4,
     // How long this service can run for
     maxExecutionTimeout: MAXIMUM_LAMBDA_TIMEOUT,
   };

--- a/packages/infra/lib/ehr-nested-stack.ts
+++ b/packages/infra/lib/ehr-nested-stack.ts
@@ -11,7 +11,7 @@ import { createLambda } from "./shared/lambda";
 import { LambdaLayers } from "./shared/lambda-layers";
 import { createQueue } from "./shared/sqs";
 
-const waitTimePatientSync = Duration.seconds(60); // 6 patients/min
+const waitTimePatientSync = Duration.seconds(60); // 1 patient/min
 
 function settings() {
   const syncPatientLambdaTimeout = waitTimePatientSync.plus(Duration.seconds(25));

--- a/packages/infra/lib/ehr-nested-stack.ts
+++ b/packages/infra/lib/ehr-nested-stack.ts
@@ -11,7 +11,7 @@ import { createLambda } from "./shared/lambda";
 import { LambdaLayers } from "./shared/lambda-layers";
 import { createQueue } from "./shared/sqs";
 
-const waitTimePatientSync = Duration.seconds(6); // 10 patients/min
+const waitTimePatientSync = Duration.seconds(60); // 6 patients/min
 
 function settings() {
   const syncPatientLambdaTimeout = waitTimePatientSync.plus(Duration.seconds(25));

--- a/packages/shared/src/interface/external/ehr/athenahealth/cx-mapping.ts
+++ b/packages/shared/src/interface/external/ehr/athenahealth/cx-mapping.ts
@@ -2,5 +2,6 @@ import { z } from "zod";
 
 export const athenaSecondaryMappingsSchema = z.object({
   departmentIds: z.string().array(),
+  backgroundAppointmentsDisabled: z.boolean().optional(),
 });
 export type AthenaSecondaryMappings = z.infer<typeof athenaSecondaryMappingsSchema>;


### PR DESCRIPTION
Ref: #1040

### Description

- add optional boolean to cx mapping that will disable background collection for athena

### Testing

- Local
  - [x] edit boolean and confirm exit
  - [x] new cx mapping can be created with new value
- Staging
  - [ ] edit boolean and confirm exit
  - [ ] new cx mapping can be created with new value
- Sandbox
  - [ ] N/A
- Production
  - [ ] edit boolean and confirm exit
  - [ ] new cx mapping can be created with new value

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional setting allowing the system to skip processing of background appointments, reducing unnecessary API calls.

- **Refactor**
  - Enhanced appointment handling logic by conditionally filtering out background appointments when the new setting is enabled, leading to more efficient processing.
  - Increased the minimum and maximum task counts for production environments to improve task allocation.
  - Adjusted the processing wait time for patient synchronization, affecting throughput.

- **Documentation**
  - Updated the documentation for the appointment creation webhook to clarify the expected HTTP response on successful processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->