### PR TITLE
feat(api): surface network type in network entries api response

### DIFF
--- a/packages/api-sdk/src/medical/models/network-entry.ts
+++ b/packages/api-sdk/src/medical/models/network-entry.ts
@@ -1,10 +1,11 @@
-import { USState } from "@metriport/shared/dist/domain/address/state";
+import { USStateForAddress } from "@metriport/shared/domain/address";
 
 export interface NetworkEntry {
   name: string;
   oid: string;
   zip?: string;
-  state?: USState;
+  state?: USStateForAddress;
   rootOrganization?: string;
   managingOrgOid?: string;
+  network: "COMMONWELL" | "CAREQUALITY";
 }

--- a/packages/api/src/domain/medical/network-entry.ts
+++ b/packages/api/src/domain/medical/network-entry.ts
@@ -8,4 +8,5 @@ export interface NetworkEntry {
   state?: USStateForAddress | undefined;
   managingOrgOid?: string;
   rootOrganization?: string;
+  network: "COMMONWELL" | "CAREQUALITY";
 }

--- a/packages/api/src/external/hie/command/get-hie-directory-entries.ts
+++ b/packages/api/src/external/hie/command/get-hie-directory-entries.ts
@@ -25,7 +25,7 @@ export async function getHieDirectoryEntriesByFilter({
   const { query, replacements } = paginationSqlExpressions(pagination);
   const queryFinal = queryFTS + query;
 
-  const cqDirectoryEntries = await sequelize.query(queryFinal, {
+  const networkEntries = await sequelize.query(queryFinal, {
     model: HIEDirectoryEntryViewModel,
     mapToModel: true,
     replacements: {
@@ -35,8 +35,8 @@ export async function getHieDirectoryEntriesByFilter({
     type: QueryTypes.SELECT,
   });
 
-  const sortedCqDirectoryEntries = sortForPagination(cqDirectoryEntries, pagination);
-  return sortedCqDirectoryEntries.map(entry => entry.dataValues);
+  const sortedNetworkEntries = sortForPagination(networkEntries, pagination);
+  return sortedNetworkEntries.map(entry => entry.dataValues);
 }
 
 export async function getHieDirectoryEntriesByFilterCount({

--- a/packages/api/src/external/hie/domain/hie-directory-entry.ts
+++ b/packages/api/src/external/hie/domain/hie-directory-entry.ts
@@ -9,4 +9,5 @@ export interface HieDirectoryEntry {
   city?: string;
   state?: string;
   zipCode?: string;
+  network: "COMMONWELL" | "CAREQUALITY";
 }

--- a/packages/api/src/external/hie/models/hie-directory-view.ts
+++ b/packages/api/src/external/hie/models/hie-directory-view.ts
@@ -13,6 +13,7 @@ export class HIEDirectoryEntryViewModel extends BaseModel<HIEDirectoryEntryViewM
   declare city?: string;
   declare state?: string;
   declare zipCode?: string;
+  declare network: "COMMONWELL" | "CAREQUALITY";
 
   static setup: ModelSetup = (sequelize: Sequelize) => {
     HIEDirectoryEntryViewModel.init(
@@ -41,6 +42,13 @@ export class HIEDirectoryEntryViewModel extends BaseModel<HIEDirectoryEntryViewM
         managingOrganizationId: {
           type: DataTypes.STRING,
           field: "managing_organization_id",
+        },
+        network: {
+          type: DataTypes.STRING,
+          field: "network",
+          validate: {
+            isIn: [["COMMONWELL", "CAREQUALITY"]],
+          },
         },
         state: {
           type: DataTypes.STRING,

--- a/packages/api/src/routes/medical/dtos/network-entry-dto.ts
+++ b/packages/api/src/routes/medical/dtos/network-entry-dto.ts
@@ -12,5 +12,6 @@ export function dtoFromHieDirectoryEntry(networkEntry: HieDirectoryEntry): Netwo
     state: normalizeUSStateForAddressSafe(networkEntry.state ?? ""),
     rootOrganization: networkEntry.rootOrganization,
     managingOrgOid: networkEntry.managingOrganizationId,
+    network: networkEntry.network,
   };
 }


### PR DESCRIPTION
refs. metriport/metriport-internal#2790

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

- Downstream: https://github.com/metriport/metriport-internal/pull/2793

### Description

Exposes the 'network' property from the hie_directory_view to our 

### Testing

Local
✅ Check endpoint w/ postman

Staging
- Check endpoint w/ postman

Sandbox
- Check endpoint w/ postman

Prod
- Check endpoint w/ postman

### Release Plan

- [ ] Merge this