### PR TITLE
feat(api): adding internal route to get adt subscribers

### DIFF
--- a/packages/api/src/command/medical/patient/get-adt-subscribers.ts
+++ b/packages/api/src/command/medical/patient/get-adt-subscribers.ts
@@ -1,0 +1,27 @@
+import { out } from "@metriport/core/util/log";
+import { PatientModel } from "../../../models/medical/patient";
+import { PatientSettingsModel } from "../../../models/patient-settings";
+
+export async function getAdtSubscribers(states: string[]): Promise<PatientModel[]> {
+  const { log } = out(`Get ADT Subscribers`);
+  log(`States: ${states}`);
+
+  const patientIds = await PatientSettingsModel.findAll({
+    where: {
+      adtSubscription: true,
+    },
+    attributes: ["patientId"],
+  });
+
+  const patients = await PatientModel.findAll({
+    where: {
+      id: patientIds.map(p => p.patientId),
+    },
+  });
+
+  const patientsInSelectedStates = patients.filter(p =>
+    p.data.address?.some(a => states.includes(a.state))
+  );
+
+  return patientsInSelectedStates;
+}

--- a/packages/api/src/routes/medical/internal-patient.ts
+++ b/packages/api/src/routes/medical/internal-patient.ts
@@ -35,6 +35,7 @@ import { getCoverageAssessments } from "../../command/medical/patient/coverage-a
 import { PatientCreateCmd, createPatient } from "../../command/medical/patient/create-patient";
 import { createOrUpdatePatientSettings } from "../../command/medical/patient/create-patient-settings";
 import { deletePatient } from "../../command/medical/patient/delete-patient";
+import { getAdtSubscribers } from "../../command/medical/patient/get-adt-subscribers";
 import {
   getPatientIds,
   getPatientOrFail,
@@ -934,6 +935,25 @@ router.post(
       patientIds,
       adtSubscription,
     });
+
+    return res.status(status.OK).json(result);
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * POST /internal/patient/adt-subscribers
+ *
+ * Gets all patients that have ADT subscriptions enabled for the given states.
+ *
+ * @param req.query.states List of US state codes to filter by
+ * @returns List of patients with ADT subscriptions in the specified states
+ */
+router.post(
+  "/adt-subscribers",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const states = getFromQueryAsArrayOrFail("states", req);
+    const result = await getAdtSubscribers(states);
 
     return res.status(status.OK).json(result);
   })


### PR DESCRIPTION
refs. metriport/metriport-internal#2791

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3463

### Description
- Added internal route to get all ADT subscribers in specified states

### Testing

- Local
  - [x] Send the request with different states and check results
- Staging
  - [ ] Send the request with different states and check results
- Production
  - [ ] Send the request with different states and check results

### Release Plan
- [ ] Merge this
