### PR TITLE
799 Paginate S3Utils listObject

### DIFF
--- a/packages/api/src/command/medical/patient/__tests__/validate.test.ts
+++ b/packages/api/src/command/medical/patient/__tests__/validate.test.ts
@@ -1,4 +1,4 @@
-import dayjs from "dayjs";
+import { buildDayjs } from "@metriport/shared/common/date";
 import { makeAddressStrict } from "../../../../domain/medical/__tests__/location-address";
 import { makePatientCreate } from "../../../../domain/medical/__tests__/patient";
 import { validate } from "../shared";
@@ -41,26 +41,26 @@ describe("validate", () => {
 
   describe("dob", () => {
     it("throws an error if dob is in the future", async () => {
-      const futureDate = dayjs().add(1, "day").format("YYYY-MM-DD");
+      const futureDate = buildDayjs().add(1, "day").format("YYYY-MM-DD");
       const patient = makePatientCreate({ dob: futureDate });
       expect(() => validate(patient)).toThrow(`Date can't be in the future`);
     });
 
     it("throws an error when dob is a minute in the future", async () => {
-      const futureDate = dayjs().add(1, "minute").toISOString();
+      const futureDate = buildDayjs().add(1, "minute").toISOString();
       const patient = makePatientCreate({ dob: futureDate });
       expect(() => validate(patient)).toThrow(`Date can't be in the future`);
     });
 
     it("returns true when dob is the current date", async () => {
-      const currentDate = dayjs().format("YYYY-MM-DD");
+      const currentDate = buildDayjs().format("YYYY-MM-DD");
       const patient = makePatientCreate({ dob: currentDate });
       const resp = validate(patient);
       expect(resp).toBeTruthy();
     });
 
     it("returns true when dob is in the past", async () => {
-      const pastDate = dayjs().subtract(1, "day").format("YYYY-MM-DD");
+      const pastDate = buildDayjs().subtract(1, "day").format("YYYY-MM-DD");
       const patient = makePatientCreate({ dob: pastDate });
       const resp = validate(patient);
       expect(resp).toBeTruthy();

--- a/packages/core/src/external/aws/s3.ts
+++ b/packages/core/src/external/aws/s3.ts
@@ -449,10 +449,24 @@ export class S3Utils {
   }
 
   async listObjects(bucket: string, prefix: string): Promise<AWS.S3.ObjectList | undefined> {
-    const res = await executeWithRetriesS3(() =>
-      this._s3.listObjectsV2({ Bucket: bucket, Prefix: prefix }).promise()
-    );
-    return res.Contents;
+    const allObjects: AWS.S3.Object[] = [];
+    let continuationToken: string | undefined;
+    do {
+      const res = await executeWithRetriesS3(() =>
+        this._s3
+          .listObjectsV2({
+            Bucket: bucket,
+            Prefix: prefix,
+            ...(continuationToken ? { ContinuationToken: continuationToken } : {}),
+          })
+          .promise()
+      );
+      if (res.Contents) {
+        allObjects.push(...res.Contents);
+      }
+      continuationToken = res.NextContinuationToken;
+    } while (continuationToken);
+    return allObjects;
   }
 }
 

--- a/packages/core/src/external/aws/s3.ts
+++ b/packages/core/src/external/aws/s3.ts
@@ -448,7 +448,7 @@ export class S3Utils {
     }
   }
 
-  async listObjects(bucket: string, prefix: string): Promise<AWS.S3.ObjectList | undefined> {
+  async listObjects(bucket: string, prefix: string): Promise<AWS.S3.ObjectList> {
     const allObjects: AWS.S3.Object[] = [];
     let continuationToken: string | undefined;
     do {

--- a/packages/utils/src/s3/list-objects.ts
+++ b/packages/utils/src/s3/list-objects.ts
@@ -1,0 +1,30 @@
+import { S3Utils } from "@metriport/core/external/aws/s3";
+import { getEnvVarOrFail } from "@metriport/core/util/env-var";
+
+/**
+ * List objects from S3.
+ *
+ * Set:
+ * - bucketName: the bucket name;
+ * - filePrefix: the prefix of the files to list;
+ * - AWS_REGION env var
+ */
+const bucketName = ``;
+const filePrefix = ``;
+
+const region = getEnvVarOrFail("AWS_REGION");
+
+async function main() {
+  const s3 = new S3Utils(region);
+
+  console.log(`Getting files w/ prefix ${filePrefix}...`);
+  const objs = await s3.listObjects(bucketName, filePrefix);
+
+  console.log(`Response (${objs?.length} files):`);
+  objs?.forEach(obj => {
+    console.log(`- ${obj.Key}`);
+  });
+  console.log(`Done listing files (${objs?.length} files)`);
+}
+
+main();


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Dependencies

none

### Description

Paginate S3Utils' `listObject()` function - [context](https://metriport.slack.com/archives/C06CQC7GQG3/p1741908942986889?thread_ts=1741905439.527419&cid=C06CQC7GQG3).

### Testing

- Local
  - [x] Limit the amount of items to force pagination and get expected list of keys
  - [x] Don't limit the amount of items and get expected list of keys
- Staging
  - [ ] Generating consolidated lists files from S3 (check entries of `conversion bundles` on the logs of `FhirToBundleLambda`)
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a utility tool that lists files from a cloud storage bucket with detailed logging of file counts and keys.
- **Improvements**
  - Enhanced the file retrieval process to handle pagination, ensuring that all matching files are returned instead of just a single page.
- **Tests**
  - Updated date manipulation in tests to utilize a custom date function, ensuring consistency across date validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->