### PR TITLE
fix(core): downgrade error alert to warning for doc missing uniqueDocId - not actionable

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dq-response.ts
@@ -119,11 +119,12 @@ export function parseDocumentReference({
 
   if (!docUniqueId) {
     const msg = "Document Reference is missing docUniqueId";
-    capture.error(msg, {
+    capture.message(msg, {
       extra: {
         extrinsicObject,
         outboundRequest,
       },
+      level: "warning",
     });
     return undefined;
   }


### PR DESCRIPTION
refs. metriport/metriport-internal#0000

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

None

### Description

Sometimes files coming from ihe gateway are missing a value in their unique doc id XML tag. We can't process it, but there's no real action item so I think severity needs to be downgraded 🔴  => 🟡 .

### Testing

None

### Release Plan

- [ ] Merge this
