### PR TITLE
2796 fix(lambdas): resolve xml crypto crit vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22278,6 +22278,7 @@
     },
     "node_modules/ignore": {
       "version": "5.2.4",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -34110,9 +34111,9 @@
       }
     },
     "node_modules/xml-crypto": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.0.tgz",
-      "integrity": "sha512-L3RgnkaDrHaYcCnoENv4Idzt1ZRj5U1z1BDH98QdDTQfssScx8adgxhd9qwyYo+E3fXbQZjEQH7aiXHLVgxGvw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.1.tgz",
+      "integrity": "sha512-v05aU7NS03z4jlZ0iZGRFeZsuKO1UfEbbYiaeRMiATBFs6Jq9+wqKquEMTn4UTrYZ9iGD8yz3KT4L9o2iF682w==",
       "dependencies": {
         "@xmldom/is-dom-node": "^1.0.1",
         "@xmldom/xmldom": "^0.8.10",
@@ -34627,7 +34628,7 @@
         "pvutils": "^1.1.3",
         "sequelize": "^6.37.1",
         "whatwg-mimetype": "^4.0.0",
-        "xml-crypto": "^6.0.0",
+        "xml-crypto": "^6.0.1",
         "xml2js": "^0.6.2",
         "xmldom": "^0.6.0",
         "zod-to-json-schema": "3.22.5"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -139,7 +139,7 @@
     "pvutils": "^1.1.3",
     "sequelize": "^6.37.1",
     "whatwg-mimetype": "^4.0.0",
-    "xml-crypto": "^6.0.0",
+    "xml-crypto": "^6.0.1",
     "xml2js": "^0.6.2",
     "xmldom": "^0.6.0",
     "zod-to-json-schema": "3.22.5"

--- a/packages/core/src/external/carequality/ihe-gateway-v2/saml/security/verify.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/saml/security/verify.ts
@@ -3,6 +3,7 @@ import * as xpath from "xpath";
 import * as isDomNode from "@xmldom/is-dom-node";
 import * as crypto from "crypto";
 import { DOMParser } from "xmldom";
+import { capture } from "../../../../../util/notifications";
 
 export function verifySaml({
   xmlString,
@@ -13,6 +14,22 @@ export function verifySaml({
 }): boolean {
   try {
     const doc = new DOMParser().parseFromString(xmlString, "application/xml");
+    const digestValues = xpath.select(
+      "//*[local-name()='DigestValue'][count(node()) > 1]",
+      doc
+    ) as Node[];
+
+    if (digestValues && digestValues.length > 0) {
+      const msg = "Digest value is compromised - saml verification failed";
+      capture.message(msg, {
+        extra: {
+          digestValues,
+        },
+        level: "warning",
+      });
+      throw new Error(msg);
+    }
+
     const signatures = xpath.select("//*[local-name(.)='Signature']", doc);
     if (!Array.isArray(signatures)) return false;
 

--- a/packages/lambdas/package-lock.json
+++ b/packages/lambdas/package-lock.json
@@ -43,7 +43,7 @@
         "sequelize": "^6.37.1",
         "uuid": "^9.0.0",
         "whatwg-mimetype": "^4.0.0",
-        "xml-crypto": "^6.0.0",
+        "xml-crypto": "^6.0.1",
         "xml2js": "^0.6.2",
         "xmldom": "^0.6.0",
         "zod": "^3.22.4"
@@ -12213,9 +12213,9 @@
       }
     },
     "node_modules/xml-crypto": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.0.tgz",
-      "integrity": "sha512-L3RgnkaDrHaYcCnoENv4Idzt1ZRj5U1z1BDH98QdDTQfssScx8adgxhd9qwyYo+E3fXbQZjEQH7aiXHLVgxGvw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.1.tgz",
+      "integrity": "sha512-v05aU7NS03z4jlZ0iZGRFeZsuKO1UfEbbYiaeRMiATBFs6Jq9+wqKquEMTn4UTrYZ9iGD8yz3KT4L9o2iF682w==",
       "dependencies": {
         "@xmldom/is-dom-node": "^1.0.1",
         "@xmldom/xmldom": "^0.8.10",

--- a/packages/lambdas/package.json
+++ b/packages/lambdas/package.json
@@ -58,7 +58,7 @@
     "sequelize": "^6.37.1",
     "uuid": "^9.0.0",
     "whatwg-mimetype": "^4.0.0",
-    "xml-crypto": "^6.0.0",
+    "xml-crypto": "^6.0.1",
     "xml2js": "^0.6.2",
     "xmldom": "^0.6.0",
     "zod": "^3.22.4"


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/2796

### Dependencies

None

### Description

Patches critical security vulnerability in xml-crypto 6.0.0

### Testing

Verify that `sdks/typescript/tester-local` passes.

### Release Plan

We abort if there is a detected vulnerability in the XML.

- [ ] Merge this
