### PR TITLE
feat(ehr): patch ehr routes

### DIFF
--- a/packages/api/src/routes/ehr/athenahealth/routes/dash.ts
+++ b/packages/api/src/routes/ehr/athenahealth/routes/dash.ts
@@ -19,12 +19,7 @@ routes.use(
   patientAuthorization("query"),
   medicalPatient
 );
-routes.use(
-  "/medical/v1/document",
-  processDocumentRoute,
-  patientAuthorization("query"),
-  medicalDocument
-);
+routes.use("/medical/v1/document", processDocumentRoute, medicalDocument);
 routes.use("/settings", settings);
 
 export default routes;

--- a/packages/api/src/routes/ehr/canvas/routes/dash.ts
+++ b/packages/api/src/routes/ehr/canvas/routes/dash.ts
@@ -17,12 +17,7 @@ routes.use(
   patientAuthorization("query"),
   medicalPatient
 );
-routes.use(
-  "/medical/v1/document",
-  processDocumentRoute,
-  patientAuthorization("query"),
-  medicalDocument
-);
+routes.use("/medical/v1/document", processDocumentRoute, medicalDocument);
 routes.use("/settings", settings);
 
 export default routes;

--- a/packages/api/src/routes/ehr/elation/routes/dash.ts
+++ b/packages/api/src/routes/ehr/elation/routes/dash.ts
@@ -28,8 +28,7 @@ routes.use(
 routes.use(
   "/medical/v1/document",
   processDocumentRoute,
-  processEhrPatientId(tokenEhrPatientIdQueryParam, "query"),
-  patientAuthorization("query"),
+  processEhrPatientId(tokenEhrPatientIdQueryParam, "query", [new RegExp(`^/download-url$`)]),
   medicalDocument
 );
 routes.use("/settings", settings);

--- a/packages/api/src/routes/ehr/elation/routes/dash.ts
+++ b/packages/api/src/routes/ehr/elation/routes/dash.ts
@@ -15,6 +15,8 @@ import patient from "../patient";
 
 const routes = Router();
 
+const documentSkipPathsForElationIdCheck = [new RegExp(`^/download-url$`)];
+
 routes.use("/patient", patient);
 routes.use("/chart", chart);
 routes.use(
@@ -28,7 +30,7 @@ routes.use(
 routes.use(
   "/medical/v1/document",
   processDocumentRoute,
-  processEhrPatientId(tokenEhrPatientIdQueryParam, "query", [new RegExp(`^/download-url$`)]),
+  processEhrPatientId(tokenEhrPatientIdQueryParam, "query", documentSkipPathsForElationIdCheck),
   medicalDocument
 );
 routes.use("/settings", settings);

--- a/packages/api/src/routes/ehr/shared.ts
+++ b/packages/api/src/routes/ehr/shared.ts
@@ -128,9 +128,14 @@ export async function replaceIdInQueryParams(
  */
 export function processEhrPatientId(
   tokenEhrPatientIdQueryParam: string,
-  context: "query" | "params" = "params"
+  context: "query" | "params" = "params",
+  skipPaths: RegExp[] = []
 ): (req: Request, res: Response, next: NextFunction) => void {
   return (req: Request, res: Response, next: NextFunction): void => {
+    if (skipPaths.some(path => path.test(req.path))) {
+      next();
+      return;
+    }
     const tokenEhrPatientId = getFromQueryOrFail(tokenEhrPatientIdQueryParam, req);
     const requestEhrPatientId =
       context === "query"


### PR DESCRIPTION
Ref: #1040

### Description

- removing patientAuthorization piece cause `download-url` doesn't have a patient ID
- create a skipPaths array for patient ID matching so that we can skip `dowload-url`

### Testing

- Local
  - [ ] no download docs
- Staging
  - [ ] downloading docs from ehr works
- Sandbox
  - [ ] N/A
- Production
 - [ ] downloading docs from ehr works

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the processing of medical document requests to provide a more consistent and efficient experience.
	- Enhanced the backend logic for verifying access in a more flexible manner for specific document requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->