### PR TITLE
chore(release): publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34275,7 +34275,7 @@
       }
     },
     "packages/api": {
-      "version": "1.25.2-alpha.0",
+      "version": "1.25.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -34359,12 +34359,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "14.12.2-alpha.0",
+      "version": "14.12.2",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.6.2-alpha.0",
-        "@metriport/shared": "^0.20.2-alpha.0",
+        "@metriport/commonwell-sdk": "^5.6.2",
+        "@metriport/shared": "^0.20.2",
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -34420,10 +34420,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.16.2-alpha.0",
+      "version": "1.16.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.17.2-alpha.0",
+        "@metriport/ihe-gateway-sdk": "^0.17.2",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -34437,7 +34437,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.4.2-alpha.0",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -34461,10 +34461,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.24.2-alpha.0",
+      "version": "1.24.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.6.2-alpha.0",
+        "@metriport/commonwell-sdk": "^5.6.2",
         "axios": "^1.4.0",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -34503,10 +34503,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.22.2-alpha.0",
+      "version": "1.22.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.6.2-alpha.0",
+        "@metriport/commonwell-sdk": "^5.6.2",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -34538,10 +34538,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.6.2-alpha.0",
+      "version": "5.6.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.20.2-alpha.0",
+        "@metriport/shared": "^0.20.2",
         "axios": "^1.4.0",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -34589,7 +34589,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.22.2-alpha.0",
+      "version": "1.22.2",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -35812,17 +35812,17 @@
     "packages/core/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.17.2-alpha.0",
+      "version": "0.17.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.20.2-alpha.0",
+        "@metriport/shared": "^0.20.2",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.20.2-alpha.0",
+      "version": "1.20.2",
       "dependencies": {
         "@metriport/shared": "file:packages/shared",
         "aws-cdk-lib": "~2.133.0",
@@ -35875,7 +35875,7 @@
     },
     "packages/infra/packages/shared": {},
     "packages/mllp-server": {
-      "version": "0.1.2-alpha.0",
+      "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
         "@medplum/hl7": "^3.2.33",
@@ -36013,7 +36013,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.20.2-alpha.0",
+      "version": "0.20.2",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -36061,7 +36061,7 @@
       }
     },
     "packages/utils": {
-      "version": "1.23.2-alpha.0",
+      "version": "1.23.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.658.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "14.12.2-alpha.0",
+  "version": "14.12.2",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.6.2-alpha.0",
-    "@metriport/shared": "^0.20.2-alpha.0",
+    "@metriport/commonwell-sdk": "^5.6.2",
+    "@metriport/shared": "^0.20.2",
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.25.2-alpha.0",
+  "version": "1.25.2",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.16.2-alpha.0",
+  "version": "1.16.2",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.17.2-alpha.0",
+    "@metriport/ihe-gateway-sdk": "^0.17.2",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.4.2-alpha.0",
+  "version": "1.4.2",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.24.2-alpha.0",
+  "version": "1.24.2",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.6.2-alpha.0",
+    "@metriport/commonwell-sdk": "^5.6.2",
     "axios": "^1.4.0",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.22.2-alpha.0",
+  "version": "1.22.2",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.6.2-alpha.0",
+    "@metriport/commonwell-sdk": "^5.6.2",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.6.2-alpha.0",
+  "version": "5.6.2",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.20.2-alpha.0",
+    "@metriport/shared": "^0.20.2",
     "axios": "^1.4.0",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.22.2-alpha.0",
+  "version": "1.22.2",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.17.2-alpha.0",
+  "version": "0.17.2",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.20.2-alpha.0",
+    "@metriport/shared": "^0.20.2",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.20.2-alpha.0",
+  "version": "1.20.2",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mllp-server",
-  "version": "0.1.2-alpha.0",
+  "version": "0.1.2",
   "description": "MLLP server that reads HL7 messages off of a raw tcp connection",
   "main": "app.js",
   "private": true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.20.2-alpha.0",
+  "version": "0.20.2",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.23.2-alpha.0",
+  "version": "1.23.2",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ref: #000

 - api@1.25.2
 - @metriport/api-sdk@14.12.2
 - @metriport/carequality-cert-runner@1.16.2
 - @metriport/carequality-sdk@1.4.2
 - @metriport/commonwell-cert-runner@1.24.2
 - @metriport/commonwell-jwt-maker@1.22.2
 - @metriport/commonwell-sdk@5.6.2
 - @metriport/core@1.22.2
 - @metriport/ihe-gateway-sdk@0.17.2
 - infrastructure@1.20.2
 - mllp-server@0.1.2
 - @metriport/shared@0.20.2
 - utils@1.23.2

Ticket: #https://github.com/metriport/metriport-internal/issues/2791

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Transitioned several modules from pre-release (alpha) to stable release versions.
	- Updated associated dependencies to their stable releases, enhancing overall consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->