### PR TITLE
PATCH Reports not showing

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
@@ -66,8 +66,11 @@ export function buildEncounterSections(diagnosticReports: DiagnosticReport[]): E
           const reportInsideDate = formatDateForDisplay(reportInsideTime);
           const isDuplicateDate = reportInsideDate === reportDate;
 
-          const hasSamePresentedForm = report.presentedForm?.some(pf =>
-            reportInside.presentedForm?.some(ripf => pf.data === ripf.data)
+          const hasSamePresentedForm = report.presentedForm?.some(reportForm =>
+            reportInside.presentedForm?.some(
+              insideForm =>
+                reportForm.data && insideForm.data && reportForm.data === insideForm.data
+            )
           );
 
           return isDuplicateDate && hasSamePresentedForm;

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -852,7 +852,7 @@ function createWhatWasDocumentedFromDiagnosticReports(
         ${
           notes.length > 0
             ? `<p style="margin-bottom: 10px; line-height: 25px; white-space: pre-line;">${notes.join(
-                "<br />"
+                "<br /><hr/>"
               )}</p>`
             : ""
         }


### PR DESCRIPTION
Ticket: #_[ticket-number]_

### Dependencies

- Upstream: none
- Downstream: none

### Description

- Bug where we arent rendering every report because its considering 2 notes the same because we are matching the arrays against empty fields

### Testing

- Local
  - [ ] Renders expected reports
- Production
  - [ ] Renders expected reports

_[Release PRs:]_

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
