### PR TITLE
feat(ehr): patching signing key route

### DIFF
--- a/packages/api/src/routes/internal/ehr/elation/index.ts
+++ b/packages/api/src/routes/internal/ehr/elation/index.ts
@@ -1,7 +1,9 @@
 import Router from "express-promise-router";
 import patient from "./patient";
+import signingKey from "./signing-key";
 const routes = Router();
 
 routes.use("/patient", patient);
+routes.use("/signing-key", signingKey);
 
 export default routes;

--- a/packages/api/src/routes/internal/ehr/elation/patient.ts
+++ b/packages/api/src/routes/internal/ehr/elation/patient.ts
@@ -1,12 +1,9 @@
 import { processAsyncError } from "@metriport/core/util/error/shared";
-import { BadRequestError } from "@metriport/shared";
-import { isSubscriptionResource } from "@metriport/shared/interface/external/ehr/elation/subscription";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import httpStatus from "http-status";
 import { processPatientsFromAppointments } from "../../../../external/ehr/elation/command/process-patients-from-appointments";
 import { syncElationPatientIntoMetriport } from "../../../../external/ehr/elation/command/sync-patient";
-import { getElationSigningKeyInfo } from "../../../../external/ehr/elation/shared";
 import { requestLogger } from "../../../helpers/request-logger";
 import { getUUIDFrom } from "../../../schemas/uuid";
 import { asyncHandler, getFromQueryAsBoolean, getFromQueryOrFail } from "../../../util";
@@ -67,28 +64,6 @@ router.post(
       triggerDq,
     }).catch(processAsyncError("Elation syncElationPatientIntoMetriport"));
     return res.sendStatus(httpStatus.OK);
-  })
-);
-
-/**
- * GET /internal/ehr/elation/signing-key
- *
- * Tries to retrieve the signing key for the given applicationId and resource
- * @param req.query.applicationId The ID of the Elation application.
- * @param req.query.resource The subscription resource type.
- * @returns The signing key.
- */
-router.get(
-  "/signing-key",
-  requestLogger,
-  asyncHandler(async (req: Request, res: Response) => {
-    const applicationId = getFromQueryOrFail("applicationId", req);
-    const resource = getFromQueryOrFail("resource", req);
-    if (!isSubscriptionResource(resource)) {
-      throw new BadRequestError("Invalid resource", undefined, { resource });
-    }
-    const signingKey = await getElationSigningKeyInfo(applicationId, resource);
-    return res.status(httpStatus.OK).json({ signingKey });
   })
 );
 

--- a/packages/api/src/routes/internal/ehr/elation/signing-key.ts
+++ b/packages/api/src/routes/internal/ehr/elation/signing-key.ts
@@ -1,0 +1,34 @@
+import { BadRequestError } from "@metriport/shared";
+import { isSubscriptionResource } from "@metriport/shared/interface/external/ehr/elation/subscription";
+import { Request, Response } from "express";
+import Router from "express-promise-router";
+import httpStatus from "http-status";
+import { getElationSigningKeyInfo } from "../../../../external/ehr/elation/shared";
+import { requestLogger } from "../../../helpers/request-logger";
+import { asyncHandler, getFromQueryOrFail } from "../../../util";
+
+const router = Router();
+
+/**
+ * GET /internal/ehr/elation/signing-key
+ *
+ * Tries to retrieve the signing key for the given applicationId and resource
+ * @param req.query.applicationId The ID of the Elation application.
+ * @param req.query.resource The subscription resource type.
+ * @returns The signing key.
+ */
+router.get(
+  "/",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const applicationId = getFromQueryOrFail("applicationId", req);
+    const resource = getFromQueryOrFail("resource", req);
+    if (!isSubscriptionResource(resource)) {
+      throw new BadRequestError("Invalid resource", undefined, { resource });
+    }
+    const signingKey = await getElationSigningKeyInfo(applicationId, resource);
+    return res.status(httpStatus.OK).json({ signingKey });
+  })
+);
+
+export default router;


### PR DESCRIPTION
Ref: #1040

### Description

- signing key route was living under patient accidentally

### Testing

_[Patch PRs:]_

- :warning: [ ] Run E2E tests locally

_[Regular PRs:]_

_[Plan ahead how you're validating your changes work and don't break other features. Add tests to validate the happy
path and the alternative ones. Be specific.]_

- Local
  - [x] hit endpoint on correct route
- Staging
  - [ ] N/A
- Sandbox
  - [ ] N/A
- Production
  - [ ] N/A

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated endpoint for retrieving signing key information, allowing for robust query validation and consistent responses.

- **Refactor**
  - Consolidated the signing key functionality, removing redundant routes for a streamlined and maintainable API experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->