### PR TITLE
feat(ehr): adding process patient boolean

### DIFF
--- a/packages/api/src/external/ehr/athenahealth/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/process-patients-from-appointments.ts
@@ -6,7 +6,7 @@ import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import { MetriportError, errorToString } from "@metriport/shared";
 import {
-  AthenaSecondaryMappings,
+  athenaSecondaryMappingsSchema,
   BookedAppointment,
 } from "@metriport/shared/interface/external/ehr/athenahealth/index";
 import { EhrSources } from "@metriport/shared/interface/external/ehr/source";
@@ -59,7 +59,7 @@ export async function processPatientsFromAppointments({ lookupMode }: { lookupMo
         source: EhrSources.athena,
       });
     }
-    const secondaryMappings = mapping.secondaryMappings as AthenaSecondaryMappings;
+    const secondaryMappings = athenaSecondaryMappingsSchema.parse(mapping.secondaryMappings);
     if (secondaryMappings.backgroundAppointmentsDisabled) {
       return [];
     }

--- a/packages/api/src/external/ehr/elation/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/elation/command/process-patients-from-appointments.ts
@@ -3,7 +3,10 @@ import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import { errorToString, MetriportError } from "@metriport/shared";
-import { ElationSecondaryMappings } from "@metriport/shared/interface/external/ehr/elation/cx-mapping";
+import {
+  ElationSecondaryMappings,
+  elationSecondaryMappingsSchema,
+} from "@metriport/shared/interface/external/ehr/elation/cx-mapping";
 import { EhrSources } from "@metriport/shared/interface/external/ehr/source";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
@@ -46,7 +49,7 @@ export async function processPatientsFromAppointments(): Promise<void> {
         source: EhrSources.elation,
       });
     }
-    const secondaryMappings = cxMapping.secondaryMappings as ElationSecondaryMappings;
+    const secondaryMappings = elationSecondaryMappingsSchema.parse(cxMapping.secondaryMappings);
     return { ...acc, [cxMapping.externalId]: secondaryMappings };
   }, {} as Record<string, ElationSecondaryMappings>);
 

--- a/packages/api/src/external/ehr/elation/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/elation/command/process-patients-from-appointments.ts
@@ -100,7 +100,7 @@ export async function processPatientsFromAppointments(): Promise<void> {
 
   const syncPatientsArgs: SyncElationPatientIntoMetriportParams[] = uniqueAppointments.flatMap(
     appointment => {
-      const secondaryMappings = secondaryMappingsMap[appointment.cxId];
+      const secondaryMappings = secondaryMappingsMap[appointment.practiceId];
       if (!secondaryMappings) {
         throw new MetriportError("Elation secondary mappings not found", undefined, {
           externalId: appointment.practiceId,

--- a/packages/api/src/external/ehr/elation/command/subscribe-to-webhook.ts
+++ b/packages/api/src/external/ehr/elation/command/subscribe-to-webhook.ts
@@ -1,5 +1,5 @@
 import { MetriportError } from "@metriport/shared";
-import { ElationSecondaryMappings } from "@metriport/shared/interface/external/ehr/elation/cx-mapping";
+import { elationSecondaryMappingsSchema } from "@metriport/shared/interface/external/ehr/elation/cx-mapping";
 import {
   CreatedSubscription,
   SubscriptionResource,
@@ -28,7 +28,7 @@ export async function subscribeToWebhook({
       source: EhrSources.elation,
     });
   }
-  const secondaryMappings = cxMapping.secondaryMappings as ElationSecondaryMappings;
+  const secondaryMappings = elationSecondaryMappingsSchema.parse(cxMapping.secondaryMappings);
   const api = await createElationClient({ cxId, practiceId: elationPracticeId });
   const subscription = await api.subscribeToResource({ cxId, resource });
   await setSecondaryMappingsOnCxMappingById({

--- a/packages/api/src/external/ehr/elation/shared.ts
+++ b/packages/api/src/external/ehr/elation/shared.ts
@@ -13,7 +13,7 @@ import {
   NotFoundError,
   toTitleCase,
 } from "@metriport/shared";
-import { ElationSecondaryMappings } from "@metriport/shared/interface/external/ehr/elation/cx-mapping";
+import { elationSecondaryMappingsSchema } from "@metriport/shared/interface/external/ehr/elation/cx-mapping";
 import { Patient as ElationPatient } from "@metriport/shared/interface/external/ehr/elation/patient";
 import { SubscriptionResource } from "@metriport/shared/interface/external/ehr/elation/subscription";
 import { getCxMappingOrFail } from "../../../command/mapping/cx";
@@ -145,7 +145,7 @@ export async function getElationSigningKeyInfo(
       source: EhrSources.elation,
     });
   }
-  const secondaryMappings = cxMapping.secondaryMappings as ElationSecondaryMappings;
+  const secondaryMappings = elationSecondaryMappingsSchema.parse(cxMapping.secondaryMappings);
   const signingKey = secondaryMappings.webhooks?.[resource]?.signingKey;
   if (!signingKey) {
     throw new NotFoundError("Elation signing key not found", {

--- a/packages/api/src/routes/ehr/elation/appointment-webhook.ts
+++ b/packages/api/src/routes/ehr/elation/appointment-webhook.ts
@@ -1,7 +1,7 @@
 import { buildEhrSyncPatientHandler } from "@metriport/core/external/ehr/sync-patient/ehr-sync-patient-factory";
 import { out } from "@metriport/core/util/log";
 import { MetriportError } from "@metriport/shared";
-import { ElationSecondaryMappings } from "@metriport/shared/interface/external/ehr/elation/cx-mapping";
+import { elationSecondaryMappingsSchema } from "@metriport/shared/interface/external/ehr/elation/cx-mapping";
 import { elationAppointmentEventSchema } from "@metriport/shared/interface/external/ehr/elation/event";
 import { EhrSources } from "@metriport/shared/interface/external/ehr/source";
 import { Request, Response } from "express";
@@ -48,7 +48,7 @@ router.post(
         source: EhrSources.elation,
       });
     }
-    const secondaryMappings = cxMapping.secondaryMappings as ElationSecondaryMappings;
+    const secondaryMappings = elationSecondaryMappingsSchema.parse(cxMapping.secondaryMappings);
     await createOrUpdateElationPatientMetadata({
       cxId,
       elationPracticeId,

--- a/packages/api/src/routes/ehr/elation/patient-webhook.ts
+++ b/packages/api/src/routes/ehr/elation/patient-webhook.ts
@@ -1,7 +1,7 @@
 import { buildEhrSyncPatientHandler } from "@metriport/core/external/ehr/sync-patient/ehr-sync-patient-factory";
 import { out } from "@metriport/core/util/log";
 import { MetriportError } from "@metriport/shared";
-import { ElationSecondaryMappings } from "@metriport/shared/interface/external/ehr/elation/cx-mapping";
+import { elationSecondaryMappingsSchema } from "@metriport/shared/interface/external/ehr/elation/cx-mapping";
 import { elationPatientEventSchema } from "@metriport/shared/interface/external/ehr/elation/event";
 import { EhrSources } from "@metriport/shared/interface/external/ehr/source";
 import { Request, Response } from "express";
@@ -48,7 +48,7 @@ router.post(
         source: EhrSources.elation,
       });
     }
-    const secondaryMappings = cxMapping.secondaryMappings as ElationSecondaryMappings;
+    const secondaryMappings = elationSecondaryMappingsSchema.parse(cxMapping.secondaryMappings);
     await createOrUpdateElationPatientMetadata({
       cxId,
       elationPracticeId,

--- a/packages/api/src/routes/ehr/elation/patient-webhook.ts
+++ b/packages/api/src/routes/ehr/elation/patient-webhook.ts
@@ -1,8 +1,13 @@
+import { buildEhrSyncPatientHandler } from "@metriport/core/external/ehr/sync-patient/ehr-sync-patient-factory";
 import { out } from "@metriport/core/util/log";
+import { MetriportError } from "@metriport/shared";
+import { ElationSecondaryMappings } from "@metriport/shared/interface/external/ehr/elation/cx-mapping";
 import { elationPatientEventSchema } from "@metriport/shared/interface/external/ehr/elation/event";
+import { EhrSources } from "@metriport/shared/interface/external/ehr/source";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import httpStatus from "http-status";
+import { getCxMappingOrFail } from "../../../command/mapping/cx";
 import { createOrUpdateElationPatientMetadata } from "../../../external/ehr/elation/command/sync-patient";
 import { handleParams } from "../../helpers/handle-params";
 import { requestLogger } from "../../helpers/request-logger";
@@ -33,11 +38,32 @@ router.post(
       log(`Patient event is not a created event for patient ${event.data.id}`);
       return res.sendStatus(httpStatus.OK);
     }
+    const cxMapping = await getCxMappingOrFail({
+      externalId: elationPracticeId,
+      source: EhrSources.elation,
+    });
+    if (!cxMapping.secondaryMappings) {
+      throw new MetriportError("Elation secondary mappings not found", undefined, {
+        externalId: elationPracticeId,
+        source: EhrSources.elation,
+      });
+    }
+    const secondaryMappings = cxMapping.secondaryMappings as ElationSecondaryMappings;
     await createOrUpdateElationPatientMetadata({
       cxId,
       elationPracticeId,
       elationPatientId: event.data.id,
     });
+    if (secondaryMappings.webhookPatientPatientProcessingEnabled) {
+      const handler = buildEhrSyncPatientHandler();
+      await handler.processSyncPatient({
+        ehr: EhrSources.elation,
+        cxId,
+        practiceId: elationPracticeId,
+        patientId: event.data.id,
+        triggerDq: true,
+      });
+    }
     return res.sendStatus(httpStatus.OK);
   })
 );

--- a/packages/shared/src/interface/external/ehr/elation/cx-mapping.ts
+++ b/packages/shared/src/interface/external/ehr/elation/cx-mapping.ts
@@ -8,6 +8,7 @@ const webhookSchema = z.object({
 
 export const elationSecondaryMappingsSchema = z.object({
   webhooks: z.record(z.enum(subscriptionResources), webhookSchema).optional(),
+  webhookPatientPatientProcessingEnabled: z.boolean().optional(),
   webhookAppointmentPatientProcessingDisabled: z.boolean().optional(),
   backgroundAppointmentPatientProcessingDisabled: z.boolean().optional(),
 });


### PR DESCRIPTION
Ref: #1040

### Description

- add boolean for proceeding to full patient processing on patient create WHs from elation

### Testing

- Local
  - [x] http call for patient processing is made when boolean is true
  - [x] no http call for patient processing when boolean is false or undefined
- Staging
  - [ ] http call for patient processing is made when boolean is true
  - [ ] no http call for patient processing when boolean is false or undefined
- Sandbox
  - [ ] N/A
- Production
  - [ ] http call for patient processing is made when boolean is true
  - [ ] no http call for patient processing when boolean is false or undefined

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced patient data synchronization during external system events.
	- Introduced a new configuration option that lets administrators enable or disable automatic patient processing for improved reliability.
	- Added flexibility to the patient processing settings related to webhooks with a new optional property.

- **Bug Fixes**
	- Improved error handling for missing secondary mappings during patient synchronization.
	- Enhanced validation of secondary mappings to prevent runtime errors related to unexpected data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->