### PR TITLE
fix(infra): pull psks from secrets manager

### DIFF
--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -117,5 +117,21 @@ export class MllpStack extends cdk.NestedStack {
       scaleInCooldown: Duration.seconds(60),
       scaleOutCooldown: Duration.seconds(60),
     });
+
+    // Add CloudFormation outputs
+    new cdk.CfnOutput(this, "MllpClusterArn", {
+      value: cluster.clusterArn,
+      description: "ARN of the MLLP ECS Cluster",
+    });
+
+    new cdk.CfnOutput(this, "MllpServiceArn", {
+      value: fargateService.serviceArn,
+      description: "ARN of the MLLP Fargate Service",
+    });
+
+    new cdk.CfnOutput(this, "MllpNlbDnsName", {
+      value: nlb.loadBalancerDnsName,
+      description: "DNS name of the Network Load Balancer for MLLP",
+    });
   }
 }


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/2754

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3492

### Description

This PR pulls a secret containing a pair of preshared keys per partner from secrets manager to establish VPN tunnels.

I've also added some new CFN outputs to simplify the release process for myself.

### Testing

- Local
  - [x] After the deploy, verify that the VPN tunnel config files contain the PSKs from secrets manager
- Staging
  - [ ] After the deploy, verify that the VPN tunnel config files contain the PSKs from secrets manager
- Production
  - [ ] After the deploy, verify that the VPN tunnel config files contain the PSKs from secrets manager

### Release Plan

- [ ] Merge into Upstream before release
