### PR TITLE
feat(ehr): elation pagination

### DIFF
--- a/packages/api/src/external/ehr/athenahealth/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/process-patients-from-appointments.ts
@@ -60,9 +60,7 @@ export async function processPatientsFromAppointments({ lookupMode }: { lookupMo
       });
     }
     const secondaryMappings = athenaSecondaryMappingsSchema.parse(mapping.secondaryMappings);
-    if (secondaryMappings.backgroundAppointmentsDisabled) {
-      return [];
-    }
+    if (secondaryMappings.backgroundAppointmentsDisabled) return [];
     return [
       {
         cxId: mapping.cxId,

--- a/packages/api/src/external/ehr/canvas/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/canvas/command/process-patients-from-appointments.ts
@@ -94,7 +94,9 @@ async function getAppointments({
 }: GetAppointmentsParams): Promise<{ appointments?: Appointment[]; error?: unknown }> {
   const { log } = out(`Canvas getAppointments - cxId ${cxId} practiceId ${practiceId}`);
   const api = await createCanvasClient({ cxId, practiceId });
-  const { startRange, endRange } = getLookForwardTimeRange({ appointmentsLookForward });
+  const { startRange, endRange } = getLookForwardTimeRange({
+    lookForward: appointmentsLookForward,
+  });
   log(`Getting appointments from ${startRange} to ${endRange}`);
   try {
     const appointments = await api.getAppointments({

--- a/packages/api/src/external/ehr/canvas/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/canvas/command/process-patients-from-appointments.ts
@@ -21,7 +21,7 @@ import { SyncCanvasPatientIntoMetriportParams } from "./sync-patient";
 
 dayjs.extend(duration);
 
-const lookForward = dayjs.duration(1, "day");
+const appointmentsLookForward = dayjs.duration(1, "day");
 
 type GetAppointmentsParams = {
   cxId: string;
@@ -94,7 +94,7 @@ async function getAppointments({
 }: GetAppointmentsParams): Promise<{ appointments?: Appointment[]; error?: unknown }> {
   const { log } = out(`Canvas getAppointments - cxId ${cxId} practiceId ${practiceId}`);
   const api = await createCanvasClient({ cxId, practiceId });
-  const { startRange, endRange } = getLookForwardTimeRange({ lookForward });
+  const { startRange, endRange } = getLookForwardTimeRange({ appointmentsLookForward });
   log(`Getting appointments from ${startRange} to ${endRange}`);
   try {
     const appointments = await api.getAppointments({

--- a/packages/api/src/external/ehr/elation/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/elation/command/process-patients-from-appointments.ts
@@ -57,6 +57,8 @@ export async function processPatientsFromAppointments(): Promise<void> {
   const allAppointments: Appointment[] = [];
   const getAppointmentsErrors: { error: unknown; cxId: string; practiceId: string }[] = [];
   const getAppointmentsArgs: GetAppointmentsParams[] = cxMappings.map(mapping => {
+    const secondaryMappings = secondaryMappingsMap[mapping.externalId];
+    if (secondaryMappings.backgroundAppointmentsDisabled) return [];
     return {
       cxId: mapping.cxId,
       practiceId: mapping.externalId,

--- a/packages/api/src/external/ehr/elation/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/elation/command/process-patients-from-appointments.ts
@@ -29,7 +29,7 @@ import {
 
 dayjs.extend(duration);
 
-const lookForward = dayjs.duration(14, "days");
+const appointmentsLookForward = dayjs.duration(1, "day");
 
 type GetAppointmentsParams = {
   cxId: string;
@@ -144,7 +144,7 @@ async function getAppointments({
 }: GetAppointmentsParams): Promise<{ appointments?: Appointment[]; error?: unknown }> {
   const { log } = out(`Elation getAppointments - cxId ${cxId} practiceId ${practiceId}`);
   const api = await createElationClient({ cxId, practiceId });
-  const { startRange, endRange } = getLookForwardTimeRange({ lookForward });
+  const { startRange, endRange } = getLookForwardTimeRange({ appointmentsLookForward });
   log(`Getting appointments from ${startRange} to ${endRange}`);
   try {
     const appointments = await api.getAppointments({

--- a/packages/api/src/external/ehr/shared.ts
+++ b/packages/api/src/external/ehr/shared.ts
@@ -40,7 +40,7 @@ import {
   getLatestExpiringJwtTokenBySourceAndData,
 } from "../../command/jwt-token";
 
-export const delayBetweenPracticeBatches = dayjs.duration(0, "seconds");
+export const delayBetweenPracticeBatches = dayjs.duration(15, "seconds");
 export const delayBetweenPatientBatches = dayjs.duration(1, "seconds");
 export const parallelPractices = 10;
 export const parallelPatients = 200;

--- a/packages/api/src/external/ehr/shared.ts
+++ b/packages/api/src/external/ehr/shared.ts
@@ -40,7 +40,7 @@ import {
   getLatestExpiringJwtTokenBySourceAndData,
 } from "../../command/jwt-token";
 
-export const delayBetweenPracticeBatches = dayjs.duration(30, "seconds");
+export const delayBetweenPracticeBatches = dayjs.duration(0, "seconds");
 export const delayBetweenPatientBatches = dayjs.duration(1, "seconds");
 export const parallelPractices = 10;
 export const parallelPatients = 200;

--- a/packages/shared/src/interface/external/ehr/elation/appointment.ts
+++ b/packages/shared/src/interface/external/ehr/elation/appointment.ts
@@ -12,5 +12,6 @@ export const appointmentSchema = z.object({
 export type Appointment = z.infer<typeof appointmentSchema>;
 export const appointmentsSchema = z.object({
   results: appointmentSchema.array(),
+  next: z.string().nullable(),
 });
 export type Appointments = z.infer<typeof appointmentsSchema>;

--- a/packages/shared/src/interface/external/ehr/elation/cx-mapping.ts
+++ b/packages/shared/src/interface/external/ehr/elation/cx-mapping.ts
@@ -8,6 +8,7 @@ const webhookSchema = z.object({
 
 export const elationSecondaryMappingsSchema = z.object({
   webhooks: z.record(z.enum(subscriptionResources), webhookSchema).optional(),
+  backgroundAppointmentsDisabled: z.boolean().optional(),
   webhookPatientPatientLinkingDisabled: z.boolean().optional(),
   webhookPatientPatientProcessingEnabled: z.boolean().optional(),
   webhookAppointmentPatientLinkingDisabled: z.boolean().optional(),


### PR DESCRIPTION
Ref: #1040

### Description

- paginate elation appointment requests

### Testing

- Local
  - [x] paginate sandbox appointments successfully
- Staging
  - [ ] N/A (limit by default is 100 -- so can't create this many appointments on staging)
- Sandbox
  - [ ] N?A
- Production
  - [ ] paginate appointments successfully

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled paginated appointment retrieval to enhance data integration.
  - Expanded appointment configuration with added pagination metadata and options to customize background processing.

- **Chores**
  - Reduced the processing delay between batches for faster updates.
  - Streamlined internal appointment handling logic while preserving overall functionality.
  - Enhanced clarity with updated naming conventions for duration constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->