### PR TITLE
PATCH: Remove beta from AI summaries

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-shared.ts
@@ -100,7 +100,6 @@ export function createBrief(brief?: Brief): string {
   const { link, content } = brief;
   const briefContents = `
   <div class="brief-section-content">
-    <div class="beta-flag">BETA</div>
     <table><tbody><tr><td>${content.replace(/\n/g, "<br/>")}</td></tr></tbody></table>
     <div class="brief-warning">
       <div class="brief-warning-contents">


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

Ticket: #1040

### Dependencies

- Upstream: none
- Downstream:https://github.com/metriport/metriport-internal/pull/2825

### Description

- Remove beta from PDF

### Testing

- Local
  - [X] remove beta from pdf
- Production
  - [ ] remove beta from pdf

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed the "BETA" indicator from brief outputs, updating the visual presentation of brief content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->