### PR TITLE
2823 set up vpc peering for api access from hl7 vpc

### DIFF
--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -147,6 +147,7 @@ export const config: EnvConfigNonSandbox = {
   },
   generalBucketName: "test-bucket",
   hl7Notification: {
+    apiVpcId: "vpc-00000000000000000",
     vpnConfigs: [
       {
         partnerName: "SampleHIE",

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -1,4 +1,5 @@
 export interface Hl7NotificationConfig {
+  apiVpcId: string;
   vpnConfigs: Hl7NotificationVpnConfig[];
   mllpServer: {
     fargateCpu: number;

--- a/packages/infra/lib/vpc-peering.ts
+++ b/packages/infra/lib/vpc-peering.ts
@@ -1,0 +1,54 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { Construct } from "constructs";
+
+interface VpcConfig {
+  vpc: ec2.Vpc;
+  identifier: string; // Human readable identifier for the VPC
+  subnets?: ec2.ISubnet[];
+}
+
+interface VpcPeeringStackProps extends cdk.StackProps {
+  vpcConfigs: [VpcConfig, VpcConfig];
+}
+
+export class VpcPeeringStack extends cdk.Stack {
+  readonly peeringConnection: ec2.CfnVPCPeeringConnection;
+
+  constructor(scope: Construct, id: string, props: VpcPeeringStackProps) {
+    super(scope, id, props);
+
+    const [vpcConfigA, vpcConfigB] = props.vpcConfigs;
+
+    // Create the VPC Peering Connection with readable name
+    this.peeringConnection = new ec2.CfnVPCPeeringConnection(this, "VpcPeering", {
+      vpcId: vpcConfigA.vpc.vpcId,
+      peerVpcId: vpcConfigB.vpc.vpcId,
+      tags: [
+        {
+          key: "Name",
+          value: `${vpcConfigA.identifier}-to-${vpcConfigB.identifier}-peering`,
+        },
+      ],
+    });
+
+    // Create routes for both VPCs using readable identifiers
+    this.createRoutesForVpc(vpcConfigA, vpcConfigB);
+    this.createRoutesForVpc(vpcConfigB, vpcConfigA);
+  }
+
+  private createRoutesForVpc(sourceConfig: VpcConfig, destinationConfig: VpcConfig): void {
+    const subnets = sourceConfig.subnets ?? sourceConfig.vpc.privateSubnets;
+    subnets.forEach((subnet, i) => {
+      new ec2.CfnRoute(
+        this,
+        `Route${sourceConfig.identifier}To${destinationConfig.identifier}${i}`,
+        {
+          routeTableId: subnet.routeTable.routeTableId,
+          destinationCidrBlock: destinationConfig.vpc.vpcCidrBlock,
+          vpcPeeringConnectionId: this.peeringConnection.ref,
+        }
+      );
+    });
+  }
+}

--- a/packages/infra/lib/vpc-peering.ts
+++ b/packages/infra/lib/vpc-peering.ts
@@ -3,7 +3,7 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
 
 interface VpcConfig {
-  vpc: ec2.Vpc;
+  vpc: ec2.IVpc;
   identifier: string; // Human readable identifier for the VPC
   subnets?: ec2.ISubnet[];
 }
@@ -19,11 +19,12 @@ export class VpcPeeringStack extends cdk.Stack {
     super(scope, id, props);
 
     const [vpcConfigA, vpcConfigB] = props.vpcConfigs;
+    const vpcA = vpcConfigA.vpc;
+    const vpcB = vpcConfigB.vpc;
 
-    // Create the VPC Peering Connection with readable name
-    this.peeringConnection = new ec2.CfnVPCPeeringConnection(this, "VpcPeering", {
-      vpcId: vpcConfigA.vpc.vpcId,
-      peerVpcId: vpcConfigB.vpc.vpcId,
+    this.peeringConnection = new ec2.CfnVPCPeeringConnection(this, `${id}Connection`, {
+      vpcId: vpcA.vpcId,
+      peerVpcId: vpcB.vpcId,
       tags: [
         {
           key: "Name",
@@ -32,7 +33,6 @@ export class VpcPeeringStack extends cdk.Stack {
       ],
     });
 
-    // Create routes for both VPCs using readable identifiers
     this.createRoutesForVpc(vpcConfigA, vpcConfigB);
     this.createRoutesForVpc(vpcConfigB, vpcConfigA);
   }


### PR DESCRIPTION
Ticket: 

### Dependencies

- Upstream: 

### Description

Sets up VPC peering between our two VPCs, and sets NACLs that block all traffic so that we can open them as needed.

### Testing

- Local
  - [ ] 
  - [ ] ...
- Staging
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Sandbox
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Production
  - [ ] _testing step 1_
  - [ ] _testing step 2_


### Release Plan


- :warning: Changes important infrastructure, has security implications
- [ ] Merge this
