### PR TITLE
1040 Update address match threshold from .9 to .85

### DIFF
--- a/packages/api/src/command/medical/patient/add-coordinates.ts
+++ b/packages/api/src/command/medical/patient/add-coordinates.ts
@@ -4,7 +4,7 @@ import { capture } from "@metriport/core/util/notifications";
 import { AddressGeocodingResult, geocodeAddress } from "../../../external/aws/address";
 import { Config } from "../../../shared/config";
 
-const ADDRESS_MATCH_RELEVANCE_THRESHOLD = 0.9;
+const ADDRESS_MATCH_RELEVANCE_THRESHOLD = 0.85;
 
 type AddressBelowThreshold = {
   relevance: number;


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

Ticket: #_[ticket-number]_

### Dependencies

none

### Description

Update address match threshold from .9 to .85 - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1742862878865559?thread_ts=1739650141.477969&cid=C04T256DQPQ).

### Testing

none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined address matching criteria to more inclusively assess geographic data, which may result in additional addresses being accurately processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->