### PR TITLE
feat(infra): add specific cidr for HL7 vpc

### DIFF
--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -1,4 +1,5 @@
 export const MLLP_DEFAULT_PORT = 2575;
+export const HL7_NOTIFICATION_VPC_CIDR = "10.1.0.0/16";
 
 export const VPN_ACCESSIBLE_SUBNET_GROUP_NAME = "Private-VpnAccessible-MllpServer";
 export const INTERNAL_SERVICES_SUBNET_GROUP_NAME = "Private-InternalServices";

--- a/packages/infra/lib/hl7-notification-stack/index.ts
+++ b/packages/infra/lib/hl7-notification-stack/index.ts
@@ -7,7 +7,7 @@ import { MetriportCompositeStack } from "../shared/metriport-composite-stack";
 import { MllpStack } from "./mllp";
 import { NetworkStack } from "./network";
 import { VpnStack } from "./vpn";
-import { INTERNAL_SERVICES_SUBNET_GROUP_NAME } from "./constants";
+import { HL7_NOTIFICATION_VPC_CIDR, INTERNAL_SERVICES_SUBNET_GROUP_NAME } from "./constants";
 import { VPN_ACCESSIBLE_SUBNET_GROUP_NAME } from "./constants";
 import { Secret } from "aws-cdk-lib/aws-secretsmanager";
 
@@ -32,6 +32,7 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
 
     const vpc = new ec2.Vpc(this, "Vpc", {
       maxAzs: NUM_AZS,
+      ipAddresses: ec2.IpAddresses.cidr(HL7_NOTIFICATION_VPC_CIDR),
       subnetConfiguration: [
         {
           cidrMask: 24,

--- a/packages/infra/lib/hl7-notification-stack/index.ts
+++ b/packages/infra/lib/hl7-notification-stack/index.ts
@@ -16,7 +16,7 @@ export interface Hl7NotificationStackProps extends cdk.StackProps {
   version: string | undefined;
 }
 
-const NUM_AZS = 2;
+const NUM_AZS = 1;
 
 const fetchSecretsForPartner = (scope: Construct, partnerName: string) => {
   const secretName = `PresharedKey-${partnerName}`;


### PR DESCRIPTION
Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

Ticket: https://github.com/metriport/metriport-internal/issues/2817

### Dependencies

None

### Description

This PR sets a specific CIDR block for the HL7 notification VPC. 

This PR requires a complete redeployment of the HL7 notification stack, see Release notes below.

### Testing

- [x] Verified as setting the default cidr for the vpc to 10.1.0.0/16

### Release Plan

- [ ] Nuke staging HL7 notification VPC
- [ ] Merge to stage
- [ ] On release to staging, expect deploy to get stuck trying to spin up task, but failing to find image, then update environment state:
  - [ ] `gh variable set ECS_CLUSTER_MLLP_SERVER_STAGING --body "_"`
  - [ ] `gh variable set ECS_SERVICE_MLLP_SERVER_STAGING --body "_"`
- [ ] Nuke prod HL7 notification VPC
- [ ] Merge to prod
- [ ] On release to prod, expect deploy to get stuck trying to spin up task, but failing to find image, then update environment state:
  - [ ] `gh variable set ECS_CLUSTER_MLLP_SERVER_PRODUCTION--body "_"`
  - [ ] `gh variable set ECS_SERVICE_MLLP_SERVER_PRODUCTION --body "_"`
- [ ] Follow up with DNS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved networking configuration for HL7 notifications by introducing a dedicated IP address range for VPC deployments. This enhancement ensures a clearly defined network environment for HL7 notifications.
  - Reduced the number of availability zones utilized in the VPC configuration for more efficient resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->