### PR TITLE
feat(infra): Track tunnel secrets in cdk

### DIFF
--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -2,13 +2,14 @@ import * as cdk from "aws-cdk-lib";
 import "source-map-support/register";
 import { EnvConfig } from "../config/env-config";
 import { APIStack } from "../lib/api-stack";
+import { ConnectWidgetStack } from "../lib/connect-widget-stack";
 import { Hl7NotificationStack } from "../lib/hl7-notification-stack";
+import { VpnStack } from "../lib/hl7-notification-stack/vpn";
+import { IHEStack } from "../lib/ihe-stack";
 import { LocationServicesStack } from "../lib/location-services-stack";
 import { SecretsStack } from "../lib/secrets-stack";
 import { initConfig } from "../lib/shared/config";
 import { getEnvVar, isSandbox } from "../lib/shared/util";
-import { IHEStack } from "../lib/ihe-stack";
-import { ConnectWidgetStack } from "../lib/connect-widget-stack";
 
 const app = new cdk.App();
 
@@ -50,10 +51,21 @@ async function deploy(config: EnvConfig) {
   // 4. Deploy the HL7 Notification Routing stack.
   //---------------------------------------------------------------------------------
   if (!isSandbox(config)) {
-    new Hl7NotificationStack(app, "Hl7NotificationStack", {
+    const hl7NotificationStack = new Hl7NotificationStack(app, "Hl7NotificationStack", {
       env,
       config,
       version,
+    });
+
+    config.hl7Notification.vpnConfigs.forEach((config, index) => {
+      const vpnStack = new VpnStack(app, `VpnStack${config.partnerName}`, {
+        vpnConfig: { ...config, presharedKeyName: `PresharedKey-${config.partnerName}` },
+        index,
+        networkStackId: "NestedNetworkStack",
+        description: `VPN Configuration for routing HL7 messages from ${config.partnerName}`,
+      });
+
+      vpnStack.addDependency(hl7NotificationStack);
     });
   }
 

--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -58,8 +58,8 @@ async function deploy(config: EnvConfig) {
     });
 
     config.hl7Notification.vpnConfigs.forEach((config, index) => {
-      const vpnStack = new VpnStack(app, `VpnStack${config.partnerName}`, {
-        vpnConfig: { ...config, presharedKeyName: `PresharedKey-${config.partnerName}` },
+      const vpnStack = new VpnStack(app, `VpnStack-${config.partnerName}`, {
+        vpnConfig: { ...config },
         index,
         networkStackId: "NestedNetworkStack",
         description: `VPN Configuration for routing HL7 messages from ${config.partnerName}`,

--- a/packages/infra/lib/hl7-notification-stack/index.ts
+++ b/packages/infra/lib/hl7-notification-stack/index.ts
@@ -4,12 +4,9 @@ import { Repository } from "aws-cdk-lib/aws-ecr";
 import { Construct } from "constructs";
 import { EnvConfigNonSandbox } from "../../config/env-config";
 import { MetriportCompositeStack } from "../shared/metriport-composite-stack";
+import { INTERNAL_SERVICES_SUBNET_GROUP_NAME, VPN_ACCESSIBLE_SUBNET_GROUP_NAME } from "./constants";
 import { MllpStack } from "./mllp";
 import { NetworkStack } from "./network";
-import { VpnStack } from "./vpn";
-import { INTERNAL_SERVICES_SUBNET_GROUP_NAME } from "./constants";
-import { VPN_ACCESSIBLE_SUBNET_GROUP_NAME } from "./constants";
-import { Secret } from "aws-cdk-lib/aws-secretsmanager";
 
 export interface Hl7NotificationStackProps extends cdk.StackProps {
   config: EnvConfigNonSandbox;
@@ -18,17 +15,9 @@ export interface Hl7NotificationStackProps extends cdk.StackProps {
 
 const NUM_AZS = 2;
 
-const fetchSecretsForPartner = (scope: Construct, partnerName: string) => {
-  const secretName = `PresharedKey-${partnerName}`;
-  return Secret.fromSecretNameV2(scope, secretName, secretName);
-};
-
 export class Hl7NotificationStack extends MetriportCompositeStack {
-  public readonly networkStack: NetworkStack;
-
   constructor(scope: Construct, id: string, props: Hl7NotificationStackProps) {
     super(scope, id, props);
-    const vpnConfigs = props.config.hl7Notification.vpnConfigs;
 
     const vpc = new ec2.Vpc(this, "Vpc", {
       maxAzs: NUM_AZS,
@@ -65,21 +54,11 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
       description: "HL7 Notification Routing MLLP Server",
     });
 
-    this.networkStack = new NetworkStack(this, "NestedNetworkStack", {
+    new NetworkStack(this, "NestedNetworkStack", {
       stackName: "NestedNetworkStack",
       config: props.config,
       vpc,
       description: "HL7 Notification Routing Network Infrastructure",
-    });
-
-    vpnConfigs.forEach((config, index) => {
-      new VpnStack(this, `NestedVpnStack${config.partnerName}`, {
-        vpnConfig: { ...config, presharedKey: fetchSecretsForPartner(this, config.partnerName) },
-        vpc,
-        index,
-        networkStack: this.networkStack.output,
-        description: `VPN Configuration for routing HL7 messages from ${config.partnerName}`,
-      });
     });
 
     new cdk.CfnOutput(this, "MllpECRRepoURI", {

--- a/packages/infra/lib/hl7-notification-stack/network.ts
+++ b/packages/infra/lib/hl7-notification-stack/network.ts
@@ -70,8 +70,6 @@ export class NetworkStack extends cdk.NestedStack {
      * Read more about needing to set the dependency here:
      * https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ec2/CfnVPNGatewayRoutePropagation.html
      * */
-
-    // Enable route propagation for each of our private subnets back out to the vgw
     const vpnAccessibleSubnets = vpc.selectSubnets({
       subnetGroupName: VPN_ACCESSIBLE_SUBNET_GROUP_NAME,
     }).subnets;
@@ -87,6 +85,16 @@ export class NetworkStack extends cdk.NestedStack {
       );
 
       routePropagation.node.addDependency(vgwAttachment);
+    });
+
+    new cdk.CfnOutput(this, "NetworkAclId", {
+      value: networkAcl.networkAclId,
+      exportName: `NestedNetworkStack-NetworkAclId`,
+    });
+
+    new cdk.CfnOutput(this, "VgwId", {
+      value: vgw.ref,
+      exportName: `NestedNetworkStack-VgwId`,
     });
 
     this.output = {


### PR DESCRIPTION
refs. metriport/metriport-internal#2817

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Related PRs

Same release: https://github.com/metriport/metriport/pull/3529

### Description

This PR...
- tracks secrets in CDK 
- decouples the existing vpn stacks so that they can be booted up and down separately from the main HL7 vpc, so we can change our secret, restart the stack and ensure the tunnel picks up our changed secret.

The reason we're not tracking all tunnel secrets together is because if our one tunnel secret was compromised, it would be a massive security risk, forcing us to email dozens of state HIEs to change our tunnel settings, and rebooting dozens of tunnels, with multiple days where our tunnels are potentially compromised or down (depending on course of action).

### Testing

- [x] Booted up and down the vpn conn without affecting the rest of the stack, and on bootup it creates a new secret / picks up updates to the same secret.  

### Release Plan

See release notes in https://github.com/metriport/metriport/pull/3529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dedicated VPN configuration management to enhance connectivity support.
  - Added network outputs that expose key identifiers for easier integration with other resources.

- **Refactor**
  - Separated VPN handling from the core notification workflow to improve deployment sequencing.
  - Streamlined resource creation and configuration processing for improved maintainability and security. 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->