### PR TITLE
feat(ehr): patch canvas

### DIFF
--- a/packages/api/src/external/ehr/shared-fhir.ts
+++ b/packages/api/src/external/ehr/shared-fhir.ts
@@ -26,6 +26,7 @@ import {
 import { handleMetriportSync, HandleMetriportSyncParams } from "./patient";
 
 const parallelPatientMatches = 5;
+const testLastName = "zztest";
 
 type GetPatientByDemoParams = {
   cxId: string;
@@ -91,6 +92,7 @@ export function createNamesFromFhir(patient: Patient): { firstName: string; last
   if (!patient.name) throw new BadRequestError("Patient has no name");
   const names = patient.name.flatMap(name => {
     if (!name.family) return [];
+    if (name.family === testLastName) throw new BadRequestError("Patient has test name");
     const lastName = name.family.trim();
     if (lastName === "") return [];
     if (!name.given) return [];

--- a/packages/shared/src/interface/external/ehr/canvas/appointment.ts
+++ b/packages/shared/src/interface/external/ehr/canvas/appointment.ts
@@ -15,7 +15,7 @@ export const appointmentSchema = z.object({
       }),
     })
     .array(),
-  status: z.literal("booked"),
+  status: z.string(),
 });
 export type Appointment = z.infer<typeof appointmentSchema>;
 export const appointmentListResponseSchema = z.object({


### PR DESCRIPTION
Ref: #1040

### Description

- did push change that allows all statuses from canvas
- throwing 400 on test patients from Canvas / Athena

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced name validation now prevents the submission of patients with reserved test names.
  - Appointment scheduling now supports a wider range of status values, offering greater flexibility in managing appointments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->