### PR TITLE
fix(core): remove alert for failed pd response to s3

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/ihe-gateway-v2-logic.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/ihe-gateway-v2-logic.ts
@@ -223,7 +223,6 @@ export async function createSignSendProcessXCPDRequest({
         const msg = "Failed to send PD response to S3";
         const extra = { cxId, patientId, result };
         log(`${msg} - ${errorToString(error)} - ${JSON.stringify(extra)}`);
-        capture.error(msg, { extra: { ...extra, error } });
       }
     }
   });


### PR DESCRIPTION
refs. metriport/metriport-internal#799

### Description
- Removing alert for failed attempt to store PD response on S3 - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1743090669627689?thread_ts=1738767862.741679&cid=C04T256DQPQ) 

### Testing
- N/A

### Release Plan
- [ ] Merge this
