### PR TITLE
2835 Revert redeploy of HL7 infra

### DIFF
--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -2,14 +2,13 @@ import * as cdk from "aws-cdk-lib";
 import "source-map-support/register";
 import { EnvConfig } from "../config/env-config";
 import { APIStack } from "../lib/api-stack";
-import { ConnectWidgetStack } from "../lib/connect-widget-stack";
 import { Hl7NotificationStack } from "../lib/hl7-notification-stack";
-import { VpnStack } from "../lib/hl7-notification-stack/vpn";
-import { IHEStack } from "../lib/ihe-stack";
 import { LocationServicesStack } from "../lib/location-services-stack";
 import { SecretsStack } from "../lib/secrets-stack";
 import { initConfig } from "../lib/shared/config";
 import { getEnvVar, isSandbox } from "../lib/shared/util";
+import { IHEStack } from "../lib/ihe-stack";
+import { ConnectWidgetStack } from "../lib/connect-widget-stack";
 
 const app = new cdk.App();
 
@@ -51,21 +50,10 @@ async function deploy(config: EnvConfig) {
   // 4. Deploy the HL7 Notification Routing stack.
   //---------------------------------------------------------------------------------
   if (!isSandbox(config)) {
-    const hl7NotificationStack = new Hl7NotificationStack(app, "Hl7NotificationStack", {
+    new Hl7NotificationStack(app, "Hl7NotificationStack", {
       env,
       config,
       version,
-    });
-
-    config.hl7Notification.vpnConfigs.forEach((config, index) => {
-      const vpnStack = new VpnStack(app, `VpnStack-${config.partnerName}`, {
-        vpnConfig: { ...config },
-        index,
-        networkStackId: "NestedNetworkStack",
-        description: `VPN Configuration for routing HL7 messages from ${config.partnerName}`,
-      });
-
-      vpnStack.addDependency(hl7NotificationStack);
     });
   }
 

--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -1,5 +1,4 @@
 export const MLLP_DEFAULT_PORT = 2575;
-export const HL7_NOTIFICATION_VPC_CIDR = "10.1.0.0/16";
 
 export const VPN_ACCESSIBLE_SUBNET_GROUP_NAME = "Private-VpnAccessible-MllpServer";
 export const INTERNAL_SERVICES_SUBNET_GROUP_NAME = "Private-InternalServices";

--- a/packages/infra/lib/hl7-notification-stack/index.ts
+++ b/packages/infra/lib/hl7-notification-stack/index.ts
@@ -4,13 +4,12 @@ import { Repository } from "aws-cdk-lib/aws-ecr";
 import { Construct } from "constructs";
 import { EnvConfigNonSandbox } from "../../config/env-config";
 import { MetriportCompositeStack } from "../shared/metriport-composite-stack";
-import {
-  HL7_NOTIFICATION_VPC_CIDR,
-  INTERNAL_SERVICES_SUBNET_GROUP_NAME,
-  VPN_ACCESSIBLE_SUBNET_GROUP_NAME,
-} from "./constants";
 import { MllpStack } from "./mllp";
 import { NetworkStack } from "./network";
+import { VpnStack } from "./vpn";
+import { HL7_NOTIFICATION_VPC_CIDR, INTERNAL_SERVICES_SUBNET_GROUP_NAME } from "./constants";
+import { VPN_ACCESSIBLE_SUBNET_GROUP_NAME } from "./constants";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
 
 export interface Hl7NotificationStackProps extends cdk.StackProps {
   config: EnvConfigNonSandbox;
@@ -19,9 +18,17 @@ export interface Hl7NotificationStackProps extends cdk.StackProps {
 
 const NUM_AZS = 1;
 
+const fetchSecretsForPartner = (scope: Construct, partnerName: string) => {
+  const secretName = `PresharedKey-${partnerName}`;
+  return Secret.fromSecretNameV2(scope, secretName, secretName);
+};
+
 export class Hl7NotificationStack extends MetriportCompositeStack {
+  public readonly networkStack: NetworkStack;
+
   constructor(scope: Construct, id: string, props: Hl7NotificationStackProps) {
     super(scope, id, props);
+    const vpnConfigs = props.config.hl7Notification.vpnConfigs;
 
     const vpc = new ec2.Vpc(this, "Vpc", {
       maxAzs: NUM_AZS,
@@ -59,11 +66,21 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
       description: "HL7 Notification Routing MLLP Server",
     });
 
-    new NetworkStack(this, "NestedNetworkStack", {
+    this.networkStack = new NetworkStack(this, "NestedNetworkStack", {
       stackName: "NestedNetworkStack",
       config: props.config,
       vpc,
       description: "HL7 Notification Routing Network Infrastructure",
+    });
+
+    vpnConfigs.forEach((config, index) => {
+      new VpnStack(this, `NestedVpnStack${config.partnerName}`, {
+        vpnConfig: { ...config, presharedKey: fetchSecretsForPartner(this, config.partnerName) },
+        vpc,
+        index,
+        networkStack: this.networkStack.output,
+        description: `VPN Configuration for routing HL7 messages from ${config.partnerName}`,
+      });
     });
 
     new cdk.CfnOutput(this, "MllpECRRepoURI", {

--- a/packages/infra/lib/hl7-notification-stack/index.ts
+++ b/packages/infra/lib/hl7-notification-stack/index.ts
@@ -7,7 +7,7 @@ import { MetriportCompositeStack } from "../shared/metriport-composite-stack";
 import { MllpStack } from "./mllp";
 import { NetworkStack } from "./network";
 import { VpnStack } from "./vpn";
-import { HL7_NOTIFICATION_VPC_CIDR, INTERNAL_SERVICES_SUBNET_GROUP_NAME } from "./constants";
+import { INTERNAL_SERVICES_SUBNET_GROUP_NAME } from "./constants";
 import { VPN_ACCESSIBLE_SUBNET_GROUP_NAME } from "./constants";
 import { Secret } from "aws-cdk-lib/aws-secretsmanager";
 
@@ -16,7 +16,7 @@ export interface Hl7NotificationStackProps extends cdk.StackProps {
   version: string | undefined;
 }
 
-const NUM_AZS = 1;
+const NUM_AZS = 2;
 
 const fetchSecretsForPartner = (scope: Construct, partnerName: string) => {
   const secretName = `PresharedKey-${partnerName}`;
@@ -32,7 +32,6 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
 
     const vpc = new ec2.Vpc(this, "Vpc", {
       maxAzs: NUM_AZS,
-      ipAddresses: ec2.IpAddresses.cidr(HL7_NOTIFICATION_VPC_CIDR),
       subnetConfiguration: [
         {
           cidrMask: 24,

--- a/packages/infra/lib/hl7-notification-stack/network.ts
+++ b/packages/infra/lib/hl7-notification-stack/network.ts
@@ -70,6 +70,8 @@ export class NetworkStack extends cdk.NestedStack {
      * Read more about needing to set the dependency here:
      * https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ec2/CfnVPNGatewayRoutePropagation.html
      * */
+
+    // Enable route propagation for each of our private subnets back out to the vgw
     const vpnAccessibleSubnets = vpc.selectSubnets({
       subnetGroupName: VPN_ACCESSIBLE_SUBNET_GROUP_NAME,
     }).subnets;
@@ -85,16 +87,6 @@ export class NetworkStack extends cdk.NestedStack {
       );
 
       routePropagation.node.addDependency(vgwAttachment);
-    });
-
-    new cdk.CfnOutput(this, "NetworkAclId", {
-      value: networkAcl.networkAclId,
-      exportName: `NestedNetworkStack-NetworkAclId`,
-    });
-
-    new cdk.CfnOutput(this, "VgwId", {
-      value: vgw.ref,
-      exportName: `NestedNetworkStack-VgwId`,
     });
 
     this.output = {


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/2835

### Dependencies

None

### Description

In CI we're only deploying the HL7 notification stack - which no longer includes the VPN stacks as they are no longer nested stacks. Need to consider how to deploy these.

### Testing

- [ ] Ship this to staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced high availability through deployment across multiple zones.
  - Introduced secure handling of partner connection configurations for improved reliability.

- **Refactor**
  - Streamlined network connectivity and deployment processes for a more efficient experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->