### PR TITLE
2840 Add FF stack

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -45,6 +45,7 @@ import { TerminologyServerNestedStack } from "./api-stack/terminology-server-ser
 import { createAppConfigStack } from "./app-config-stack";
 import { EhrNestedStack } from "./ehr-nested-stack";
 import { EnvType } from "./env-type";
+import { FeatureFlagsNestedStack } from "./feature-flags-nested-stack";
 import { IHEGatewayV2LambdasNestedStack } from "./ihe-gateway-v2-stack";
 import { CDA_TO_VIS_TIMEOUT, LambdasNestedStack } from "./lambdas-nested-stack";
 import { PatientImportNestedStack } from "./patient-import-nested-stack";
@@ -146,6 +147,10 @@ export class APIStack extends Stack {
         stack: this,
         props: { config: props.config },
       });
+    new FeatureFlagsNestedStack(this, "FeatureFlags", {
+      config: props.config,
+      alarmAction: slackNotification?.alarmAction,
+    });
 
     //-------------------------------------------
     // Aurora Database for backend data

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -147,7 +147,7 @@ export class APIStack extends Stack {
         stack: this,
         props: { config: props.config },
       });
-    new FeatureFlagsNestedStack(this, "FeatureFlags", {
+    const { featureFlagsTable } = new FeatureFlagsNestedStack(this, "FeatureFlags", {
       config: props.config,
       alarmAction: slackNotification?.alarmAction,
     });
@@ -521,6 +521,7 @@ export class APIStack extends Stack {
         envId: appConfigEnvId,
         deploymentStrategyId: deploymentStrategyId,
       },
+      featureFlagsTable,
       cookieStore,
     });
     const apiLoadBalancerAddress = apiLoadBalancer.loadBalancerDnsName;

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -113,6 +113,7 @@ export function createAPIService({
   searchAuth,
   searchIndexName,
   appConfigEnvVars,
+  featureFlagsTable,
   cookieStore,
 }: {
   stack: Construct;
@@ -155,6 +156,7 @@ export function createAPIService({
     envId: string;
     deploymentStrategyId: string;
   };
+  featureFlagsTable: dynamodb.Table;
   cookieStore: secret.ISecret | undefined;
 }): {
   cluster: ecs.Cluster;
@@ -304,6 +306,7 @@ export function createAPIService({
           APPCONFIG_CONFIGURATION_ID: appConfigEnvVars.configId,
           APPCONFIG_ENVIRONMENT_ID: appConfigEnvVars.envId,
           APPCONFIG_DEPLOYMENT_STRATEGY_ID: appConfigEnvVars.deploymentStrategyId,
+          FEATURE_FLAGS_TABLE_NAME: featureFlagsTable.tableName,
           ...(coverageEnhancementConfig && {
             CW_MANAGEMENT_URL: coverageEnhancementConfig.managementUrl,
           }),
@@ -386,6 +389,7 @@ export function createAPIService({
   // RW grant for Dynamo DB
   dynamoDBTokenTable.grantReadWriteData(fargateService.taskDefinition.taskRole);
   rateLimitTable.grantReadWriteData(fargateService.taskDefinition.taskRole);
+  featureFlagsTable.grantReadWriteData(fargateService.taskDefinition.taskRole);
 
   cdaToVisualizationLambda.grantInvoke(fargateService.taskDefinition.taskRole);
   documentDownloaderLambda.grantInvoke(fargateService.taskDefinition.taskRole);

--- a/packages/infra/lib/feature-flags-nested-stack.ts
+++ b/packages/infra/lib/feature-flags-nested-stack.ts
@@ -73,7 +73,7 @@ export class FeatureFlagsNestedStack extends NestedStack {
   }): dynamodb.Table {
     const {
       dynamoConstructName,
-      dynamoPartitionKey: dynamoRateLimitPartitionKey,
+      dynamoPartitionKey,
       dynamoReplicationRegions,
       dynamoReplicationTimeout,
       dynamoPointInTimeRecovery,
@@ -85,7 +85,7 @@ export class FeatureFlagsNestedStack extends NestedStack {
     } = ownProps;
     const table = new dynamodb.Table(this, dynamoConstructName, {
       partitionKey: {
-        name: dynamoRateLimitPartitionKey,
+        name: dynamoPartitionKey,
         type: dynamodb.AttributeType.STRING,
       },
       replicationRegions: dynamoReplicationRegions,
@@ -137,8 +137,8 @@ export class FeatureFlagsNestedStack extends NestedStack {
       this,
       `${dynamoConstructName}ConsumedReadCapacityUnitsAlarm`,
       {
-        threshold: consumedWriteCapacityUnitsAlarmThreshold, // units per second
-        evaluationPeriods: consumedWriteCapacityUnitsAlarmPeriod,
+        threshold: consumedReadCapacityUnitsAlarmThreshold, // units per second
+        evaluationPeriods: consumedReadCapacityUnitsAlarmPeriod,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }
     );
@@ -150,8 +150,8 @@ export class FeatureFlagsNestedStack extends NestedStack {
       this,
       `${dynamoConstructName}ConsumedWriteCapacityUnitsAlarm`,
       {
-        threshold: consumedReadCapacityUnitsAlarmThreshold, // units per second
-        evaluationPeriods: consumedReadCapacityUnitsAlarmPeriod,
+        threshold: consumedWriteCapacityUnitsAlarmThreshold, // units per second
+        evaluationPeriods: consumedWriteCapacityUnitsAlarmPeriod,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }
     );

--- a/packages/infra/lib/feature-flags-nested-stack.ts
+++ b/packages/infra/lib/feature-flags-nested-stack.ts
@@ -1,0 +1,161 @@
+import { Duration, NestedStack, NestedStackProps } from "aws-cdk-lib";
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import { Construct } from "constructs";
+import { EnvConfig } from "../config/env-config";
+import { isProd } from "./shared/util";
+
+interface FeatureFlagsNestedStackProps extends NestedStackProps {
+  config: EnvConfig;
+  alarmAction?: SnsAction;
+}
+
+function getSettings(props: FeatureFlagsNestedStackProps) {
+  return {
+    ...props,
+    dynamoConstructName: "FeatureFlags",
+    dynamoPartitionKey: "id",
+    dynamoReplicationRegions: isProd(props.config) ? ["us-east-1"] : ["ca-central-1"],
+    dynamoReplicationTimeout: Duration.hours(3),
+    dynamoPointInTimeRecovery: true,
+    consumedWriteCapacityUnitsAlarmThreshold: isProd(props.config) ? 100 : 10,
+    consumedWriteCapacityUnitsAlarmPeriod: 1,
+    consumedReadCapacityUnitsAlarmThreshold: isProd(props.config) ? 5000 : 100,
+    consumedReadCapacityUnitsAlarmPeriod: 2,
+  };
+}
+
+export class FeatureFlagsNestedStack extends NestedStack {
+  readonly featureFlagsTable: dynamodb.Table;
+
+  constructor(scope: Construct, id: string, props: FeatureFlagsNestedStackProps) {
+    super(scope, id, props);
+
+    const {
+      alarmAction,
+      dynamoConstructName,
+      dynamoPartitionKey,
+      dynamoReplicationRegions,
+      dynamoReplicationTimeout,
+      dynamoPointInTimeRecovery,
+      consumedWriteCapacityUnitsAlarmThreshold,
+      consumedWriteCapacityUnitsAlarmPeriod,
+      consumedReadCapacityUnitsAlarmThreshold,
+      consumedReadCapacityUnitsAlarmPeriod,
+    } = getSettings(props);
+
+    this.featureFlagsTable = this.setupFeatureFlagsTable({
+      dynamoConstructName,
+      dynamoPartitionKey,
+      dynamoReplicationRegions,
+      dynamoReplicationTimeout,
+      dynamoPointInTimeRecovery,
+      alarmAction,
+      consumedWriteCapacityUnitsAlarmThreshold,
+      consumedWriteCapacityUnitsAlarmPeriod,
+      consumedReadCapacityUnitsAlarmThreshold,
+      consumedReadCapacityUnitsAlarmPeriod,
+    });
+  }
+
+  private setupFeatureFlagsTable(ownProps: {
+    dynamoConstructName: string;
+    dynamoPartitionKey: string;
+    dynamoReplicationRegions: string[];
+    dynamoReplicationTimeout: Duration;
+    dynamoPointInTimeRecovery: boolean;
+    alarmAction?: SnsAction;
+    consumedWriteCapacityUnitsAlarmThreshold: number;
+    consumedWriteCapacityUnitsAlarmPeriod: number;
+    consumedReadCapacityUnitsAlarmThreshold: number;
+    consumedReadCapacityUnitsAlarmPeriod: number;
+  }): dynamodb.Table {
+    const {
+      dynamoConstructName,
+      dynamoPartitionKey: dynamoRateLimitPartitionKey,
+      dynamoReplicationRegions,
+      dynamoReplicationTimeout,
+      dynamoPointInTimeRecovery,
+      alarmAction,
+      consumedWriteCapacityUnitsAlarmThreshold,
+      consumedWriteCapacityUnitsAlarmPeriod,
+      consumedReadCapacityUnitsAlarmThreshold,
+      consumedReadCapacityUnitsAlarmPeriod,
+    } = ownProps;
+    const table = new dynamodb.Table(this, dynamoConstructName, {
+      partitionKey: {
+        name: dynamoRateLimitPartitionKey,
+        type: dynamodb.AttributeType.STRING,
+      },
+      replicationRegions: dynamoReplicationRegions,
+      replicationTimeout: dynamoReplicationTimeout,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+      pointInTimeRecovery: dynamoPointInTimeRecovery,
+    });
+    // TODO: note that the pointInTimeRecovery (PITR) setting does not persist
+    // through to the replica tables.
+    //
+    // See this CDK issue: https://github.com/aws/aws-cdk/issues/18582
+    //
+    // For future DDB tables, can potentailly use this is a workaround:
+    // https://stackoverflow.com/questions/70687039/how-to-set-point-in-time-recovery-on-a-dynamodb-replica
+    //
+    // For now, we will manually enable PITR on replicas in the console.
+    // add performance alarms for monitoring prod environment
+    this.addDynamoPerformanceAlarms({
+      table,
+      dynamoConstructName,
+      consumedWriteCapacityUnitsAlarmThreshold,
+      consumedWriteCapacityUnitsAlarmPeriod,
+      consumedReadCapacityUnitsAlarmThreshold,
+      consumedReadCapacityUnitsAlarmPeriod,
+      alarmAction,
+    });
+    return table;
+  }
+
+  private addDynamoPerformanceAlarms({
+    table,
+    dynamoConstructName,
+    consumedWriteCapacityUnitsAlarmThreshold,
+    consumedWriteCapacityUnitsAlarmPeriod,
+    consumedReadCapacityUnitsAlarmThreshold,
+    consumedReadCapacityUnitsAlarmPeriod,
+    alarmAction,
+  }: {
+    table: dynamodb.Table;
+    dynamoConstructName: string;
+    consumedWriteCapacityUnitsAlarmThreshold: number;
+    consumedWriteCapacityUnitsAlarmPeriod: number;
+    consumedReadCapacityUnitsAlarmThreshold: number;
+    consumedReadCapacityUnitsAlarmPeriod: number;
+    alarmAction?: SnsAction;
+  }) {
+    const readUnitsMetric = table.metricConsumedReadCapacityUnits();
+    const readAlarm = readUnitsMetric.createAlarm(
+      this,
+      `${dynamoConstructName}ConsumedReadCapacityUnitsAlarm`,
+      {
+        threshold: consumedWriteCapacityUnitsAlarmThreshold, // units per second
+        evaluationPeriods: consumedWriteCapacityUnitsAlarmPeriod,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      }
+    );
+    alarmAction && readAlarm.addAlarmAction(alarmAction);
+    alarmAction && readAlarm.addOkAction(alarmAction);
+
+    const writeUnitsMetric = table.metricConsumedWriteCapacityUnits();
+    const writeAlarm = writeUnitsMetric.createAlarm(
+      this,
+      `${dynamoConstructName}ConsumedWriteCapacityUnitsAlarm`,
+      {
+        threshold: consumedReadCapacityUnitsAlarmThreshold, // units per second
+        evaluationPeriods: consumedReadCapacityUnitsAlarmPeriod,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      }
+    );
+    alarmAction && writeAlarm.addAlarmAction(alarmAction);
+    alarmAction && writeAlarm.addOkAction(alarmAction);
+  }
+}

--- a/packages/infra/lib/feature-flags-nested-stack.ts
+++ b/packages/infra/lib/feature-flags-nested-stack.ts
@@ -16,7 +16,9 @@ function getSettings(props: FeatureFlagsNestedStackProps) {
     ...props,
     dynamoConstructName: "FeatureFlags",
     dynamoPartitionKey: "id",
-    dynamoSortKey: "updatedAt",
+    dynamoPartitionType: dynamodb.AttributeType.STRING,
+    dynamoSortKey: "version",
+    dynamoSortType: dynamodb.AttributeType.NUMBER,
     dynamoReplicationRegions: isProd(props.config) ? ["us-east-1"] : ["ca-central-1"],
     dynamoReplicationTimeout: Duration.hours(3),
     dynamoPointInTimeRecovery: true,
@@ -32,40 +34,15 @@ export class FeatureFlagsNestedStack extends NestedStack {
 
   constructor(scope: Construct, id: string, props: FeatureFlagsNestedStackProps) {
     super(scope, id, props);
-
-    const {
-      alarmAction,
-      dynamoConstructName,
-      dynamoPartitionKey,
-      dynamoSortKey,
-      dynamoReplicationRegions,
-      dynamoReplicationTimeout,
-      dynamoPointInTimeRecovery,
-      consumedWriteCapacityUnitsAlarmThreshold,
-      consumedWriteCapacityUnitsAlarmPeriod,
-      consumedReadCapacityUnitsAlarmThreshold,
-      consumedReadCapacityUnitsAlarmPeriod,
-    } = getSettings(props);
-
-    this.featureFlagsTable = this.setupFeatureFlagsTable({
-      dynamoConstructName,
-      dynamoPartitionKey,
-      dynamoSortKey,
-      dynamoReplicationRegions,
-      dynamoReplicationTimeout,
-      dynamoPointInTimeRecovery,
-      alarmAction,
-      consumedWriteCapacityUnitsAlarmThreshold,
-      consumedWriteCapacityUnitsAlarmPeriod,
-      consumedReadCapacityUnitsAlarmThreshold,
-      consumedReadCapacityUnitsAlarmPeriod,
-    });
+    this.featureFlagsTable = this.setupFeatureFlagsTable(getSettings(props));
   }
 
   private setupFeatureFlagsTable(ownProps: {
     dynamoConstructName: string;
     dynamoPartitionKey: string;
+    dynamoPartitionType: dynamodb.AttributeType;
     dynamoSortKey: string;
+    dynamoSortType: dynamodb.AttributeType;
     dynamoReplicationRegions: string[];
     dynamoReplicationTimeout: Duration;
     dynamoPointInTimeRecovery: boolean;
@@ -78,7 +55,9 @@ export class FeatureFlagsNestedStack extends NestedStack {
     const {
       dynamoConstructName,
       dynamoPartitionKey,
+      dynamoPartitionType,
       dynamoSortKey,
+      dynamoSortType,
       dynamoReplicationRegions,
       dynamoReplicationTimeout,
       dynamoPointInTimeRecovery,
@@ -91,11 +70,11 @@ export class FeatureFlagsNestedStack extends NestedStack {
     const table = new dynamodb.Table(this, dynamoConstructName, {
       partitionKey: {
         name: dynamoPartitionKey,
-        type: dynamodb.AttributeType.STRING,
+        type: dynamoPartitionType,
       },
       sortKey: {
         name: dynamoSortKey,
-        type: dynamodb.AttributeType.STRING,
+        type: dynamoSortType,
       },
       replicationRegions: dynamoReplicationRegions,
       replicationTimeout: dynamoReplicationTimeout,

--- a/packages/infra/lib/feature-flags-nested-stack.ts
+++ b/packages/infra/lib/feature-flags-nested-stack.ts
@@ -16,6 +16,7 @@ function getSettings(props: FeatureFlagsNestedStackProps) {
     ...props,
     dynamoConstructName: "FeatureFlags",
     dynamoPartitionKey: "id",
+    dynamoSortKey: "updatedAt",
     dynamoReplicationRegions: isProd(props.config) ? ["us-east-1"] : ["ca-central-1"],
     dynamoReplicationTimeout: Duration.hours(3),
     dynamoPointInTimeRecovery: true,
@@ -36,6 +37,7 @@ export class FeatureFlagsNestedStack extends NestedStack {
       alarmAction,
       dynamoConstructName,
       dynamoPartitionKey,
+      dynamoSortKey,
       dynamoReplicationRegions,
       dynamoReplicationTimeout,
       dynamoPointInTimeRecovery,
@@ -48,6 +50,7 @@ export class FeatureFlagsNestedStack extends NestedStack {
     this.featureFlagsTable = this.setupFeatureFlagsTable({
       dynamoConstructName,
       dynamoPartitionKey,
+      dynamoSortKey,
       dynamoReplicationRegions,
       dynamoReplicationTimeout,
       dynamoPointInTimeRecovery,
@@ -62,6 +65,7 @@ export class FeatureFlagsNestedStack extends NestedStack {
   private setupFeatureFlagsTable(ownProps: {
     dynamoConstructName: string;
     dynamoPartitionKey: string;
+    dynamoSortKey: string;
     dynamoReplicationRegions: string[];
     dynamoReplicationTimeout: Duration;
     dynamoPointInTimeRecovery: boolean;
@@ -74,6 +78,7 @@ export class FeatureFlagsNestedStack extends NestedStack {
     const {
       dynamoConstructName,
       dynamoPartitionKey,
+      dynamoSortKey,
       dynamoReplicationRegions,
       dynamoReplicationTimeout,
       dynamoPointInTimeRecovery,
@@ -86,6 +91,10 @@ export class FeatureFlagsNestedStack extends NestedStack {
     const table = new dynamodb.Table(this, dynamoConstructName, {
       partitionKey: {
         name: dynamoPartitionKey,
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: dynamoSortKey,
         type: dynamodb.AttributeType.STRING,
       },
       replicationRegions: dynamoReplicationRegions,

--- a/packages/infra/lib/rate-limiting-nested-stack.ts
+++ b/packages/infra/lib/rate-limiting-nested-stack.ts
@@ -137,8 +137,8 @@ export class RateLimitingNestedStack extends NestedStack {
       this,
       `${dynamoConstructName}ConsumedReadCapacityUnitsAlarm`,
       {
-        threshold: consumedWriteCapacityUnitsAlarmThreshold, // units per second
-        evaluationPeriods: consumedWriteCapacityUnitsAlarmPeriod,
+        threshold: consumedReadCapacityUnitsAlarmThreshold, // units per second
+        evaluationPeriods: consumedReadCapacityUnitsAlarmPeriod,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }
     );
@@ -150,8 +150,8 @@ export class RateLimitingNestedStack extends NestedStack {
       this,
       `${dynamoConstructName}ConsumedWriteCapacityUnitsAlarm`,
       {
-        threshold: consumedReadCapacityUnitsAlarmThreshold, // units per second
-        evaluationPeriods: consumedReadCapacityUnitsAlarmPeriod,
+        threshold: consumedWriteCapacityUnitsAlarmThreshold, // units per second
+        evaluationPeriods: consumedWriteCapacityUnitsAlarmPeriod,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }
     );


### PR DESCRIPTION
Ref. metriport/metriport-internal#2840

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport/pull/3548

### Description

First PR of the series that switches FFs from AppConfig to DynamoDB - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1743200093894309).

Add FF stack.

Next PRs:
- [x] PR w/ endpoint to update/get FFs on/from DDB
- [x] PR to 
   - [x] make apps use the new FF infra
   - [x] move types from app-config to ffs/types
- [x] PR to remove AppConfig stack
- [ ] document new process to update FFs

### Testing

- Local
  - [x] branch to staging creates FF DDB table
- Staging
  - [ ] creates FF DDB table
- Sandbox
  - [ ] creates FF DDB table
- Production
  - [ ] creates FF DDB table

### Release Plan

- :warning: Contains infra changes
- Release plan spanning multiple PRs: https://metriport.slack.com/archives/C04DMKE9DME/p1743289898308699?thread_ts=1743200093.894309&cid=C04DMKE9DME


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced the API service with dynamic feature flag management, enabling flexible toggling of functionality.
  - Introduced a dedicated system for managing feature flags, including integrated performance monitoring and alerting.
  - Streamlined configuration and permission handling to support smoother feature rollouts and improved operational visibility.
  - Added a new `FeatureFlagsNestedStack` for managing a DynamoDB table dedicated to feature flags.
  - Updated the API service to utilize the new feature flags table for enhanced configuration.

- **Bug Fixes**
  - Corrected parameter assignments in the `RateLimitingNestedStack` for read and write capacity unit alarms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->