### PR TITLE
feat(api): add raw resource column to docref mapping

### DIFF
--- a/packages/api/src/command/medical/docref-mapping/get-docref-mapping.ts
+++ b/packages/api/src/command/medical/docref-mapping/get-docref-mapping.ts
@@ -8,7 +8,9 @@ import {
 } from "../../../models/medical/docref-mapping";
 
 export const getDocRefMapping = async (id: string): Promise<DocRefMapping | undefined> => {
-  const docRef = await DocRefMappingModel.findByPk(id);
+  const docRef = await DocRefMappingModel.findByPk(id, {
+    attributes: ["id", "externalId", "cxId", "patientId", "source", "requestId"],
+  });
   return docRef ?? undefined;
 };
 
@@ -22,6 +24,7 @@ export const getAllDocRefMapping = async ({
   cxId?: string;
 }): Promise<DocRefMapping[]> => {
   const docRefs = await DocRefMappingModel.findAll({
+    attributes: ["id", "externalId", "cxId", "patientId", "source", "requestId"],
     where: {
       requestId,
       ...(patientId && { patientId }),
@@ -91,6 +94,7 @@ export const getDocRefMappings = async ({
 }): Promise<DocRefMapping[]> => {
   const patientIds = Array.isArray(patientIdParam) ? patientIdParam : [patientIdParam];
   const res = await DocRefMappingModel.findAll({
+    attributes: ["id", "externalId", "cxId", "patientId", "source", "requestId"],
     where: {
       cxId,
       ...(ids && ids.length ? { id: { [Op.in]: ids } } : {}),

--- a/packages/api/src/models/medical/docref-mapping.ts
+++ b/packages/api/src/models/medical/docref-mapping.ts
@@ -22,6 +22,7 @@ export class DocRefMappingModel extends BaseModel<DocRefMappingModel> implements
   declare cxId: string;
   declare patientId: string;
   declare requestId: string;
+  declare rawResource: string;
   declare source: MedicalDataSource;
 
   static setup: ModelSetup = (sequelize: Sequelize) => {
@@ -41,6 +42,9 @@ export class DocRefMappingModel extends BaseModel<DocRefMappingModel> implements
           type: DataTypes.STRING,
         },
         requestId: {
+          type: DataTypes.STRING,
+        },
+        rawResource: {
           type: DataTypes.STRING,
         },
       },

--- a/packages/api/src/sequelize/migrations/2025-03-29_00_add-raw-resource-column-to-docref-mapping.ts
+++ b/packages/api/src/sequelize/migrations/2025-03-29_00_add-raw-resource-column-to-docref-mapping.ts
@@ -1,0 +1,17 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "docref_mapping";
+const columnName = "raw_resource";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn(tableName, columnName, {
+    type: DataTypes.STRING,
+    defaultValue: "",
+    allowNull: false,
+  });
+};
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  return await queryInterface.removeColumn(tableName, columnName);
+};


### PR DESCRIPTION
Ticket: 

### Dependencies

- Upstream: 

### Description

This PR adds a 'rawResources' field to our model used to hold a raw FHIR docref. It uses a STRING type instead of JSONB to minimize the processing overhead, as we're never changing the FHIR resource - we read it out, or completely overwrite it.

### Testing

Migration runs

### Release Plan

- :warning: This contains a DB migration
- [ ] Merge this
