### PR TITLE
2840 Remove non-existing FF

### DIFF
--- a/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
+++ b/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
@@ -51,7 +51,6 @@ export const initialFeatureFlags: FeatureFlagDatastore = {
   cxsWithDemoAugEnabled: { enabled: false, values: [] },
   cxsWithStalePatientUpdateEnabled: { enabled: false, values: [] },
   cxsWithStrictMatchingAlgorithm: { enabled: false, values: [] },
-  cxsUsingWkhtmltopdfInsteadOfPuppeteer: { enabled: false, values: [] },
   cxsWithAthenaCustomFieldsEnabled: { enabled: false, values: [] },
   oidsWithIHEGatewayV2Enabled: { enabled: false, values: [] },
   e2eCxIds: { enabled: false, values: [] },

--- a/packages/core/src/command/feature-flags/index.ts
+++ b/packages/core/src/command/feature-flags/index.ts
@@ -134,14 +134,6 @@ export async function isAiBriefFeatureFlagEnabledForCx(cxId: string): Promise<bo
   return cxsWithADHDFeatureFlagValue.includes(cxId);
 }
 
-export async function isWkhtmltopdfEnabledForCx(cxId: string): Promise<boolean> {
-  const cxIdsWithWkhtmltopdfEnabled = await getCxsUsingWkhtmltopdfInsteadOfPuppeteer();
-  return cxIdsWithWkhtmltopdfEnabled.some(i => i === cxId);
-}
-export async function getCxsUsingWkhtmltopdfInsteadOfPuppeteer(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsUsingWkhtmltopdfInsteadOfPuppeteer");
-}
-
 export async function isAthenaCustomFieldsEnabledForCx(cxId: string): Promise<boolean> {
   const cxsWithAthenaCustomFieldsEnabled = await getCxsWithAthenaCustomFieldsEnabled();
   return cxsWithAthenaCustomFieldsEnabled.includes(cxId);


### PR DESCRIPTION
Ref. metriport/metriport-internal#2840

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3548
- Downstream: https://github.com/metriport/metriport/pull/3549

### Description

Remove non-existing FF.

### Testing

- [ ] It compiles

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified feature management by removing a legacy configuration option and its associated checks, reducing complexity in our system. These internal changes streamline operations and help maintain a more efficient environment. End-users will experience the same functionality with a cleaner underlying process. This update is part of ongoing efforts to improve system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->