### PR TITLE
1040 Query CQ directory

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/list-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/list-cq-directory.ts
@@ -1,0 +1,52 @@
+import { OrganizationWithId } from "@metriport/carequality-sdk/client/carequality";
+import { out } from "@metriport/core/util/log";
+import { makeCarequalityManagementApiOrFail } from "../../api";
+
+const BATCH_SIZE = 100;
+
+/**
+ * Lists organizations from the Carequality Directory.
+ *
+ * @param oid Optional, the OID of the organization to fetch.
+ * @param active Indicates whether to list active or inactive organizations.
+ * @returns a list of FHIR R4 Organization resources with the `id` field populated.
+ */
+export async function listCQDirectory({
+  oid,
+  active,
+  limit,
+}: {
+  oid?: string;
+  active: boolean;
+  limit?: number;
+}): Promise<OrganizationWithId[]> {
+  const { log } = out(`listCQDirectory, active ${active}, oid ${oid}`);
+
+  const cq = makeCarequalityManagementApiOrFail();
+  const orgs: OrganizationWithId[] = [];
+
+  const itemsToFetch = limit ?? BATCH_SIZE;
+  let currentPosition = 0;
+  let isDone = false;
+
+  while (!isDone) {
+    const batch = await cq.listOrganizations({
+      start: currentPosition,
+      count: itemsToFetch,
+      oid,
+      active,
+    });
+
+    orgs.push(...batch);
+
+    if (batch.length < itemsToFetch || (limit && orgs.length >= limit)) {
+      isDone = true;
+    } else {
+      currentPosition += BATCH_SIZE;
+    }
+  }
+
+  log(`Found ${orgs.length} organizations in the Carequality Directory`);
+
+  return orgs;
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Query CQ directory - [context](https://metriport.slack.com/archives/C065BLRBUDQ/p1743470070021769)

### Testing

- Local
  - [x] Queries active entries of the CQ directory
  - [x] Queries inactive entries of the CQ directory
  - [x] Limits entries
  - [x] Filters by OID
  - [x] Required active to be set
- Staging
  - [ ] Queries active entries of the CQ directory
  - [ ] Queries inactive entries of the CQ directory
  - [ ] Limits entries
  - [ ] Filters by OID
  - [ ] Required active to be set
- Sandbox
  - none
- Production
  - [ ] Queries active entries of the CQ directory
  - [ ] Queries inactive entries of the CQ directory
  - [ ] Limits entries
  - [ ] Filters by OID

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint that retrieves a list of organizations from the Carequality Directory.
	- The endpoint supports filtering by active status with optional parameters for organization identification and result limits.
	- The response is structured as JSON, including the organization count and details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->