### PR TITLE
feat(athena): adding department level fetching for custom fields

### DIFF
--- a/packages/api/src/external/ehr/athenahealth/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/process-patients-from-appointments.ts
@@ -118,6 +118,7 @@ export async function processPatientsFromAppointments({ lookupMode }: { lookupMo
         cxId: appointment.cxId,
         athenaPracticeId: appointment.practiceId,
         athenaPatientId: appointment.patientId,
+        athenaDepartmentId: appointment.departmentId,
       };
     }
   );
@@ -153,7 +154,12 @@ async function getAppointments({
     }
     return {
       appointments: appointments.map(appointment => {
-        return { cxId, practiceId, patientId: api.createPatientId(appointment.patientid) };
+        return {
+          cxId,
+          practiceId,
+          patientId: api.createPatientId(appointment.patientid),
+          departmentId: api.createDepartmentId(appointment.departmentid),
+        };
       }),
     };
   } catch (error) {
@@ -209,6 +215,7 @@ async function syncPatient({
   cxId,
   athenaPracticeId,
   athenaPatientId,
+  athenaDepartmentId,
 }: Omit<SyncAthenaPatientIntoMetriportParams, "api" | "triggerDq">): Promise<void> {
   const handler = buildEhrSyncPatientHandler();
   await handler.processSyncPatient({
@@ -216,6 +223,7 @@ async function syncPatient({
     cxId,
     practiceId: athenaPracticeId,
     patientId: athenaPatientId,
+    departmentId: athenaDepartmentId,
     triggerDq: true,
   });
 }

--- a/packages/api/src/external/ehr/shared.ts
+++ b/packages/api/src/external/ehr/shared.ts
@@ -108,6 +108,7 @@ export const ehrCxMappingSecondaryMappingsSchemaMap: {
 export type Appointment = {
   cxId: string;
   practiceId: string;
+  departmentId?: string;
   patientId: string;
 };
 

--- a/packages/api/src/routes/ehr/athenahealth/patient.ts
+++ b/packages/api/src/routes/ehr/athenahealth/patient.ts
@@ -23,10 +23,12 @@ router.get(
     const cxId = getCxIdOrFail(req);
     const athenaPatientId = getFrom("params").orFail("id", req);
     const athenaPracticeId = getFromQueryOrFail("practiceId", req);
+    const athenaDepartmentId = getFromQueryOrFail("departmentId", req);
     const patientId = await syncAthenaPatientIntoMetriport({
       cxId,
       athenaPracticeId,
       athenaPatientId,
+      athenaDepartmentId,
     });
     return res.status(httpStatus.OK).json(patientId);
   })
@@ -47,10 +49,12 @@ router.post(
     const cxId = getCxIdOrFail(req);
     const athenaPatientId = getFrom("params").orFail("id", req);
     const athenaPracticeId = getFromQueryOrFail("practiceId", req);
+    const athenaDepartmentId = getFromQueryOrFail("departmentId", req);
     const patientId = await syncAthenaPatientIntoMetriport({
       cxId,
       athenaPracticeId,
       athenaPatientId,
+      athenaDepartmentId,
     });
     return res.status(httpStatus.OK).json(patientId);
   })

--- a/packages/api/src/routes/internal/ehr/athenahealth/patient.ts
+++ b/packages/api/src/routes/internal/ehr/athenahealth/patient.ts
@@ -7,7 +7,12 @@ import { syncAthenaPatientIntoMetriport } from "../../../../external/ehr/athenah
 import { LookupModes } from "../../../../external/ehr/athenahealth/shared";
 import { requestLogger } from "../../../helpers/request-logger";
 import { getUUIDFrom } from "../../../schemas/uuid";
-import { asyncHandler, getFromQueryAsBoolean, getFromQueryOrFail } from "../../../util";
+import {
+  asyncHandler,
+  getFromQuery,
+  getFromQueryAsBoolean,
+  getFromQueryOrFail,
+} from "../../../util";
 
 const router = Router();
 
@@ -92,11 +97,13 @@ router.post(
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const athenaPatientId = getFromQueryOrFail("patientId", req);
     const athenaPracticeId = getFromQueryOrFail("practiceId", req);
+    const athenaDepartmentId = getFromQuery("departmentId", req);
     const triggerDq = getFromQueryAsBoolean("triggerDq", req);
     syncAthenaPatientIntoMetriport({
       cxId,
       athenaPracticeId,
       athenaPatientId,
+      athenaDepartmentId,
       triggerDq,
     }).catch(processAsyncError("AthenaHealth syncAthenaPatientIntoMetriport"));
     return res.sendStatus(httpStatus.OK);

--- a/packages/core/src/external/ehr/api/sync-patient.ts
+++ b/packages/core/src/external/ehr/api/sync-patient.ts
@@ -17,12 +17,14 @@ export async function syncPatient({
   ehr,
   cxId,
   practiceId,
+  departmentId,
   patientId,
   triggerDq,
 }: {
   ehr: EhrSource;
   cxId: string;
   practiceId: string;
+  departmentId?: string;
   patientId: string;
   triggerDq: boolean;
 }): Promise<void> {
@@ -33,6 +35,7 @@ export async function syncPatient({
     practiceId,
     patientId,
     triggerDq: triggerDq.toString(),
+    ...(departmentId ? { departmentId } : {}),
   });
   const syncPatientUrl = `/internal/ehr/${ehr}/patient?${queryParams.toString()}`;
   try {

--- a/packages/core/src/external/ehr/athenahealth/index.ts
+++ b/packages/core/src/external/ehr/athenahealth/index.ts
@@ -303,9 +303,11 @@ class AthenaHealthApi {
   async getCustomFieldsForPatient({
     cxId,
     patientId,
+    departmentId,
   }: {
     cxId: string;
     patientId: string;
+    departmentId?: string;
   }): Promise<PatientCustomField[]> {
     const { debug } = out(
       `AthenaHealth getCustomFieldsForPatient - cxId ${cxId} practiceId ${this.practiceId} patientId ${patientId}`
@@ -313,6 +315,7 @@ class AthenaHealthApi {
     const params = {
       showprivacycustomfields: "true",
       showcustomfields: "true",
+      ...(departmentId ? { departmentid: this.stripDepartmentId(departmentId) } : {}),
     };
     const queryParams = new URLSearchParams(params);
     const patientsUrl = `/patients/${this.stripPatientId(patientId)}?${queryParams.toString()}`;
@@ -919,6 +922,12 @@ class AthenaHealthApi {
 
   stripDepartmentId(id: string) {
     return id.replace(`a-${this.practiceId}.${athenaDepartmentPrefix}-`, "");
+  }
+
+  createDepartmentId(id: string) {
+    const prefix = `a-${this.practiceId}.${athenaDepartmentPrefix}-`;
+    if (id.startsWith(prefix)) return id;
+    return `${prefix}${id}`;
   }
 
   private createVitalsData(

--- a/packages/core/src/external/ehr/sync-patient/ehr-sync-patient-local.ts
+++ b/packages/core/src/external/ehr/sync-patient/ehr-sync-patient-local.ts
@@ -11,6 +11,7 @@ export class EhrSyncPatientLocal implements EhrSyncPatientHandler {
     ehr,
     cxId,
     practiceId,
+    departmentId,
     patientId,
     triggerDq,
   }: ProcessSyncPatientRequest): Promise<void> {
@@ -24,6 +25,7 @@ export class EhrSyncPatientLocal implements EhrSyncPatientHandler {
         practiceId,
         patientId,
         triggerDq,
+        ...(departmentId ? { departmentId } : {}),
       });
 
       if (this.waitTimeInMillis > 0) await sleep(this.waitTimeInMillis);

--- a/packages/core/src/external/ehr/sync-patient/ehr-sync-patient.ts
+++ b/packages/core/src/external/ehr/sync-patient/ehr-sync-patient.ts
@@ -4,6 +4,7 @@ export type ProcessSyncPatientRequest = {
   ehr: EhrSource;
   cxId: string;
   practiceId: string;
+  departmentId?: string;
   patientId: string;
   triggerDq: boolean;
 };

--- a/packages/shared/src/interface/external/ehr/athenahealth/appointment.ts
+++ b/packages/shared/src/interface/external/ehr/athenahealth/appointment.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const bookedAppointmentSchema = z.object({
   patientid: z.string(),
+  departmentid: z.string(),
   appointmenttypeid: z.string(),
 });
 export type BookedAppointment = z.infer<typeof bookedAppointmentSchema>;
@@ -13,6 +14,7 @@ export type BookedAppointmentListResponse = z.infer<typeof bookedAppointmentList
 
 const appointmentEventSchema = z.object({
   patientid: z.string().optional(),
+  departmentid: z.string(),
   appointmentstatus: z.string(),
   appointmenttypeid: z.string(),
 });


### PR DESCRIPTION
Ref: #1040

### Description

- add department ID to athena Patient call to get back department level settings within sync patient
- add department ID to all calls to athena sync patient

### Testing

- Local
  - [ ] we get back the department level settings from the Patient endpoint
- Staging
  - [ ] we get back the department level settings from the Patient endpoint
- Sandbox
  - [ ] N/A
- Production
  - [ ] we get back the department level settings from the Patient endpoint

### Release Plan

- [ ] Merge this
