### PR TITLE
2835 Unrevert hl7 deploy, move secrets to secret stack

### DIFF
--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -2,13 +2,14 @@ import * as cdk from "aws-cdk-lib";
 import "source-map-support/register";
 import { EnvConfig } from "../config/env-config";
 import { APIStack } from "../lib/api-stack";
+import { ConnectWidgetStack } from "../lib/connect-widget-stack";
 import { Hl7NotificationStack } from "../lib/hl7-notification-stack";
+import { VpnStack } from "../lib/hl7-notification-stack/vpn";
+import { IHEStack } from "../lib/ihe-stack";
 import { LocationServicesStack } from "../lib/location-services-stack";
 import { SecretsStack } from "../lib/secrets-stack";
 import { initConfig } from "../lib/shared/config";
 import { getEnvVar, isSandbox } from "../lib/shared/util";
-import { IHEStack } from "../lib/ihe-stack";
-import { ConnectWidgetStack } from "../lib/connect-widget-stack";
 
 const app = new cdk.App();
 
@@ -50,10 +51,21 @@ async function deploy(config: EnvConfig) {
   // 4. Deploy the HL7 Notification Routing stack.
   //---------------------------------------------------------------------------------
   if (!isSandbox(config)) {
-    new Hl7NotificationStack(app, "Hl7NotificationStack", {
+    const hl7NotificationStack = new Hl7NotificationStack(app, "Hl7NotificationStack", {
       env,
       config,
       version,
+    });
+
+    config.hl7Notification.vpnConfigs.forEach((config, index) => {
+      const vpnStack = new VpnStack(app, `VpnStack-${config.partnerName}`, {
+        vpnConfig: { ...config },
+        index,
+        networkStackId: "NestedNetworkStack",
+        description: `VPN Configuration for routing HL7 messages from ${config.partnerName}`,
+      });
+
+      vpnStack.addDependency(hl7NotificationStack);
     });
   }
 

--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -1,3 +1,3 @@
 export const MLLP_DEFAULT_PORT = 2575;
 export const HL7_NOTIFICATION_VPC_CIDR = "10.1.0.0/16";
-export const PROBLEMATIC_IPSEC_CHARACTERS = "!@#$%^&*()_+-=[]{}|;:,.<>?";
+export const PROBLEMATIC_IPSEC_CHARACTERS = "!@#$%^&*()_+-=[]{}|;:,.<>?~`'\"\\/";

--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -1,5 +1,2 @@
 export const MLLP_DEFAULT_PORT = 2575;
 export const HL7_NOTIFICATION_VPC_CIDR = "10.1.0.0/16";
-
-export const VPN_ACCESSIBLE_SUBNET_GROUP_NAME = "Private-VpnAccessible-MllpServer";
-export const INTERNAL_SERVICES_SUBNET_GROUP_NAME = "Private-InternalServices";

--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -1,2 +1,3 @@
 export const MLLP_DEFAULT_PORT = 2575;
 export const HL7_NOTIFICATION_VPC_CIDR = "10.1.0.0/16";
+export const PROBLEMATIC_IPSEC_CHARACTERS = "!@#$%^&*()_+-=[]{}|;:,.<>?";

--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -1,4 +1,5 @@
 export const MLLP_DEFAULT_PORT = 2575;
+export const HL7_NOTIFICATION_VPC_CIDR = "10.1.0.0/16";
 
 export const VPN_ACCESSIBLE_SUBNET_GROUP_NAME = "Private-VpnAccessible-MllpServer";
 export const INTERNAL_SERVICES_SUBNET_GROUP_NAME = "Private-InternalServices";

--- a/packages/infra/lib/hl7-notification-stack/index.ts
+++ b/packages/infra/lib/hl7-notification-stack/index.ts
@@ -4,11 +4,7 @@ import { Repository } from "aws-cdk-lib/aws-ecr";
 import { Construct } from "constructs";
 import { EnvConfigNonSandbox } from "../../config/env-config";
 import { MetriportCompositeStack } from "../shared/metriport-composite-stack";
-import {
-  HL7_NOTIFICATION_VPC_CIDR,
-  INTERNAL_SERVICES_SUBNET_GROUP_NAME,
-  VPN_ACCESSIBLE_SUBNET_GROUP_NAME,
-} from "./constants";
+import { HL7_NOTIFICATION_VPC_CIDR } from "./constants";
 import { MllpStack } from "./mllp";
 import { NetworkStack } from "./network";
 
@@ -34,12 +30,7 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
         },
         {
           cidrMask: 24,
-          name: VPN_ACCESSIBLE_SUBNET_GROUP_NAME,
-          subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
-        },
-        {
-          cidrMask: 24,
-          name: INTERNAL_SERVICES_SUBNET_GROUP_NAME,
+          name: "Private-VpnAccessible-MllpServer",
           subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
         },
       ],

--- a/packages/infra/lib/hl7-notification-stack/index.ts
+++ b/packages/infra/lib/hl7-notification-stack/index.ts
@@ -4,34 +4,28 @@ import { Repository } from "aws-cdk-lib/aws-ecr";
 import { Construct } from "constructs";
 import { EnvConfigNonSandbox } from "../../config/env-config";
 import { MetriportCompositeStack } from "../shared/metriport-composite-stack";
+import {
+  HL7_NOTIFICATION_VPC_CIDR,
+  INTERNAL_SERVICES_SUBNET_GROUP_NAME,
+  VPN_ACCESSIBLE_SUBNET_GROUP_NAME,
+} from "./constants";
 import { MllpStack } from "./mllp";
 import { NetworkStack } from "./network";
-import { VpnStack } from "./vpn";
-import { INTERNAL_SERVICES_SUBNET_GROUP_NAME } from "./constants";
-import { VPN_ACCESSIBLE_SUBNET_GROUP_NAME } from "./constants";
-import { Secret } from "aws-cdk-lib/aws-secretsmanager";
 
 export interface Hl7NotificationStackProps extends cdk.StackProps {
   config: EnvConfigNonSandbox;
   version: string | undefined;
 }
 
-const NUM_AZS = 2;
-
-const fetchSecretsForPartner = (scope: Construct, partnerName: string) => {
-  const secretName = `PresharedKey-${partnerName}`;
-  return Secret.fromSecretNameV2(scope, secretName, secretName);
-};
+const NUM_AZS = 1;
 
 export class Hl7NotificationStack extends MetriportCompositeStack {
-  public readonly networkStack: NetworkStack;
-
   constructor(scope: Construct, id: string, props: Hl7NotificationStackProps) {
     super(scope, id, props);
-    const vpnConfigs = props.config.hl7Notification.vpnConfigs;
 
     const vpc = new ec2.Vpc(this, "Vpc", {
       maxAzs: NUM_AZS,
+      ipAddresses: ec2.IpAddresses.cidr(HL7_NOTIFICATION_VPC_CIDR),
       subnetConfiguration: [
         {
           cidrMask: 24,
@@ -65,21 +59,11 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
       description: "HL7 Notification Routing MLLP Server",
     });
 
-    this.networkStack = new NetworkStack(this, "NestedNetworkStack", {
+    new NetworkStack(this, "NestedNetworkStack", {
       stackName: "NestedNetworkStack",
       config: props.config,
       vpc,
       description: "HL7 Notification Routing Network Infrastructure",
-    });
-
-    vpnConfigs.forEach((config, index) => {
-      new VpnStack(this, `NestedVpnStack${config.partnerName}`, {
-        vpnConfig: { ...config, presharedKey: fetchSecretsForPartner(this, config.partnerName) },
-        vpc,
-        index,
-        networkStack: this.networkStack.output,
-        description: `VPN Configuration for routing HL7 messages from ${config.partnerName}`,
-      });
     });
 
     new cdk.CfnOutput(this, "MllpECRRepoURI", {

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -6,7 +6,7 @@ import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { Construct } from "constructs";
 import { EnvConfigNonSandbox } from "../../config/env-config";
-import { MLLP_DEFAULT_PORT, VPN_ACCESSIBLE_SUBNET_GROUP_NAME } from "./constants";
+import { MLLP_DEFAULT_PORT } from "./constants";
 
 interface MllpStackProps extends cdk.StackProps {
   config: EnvConfigNonSandbox;
@@ -50,7 +50,7 @@ export class MllpStack extends cdk.NestedStack {
       vpc,
       internetFacing: false,
       vpcSubnets: {
-        subnetGroupName: VPN_ACCESSIBLE_SUBNET_GROUP_NAME,
+        subnets: vpc.privateSubnets,
       },
     });
 
@@ -93,7 +93,7 @@ export class MllpStack extends cdk.NestedStack {
       taskDefinition,
       desiredCount: fargateTaskCountMin,
       vpcSubnets: {
-        subnetGroupName: VPN_ACCESSIBLE_SUBNET_GROUP_NAME,
+        subnets: vpc.privateSubnets,
       },
       securityGroups: [mllpSecurityGroup],
     });

--- a/packages/infra/lib/hl7-notification-stack/network.ts
+++ b/packages/infra/lib/hl7-notification-stack/network.ts
@@ -70,8 +70,6 @@ export class NetworkStack extends cdk.NestedStack {
      * Read more about needing to set the dependency here:
      * https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ec2/CfnVPNGatewayRoutePropagation.html
      * */
-
-    // Enable route propagation for each of our private subnets back out to the vgw
     const vpnAccessibleSubnets = vpc.selectSubnets({
       subnetGroupName: VPN_ACCESSIBLE_SUBNET_GROUP_NAME,
     }).subnets;
@@ -87,6 +85,16 @@ export class NetworkStack extends cdk.NestedStack {
       );
 
       routePropagation.node.addDependency(vgwAttachment);
+    });
+
+    new cdk.CfnOutput(this, "NetworkAclId", {
+      value: networkAcl.networkAclId,
+      exportName: `NestedNetworkStack-NetworkAclId`,
+    });
+
+    new cdk.CfnOutput(this, "VgwId", {
+      value: vgw.ref,
+      exportName: `NestedNetworkStack-VgwId`,
     });
 
     this.output = {

--- a/packages/infra/lib/hl7-notification-stack/network.ts
+++ b/packages/infra/lib/hl7-notification-stack/network.ts
@@ -2,7 +2,6 @@ import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
 import { EnvConfigNonSandbox } from "../../config/env-config";
-import { VPN_ACCESSIBLE_SUBNET_GROUP_NAME } from "./constants";
 
 const IPSEC_1 = "ipsec.1";
 
@@ -45,7 +44,7 @@ export class NetworkStack extends cdk.NestedStack {
 
     const networkAcl = new ec2.NetworkAcl(this, "VpnAccessibleMllpServerNacl", {
       vpc,
-      subnetSelection: { subnetGroupName: VPN_ACCESSIBLE_SUBNET_GROUP_NAME },
+      subnetSelection: { subnets: vpc.privateSubnets },
     });
 
     // Ephemeral ports to allow for TCP handshakes with ECR
@@ -70,11 +69,7 @@ export class NetworkStack extends cdk.NestedStack {
      * Read more about needing to set the dependency here:
      * https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ec2/CfnVPNGatewayRoutePropagation.html
      * */
-    const vpnAccessibleSubnets = vpc.selectSubnets({
-      subnetGroupName: VPN_ACCESSIBLE_SUBNET_GROUP_NAME,
-    }).subnets;
-
-    vpnAccessibleSubnets.forEach((subnet, index) => {
+    vpc.privateSubnets.forEach((subnet, index) => {
       const routePropagation = new ec2.CfnVPNGatewayRoutePropagation(
         this,
         `RouteTablePropagation${index}`,

--- a/packages/infra/lib/hl7-notification-stack/vpn.ts
+++ b/packages/infra/lib/hl7-notification-stack/vpn.ts
@@ -7,7 +7,6 @@ import { Hl7NotificationVpnConfig } from "../../config/hl7-notification-config";
 import { MLLP_DEFAULT_PORT } from "./constants";
 
 const IPSEC_1 = "ipsec.1";
-const PROBLEMATIC_IPSEC_CHARACTERS = "!@#$%^&*()_+-=[]{}|;:,.<>?";
 
 export interface VpnStackProps extends cdk.NestedStackProps {
   vpnConfig: Hl7NotificationVpnConfig;
@@ -77,18 +76,16 @@ export class VpnStack extends cdk.Stack {
       },
     ]);
 
-    const createPskSecret = (index: number) => {
-      return new secret.Secret(this, `PresharedKey${index}-${partnerName}`, {
-        secretName: `PresharedKey${index}-${partnerName}`,
-        generateSecretString: {
-          excludePunctuation: true,
-          excludeCharacters: PROBLEMATIC_IPSEC_CHARACTERS,
-        },
-      });
-    };
-
-    const presharedKey1 = createPskSecret(1);
-    const presharedKey2 = createPskSecret(2);
+    const presharedKey1 = secret.Secret.fromSecretNameV2(
+      this,
+      `PresharedKey1-${partnerName}`,
+      `PresharedKey1-${partnerName}`
+    );
+    const presharedKey2 = secret.Secret.fromSecretNameV2(
+      this,
+      `PresharedKey2-${partnerName}`,
+      `PresharedKey2-${partnerName}`
+    );
     /**
      * We use 2 tunnels here because state HIEs often have a failover to a backup IP..
      */

--- a/packages/infra/lib/hl7-notification-stack/vpn.ts
+++ b/packages/infra/lib/hl7-notification-stack/vpn.ts
@@ -1,20 +1,17 @@
 import * as cdk from "aws-cdk-lib";
+import { Fn } from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 import { Hl7NotificationVpnConfig } from "../../config/hl7-notification-config";
-import { NetworkStackOutput } from "./network";
 import { MLLP_DEFAULT_PORT } from "./constants";
-import * as secret from "aws-cdk-lib/aws-secretsmanager";
-import { Fn } from "aws-cdk-lib";
 
 const IPSEC_1 = "ipsec.1";
+const PROBLEMATIC_IPSEC_CHARACTERS = "!@#$%^&*()_+-=[]{}|;:,.<>?";
 
 export interface VpnStackProps extends cdk.NestedStackProps {
-  vpc: ec2.Vpc;
-  vpnConfig: Hl7NotificationVpnConfig & {
-    presharedKey: secret.ISecret;
-  };
-  networkStack: NetworkStackOutput;
+  vpnConfig: Hl7NotificationVpnConfig;
+  networkStackId: string;
   index: number;
 }
 
@@ -22,28 +19,31 @@ export interface VpnStackProps extends cdk.NestedStackProps {
  * This stack creates all the infra to setup a VPN tunnel with an HIE sending us HL7 messages.
  * @see https://docs.aws.amazon.com/vpn/latest/s2svpn/VPC_VPN.html
  */
-export class VpnStack extends cdk.NestedStack {
+export class VpnStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: VpnStackProps) {
     super(scope, id, props);
 
-    const { networkAcl } = props.networkStack;
-    const { partnerInternalCidrBlock, presharedKey } = props.vpnConfig;
+    const { partnerName, partnerInternalCidrBlock } = props.vpnConfig;
 
-    const customerGateway = new ec2.CfnCustomerGateway(
+    const networkAcl = ec2.NetworkAcl.fromNetworkAclId(
       this,
-      `${props.vpnConfig.partnerName}CustomerGateway`,
-      {
-        ipAddress: props.vpnConfig.partnerGatewayPublicIp,
-        type: IPSEC_1,
-        bgpAsn: 65000,
-        tags: [
-          {
-            key: "Name",
-            value: `${props.vpnConfig.partnerName}-cgw`,
-          },
-        ],
-      }
+      `NetworkAcl-${partnerName}`,
+      Fn.importValue(`${props.networkStackId}-NetworkAclId`)
     );
+
+    const vgwId = Fn.importValue(`${props.networkStackId}-VgwId`);
+
+    const customerGateway = new ec2.CfnCustomerGateway(this, `CustomerGateway-${partnerName}`, {
+      ipAddress: props.vpnConfig.partnerGatewayPublicIp,
+      type: IPSEC_1,
+      bgpAsn: 65000,
+      tags: [
+        {
+          key: "Name",
+          value: `${partnerName}-cgw`,
+        },
+      ],
+    });
 
     /**
      * Add new rules to the NACL for the static IPs we're using for this VPN.
@@ -77,61 +77,59 @@ export class VpnStack extends cdk.NestedStack {
       },
     ]);
 
+    const createPskSecret = (index: number) => {
+      return new secret.Secret(this, `PresharedKey${index}-${partnerName}`, {
+        secretName: `PresharedKey${index}-${partnerName}`,
+        generateSecretString: {
+          excludePunctuation: true,
+          excludeCharacters: PROBLEMATIC_IPSEC_CHARACTERS,
+        },
+      });
+    };
+
+    const presharedKey1 = createPskSecret(1);
+    const presharedKey2 = createPskSecret(2);
     /**
      * We use 2 tunnels here because state HIEs often have a failover to a backup IP..
      */
-    const vpnConnection = new ec2.CfnVPNConnection(
-      this,
-      `${props.vpnConfig.partnerName}VpnConnection`,
-      {
-        type: IPSEC_1,
-        vpnGatewayId: props.networkStack.vgw.ref,
-        customerGatewayId: customerGateway.ref,
-        staticRoutesOnly: true,
-        tags: [
-          {
-            key: "Name",
-            value: `${props.vpnConfig.partnerName}-vpn`,
-          },
-        ],
-        vpnTunnelOptionsSpecifications: [
-          {
-            preSharedKey: Fn.sub(
-              "{{resolve:secretsmanager:${SecretArn}:SecretString:presharedKey1}}",
-              {
-                SecretArn: presharedKey.secretArn,
-              }
-            ),
-          },
-          {
-            preSharedKey: Fn.sub(
-              "{{resolve:secretsmanager:${SecretArn}:SecretString:presharedKey2}}",
-              {
-                SecretArn: presharedKey.secretArn,
-              }
-            ),
-          },
-        ],
-      }
-    );
+    const vpnConnection = new ec2.CfnVPNConnection(this, `VpnConnection-${partnerName}`, {
+      type: IPSEC_1,
+      vpnGatewayId: vgwId,
+      customerGatewayId: customerGateway.ref,
+      staticRoutesOnly: true,
+      tags: [
+        {
+          key: "Name",
+          value: `${partnerName}-vpn`,
+        },
+      ],
+      vpnTunnelOptionsSpecifications: [
+        {
+          preSharedKey: Fn.sub("{{resolve:secretsmanager:${SecretArn}:SecretString}}", {
+            SecretArn: presharedKey1.secretArn,
+          }),
+        },
+        {
+          preSharedKey: Fn.sub("{{resolve:secretsmanager:${SecretArn}:SecretString}}", {
+            SecretArn: presharedKey2.secretArn,
+          }),
+        },
+      ],
+    });
 
-    new ec2.CfnVPNConnectionRoute(
-      this,
-      `${props.vpnConfig.partnerName}-HieSideVpnConnectionRoute`,
-      {
-        destinationCidrBlock: props.vpnConfig.partnerInternalCidrBlock,
-        vpnConnectionId: vpnConnection.ref,
-      }
-    );
+    new ec2.CfnVPNConnectionRoute(this, `VpnConnectionRoute-${partnerName}`, {
+      destinationCidrBlock: props.vpnConfig.partnerInternalCidrBlock,
+      vpnConnectionId: vpnConnection.ref,
+    });
 
-    new cdk.CfnOutput(this, `${props.vpnConfig.partnerName}VpnConnectionId`, {
+    new cdk.CfnOutput(this, `VpnConnectionId-${partnerName}`, {
       value: vpnConnection.ref,
-      description: `VPN Connection for ${props.vpnConfig.partnerName}`,
+      description: `VPN Connection for ${partnerName}`,
     });
   }
 
   private setNaclRules(
-    networkAcl: ec2.NetworkAcl,
+    networkAcl: ec2.INetworkAcl,
     partnerInternalCidrBlock: string,
     direction: ec2.TrafficDirection,
     rules: {
@@ -157,7 +155,7 @@ export class VpnStack extends cdk.NestedStack {
   }
 
   private addIngressRules(
-    networkAcl: ec2.NetworkAcl,
+    networkAcl: ec2.INetworkAcl,
     partnerInternalCidrBlock: string,
     rules: {
       ruleNumber: number;
@@ -169,7 +167,7 @@ export class VpnStack extends cdk.NestedStack {
   }
 
   private addEgressRules(
-    networkAcl: ec2.NetworkAcl,
+    networkAcl: ec2.INetworkAcl,
     partnerInternalCidrBlock: string,
     rules: {
       ruleNumber: number;

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -87,6 +87,7 @@ export class SecretsStack extends Stack {
       for (const secretName of vpnTunnelSecretNames) {
         const secret = makeSecret(secretName, {
           generateSecretString: {
+            excludePunctuation: true,
             excludeCharacters: PROBLEMATIC_IPSEC_CHARACTERS,
           },
         });


### PR DESCRIPTION
Ticket: metriport/metriport-internal#2835

### Dependencies

Peer: https://github.com/metriport/metriport/pull/3544

### Description

This PR:
- unreverts prior changes
  - sets the vpc cidr to 10.1.0.0/16
  - decouples vpn tunnel stacks from hl7 notification stacks
- moves tunnel secrets into our secret stack
- cleans up some of the subnet messiness now that the lambda to process the hl7 message will live in the API vpc

### Testing

- [x] cdk deploy works, vpc tunnel is set 10.1.0.0/16
- [x] mllp server can be connected to over the vpn tunnel on port 2575 

### Release Plan

### Staging
- [ ] Nuke staging HL7 notification VPC
- [ ] Merge to stage
- [ ] On release to staging, expect deploy to get stuck trying to spin up task, but failing to find image, then update environment state:
  - [ ] `gh variable set ECS_CLUSTER_MLLP_SERVER_STAGING --body "_"`
  - [ ] `gh variable set ECS_SERVICE_MLLP_SERVER_STAGING --body "_"`
- [ ] Trigger staging HL7 tunnel deployment workflow 

### Prod
- [ ] Nuke prod HL7 notification VPC
- [ ] Merge to prod
- [ ] On release to prod, expect deploy to get stuck trying to spin up task, but failing to find image, then update environment state:
  - [ ] `gh variable set ECS_CLUSTER_MLLP_SERVER_PRODUCTION --body "_"`
  - [ ] `gh variable set ECS_SERVICE_MLLP_SERVER_PRODUCTION --body "_"`
- [ ] Trigger redeploy for prod
- [ ] Trigger staging HL7 tunnel deployment workflow 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic deployment of VPN connections associated with HL7 notifications.
  - Enabled environment-aware secret generation for VPN tunnels with improved character filtering.

- **Refactor**
  - Streamlined network configurations by simplifying subnet selections and reducing availability zones.
  - Consolidated VPN and network component dependencies for enhanced stability and easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->