### PR TITLE
2840 Move FF from api to core

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -10,7 +10,7 @@ import duration from "dayjs/plugin/duration";
 import express, { Application, Request, Response } from "express";
 import helmet from "helmet";
 import { initEvents } from "./event";
-import { initFeatureFlags } from "./external/aws/app-config";
+import { initFeatureFlags } from "./external/feature-flags";
 import initDB from "./models/db";
 import { initRateLimiter } from "./routes/middlewares/rate-limiting";
 import { VERSION_HEADER_NAME } from "./routes/header";

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -1,5 +1,9 @@
 import { deleteConsolidated } from "@metriport/core/command/consolidated/consolidated-delete";
 import {
+  isCarequalityEnabled,
+  isCommonwellEnabled,
+} from "@metriport/core/command/feature-flags/domain-ffs";
+import {
   ConvertResult,
   DocumentQueryProgress,
   DocumentQueryStatus,
@@ -14,7 +18,6 @@ import { BadRequestError, emptyFunction } from "@metriport/shared";
 import { calculateConversionProgress } from "../../../domain/medical/conversion-progress";
 import { validateOptionalFacilityId } from "../../../domain/medical/patient-facility";
 import { processAsyncError } from "../../../errors";
-import { isCarequalityEnabled, isCommonwellEnabled } from "../../../external/aws/app-config";
 import { getDocumentsFromCQ } from "../../../external/carequality/document/query-documents";
 import { queryAndProcessDocuments as getDocumentsFromCW } from "../../../external/commonwell/document/document-query";
 import { getCqOrgIdsToDenyOnCw } from "../../../external/hie/cross-hie-ids";

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -1,3 +1,4 @@
+import { isWebhookPongDisabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { webhookDisableFlagName } from "@metriport/core/domain/webhook/index";
 import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
 import { out } from "@metriport/core/util/log";
@@ -14,7 +15,7 @@ import { z, ZodError } from "zod";
 import { Product } from "../../domain/product";
 import { WebhookRequestStatus } from "../../domain/webhook";
 import WebhookError from "../../errors/webhook";
-import { isE2eCx, isWebhookPongDisabledForCx } from "../../external/aws/app-config";
+import { isE2eCx } from "../../external/aws/app-config";
 import { Settings, WEBHOOK_STATUS_OK } from "../../models/settings";
 import { WebhookRequest } from "../../models/webhook-request";
 import { getHttpStatusFromAxiosError } from "../../shared/http";

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -15,7 +15,7 @@ import { z, ZodError } from "zod";
 import { Product } from "../../domain/product";
 import { WebhookRequestStatus } from "../../domain/webhook";
 import WebhookError from "../../errors/webhook";
-import { isE2eCx } from "../../external/aws/app-config";
+import { isE2eCx } from "../../external/feature-flags";
 import { Settings, WEBHOOK_STATUS_OK } from "../../models/settings";
 import { WebhookRequest } from "../../models/webhook-request";
 import { getHttpStatusFromAxiosError } from "../../shared/http";

--- a/packages/api/src/domain/medical/get-patient-limit.ts
+++ b/packages/api/src/domain/medical/get-patient-limit.ts
@@ -1,7 +1,7 @@
+import { getCxsWithIncreasedSandboxLimitFeatureFlagValue } from "@metriport/core/command/feature-flags/domain-ffs";
 import { MetriportError } from "@metriport/core/util/error/metriport-error";
 import { capture } from "@metriport/core/util/notifications";
 import { errorToString } from "@metriport/shared/common/error";
-import { getCxsWithIncreasedSandboxLimitFeatureFlagValue } from "../../external/aws/app-config";
 import { Config } from "../../shared/config";
 
 export async function getSandboxPatientLimitForCx(cxId: string): Promise<number> {

--- a/packages/api/src/external/aws/app-config.ts
+++ b/packages/api/src/external/aws/app-config.ts
@@ -1,7 +1,4 @@
-import {
-  getCxsWithFeatureFlagEnabled,
-  isFeatureFlagEnabled,
-} from "@metriport/core/command/feature-flags/domain-ffs";
+import { getCxsWithFeatureFlagEnabled } from "@metriport/core/command/feature-flags/domain-ffs";
 import { getFeatureFlags } from "@metriport/core/command/feature-flags/ffs-on-dynamodb";
 import { Config as ConfigCore } from "@metriport/core/util/config";
 import { MetriportError } from "@metriport/core/util/error/metriport-error";
@@ -29,48 +26,6 @@ export async function initFeatureFlags() {
   log(`Feature Flags initialized.`);
 }
 
-// TODO move these to core's packages/core/src/command/feature-flags/index.ts
-
-export async function getCxsWithEnhancedCoverageFeatureFlagValue(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsWithEnhancedCoverageFeatureFlag");
-}
-
-export async function getCxsWithCQDirectFeatureFlagValue(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsWithCQDirectFeatureFlag");
-}
-
-export async function getCxsWithCWFeatureFlagValue(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsWithCWFeatureFlag");
-}
-
-export async function getCxsWithIncreasedSandboxLimitFeatureFlagValue(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsWithIncreasedSandboxLimitFeatureFlag");
-}
-
-export async function getCxsWithNoWebhookPongFeatureFlagValue(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsWithNoWebhookPongFeatureFlag");
-}
-
-export async function getCxsWithEpicEnabled(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsWithEpicEnabled");
-}
-
-export async function getCxsWithAiBriefFeatureFlag(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsWithAiBriefFeatureFlag");
-}
-
-export async function getCxsWithCdaCustodianFeatureFlag(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("getCxsWithCdaCustodianFeatureFlag");
-}
-
-export async function getCxsWitDemoAugEnabled(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsWithDemoAugEnabled");
-}
-
-export async function getCxsWitStalePatientUpdateEnabled(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsWithStalePatientUpdateEnabled");
-}
-
 export async function getE2eCxIds(): Promise<string | undefined> {
   if (Config.isDev()) {
     const apiKey = getEnvVar("TEST_API_KEY");
@@ -88,52 +43,4 @@ export async function getE2eCxIds(): Promise<string | undefined> {
 export async function isE2eCx(cxId: string): Promise<boolean> {
   const e2eCxId = await getE2eCxIds();
   return e2eCxId === cxId;
-}
-
-export async function isEnhancedCoverageEnabledForCx(cxId: string): Promise<boolean> {
-  const cxIdsWithECEnabled = await getCxsWithEnhancedCoverageFeatureFlagValue();
-  return cxIdsWithECEnabled.some(i => i === cxId);
-}
-
-export async function isCQDirectEnabledForCx(cxId: string): Promise<boolean> {
-  const cxIdsWithCQDirectEnabled = await getCxsWithCQDirectFeatureFlagValue();
-  return cxIdsWithCQDirectEnabled.some(i => i === cxId);
-}
-
-export async function isCWEnabledForCx(cxId: string): Promise<boolean> {
-  const cxIdsWithCWDirectEnabled = await getCxsWithCWFeatureFlagValue();
-  return cxIdsWithCWDirectEnabled.some(i => i === cxId);
-}
-
-export async function isWebhookPongDisabledForCx(cxId: string): Promise<boolean> {
-  const cxIdsWithNoWebhookPong = await getCxsWithNoWebhookPongFeatureFlagValue();
-  return cxIdsWithNoWebhookPong.some(i => i === cxId);
-}
-
-export async function isCdaCustodianEnabledForCx(cxId: string): Promise<boolean> {
-  const cxIdsWithFhirDedupEnabled = await getCxsWithCdaCustodianFeatureFlag();
-  return cxIdsWithFhirDedupEnabled.some(i => i === cxId);
-}
-
-export async function isEpicEnabledForCx(cxId: string): Promise<boolean> {
-  const cxIdsWithEpicEnabled = await getCxsWithEpicEnabled();
-  return cxIdsWithEpicEnabled.some(i => i === cxId);
-}
-
-export async function isDemoAugEnabledForCx(cxId: string): Promise<boolean> {
-  const cxIdsWithDemoAugEnabled = await getCxsWitDemoAugEnabled();
-  return cxIdsWithDemoAugEnabled.some(i => i === cxId);
-}
-
-export async function isStalePatientUpdateEnabledForCx(cxId: string): Promise<boolean> {
-  const cxIdsWithStalePatientUpdateEnabled = await getCxsWitStalePatientUpdateEnabled();
-  return cxIdsWithStalePatientUpdateEnabled.some(i => i === cxId);
-}
-
-export async function isCommonwellEnabled(): Promise<boolean> {
-  return isFeatureFlagEnabled("commonwellFeatureFlag");
-}
-
-export async function isCarequalityEnabled(): Promise<boolean> {
-  return isFeatureFlagEnabled("carequalityFeatureFlag");
 }

--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -1,8 +1,9 @@
+import { isCQDirectEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
+import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
 import { cqExtension } from "@metriport/core/external/carequality/extension";
 import { OutboundDocQueryRespParam } from "@metriport/core/external/carequality/ihe-gateway/outbound-result-poller-direct";
 import { MedicalDataSource } from "@metriport/core/external/index";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
-import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
 import { errorToString } from "@metriport/core/util/error/shared";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
@@ -10,29 +11,28 @@ import { DocumentReference, OutboundDocumentQueryResp } from "@metriport/ihe-gat
 import { elapsedTimeFromNow } from "@metriport/shared/common/date";
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 import { mapDocRefToMetriport } from "../../../shared/external";
-import { setDocRetrieveStartAt } from "../../hie/set-doc-retrieve-start";
-import { isCQDirectEnabledForCx } from "../../aws/app-config";
 import { isConvertible } from "../../fhir-converter/converter";
 import { upsertDocumentToFHIRServer } from "../../fhir/document/save-document-reference";
-import { setDocQueryProgress } from "../../hie/set-doc-query-progress";
-import { makeOutboundResultPoller } from "../../ihe-gateway/outbound-result-poller-factory";
-import { getCQDirectoryEntry } from "../command/cq-directory/get-cq-directory-entry";
-import { getCqInitiator } from "../shared";
-import { createOutboundDocumentRetrievalReqs } from "./create-outbound-document-retrieval-req";
-import { getNonExistentDocRefs } from "./get-non-existent-doc-refs";
-import { getCQData } from "../patient";
-import {
-  cqToFHIR,
-  DocumentReferenceWithMetriportId,
-  containsMetriportId,
-  getContentTypeOrUnknown,
-  containsDuplicateMetriportId,
-} from "./shared";
 import {
   getDocumentReferenceContentTypeCounts,
   getOutboundDocQuerySuccessFailureCount,
 } from "../../hie/carequality-analytics";
+import { setDocQueryProgress } from "../../hie/set-doc-query-progress";
+import { setDocRetrieveStartAt } from "../../hie/set-doc-retrieve-start";
 import { makeIHEGatewayV2 } from "../../ihe-gateway-v2/ihe-gateway-v2-factory";
+import { makeOutboundResultPoller } from "../../ihe-gateway/outbound-result-poller-factory";
+import { getCQDirectoryEntry } from "../command/cq-directory/get-cq-directory-entry";
+import { getCQData } from "../patient";
+import { getCqInitiator } from "../shared";
+import { createOutboundDocumentRetrievalReqs } from "./create-outbound-document-retrieval-req";
+import { getNonExistentDocRefs } from "./get-non-existent-doc-refs";
+import {
+  containsDuplicateMetriportId,
+  containsMetriportId,
+  cqToFHIR,
+  DocumentReferenceWithMetriportId,
+  getContentTypeOrUnknown,
+} from "./shared";
 
 const parallelUpsertsToFhir = 10;
 const resultPoller = makeOutboundResultPoller();

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -1,27 +1,29 @@
-import { buildDayjs } from "@metriport/shared/common/date";
+import {
+  isCQDirectEnabledForCx,
+  isStalePatientUpdateEnabledForCx,
+} from "@metriport/core/command/feature-flags/domain-ffs";
 import { Patient } from "@metriport/core/domain/patient";
 import { MedicalDataSource } from "@metriport/core/external/index";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
-import { errorToString } from "@metriport/core/util/error/shared";
+import { errorToString, processAsyncError } from "@metriport/core/util/error/shared";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
-import { isCQDirectEnabledForCx, isStalePatientUpdateEnabledForCx } from "../../aws/app-config";
+import { buildDayjs } from "@metriport/shared/common/date";
+import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
+import { isFacilityEnabledToQueryCQ } from "../../carequality/shared";
 import { buildInterrupt } from "../../hie/reset-doc-query-progress";
 import { scheduleDocQuery } from "../../hie/schedule-document-query";
 import { setDocQueryProgress } from "../../hie/set-doc-query-progress";
 import { setDocQueryStartAt } from "../../hie/set-doc-query-start";
+import { makeIHEGatewayV2 } from "../../ihe-gateway-v2/ihe-gateway-v2-factory";
 import { makeOutboundResultPoller } from "../../ihe-gateway/outbound-result-poller-factory";
 import { getCQDirectoryEntry } from "../command/cq-directory/get-cq-directory-entry";
 import { getCQPatientData } from "../command/cq-patient-data/get-cq-data";
 import { CQLink } from "../cq-patient-data";
-import { getCQData, discover } from "../patient";
-import { createOutboundDocumentQueryRequests } from "./create-outbound-document-query-req";
-import { makeIHEGatewayV2 } from "../../ihe-gateway-v2/ihe-gateway-v2-factory";
+import { discover, getCQData } from "../patient";
 import { getCqInitiator } from "../shared";
-import { isFacilityEnabledToQueryCQ } from "../../carequality/shared";
+import { createOutboundDocumentQueryRequests } from "./create-outbound-document-query-req";
 import { filterCqLinksByManagingOrg } from "./filter-oids-by-managing-org";
-import { processAsyncError } from "@metriport/core/util/error/shared";
-import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 
 const staleLookbackHours = 24;
 

--- a/packages/api/src/external/carequality/gateway/index.ts
+++ b/packages/api/src/external/carequality/gateway/index.ts
@@ -4,7 +4,7 @@ import { out } from "@metriport/core/util/log";
 import { XCPDGateway } from "@metriport/ihe-gateway-sdk";
 import { MetriportError } from "@metriport/shared";
 import { Config } from "../../../shared/config";
-import { isE2eCx } from "../../aws/app-config";
+import { isE2eCx } from "../../feature-flags";
 import { getCQDirectoryEntryOrFail } from "../command/cq-directory/get-cq-directory-entry";
 import { getOrganizationsForXCPD } from "../command/cq-directory/get-organizations-for-xcpd";
 import {

--- a/packages/api/src/external/carequality/gateway/index.ts
+++ b/packages/api/src/external/carequality/gateway/index.ts
@@ -1,10 +1,10 @@
+import { isEpicEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { Patient } from "@metriport/core/domain/patient";
 import { out } from "@metriport/core/util/log";
 import { XCPDGateway } from "@metriport/ihe-gateway-sdk";
 import { MetriportError } from "@metriport/shared";
-import { CQDirectoryEntry } from "../cq-directory";
 import { Config } from "../../../shared/config";
-import { isE2eCx, isEpicEnabledForCx } from "../../aws/app-config";
+import { isE2eCx } from "../../aws/app-config";
 import { getCQDirectoryEntryOrFail } from "../command/cq-directory/get-cq-directory-entry";
 import { getOrganizationsForXCPD } from "../command/cq-directory/get-organizations-for-xcpd";
 import {
@@ -12,6 +12,7 @@ import {
   searchCQDirectoriesAroundPatientAddresses,
   toBasicOrgAttributes,
 } from "../command/cq-directory/search-cq-directory";
+import { CQDirectoryEntry } from "../cq-directory";
 import { buildXcpdGateway, cqOrgsToXCPDGateways } from "../organization-conversion";
 
 export const EPIC_ORG_NAME = "Epic";

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -1,3 +1,4 @@
+import { isDemoAugEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { Patient, PatientExternalData } from "@metriport/core/domain/patient";
 import { toIheGatewayPatientResource } from "@metriport/core/external/carequality/ihe-gateway-v2/patient";
 import { MedicalDataSource } from "@metriport/core/external/index";
@@ -8,18 +9,17 @@ import { OutboundPatientDiscoveryReq } from "@metriport/ihe-gateway-sdk";
 import { errorToString } from "@metriport/shared";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
+import { createAugmentedPatient } from "../../domain/medical/patient-demographics";
+import { resetScheduledPatientDiscovery } from "../hie/reset-scheduled-patient-discovery-request";
 import { makeIHEGatewayV2 } from "../ihe-gateway-v2/ihe-gateway-v2-factory";
 import { makeOutboundResultPoller } from "../ihe-gateway/outbound-result-poller-factory";
 import { deleteCQPatientData } from "./command/cq-patient-data/delete-cq-data";
+import { updatePatientDiscoveryStatus } from "./command/update-patient-discovery-status";
 import { createOutboundPatientDiscoveryReq } from "./create-outbound-patient-discovery-req";
 import { gatherXCPDGateways } from "./gateway";
 import { PatientDataCarequality } from "./patient-shared";
-import { updatePatientDiscoveryStatus } from "./command/update-patient-discovery-status";
-import { getCqInitiator, isCqEnabled } from "./shared";
 import { queryDocsIfScheduled } from "./process-outbound-patient-discovery-resps";
-import { createAugmentedPatient } from "../../domain/medical/patient-demographics";
-import { resetScheduledPatientDiscovery } from "../hie/reset-scheduled-patient-discovery-request";
-import { isDemoAugEnabledForCx } from "../aws/app-config";
+import { getCqInitiator, isCqEnabled } from "./shared";
 
 dayjs.extend(duration);
 

--- a/packages/api/src/external/carequality/shared.ts
+++ b/packages/api/src/external/carequality/shared.ts
@@ -1,17 +1,20 @@
+import {
+  isCarequalityEnabled,
+  isCQDirectEnabledForCx,
+} from "@metriport/core/command/feature-flags/domain-ffs";
 import { Coordinates } from "@metriport/core/domain/address";
-import { AddressStrict } from "@metriport/core/domain/location-address";
-import { Patient, PatientData, GenderAtBirth } from "@metriport/core/domain/patient";
 import { Contact } from "@metriport/core/domain/contact";
+import { AddressStrict } from "@metriport/core/domain/location-address";
+import { GenderAtBirth, Patient, PatientData } from "@metriport/core/domain/patient";
 import { MedicalDataSource } from "@metriport/core/external/index";
 import { capture } from "@metriport/core/util/notifications";
 import { isEmailValid, isPhoneValid, PurposeOfUse, USStateForAddress } from "@metriport/shared";
+import { buildDayjs, ISO_DATE } from "@metriport/shared/common/date";
 import { errorToString } from "@metriport/shared/common/error";
 import z from "zod";
 import { getAddressWithCoordinates } from "../../domain/medical/address";
 import { Config } from "../../shared/config";
-import { isCarequalityEnabled, isCQDirectEnabledForCx } from "../aws/app-config";
 import { getHieInitiator, HieInitiator, isHieEnabledToQuery } from "../hie/get-hie-initiator";
-import { buildDayjs, ISO_DATE } from "@metriport/shared/common/date";
 import { CQLink } from "./cq-patient-data";
 // TODO: adjust when we support multiple POUs
 export function createPurposeOfUse() {

--- a/packages/api/src/external/commonwell/__tests__/patient.test.ts
+++ b/packages/api/src/external/commonwell/__tests__/patient.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { faker } from "@faker-js/faker";
+import * as featureFlags from "@metriport/core/command/feature-flags/domain-ffs";
 import { makePatient } from "@metriport/core/domain/__tests__/patient";
 import { Config } from "../../../shared/config";
-import * as featureFlags from "../../aws/app-config";
 import * as hieInitiator from "../../hie/get-hie-initiator";
 import { validateCWEnabled } from "../shared";
 

--- a/packages/api/src/external/commonwell/admin/recreate-patients-at-hies.ts
+++ b/packages/api/src/external/commonwell/admin/recreate-patients-at-hies.ts
@@ -1,14 +1,14 @@
 import { CommonWellAPI, organizationQueryMeta } from "@metriport/commonwell-sdk";
+import { isCWEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { addOidPrefix } from "@metriport/core/domain/oid";
 import { Patient } from "@metriport/core/domain/patient";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import { groupBy } from "lodash";
 import { PatientModel } from "../../../models/medical/patient";
-import { isCWEnabledForCx } from "../../aws/app-config";
 import { getCqOrgIdsToDenyOnCw } from "../../hie/cross-hie-ids";
 import { makeCommonWellAPI } from "../api";
-import { getCWData, create } from "../patient";
+import { create, getCWData } from "../patient";
 import { getCwInitiator } from "../shared";
 
 export type RecreateResultOfPatient = {

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -7,6 +7,11 @@ import {
   operationOutcomeResourceType,
   organizationQueryMeta,
 } from "@metriport/commonwell-sdk";
+import {
+  isCQDirectEnabledForCx,
+  isEnhancedCoverageEnabledForCx,
+  isStalePatientUpdateEnabledForCx,
+} from "@metriport/core/command/feature-flags/domain-ffs";
 import { addOidPrefix } from "@metriport/core/domain/oid";
 import { Patient } from "@metriport/core/domain/patient";
 import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
@@ -29,11 +34,6 @@ import {
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 import { Config } from "../../../shared/config";
 import { mapDocRefToMetriport } from "../../../shared/external";
-import {
-  isCQDirectEnabledForCx,
-  isEnhancedCoverageEnabledForCx,
-  isStalePatientUpdateEnabledForCx,
-} from "../../aws/app-config";
 import { reportMetric } from "../../aws/cloudwatch";
 import { ingestIntoSearchEngine } from "../../aws/opensearch";
 import { convertCDAToFHIR, isConvertible } from "../../fhir-converter/converter";

--- a/packages/api/src/external/commonwell/link/create.ts
+++ b/packages/api/src/external/commonwell/link/create.ts
@@ -1,10 +1,11 @@
 import { CommonWellAPI, organizationQueryMeta } from "@metriport/commonwell-sdk";
+import { isCWEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { addOidPrefix } from "@metriport/core/domain/oid";
 import { out } from "@metriport/core/util/log";
 import { reset } from ".";
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 import { capture } from "../../../shared/notifications";
-import { isCWEnabledForCx } from "../../aws/app-config";
+import { validateCwLinksBelongToPatient } from "../../hie/validate-patient-links";
 import { makeCommonWellAPI } from "../api";
 import {
   updateCommonwellIdsAndStatus,
@@ -12,7 +13,6 @@ import {
 } from "../patient-external-data";
 import { getCwInitiator } from "../shared";
 import { autoUpgradeNetworkLinks, getPatientsNetworkLinks, patientWithCWData } from "./shared";
-import { validateCwLinksBelongToPatient } from "../../hie/validate-patient-links";
 
 const context = "cw.link.create";
 

--- a/packages/api/src/external/commonwell/link/get.ts
+++ b/packages/api/src/external/commonwell/link/get.ts
@@ -13,6 +13,7 @@ import {
   RequestMetadata,
 } from "@metriport/commonwell-sdk";
 import { AdditionalInfo } from "@metriport/commonwell-sdk/common/commonwell-error";
+import { isCWEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { addOidPrefix } from "@metriport/core/domain/oid";
 import { Patient } from "@metriport/core/domain/patient";
 import { errorToString } from "@metriport/core/util/error/shared";
@@ -21,15 +22,14 @@ import { capture } from "@metriport/core/util/notifications";
 import { uniqBy } from "lodash";
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 import { filterTruthy } from "../../../shared/filter-map-utils";
-import { isCWEnabledForCx } from "../../aws/app-config";
 import { makeCommonWellAPI } from "../api";
 import { getCWData } from "../patient";
+import { getCwStrongIdsFromPatient } from "../patient-conversion";
 import {
   updateCommonwellIdsAndStatus,
   updatePatientDiscoveryStatus,
 } from "../patient-external-data";
 import { PatientDataCommonwell, searchPersons } from "../patient-shared";
-import { getCwStrongIdsFromPatient } from "../patient-conversion";
 import { getCwInitiator } from "../shared";
 import { commonwellPersonLinks } from "./shared";
 

--- a/packages/api/src/external/commonwell/link/reset.ts
+++ b/packages/api/src/external/commonwell/link/reset.ts
@@ -1,8 +1,8 @@
 import { CommonWellAPI, CommonwellError, organizationQueryMeta } from "@metriport/commonwell-sdk";
+import { isCWEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { addOidPrefix } from "@metriport/core/domain/oid";
 import { out } from "@metriport/core/util/log";
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
-import { isCWEnabledForCx } from "../../aws/app-config";
 import { makeCommonWellAPI } from "../api";
 import { updateCommonwellIdsAndStatus } from "../patient-external-data";
 import { getCwInitiator } from "../shared";

--- a/packages/api/src/external/commonwell/organization.ts
+++ b/packages/api/src/external/commonwell/organization.ts
@@ -1,4 +1,5 @@
 import { Organization as CWSdkOrganization } from "@metriport/commonwell-sdk";
+import { isEnhancedCoverageEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { OID_PREFIX } from "@metriport/core/domain/oid";
 import { Organization, OrgType } from "@metriport/core/domain/organization";
 import { getOrgsByPrio } from "@metriport/core/external/commonwell/cq-bridge/get-orgs";
@@ -6,7 +7,6 @@ import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import { errorToString, NotFoundError, USState } from "@metriport/shared";
 import { Config, getEnvVarOrFail } from "../../shared/config";
-import { isEnhancedCoverageEnabledForCx } from "../aws/app-config";
 import {
   getCertificate,
   makeCommonWellAPI,

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -7,6 +7,10 @@ import {
   Patient as CommonwellPatient,
   RequestMetadata,
 } from "@metriport/commonwell-sdk";
+import {
+  isDemoAugEnabledForCx,
+  isEnhancedCoverageEnabledForCx,
+} from "@metriport/core/command/feature-flags/domain-ffs";
 import { addOidPrefix } from "@metriport/core/domain/oid";
 import { Patient, PatientExternalData } from "@metriport/core/domain/patient";
 import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
@@ -24,7 +28,6 @@ import {
   getNewDemographics,
 } from "../../domain/medical/patient-demographics";
 import MetriportError from "../../errors/metriport-error";
-import { isDemoAugEnabledForCx, isEnhancedCoverageEnabledForCx } from "../aws/app-config";
 import { checkLinkDemographicsAcrossHies } from "../hie/check-patient-link-demographics";
 import { HieInitiator } from "../hie/get-hie-initiator";
 import { resetPatientScheduledDocQueryRequestId } from "../hie/reset-scheduled-doc-query-request-id";

--- a/packages/api/src/external/commonwell/shared.ts
+++ b/packages/api/src/external/commonwell/shared.ts
@@ -1,12 +1,15 @@
-import { errorToString } from "@metriport/shared";
-import { capture } from "@metriport/core/util/notifications";
+import {
+  isCommonwellEnabled,
+  isCWEnabledForCx,
+} from "@metriport/core/command/feature-flags/domain-ffs";
 import { Patient } from "@metriport/core/domain/patient";
 import { MedicalDataSource } from "@metriport/core/external/index";
+import { capture } from "@metriport/core/util/notifications";
+import { errorToString } from "@metriport/shared";
 import z from "zod";
-import { getHieInitiator, HieInitiator, isHieEnabledToQuery } from "../hie/get-hie-initiator";
-import { isCommonwellEnabled, isCWEnabledForCx } from "../aws/app-config";
 import { Config } from "../../shared/config";
 import { CwLink } from "../commonwell/cw-patient-data";
+import { getHieInitiator, HieInitiator, isHieEnabledToQuery } from "../hie/get-hie-initiator";
 export async function getCwInitiator(
   patient: Pick<Patient, "id" | "cxId">,
   facilityId?: string

--- a/packages/api/src/external/feature-flags.ts
+++ b/packages/api/src/external/feature-flags.ts
@@ -5,8 +5,8 @@ import { MetriportError } from "@metriport/core/util/error/metriport-error";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import { getEnvVar } from "@metriport/shared";
-import { getCxIdFromApiKey } from "../../routes/middlewares/auth";
-import { Config } from "../../shared/config";
+import { getCxIdFromApiKey } from "../routes/middlewares/auth";
+import { Config } from "../shared/config";
 
 const { log } = out(`App Config - FF`);
 

--- a/packages/api/src/external/fhir-to-cda-converter/connector-direct.ts
+++ b/packages/api/src/external/fhir-to-cda-converter/connector-direct.ts
@@ -1,8 +1,8 @@
+import { isCdaCustodianEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { splitBundleByCompositions } from "@metriport/core/fhir-to-cda/composition-splitter";
 import { convertFhirBundleToCda } from "@metriport/core/fhir-to-cda/fhir-to-cda";
 import { getOrganizationOrFail } from "../../command/medical/organization/get-organization";
 import { FhirToCdaConverter, FhirToCdaConverterRequest } from "./connector";
-import { isCdaCustodianEnabledForCx } from "../aws/app-config";
 
 export class FhirToCdaConverterDirect implements FhirToCdaConverter {
   async requestConvert({

--- a/packages/api/src/external/fhir-to-cda-converter/connector-lambda.ts
+++ b/packages/api/src/external/fhir-to-cda-converter/connector-lambda.ts
@@ -1,9 +1,9 @@
+import { isCdaCustodianEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { Input } from "@metriport/core/domain/conversion/fhir-to-cda";
 import { getLambdaResultPayload, makeLambdaClient } from "@metriport/core/external/aws/lambda";
 import { getOrganizationOrFail } from "../../command/medical/organization/get-organization";
 import { Config } from "../../shared/config";
 import { FhirToCdaConverter, FhirToCdaConverterRequest } from "./connector";
-import { isCdaCustodianEnabledForCx } from "../aws/app-config";
 
 const region = Config.getAWSRegion();
 const lambdaClient = makeLambdaClient(region);

--- a/packages/api/src/routes/internal/index.ts
+++ b/packages/api/src/routes/internal/index.ts
@@ -1,3 +1,4 @@
+import { isEnhancedCoverageEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { BadRequestError, EhrSources } from "@metriport/shared";
 import { Request, Response, Router } from "express";
 import httpStatus from "http-status";
@@ -30,7 +31,6 @@ import {
 import { getOrganizationOrFail } from "../../command/medical/organization/get-organization";
 import { isCxMappingSource, secondaryMappingsSchemaMap } from "../../domain/cx-mapping";
 import { isFacilityMappingSource } from "../../domain/facility-mapping";
-import { isEnhancedCoverageEnabledForCx } from "../../external/aws/app-config";
 import { initCQOrgIncludeList } from "../../external/commonwell/organization";
 import { subscribeToAllWebhooks } from "../../external/ehr/elation/command/subscribe-to-webhook";
 import { OrganizationModel } from "../../models/medical/organization";

--- a/packages/api/src/routes/internal/medical/patient.ts
+++ b/packages/api/src/routes/internal/medical/patient.ts
@@ -1,5 +1,9 @@
 import { genderAtBirthSchema, patientCreateSchema } from "@metriport/api-sdk";
 import { getConsolidatedSnapshotFromS3 } from "@metriport/core/command/consolidated/snapshot-on-s3";
+import {
+  getCxsWithCQDirectFeatureFlagValue,
+  getCxsWithEnhancedCoverageFeatureFlagValue,
+} from "@metriport/core/command/feature-flags/domain-ffs";
 import { createPatientPayload } from "@metriport/core/command/patient-import/patient-import-shared";
 import { buildPatientImportParseHandler } from "@metriport/core/command/patient-import/steps/parse/patient-import-parse-factory";
 import { consolidationConversionType } from "@metriport/core/domain/conversion/fhir-to-medical-record";
@@ -14,9 +18,9 @@ import { out } from "@metriport/core/util/log";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import {
   BadRequestError,
-  PaginatedResponse,
   internalSendConsolidatedSchema,
   normalizeState,
+  PaginatedResponse,
   patientImportSchema,
   sleep,
   stringToBoolean,
@@ -40,18 +44,18 @@ import {
 } from "../../../command/medical/patient/consolidated-get";
 import { createCoverageAssessments } from "../../../command/medical/patient/coverage-assessment-create";
 import { getCoverageAssessments } from "../../../command/medical/patient/coverage-assessment-get";
-import { PatientCreateCmd, createPatient } from "../../../command/medical/patient/create-patient";
+import { createPatient, PatientCreateCmd } from "../../../command/medical/patient/create-patient";
 import { deletePatient } from "../../../command/medical/patient/delete-patient";
 import {
-  GetHl7v2SubscribersParams,
   getHl7v2Subscribers,
   getHl7v2SubscribersCount,
+  GetHl7v2SubscribersParams,
 } from "../../../command/medical/patient/get-hl7v2-subscribers";
 import {
   getPatientIds,
   getPatientOrFail,
-  getPatientStates,
   getPatients,
+  getPatientStates,
 } from "../../../command/medical/patient/get-patient";
 import {
   PatientUpdateCmd,
@@ -59,10 +63,6 @@ import {
 } from "../../../command/medical/patient/update-patient";
 import { Pagination } from "../../../command/pagination";
 import { getFacilityIdOrFail } from "../../../domain/medical/patient-facility";
-import {
-  getCxsWithCQDirectFeatureFlagValue,
-  getCxsWithEnhancedCoverageFeatureFlagValue,
-} from "../../../external/aws/app-config";
 import { PatientUpdaterCarequality } from "../../../external/carequality/patient-updater-carequality";
 import cwCommands from "../../../external/commonwell";
 import { findDuplicatedPersons } from "../../../external/commonwell/admin/find-patient-duplicates";

--- a/packages/core/src/command/feature-flags/domain-ffs.ts
+++ b/packages/core/src/command/feature-flags/domain-ffs.ts
@@ -116,29 +116,102 @@ export async function getCxsWithFeatureFlagEnabled(
   return [];
 }
 
-export async function getCxsWithAiBriefFeatureFlagValue(): Promise<string[]> {
+export async function getCxsWithAiBriefFeatureFlag(): Promise<string[]> {
   return getCxsWithFeatureFlagEnabled("cxsWithAiBriefFeatureFlag");
 }
-
-export async function isStrictMatchingAlgorithmEnabledForCx(cxId: string): Promise<boolean> {
-  const cxsWithStrictMatchingAlgorithmEnabled = await getCxsWithStrictMatchingAlgorithm();
-  return cxsWithStrictMatchingAlgorithmEnabled.includes(cxId);
+export async function isAiBriefFeatureFlagEnabledForCx(cxId: string): Promise<boolean> {
+  const cxsWithFeatureFlagValue = await getCxsWithAiBriefFeatureFlag();
+  return cxsWithFeatureFlagValue.includes(cxId);
 }
 
 export async function getCxsWithStrictMatchingAlgorithm(): Promise<string[]> {
   return getCxsWithFeatureFlagEnabled("cxsWithStrictMatchingAlgorithm");
 }
-
-export async function isAiBriefFeatureFlagEnabledForCx(cxId: string): Promise<boolean> {
-  const cxsWithADHDFeatureFlagValue = await getCxsWithAiBriefFeatureFlagValue();
-  return cxsWithADHDFeatureFlagValue.includes(cxId);
+export async function isStrictMatchingAlgorithmEnabledForCx(cxId: string): Promise<boolean> {
+  const cxsWithStrictMatchingAlgorithmEnabled = await getCxsWithStrictMatchingAlgorithm();
+  return cxsWithStrictMatchingAlgorithmEnabled.includes(cxId);
 }
 
+export async function getCxsWithAthenaCustomFieldsEnabled(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithAthenaCustomFieldsEnabled");
+}
 export async function isAthenaCustomFieldsEnabledForCx(cxId: string): Promise<boolean> {
   const cxsWithAthenaCustomFieldsEnabled = await getCxsWithAthenaCustomFieldsEnabled();
   return cxsWithAthenaCustomFieldsEnabled.includes(cxId);
 }
 
-export async function getCxsWithAthenaCustomFieldsEnabled(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsWithAthenaCustomFieldsEnabled");
+export async function getCxsWithEnhancedCoverageFeatureFlagValue(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithEnhancedCoverageFeatureFlag");
+}
+export async function isEnhancedCoverageEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithECEnabled = await getCxsWithEnhancedCoverageFeatureFlagValue();
+  return cxIdsWithECEnabled.some(i => i === cxId);
+}
+
+export async function getCxsWithCQDirectFeatureFlagValue(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithCQDirectFeatureFlag");
+}
+export async function isCQDirectEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithCQDirectEnabled = await getCxsWithCQDirectFeatureFlagValue();
+  return cxIdsWithCQDirectEnabled.some(i => i === cxId);
+}
+
+export async function getCxsWithCWFeatureFlagValue(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithCWFeatureFlag");
+}
+export async function isCWEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithCWDirectEnabled = await getCxsWithCWFeatureFlagValue();
+  return cxIdsWithCWDirectEnabled.some(i => i === cxId);
+}
+
+export async function getCxsWithIncreasedSandboxLimitFeatureFlagValue(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithIncreasedSandboxLimitFeatureFlag");
+}
+
+export async function getCxsWithNoWebhookPongFeatureFlagValue(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithNoWebhookPongFeatureFlag");
+}
+export async function isWebhookPongDisabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithNoWebhookPong = await getCxsWithNoWebhookPongFeatureFlagValue();
+  return cxIdsWithNoWebhookPong.some(i => i === cxId);
+}
+
+export async function getCxsWithCdaCustodianFeatureFlag(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("getCxsWithCdaCustodianFeatureFlag");
+}
+export async function isCdaCustodianEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithFhirDedupEnabled = await getCxsWithCdaCustodianFeatureFlag();
+  return cxIdsWithFhirDedupEnabled.some(i => i === cxId);
+}
+
+export async function getCxsWitDemoAugEnabled(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithDemoAugEnabled");
+}
+export async function isDemoAugEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithDemoAugEnabled = await getCxsWitDemoAugEnabled();
+  return cxIdsWithDemoAugEnabled.some(i => i === cxId);
+}
+
+export async function getCxsWitStalePatientUpdateEnabled(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithStalePatientUpdateEnabled");
+}
+export async function isStalePatientUpdateEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithStalePatientUpdateEnabled = await getCxsWitStalePatientUpdateEnabled();
+  return cxIdsWithStalePatientUpdateEnabled.some(i => i === cxId);
+}
+
+export async function getCxsWithEpicEnabled(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithEpicEnabled");
+}
+export async function isEpicEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithEpicEnabled = await getCxsWithEpicEnabled();
+  return cxIdsWithEpicEnabled.some(i => i === cxId);
+}
+
+export async function isCommonwellEnabled(): Promise<boolean> {
+  return isFeatureFlagEnabled("commonwellFeatureFlag");
+}
+
+export async function isCarequalityEnabled(): Promise<boolean> {
+  return isFeatureFlagEnabled("carequalityFeatureFlag");
 }


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/2840

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3550
- Downstream: https://github.com/metriport/metriport/pull/3579

### Description

Move FF from api to core.

### Testing

- Local
  - [x] API runs
  - [x] DQ runs
- Staging
  - [ ] API runs
  - [ ] DQ runs
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge upstream
- [ ] Merge this
