### PR TITLE
1040 Increase AI Brief timeout to 2min

### DIFF
--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -19,7 +19,7 @@ import { getConsolidatedLocation, getConsolidatedSourceLocation } from "./consol
 
 dayjs.extend(duration);
 
-const AI_BRIEF_TIMEOUT = dayjs.duration(1.5, "minutes");
+const AI_BRIEF_TIMEOUT = dayjs.duration(2, "minutes");
 const s3Utils = new S3Utils(Config.getAWSRegion());
 const TIMED_OUT = Symbol("TIMED_OUT");
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Increase AI Brief timeout to 2min - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1742562306716219)

### Testing

- Local
  - none
- Staging
  - [ ] Create consolidated w/ AI Brief
- Sandbox
  - none
- Production
  - [ ] Create consolidated w/ AI Brief

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Extended the wait time for AI brief generation from 1.5 minutes to 2 minutes, which may help reduce premature timeouts during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->