### PR TITLE
288/Security - Bump axios version

### DIFF
--- a/.github/bots/package-lock.json
+++ b/.github/bots/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@actions/github": "^6.0.0",
-        "axios": "^1.7.7"
+        "axios": "^1.7.9"
       }
     },
     "node_modules/@actions/github": {
@@ -190,9 +190,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/.github/bots/package.json
+++ b/.github/bots/package.json
@@ -9,6 +9,6 @@
   "author": "metriport",
   "dependencies": {
     "@actions/github": "^6.0.0",
-    "axios": "^1.7.7"
+    "axios": "^1.7.9"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35422,7 +35422,7 @@
         "@sentry/tracing": "^7.120.3",
         "ajv": "^8.12.0",
         "aws-sdk": "^2.1243.0",
-        "axios": "^1.7.4",
+        "axios": "^1.7.9",
         "base64url": "^3.0.1",
         "convert-units": "^2.3.4",
         "cors": "^2.8.5",
@@ -35495,7 +35495,7 @@
         "@medplum/fhirtypes": "^2.0.32",
         "@metriport/commonwell-sdk": "^5.6.2",
         "@metriport/shared": "^0.20.2",
-        "axios": "^1.7.4",
+        "axios": "^1.7.9",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
         "zod": "^3.22.1"
@@ -35511,6 +35511,16 @@
         "ts-essentials": "^9.3.1",
         "ts-jest": "29.1.1",
         "typescript": "^4.9.5"
+      }
+    },
+    "packages/api-sdk/node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/api/node_modules/@metriport/api-sdk": {
@@ -35542,6 +35552,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "packages/api/node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "packages/api/packages/api-sdk": {},
     "packages/api/packages/carequality-sdk": {},
     "packages/api/packages/commonwell-sdk": {},
@@ -35570,7 +35590,7 @@
       "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.7.4",
+        "axios": "^1.7.9",
         "axios-retry": "^3.1.9",
         "zod": "^3.22.1"
       },
@@ -35589,13 +35609,23 @@
         "typescript": "^4.9.5"
       }
     },
+    "packages/carequality-sdk/node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
       "version": "1.24.2",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^5.6.2",
-        "axios": "^1.7.4",
+        "axios": "^1.7.9",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.0.3",
@@ -35623,6 +35653,16 @@
       "version": "18.16.19",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/commonwell-cert-runner/node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "packages/commonwell-cert-runner/node_modules/commander": {
       "version": "9.5.0",
@@ -35672,7 +35712,7 @@
       "license": "MIT",
       "dependencies": {
         "@metriport/shared": "^0.20.2",
-        "axios": "^1.7.4",
+        "axios": "^1.7.9",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
         "zod": "^3.22.1"
@@ -35702,6 +35742,16 @@
       "version": "18.16.19",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/commonwell-sdk/node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "packages/commonwell-sdk/node_modules/jsonwebtoken": {
       "version": "9.0.1",
@@ -36947,8 +36997,18 @@
       "license": "MIT",
       "dependencies": {
         "@metriport/shared": "^0.20.2",
-        "axios": "^1.7.4",
+        "axios": "^1.7.9",
         "zod": "^3.22.1"
+      }
+    },
+    "packages/ihe-gateway-sdk/node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/infra": {
@@ -37148,7 +37208,7 @@
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
-        "axios": "^1.7.4",
+        "axios": "^1.7.9",
         "dayjs": "^1.11.9",
         "fast-xml-parser": "^4.4.1",
         "http-status": "~1.7.0",
@@ -37168,6 +37228,16 @@
         "ts-essentials": "^9.3.1",
         "ts-jest": "29.1.1",
         "typescript": "^4.9.5"
+      }
+    },
+    "packages/shared/node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/shared/node_modules/fast-xml-parser": {
@@ -37211,7 +37281,7 @@
         "@playwright/browser-chromium": "^1.39.0",
         "@playwright/browser-firefox": "^1.39.0",
         "aws-sdk": "2.1243",
-        "axios": "^1.7.4",
+        "axios": "^1.7.9",
         "commander": "^10.0.0",
         "csv-parser": "^3.0.0",
         "dayjs": "^1.11.9",
@@ -39398,6 +39468,16 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "packages/utils/node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/utils/node_modules/buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,7 @@
         "packages/api",
         "packages/mllp-server",
         "packages/infra",
-        "packages/utils",
-        "packages/tester-node"
+        "packages/utils"
       ],
       "dependencies": {
         "sharp": "^0.33.5"
@@ -35423,7 +35422,7 @@
         "@sentry/tracing": "^7.120.3",
         "ajv": "^8.12.0",
         "aws-sdk": "^2.1243.0",
-        "axios": "^1.4.0",
+        "axios": "^1.7.4",
         "base64url": "^3.0.1",
         "convert-units": "^2.3.4",
         "cors": "^2.8.5",
@@ -35496,7 +35495,7 @@
         "@medplum/fhirtypes": "^2.0.32",
         "@metriport/commonwell-sdk": "^5.6.2",
         "@metriport/shared": "^0.20.2",
-        "axios": "^1.4.0",
+        "axios": "^1.7.4",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
         "zod": "^3.22.1"
@@ -35571,7 +35570,7 @@
       "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.0",
+        "axios": "^1.7.4",
         "axios-retry": "^3.1.9",
         "zod": "^3.22.1"
       },
@@ -35596,7 +35595,7 @@
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^5.6.2",
-        "axios": "^1.4.0",
+        "axios": "^1.7.4",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.0.3",
@@ -35673,7 +35672,7 @@
       "license": "MIT",
       "dependencies": {
         "@metriport/shared": "^0.20.2",
-        "axios": "^1.4.0",
+        "axios": "^1.7.4",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
         "zod": "^3.22.1"
@@ -36948,7 +36947,7 @@
       "license": "MIT",
       "dependencies": {
         "@metriport/shared": "^0.20.2",
-        "axios": "^1.6.0",
+        "axios": "^1.7.4",
         "zod": "^3.22.1"
       }
     },
@@ -37149,7 +37148,7 @@
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
-        "axios": "^1.4.0",
+        "axios": "^1.7.4",
         "dayjs": "^1.11.9",
         "fast-xml-parser": "^4.4.1",
         "http-status": "~1.7.0",
@@ -37212,7 +37211,7 @@
         "@playwright/browser-chromium": "^1.39.0",
         "@playwright/browser-firefox": "^1.39.0",
         "aws-sdk": "2.1243",
-        "axios": "^1.4.0",
+        "axios": "^1.7.4",
         "commander": "^10.0.0",
         "csv-parser": "^3.0.0",
         "dayjs": "^1.11.9",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -60,7 +60,7 @@
     "@medplum/fhirtypes": "^2.0.32",
     "@metriport/commonwell-sdk": "^5.6.2",
     "@metriport/shared": "^0.20.2",
-    "axios": "^1.4.0",
+    "axios": "^1.7.4",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",
     "zod": "^3.22.1"

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -60,7 +60,7 @@
     "@medplum/fhirtypes": "^2.0.32",
     "@metriport/commonwell-sdk": "^5.6.2",
     "@metriport/shared": "^0.20.2",
-    "axios": "^1.7.4",
+    "axios": "^1.7.9",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",
     "zod": "^3.22.1"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -41,7 +41,7 @@
     "@sentry/tracing": "^7.120.3",
     "ajv": "^8.12.0",
     "aws-sdk": "^2.1243.0",
-    "axios": "^1.4.0",
+    "axios": "^1.7.4",
     "base64url": "^3.0.1",
     "convert-units": "^2.3.4",
     "cors": "^2.8.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -41,7 +41,7 @@
     "@sentry/tracing": "^7.120.3",
     "ajv": "^8.12.0",
     "aws-sdk": "^2.1243.0",
-    "axios": "^1.7.4",
+    "axios": "^1.7.9",
     "base64url": "^3.0.1",
     "convert-units": "^2.3.4",
     "cors": "^2.8.5",

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -61,7 +61,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "axios": "^1.7.4",
+    "axios": "^1.7.9",
     "axios-retry": "^3.1.9",
     "zod": "^3.22.1"
   },

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -61,7 +61,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "axios": "^1.6.0",
+    "axios": "^1.7.4",
     "axios-retry": "^3.1.9",
     "zod": "^3.22.1"
   },

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@metriport/commonwell-sdk": "^5.6.2",
-    "axios": "^1.4.0",
+    "axios": "^1.7.4",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.0.3",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@metriport/commonwell-sdk": "^5.6.2",
-    "axios": "^1.7.4",
+    "axios": "^1.7.9",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.0.3",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@metriport/shared": "^0.20.2",
-    "axios": "^1.4.0",
+    "axios": "^1.7.4",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",
     "zod": "^3.22.1"

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@metriport/shared": "^0.20.2",
-    "axios": "^1.7.4",
+    "axios": "^1.7.9",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",
     "zod": "^3.22.1"

--- a/packages/connect-widget/package-lock.json
+++ b/packages/connect-widget/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^16.18.3",
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.9",
-        "axios": "^0.27.2",
+        "axios": "^1.7.9",
         "env-cmd": "^10.1.0",
         "framer-motion": "^7.6.15",
         "jest": "^29.6.2",
@@ -4466,16 +4466,6 @@
         "zod": "^3.22.1"
       }
     },
-    "node_modules/@metriport/api-sdk/node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
-      "dependencies": {
-        "follow-redirects": "^1.15.4",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@metriport/commonwell-sdk": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-4.12.0.tgz",
@@ -4485,16 +4475,6 @@
         "http-status": "^1.7.0",
         "jsonwebtoken": "^9.0.0",
         "zod": "^3.22.1"
-      }
-    },
-    "node_modules/@metriport/commonwell-sdk/node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
-      "dependencies": {
-        "follow-redirects": "^1.15.4",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@metriport/shared": {
@@ -6542,11 +6522,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "license": "MIT",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -9921,9 +9903,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",

--- a/packages/connect-widget/package.json
+++ b/packages/connect-widget/package.json
@@ -50,7 +50,7 @@
     "@types/node": "^16.18.3",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
-    "axios": "^0.27.2",
+    "axios": "^1.7.9",
     "env-cmd": "^10.1.0",
     "framer-motion": "^7.6.15",
     "jest": "^29.6.2",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@metriport/shared": "^0.20.2",
-    "axios": "^1.6.0",
+    "axios": "^1.7.4",
     "zod": "^3.22.1"
   }
 }

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@metriport/shared": "^0.20.2",
-    "axios": "^1.7.4",
+    "axios": "^1.7.9",
     "zod": "^3.22.1"
   }
 }

--- a/packages/lambdas/package-lock.json
+++ b/packages/lambdas/package-lock.json
@@ -24,7 +24,7 @@
         "@types/xmldom": "^0.1.32",
         "asn1js": "^3.0.5",
         "aws-sdk": "^2.1248.0",
-        "axios": "^1.4.0",
+        "axios": "^1.7.4",
         "convert-units": "^2.3.4",
         "csv-parser": "^3.2.0",
         "dayjs": "^1.11.10",

--- a/packages/lambdas/package-lock.json
+++ b/packages/lambdas/package-lock.json
@@ -24,7 +24,7 @@
         "@types/xmldom": "^0.1.32",
         "asn1js": "^3.0.5",
         "aws-sdk": "^2.1248.0",
-        "axios": "^1.7.4",
+        "axios": "^1.7.9",
         "convert-units": "^2.3.4",
         "csv-parser": "^3.2.0",
         "dayjs": "^1.11.10",
@@ -8423,9 +8423,9 @@
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/packages/lambdas/package.json
+++ b/packages/lambdas/package.json
@@ -39,7 +39,7 @@
     "@types/xmldom": "^0.1.32",
     "asn1js": "^3.0.5",
     "aws-sdk": "^2.1248.0",
-    "axios": "^1.7.4",
+    "axios": "^1.7.9",
     "convert-units": "^2.3.4",
     "csv-parser": "^3.2.0",
     "dayjs": "^1.11.10",

--- a/packages/lambdas/package.json
+++ b/packages/lambdas/package.json
@@ -39,7 +39,7 @@
     "@types/xmldom": "^0.1.32",
     "asn1js": "^3.0.5",
     "aws-sdk": "^2.1248.0",
-    "axios": "^1.4.0",
+    "axios": "^1.7.4",
     "convert-units": "^2.3.4",
     "csv-parser": "^3.2.0",
     "dayjs": "^1.11.10",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "@medplum/core": "^2.2.10",
-    "axios": "^1.7.4",
+    "axios": "^1.7.9",
     "dayjs": "^1.11.9",
     "fast-xml-parser": "^4.4.1",
     "http-status": "~1.7.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "@medplum/core": "^2.2.10",
-    "axios": "^1.4.0",
+    "axios": "^1.7.4",
     "dayjs": "^1.11.9",
     "fast-xml-parser": "^4.4.1",
     "http-status": "~1.7.0",

--- a/packages/terminology/package-lock.json
+++ b/packages/terminology/package-lock.json
@@ -14,7 +14,7 @@
         "@medplum/fhirtypes": "^3.2.5",
         "@metriport/shared": "^0.12.2",
         "aws-sdk": "^2.1243.0",
-        "axios": "^1.7.3",
+        "axios": "^1.7.4",
         "dayjs": "^1.11.9",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -3209,9 +3209,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
-      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/packages/terminology/package-lock.json
+++ b/packages/terminology/package-lock.json
@@ -14,7 +14,7 @@
         "@medplum/fhirtypes": "^3.2.5",
         "@metriport/shared": "^0.12.2",
         "aws-sdk": "^2.1243.0",
-        "axios": "^1.7.4",
+        "axios": "^1.7.9",
         "dayjs": "^1.11.9",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",

--- a/packages/terminology/package.json
+++ b/packages/terminology/package.json
@@ -30,7 +30,7 @@
     "@medplum/fhirtypes": "^3.2.5",
     "@metriport/shared": "^0.12.2",
     "aws-sdk": "^2.1243.0",
-    "axios": "^1.7.4",
+    "axios": "^1.7.9",
     "dayjs": "^1.11.9",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/packages/terminology/package.json
+++ b/packages/terminology/package.json
@@ -30,7 +30,7 @@
     "@medplum/fhirtypes": "^3.2.5",
     "@metriport/shared": "^0.12.2",
     "aws-sdk": "^2.1243.0",
-    "axios": "^1.7.3",
+    "axios": "^1.7.4",
     "dayjs": "^1.11.9",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -57,7 +57,7 @@
     "@playwright/browser-chromium": "^1.39.0",
     "@playwright/browser-firefox": "^1.39.0",
     "aws-sdk": "2.1243",
-    "axios": "^1.4.0",
+    "axios": "^1.7.4",
     "commander": "^10.0.0",
     "csv-parser": "^3.0.0",
     "dayjs": "^1.11.9",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -57,7 +57,7 @@
     "@playwright/browser-chromium": "^1.39.0",
     "@playwright/browser-firefox": "^1.39.0",
     "aws-sdk": "2.1243",
-    "axios": "^1.7.4",
+    "axios": "^1.7.9",
     "commander": "^10.0.0",
     "csv-parser": "^3.0.0",
     "dayjs": "^1.11.9",


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport/security/dependabot/288

### Dependencies

- related: https://github.com/metriport/metriport-internal/pull/2849

### Description

Bump axios version

### Testing

- Local
  - [x] compiles
- Staging
  - [ ] API DQ runs
  - [ ] Consolidated created
  - [ ] MR created
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded a core network communication component across the system to a more recent version, enhancing performance, reliability, and stability for a smoother overall experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->