### PR TITLE
fix(workflows): put prep-lambda step back into tunnel deploy workflow

### DIFF
--- a/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
+++ b/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
@@ -86,6 +86,10 @@ jobs:
           npm ci --ignore-scripts --no-fund
         working-directory: "metriport/"
 
+      - name: Lambdas build shared layer
+        run: npm run prep-deploy
+        working-directory: "metriport/packages/lambdas/"
+        
       - name: Build relevant packages
         run: |
           npm run build:cloud 


### PR DESCRIPTION
refs. metriport/metriport-internal#2835

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

- Downstream: https://github.com/metriport/metriport/pull/3588/

### Description

This PR fixes the issue when deploying VPN tunnels via CICD.

See failing workflow run [here](https://github.com/metriport/metriport/actions/runs/14230325936).

### Testing

I can successfully `npm run build:cloud` locally if I have lambda layers on my machine.

### Release Plan

- [ ] Merge this
- [ ] Rerun Deploy hl7 vpn tunnel to staging GH action workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the deployment process by adding an extra preparation step for shared resources to streamline and improve build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->