### PR TITLE
2553 Scripts to download CQ dir and compare w/ DB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16462,6 +16462,11 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true
     },
+    "node_modules/@streamparser/json": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.22.tgz",
+      "integrity": "sha512-b6gTSBjJ8G8SuO3Gbbj+zXbVx8NSs1EbpbMKpzGLWMdkR+98McH9bEjSz3+0mPJf68c5nxa3CrJHp5EQNXM6zQ=="
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -37210,6 +37215,7 @@
         "@opensearch-project/opensearch": "^2.3.1",
         "@playwright/browser-chromium": "^1.39.0",
         "@playwright/browser-firefox": "^1.39.0",
+        "@streamparser/json": "^0.0.22",
         "aws-sdk": "2.1243",
         "axios": "^1.4.0",
         "commander": "^10.0.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -56,6 +56,7 @@
     "@opensearch-project/opensearch": "^2.3.1",
     "@playwright/browser-chromium": "^1.39.0",
     "@playwright/browser-firefox": "^1.39.0",
+    "@streamparser/json": "^0.0.22",
     "aws-sdk": "2.1243",
     "axios": "^1.4.0",
     "commander": "^10.0.0",

--- a/packages/utils/src/carequality/compare-directory.ts
+++ b/packages/utils/src/carequality/compare-directory.ts
@@ -1,0 +1,121 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import { Organization } from "@medplum/fhirtypes";
+import { sleep } from "@metriport/shared";
+import { JSONParser, ParsedElementInfo } from "@streamparser/json";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import fs from "fs";
+import { groupBy } from "lodash";
+import { elapsedTimeAsStr } from "../shared/duration";
+
+dayjs.extend(duration);
+
+/**
+ * Compares the raw CQ directory with the one from the DB.
+ *
+ * Update the paths to the files downloaded from CQ and DB.
+ *
+ * Run the script with `ts-node src/carequality/compare-directory.ts`
+ */
+
+// File dowloaded from CQ, see download-directory.ts
+const rawCqDirectoryPath = "";
+/*
+ File downloaded from DB, JSON file w/ the structure: CQDirectoryEntryData2[][]
+ Adjust the code as needed, if you export directly from Postgres.
+*/
+const cqDirectoryFromDbPath = "";
+
+export type CQDirectoryEntryData2 = {
+  id: string; // Organization's OID
+  name?: string;
+  urlXCPD?: string;
+  urlDQ?: string;
+  urlDR?: string;
+  lat?: number;
+  lon?: number;
+  addressLine?: string;
+  city?: string;
+  state?: string;
+  zip?: string;
+  data?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  point?: string;
+  rootOrganization?: string;
+  managingOrganizationId?: string;
+  active: boolean;
+  lastUpdatedAtCQ: string;
+};
+
+async function main() {
+  await sleep(50); // Give some time to avoid mixing logs w/ Node's
+  const startedAt = Date.now();
+  console.log(`############## Started at ${new Date(startedAt).toISOString()} ##############`);
+
+  console.log("Loading raw CQ directory...");
+
+  const rawCqDirectoryIds: string[] = [];
+  async function loadRawCqDirectory() {
+    await loadDataFromLargeJsonFile(rawCqDirectoryPath, ({ value }) => {
+      const org = value as unknown as Organization;
+      org.id && rawCqDirectoryIds.push(org.id);
+    });
+    console.log(`Done loading raw CQ directory, found ${rawCqDirectoryIds.length} entries`);
+  }
+
+  const cqDirectoryFromDbIds: string[] = [];
+  async function loadCqDirectoryFromDb() {
+    await loadDataFromLargeJsonFile(cqDirectoryFromDbPath, ({ value }) => {
+      const orgs = value as unknown as CQDirectoryEntryData2[];
+      orgs.forEach(org => org.id && cqDirectoryFromDbIds.push(org.id));
+    });
+    console.log(`Done loading CQ directory from DB, found ${cqDirectoryFromDbIds.length} entries`);
+  }
+
+  await Promise.all([loadRawCqDirectory(), loadCqDirectoryFromDb()]);
+  console.log("Done loading, now comparing...");
+
+  const duplicateRawIds = Object.entries(groupBy(rawCqDirectoryIds, id => id))
+    .filter(v => v[1].length > 1)
+    .flatMap(v => v[0]);
+  const duplicateDbIds = Object.entries(groupBy(cqDirectoryFromDbIds, id => id))
+    .filter(v => v[1].length > 1)
+    .flatMap(v => v[0]);
+
+  console.log(`Duplicate IDs in raw directory (count ${duplicateRawIds.length}):`, duplicateRawIds);
+  console.log(`Duplicate IDs in DB (count ${duplicateDbIds.length}):`, duplicateDbIds);
+
+  const rawIds = new Set(rawCqDirectoryIds);
+  const dbIds = new Set(cqDirectoryFromDbIds);
+
+  const onlyInRaw = [...rawIds].filter(id => id && !dbIds.has(id));
+  const onlyInDb = [...dbIds].filter(id => id && !rawIds.has(id));
+  const inBoth = [...rawIds].filter(id => id && dbIds.has(id));
+
+  console.log("Only in raw directory:", onlyInRaw.length);
+  console.log("Only in DB:", onlyInDb.length);
+  console.log("In both:", inBoth.length);
+
+  console.log(`>>>>>>> Done after ${elapsedTimeAsStr(startedAt)}`);
+}
+
+async function loadDataFromLargeJsonFile(
+  path: string,
+  onValue: (value: ParsedElementInfo.ParsedElementInfo) => void
+): Promise<void> {
+  const parser = new JSONParser({ stringBufferSize: undefined, paths: ["$.*"] });
+  parser.onValue = onValue;
+  await new Promise((resolve, reject) => {
+    const inputStream = fs.createReadStream(path, { encoding: "utf8" });
+    inputStream.on("error", reject);
+    parser.onError = reject;
+    parser.onEnd = () => resolve(undefined);
+    inputStream.on("data", chunk => parser.write(chunk));
+    inputStream.on("end", () => parser.end());
+  });
+}
+
+if (require.main === module) {
+  main();
+}

--- a/packages/utils/src/carequality/download-directory.ts
+++ b/packages/utils/src/carequality/download-directory.ts
@@ -1,0 +1,86 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import { Organization } from "@medplum/fhirtypes";
+import { APIMode, CarequalityManagementApiFhir } from "@metriport/carequality-sdk";
+import { getEnvVarOrFail, sleep } from "@metriport/shared";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import fs from "fs";
+import { elapsedTimeAsStr } from "../shared/duration";
+import { buildGetDirPathInside, initRunsFolder } from "../shared/folder";
+
+dayjs.extend(duration);
+
+/**
+ * Downloads the Carequality directory from the Carequality API and saves it to a file.
+ *
+ * Set the CQ_MANAGEMENT_API_KEY environment variable to your Carequality API key.
+ * Set the apiMode to APIMode.production, APIMode.staging, or APIMode.dev.
+ *
+ * Run the script with `ts-node src/carequality/download-directory.ts`
+ */
+
+const apiKey = getEnvVarOrFail("CQ_MANAGEMENT_API_KEY");
+const apiMode = APIMode.production;
+
+const BATCH_SIZE = 5_000;
+const SLEEP_TIME = dayjs.duration({ milliseconds: 750 });
+
+const dirName = "cq-directory";
+const getFolderName = buildGetDirPathInside(dirName);
+
+/**
+ * Downloads all active organizations from the Carequality directory
+ */
+export async function downloadCQDirectory(
+  apiKey: string,
+  apiMode: APIMode
+): Promise<Organization[]> {
+  const cq = new CarequalityManagementApiFhir({ apiKey, apiMode });
+  const allOrgs: Organization[] = [];
+  let currentPosition = 0;
+  let isDone = false;
+
+  while (!isDone) {
+    const maxPosition = currentPosition + BATCH_SIZE;
+    const orgs = await cq.listOrganizations({
+      start: currentPosition,
+      count: BATCH_SIZE,
+      active: true,
+      sortKey: "_id",
+    });
+    console.log(`Downloaded ${orgs.length} organizations (total: ${allOrgs.length})`);
+
+    allOrgs.push(...orgs);
+
+    if (orgs.length < BATCH_SIZE) {
+      isDone = true;
+    } else {
+      await sleep(SLEEP_TIME.asMilliseconds());
+      currentPosition = maxPosition;
+    }
+  }
+
+  return allOrgs;
+}
+
+async function main() {
+  await sleep(50); // Give some time to avoid mixing logs w/ Node's
+  const startedAt = Date.now();
+  console.log(`############## Started at ${new Date(startedAt).toISOString()} ##############`);
+  initRunsFolder(dirName);
+
+  const orgs = await downloadCQDirectory(apiKey, apiMode);
+
+  const outputFilename = getFolderName() + ".json";
+  fs.writeFileSync(outputFilename, JSON.stringify(orgs, null, 2));
+
+  console.log(`Downloaded ${orgs.length} organizations`);
+
+  console.log(`>>>>>>> Done after ${elapsedTimeAsStr(startedAt)}`);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/packages/utils/src/shared/folder.ts
+++ b/packages/utils/src/shared/folder.ts
@@ -6,7 +6,7 @@ export const runsFolderName = "runs";
 /**
  * Creates a symlink to the runs folder in the user's home directory
  */
-export function initRunsFolder() {
+export function initRunsFolder(subFolder?: string) {
   const homeDir = os.homedir();
   const dest = `${homeDir}/Documents/phi/runs`;
   if (!fs.existsSync(dest)) {
@@ -18,6 +18,12 @@ export function initRunsFolder() {
   } catch (error) {
     fs.symlinkSync(dest, pathName);
   }
+  if (subFolder) {
+    const subFolderPath = `${pathName}/${subFolder}`;
+    if (!fs.existsSync(subFolderPath)) {
+      fs.mkdirSync(subFolderPath, { recursive: true });
+    }
+  }
 }
 
 /**
@@ -28,14 +34,16 @@ export function initRunsFolder() {
  *
  * @param folder the name of the folder inside ./runs
  */
-export function buildGetDirPathInside(folder: string) {
-  return function (orgName: string): string {
-    const pathName = `./${runsFolderName}/${folder}`;
+export function buildGetDirPathInside(folder?: string) {
+  return function (orgName?: string): string {
+    const basePathName = `./${runsFolderName}`;
+    const pathName = basePathName + (folder ? `/${folder}` : "");
     return `${pathName}/${getFileNameForOrg(orgName)}`;
   };
 }
 
-export function getFileNameForOrg(orgName: string, extension?: string): string {
+export function getFileNameForOrg(orgName?: string, extension?: string): string {
   const ext = extension ? `.${extension}` : "";
-  return `${orgName?.replace(/[,.]/g, "").replaceAll(" ", "-")}_${new Date().toISOString()}${ext}`;
+  if (!orgName) return new Date().toISOString();
+  return `${orgName.replace(/[,.]/g, "").replaceAll(" ", "-")}_${new Date().toISOString()}${ext}`;
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#2553

### Dependencies

none

### Description

Scripts to download CQ dir and compare w/ DB - context

It also includes streaming based JSON parsing (maybe useful for https://github.com/metriport/metriport-internal/issues/2830)

### Testing

- Local
  - [x] download CQ directory
  - [x] compares CQ dir w/ version from DB
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management with a new JSON streaming package.
- **New Features**
  - Introduced tools for comparing directories to highlight differences and duplicates.
  - Added functionality to download and export directory data from an external source.
- **Refactor**
  - Enhanced folder management with support for optional nested directories, improving file organization and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->