### PR TITLE
2757 write request logs (hl7 messages) to s3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,7 @@
         "packages/api",
         "packages/mllp-server",
         "packages/infra",
-        "packages/utils",
-        "packages/tester-node"
+        "packages/utils"
       ],
       "dependencies": {
         "sharp": "^0.33.5"
@@ -37010,6 +37009,7 @@
       "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
+        "@medplum/core": "^3.2.33",
         "@medplum/hl7": "^3.2.33",
         "@metriport/core": "file:packages/core",
         "@metriport/shared": "file:packages/shared",
@@ -37022,6 +37022,23 @@
         "@types/node": "^22.13.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.6.3"
+      }
+    },
+    "packages/mllp-server/node_modules/@medplum/core": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@medplum/core/-/core-3.3.0.tgz",
+      "integrity": "sha512-MnuT6FsSqJzdOBqUwPclFHULal3cxXoJs7HXfTklxT1vy2HsOiB7ENoAKWIVVycJ2nrODsprHnQ3d12au1CtVw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "pdfmake": "^0.2.5"
+      },
+      "peerDependenciesMeta": {
+        "pdfmake": {
+          "optional": true
+        }
       }
     },
     "packages/mllp-server/node_modules/@metriport/core": {

--- a/packages/core/src/util/__tests__/base64-scrambler.test.ts
+++ b/packages/core/src/util/__tests__/base64-scrambler.test.ts
@@ -23,10 +23,21 @@ describe("base64-scrambler", () => {
     expect(crypto.unscramble(initial)).toEqual(expected);
   });
 
-  it("throws an error when scrambling a non-b64 string", async () => {
+  it("throws an error when scrambling non b64 strings", async () => {
     const crypto = new Base64Scrambler(secret);
-    const initial = ";;;;YyRX63dg6du0c2Bw==";
+    const nonB64String = ";;;;YyRX63dg6du0c2Bw==";
+    const emptyString = "";
 
-    expect(() => crypto.scramble(initial)).toThrow();
+    expect(() => crypto.scramble(nonB64String)).toThrow();
+    expect(() => crypto.scramble(emptyString)).toThrow();
+  });
+
+  it("throws an error when unscrambling non b64 strings", async () => {
+    const crypto = new Base64Scrambler(secret);
+    const nonB64String = ";;;;YyRX63dg6du0c2Bw==";
+    const emptyString = "";
+
+    expect(() => crypto.unscramble(nonB64String)).toThrow();
+    expect(() => crypto.unscramble(emptyString)).toThrow();
   });
 });

--- a/packages/core/src/util/__tests__/base64-scrambler.test.ts
+++ b/packages/core/src/util/__tests__/base64-scrambler.test.ts
@@ -26,18 +26,18 @@ describe("base64-scrambler", () => {
   it("throws an error when scrambling non b64 strings", async () => {
     const crypto = new Base64Scrambler(secret);
     const nonB64String = ";;;;YyRX63dg6du0c2Bw==";
-    const emptyString = "";
+    const whitespace = " ";
 
     expect(() => crypto.scramble(nonB64String)).toThrow();
-    expect(() => crypto.scramble(emptyString)).toThrow();
+    expect(() => crypto.scramble(whitespace)).toThrow();
   });
 
   it("throws an error when unscrambling non b64 strings", async () => {
     const crypto = new Base64Scrambler(secret);
     const nonB64String = ";;;;YyRX63dg6du0c2Bw==";
-    const emptyString = "";
+    const whitespace = " ";
 
     expect(() => crypto.unscramble(nonB64String)).toThrow();
-    expect(() => crypto.unscramble(emptyString)).toThrow();
+    expect(() => crypto.unscramble(whitespace)).toThrow();
   });
 });

--- a/packages/core/src/util/base64-scrambler.ts
+++ b/packages/core/src/util/base64-scrambler.ts
@@ -1,6 +1,6 @@
 import * as crypto from "crypto";
 import { BASE64_CHARS, isValidBase64 } from "./base64";
-
+import { MetriportError } from "@metriport/shared";
 /**
  * A utility for scrambling base64 strings while maintaining exact length
  */
@@ -41,7 +41,7 @@ export class Base64Scrambler {
       const scrambledChar = chars[i];
 
       if (!originalChar || !scrambledChar) {
-        throw new Error("Invalid character index");
+        throw new MetriportError("Invalid character index");
       }
 
       forwardMap.set(originalChar, scrambledChar);
@@ -63,7 +63,7 @@ export class Base64Scrambler {
    */
   scramble(base64String: string): string {
     if (!isValidBase64(base64String)) {
-      throw new Error("Input is not a valid base64 string");
+      throw new MetriportError("Input is not a valid base64 string");
     }
 
     return base64String
@@ -79,7 +79,7 @@ export class Base64Scrambler {
    */
   unscramble(scrambledString: string): string {
     if (!isValidBase64(scrambledString)) {
-      throw new Error("Input is not a valid base64 string");
+      throw new MetriportError("Input is not a valid base64 string");
     }
 
     return scrambledString

--- a/packages/core/src/util/base64-scrambler.ts
+++ b/packages/core/src/util/base64-scrambler.ts
@@ -13,7 +13,6 @@ export class Base64Scrambler {
    * @param seed - A string to use as the scrambling key
    */
   constructor(seed: string) {
-    // Create a consistent character mapping based on the seed
     [this.mappingForward, this.mappingReverse] = this.generateMappings(seed);
   }
 
@@ -37,12 +36,10 @@ export class Base64Scrambler {
     const reverseMap = new Map<string, string>();
 
     for (let i = 0; i < BASE64_CHARS.length; i++) {
-      const originalChar = BASE64_CHARS[i];
-      const scrambledChar = chars[i];
-
-      if (!originalChar || !scrambledChar) {
-        throw new MetriportError("Invalid character index");
-      }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const originalChar = BASE64_CHARS[i]!;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const scrambledChar = chars[i]!;
 
       forwardMap.set(originalChar, scrambledChar);
       reverseMap.set(scrambledChar, originalChar);

--- a/packages/core/src/util/base64-scrambler.ts
+++ b/packages/core/src/util/base64-scrambler.ts
@@ -76,6 +76,10 @@ export class Base64Scrambler {
    * @returns The original base64 string
    */
   unscramble(scrambledString: string): string {
+    if (!isValidBase64(scrambledString)) {
+      throw new Error("Input is not a valid base64 string");
+    }
+
     return scrambledString
       .split("")
       .map(char => this.mappingReverse.get(char) || char)

--- a/packages/core/src/util/base64-scrambler.ts
+++ b/packages/core/src/util/base64-scrambler.ts
@@ -9,17 +9,17 @@ export class Base64Scrambler {
   private mappingReverse: Map<string, string>;
 
   /**
-   * Initialize the scrambler with a secret string
-   * @param secret - A string to use as the scrambling key
+   * Initialize the scrambler with a seed string
+   * @param seed - A string to use as the scrambling key
    */
-  constructor(secret: string) {
-    // Create a consistent character mapping based on the secret
-    [this.mappingForward, this.mappingReverse] = this.generateMappings(secret);
+  constructor(seed: string) {
+    // Create a consistent character mapping based on the seed
+    [this.mappingForward, this.mappingReverse] = this.generateMappings(seed);
   }
 
   /**
-   * Generate consistent character mappings based on the secret
-   * @param secret - The secret key
+   * Generate consistent character mappings based on the seed
+   * @param seed - The seed key
    * @returns Two maps: forward (original→scrambled) and reverse (scrambled→original)
    */
   private generateMappings(secret: string): [Map<string, string>, Map<string, string>] {

--- a/packages/core/src/util/base64-scrambler.ts
+++ b/packages/core/src/util/base64-scrambler.ts
@@ -27,20 +27,30 @@ export class Base64Scrambler {
     const chars = BASE64_CHARS.split("");
 
     for (let i = chars.length - 1; i > 0; i--) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const j = buffer[i % buffer.length]! % (i + 1);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      [chars[i], chars[j]] = [chars[j]!, chars[i]!];
+      const bufferModI = buffer[i % buffer.length];
+      if (!bufferModI) {
+        throw new Error("Invalid buffer index");
+      }
+      const j = bufferModI % (i + 1);
+
+      const charsJ = chars[j];
+      const charsI = chars[i];
+      if (!charsJ || !charsI) {
+        throw new Error("Invalid character index");
+      }
+      [chars[i], chars[j]] = [charsJ, charsI];
     }
 
     const forwardMap = new Map<string, string>();
     const reverseMap = new Map<string, string>();
 
     for (let i = 0; i < BASE64_CHARS.length; i++) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const originalChar = BASE64_CHARS[i]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const scrambledChar = chars[i]!;
+      const originalChar = BASE64_CHARS[i];
+      const scrambledChar = chars[i];
+
+      if (!originalChar || !scrambledChar) {
+        throw new Error("Invalid character index");
+      }
 
       forwardMap.set(originalChar, scrambledChar);
       reverseMap.set(scrambledChar, originalChar);

--- a/packages/core/src/util/base64-scrambler.ts
+++ b/packages/core/src/util/base64-scrambler.ts
@@ -22,8 +22,8 @@ export class Base64Scrambler {
    * @param seed - The seed key
    * @returns Two maps: forward (original→scrambled) and reverse (scrambled→original)
    */
-  private generateMappings(secret: string): [Map<string, string>, Map<string, string>] {
-    const buffer = crypto.createHash("sha256").update(secret).digest();
+  private generateMappings(seed: string): [Map<string, string>, Map<string, string>] {
+    const buffer = crypto.createHash("sha256").update(seed).digest();
     const chars = BASE64_CHARS.split("");
 
     for (let i = chars.length - 1; i > 0; i--) {

--- a/packages/core/src/util/base64-scrambler.ts
+++ b/packages/core/src/util/base64-scrambler.ts
@@ -27,18 +27,10 @@ export class Base64Scrambler {
     const chars = BASE64_CHARS.split("");
 
     for (let i = chars.length - 1; i > 0; i--) {
-      const bufferModI = buffer[i % buffer.length];
-      if (!bufferModI) {
-        throw new Error("Invalid buffer index");
-      }
-      const j = bufferModI % (i + 1);
-
-      const charsJ = chars[j];
-      const charsI = chars[i];
-      if (!charsJ || !charsI) {
-        throw new Error("Invalid character index");
-      }
-      [chars[i], chars[j]] = [charsJ, charsI];
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const j = buffer[i % buffer.length]! % (i + 1);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      [chars[i], chars[j]] = [chars[j]!, chars[i]!];
     }
 
     const forwardMap = new Map<string, string>();

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -64,8 +64,8 @@ export class Config {
   static getSystemRootOID(): string {
     return getEnvVarOrFail("SYSTEM_ROOT_OID");
   }
-  static getBase64ScramblerSeed(): string {
-    return getEnvVarOrFail("BASE64_SCRAMBLER_SEED");
+  static getHl7Base64ScramblerSeed(): string {
+    return getEnvVarOrFail("HL7_BASE64_SCRAMBLER_SEED");
   }
 
   static getFHIRServerUrl(): string {

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -72,6 +72,9 @@ export class Config {
   static getMedicalDocumentsBucketName(): string {
     return getEnvVarOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
   }
+  static getHl7NotificationBucketName(): string {
+    return getEnvVarOrFail("HL7_NOTIFICATION_BUCKET_NAME");
+  }
   static getCdaToFhirConversionBucketName(): string | undefined {
     return getEnvVar("CONVERSION_RESULT_BUCKET_NAME");
   }

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -64,8 +64,8 @@ export class Config {
   static getSystemRootOID(): string {
     return getEnvVarOrFail("SYSTEM_ROOT_OID");
   }
-  static getBase64ScramblerSecret(): string {
-    return getEnvVarOrFail("BASE64_SCRAMBLER_SECRET");
+  static getBase64ScramblerSeed(): string {
+    return getEnvVarOrFail("BASE64_SCRAMBLER_SEED");
   }
 
   static getFHIRServerUrl(): string {

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -64,6 +64,9 @@ export class Config {
   static getSystemRootOID(): string {
     return getEnvVarOrFail("SYSTEM_ROOT_OID");
   }
+  static getBase64ScramblerSecret(): string {
+    return getEnvVarOrFail("BASE64_SCRAMBLER_SECRET");
+  }
 
   static getFHIRServerUrl(): string {
     return getEnvVarOrFail("FHIR_SERVER_URL");

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -217,6 +217,7 @@ type EnvConfigBase = {
     workspaceId: string;
     alertsChannelId: string;
   };
+  base64ScramblerSecret: string;
   acmCertMonitor: {
     /**
      * UTC-based: "Minutes Hours Day-of-month Month Day-of-week Year"

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -217,7 +217,6 @@ type EnvConfigBase = {
     workspaceId: string;
     alertsChannelId: string;
   };
-  base64ScramblerSeed: string;
   acmCertMonitor: {
     /**
      * UTC-based: "Minutes Hours Day-of-month Month Day-of-week Year"

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -217,7 +217,7 @@ type EnvConfigBase = {
     workspaceId: string;
     alertsChannelId: string;
   };
-  base64ScramblerSecret: string;
+  base64ScramblerSeed: string;
   acmCertMonitor: {
     /**
      * UTC-based: "Minutes Hours Day-of-month Month Day-of-week Year"

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -150,6 +150,7 @@ export const config: EnvConfigNonSandbox = {
     secrets: {
       HL7_BASE64_SCRAMBLER_SEED: "your-base64-scrambler-seed",
     },
+    bucketName: "test-hl7-notification-bucket",
     vpnConfigs: [
       {
         partnerName: "SampleHIE",

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -147,7 +147,9 @@ export const config: EnvConfigNonSandbox = {
   },
   generalBucketName: "test-bucket",
   hl7Notification: {
-    base64ScramblerSeed: "your-base64-scrambler-seed",
+    secrets: {
+      HL7_BASE64_SCRAMBLER_SEED: "your-base64-scrambler-seed",
+    },
     vpnConfigs: [
       {
         partnerName: "SampleHIE",

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -178,5 +178,6 @@ export const config: EnvConfigNonSandbox = {
     workspaceId: "workspace-id",
     alertsChannelId: "alerts-channel-id",
   },
+  base64ScramblerSecret: "your-base64-scrambler-secret",
 };
 export default config;

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -178,6 +178,6 @@ export const config: EnvConfigNonSandbox = {
     workspaceId: "workspace-id",
     alertsChannelId: "alerts-channel-id",
   },
-  base64ScramblerSecret: "your-base64-scrambler-secret",
+  base64ScramblerSeed: "your-base64-scrambler-seed",
 };
 export default config;

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -147,6 +147,7 @@ export const config: EnvConfigNonSandbox = {
   },
   generalBucketName: "test-bucket",
   hl7Notification: {
+    base64ScramblerSeed: "your-base64-scrambler-seed",
     vpnConfigs: [
       {
         partnerName: "SampleHIE",
@@ -178,6 +179,5 @@ export const config: EnvConfigNonSandbox = {
     workspaceId: "workspace-id",
     alertsChannelId: "alerts-channel-id",
   },
-  base64ScramblerSeed: "your-base64-scrambler-seed",
 };
 export default config;

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -1,5 +1,7 @@
 export interface Hl7NotificationConfig {
-  base64ScramblerSeed: string;
+  secrets: {
+    HL7_BASE64_SCRAMBLER_SEED: string;
+  };
   vpnConfigs: Hl7NotificationVpnConfig[];
   mllpServer: {
     fargateCpu: number;

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -2,6 +2,7 @@ export interface Hl7NotificationConfig {
   secrets: {
     HL7_BASE64_SCRAMBLER_SEED: string;
   };
+  bucketName: string;
   vpnConfigs: Hl7NotificationVpnConfig[];
   mllpServer: {
     fargateCpu: number;

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -1,4 +1,5 @@
 export interface Hl7NotificationConfig {
+  base64ScramblerSeed: string;
   vpnConfigs: Hl7NotificationVpnConfig[];
   mllpServer: {
     fargateCpu: number;

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -83,7 +83,7 @@ export class MllpStack extends cdk.NestedStack {
         NODE_ENV: "production",
         ENV_TYPE: props.config.environmentType,
         MLLP_PORT: MLLP_DEFAULT_PORT.toString(),
-        BASE64_SCRAMBLER_SECRET: props.config.base64ScramblerSecret,
+        BASE64_SCRAMBLER_SEED: props.config.base64ScramblerSeed,
         ...(props.version ? { RELEASE_SHA: props.version } : undefined),
       },
       portMappings: [{ containerPort: MLLP_DEFAULT_PORT }],

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -83,6 +83,7 @@ export class MllpStack extends cdk.NestedStack {
         NODE_ENV: "production",
         ENV_TYPE: props.config.environmentType,
         MLLP_PORT: MLLP_DEFAULT_PORT.toString(),
+        BASE64_SCRAMBLER_SECRET: props.config.base64ScramblerSecret,
         ...(props.version ? { RELEASE_SHA: props.version } : undefined),
       },
       portMappings: [{ containerPort: MLLP_DEFAULT_PORT }],

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -85,6 +85,7 @@ export class MllpStack extends cdk.NestedStack {
         NODE_ENV: "production",
         ENV_TYPE: props.config.environmentType,
         MLLP_PORT: MLLP_DEFAULT_PORT.toString(),
+        HL7_NOTIFICATION_BUCKET_NAME: props.config.hl7Notification.bucketName,
         ...(props.version ? { RELEASE_SHA: props.version } : undefined),
       },
       portMappings: [{ containerPort: MLLP_DEFAULT_PORT }],

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -20,6 +20,7 @@ export class MllpStack extends cdk.NestedStack {
     super(scope, id, props);
 
     const { vpc, ecrRepo } = props;
+    const base64ScramblerSeed = props.config.hl7Notification.base64ScramblerSeed;
     const { fargateCpu, fargateMemoryLimitMiB, fargateTaskCountMin, fargateTaskCountMax } =
       props.config.hl7Notification.mllpServer;
 
@@ -83,7 +84,7 @@ export class MllpStack extends cdk.NestedStack {
         NODE_ENV: "production",
         ENV_TYPE: props.config.environmentType,
         MLLP_PORT: MLLP_DEFAULT_PORT.toString(),
-        BASE64_SCRAMBLER_SEED: props.config.base64ScramblerSeed,
+        HL7_BASE64_SCRAMBLER_SEED: base64ScramblerSeed,
         ...(props.version ? { RELEASE_SHA: props.version } : undefined),
       },
       portMappings: [{ containerPort: MLLP_DEFAULT_PORT }],

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -80,6 +80,11 @@ export class SecretsStack extends Stack {
     }
 
     if (!isSandbox(props.config)) {
+      for (const secretName of Object.values(props.config.hl7Notification.secrets)) {
+        const secret = makeSecret(secretName);
+        logSecretInfo(this, secret, secretName);
+      }
+
       const vpnTunnelSecretNames = props.config.hl7Notification.vpnConfigs.flatMap(config => [
         `PresharedKey1-${config.partnerName}`,
         `PresharedKey2-${config.partnerName}`,

--- a/packages/mllp-server/.env.example
+++ b/packages/mllp-server/.env.example
@@ -1,3 +1,7 @@
 SENTRY_DSN=your-sentry-dsn
 RELEASE_SHA=your-release-sha
 ENV_TYPE=development
+
+HL7_NOTIFICATION_BUCKET_NAME=your-bucket-name
+AWS_REGION=your-aws-region
+HL7_BASE64_SCRAMBLER_SEED=your-seed

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/metriport/metriport#readme",
   "dependencies": {
     "@medplum/hl7": "^3.2.33",
+    "@medplum/core": "^3.2.33",
     "@metriport/core": "file:packages/core",
     "@metriport/shared": "file:packages/shared",
     "@sentry/cli": "^2.42.1",

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -1,13 +1,12 @@
 import { Hl7Server } from "@medplum/hl7";
+import { S3Utils } from "@metriport/core/external/aws/s3";
+import { Config } from "@metriport/core/util/config";
 import type { Logger } from "@metriport/core/util/log";
 import { out } from "@metriport/core/util/log";
-import { unpackUuid } from "@metriport/core/util/pack-uuid";
-import { Base64Scrambler } from "@metriport/core/util/base64-scrambler";
-import * as dotenv from "dotenv";
 import * as Sentry from "@sentry/node";
+import * as dotenv from "dotenv";
 import { initSentry } from "./sentry";
-import { Config } from "@metriport/core/util/config";
-import { S3Utils } from "@metriport/core/external/aws/s3";
+import { constructS3Key, unpackPidField } from "./utils";
 
 dotenv.config();
 
@@ -16,34 +15,8 @@ initSentry();
 const MLLP_DEFAULT_PORT = 2575;
 const bucketName = Config.getHl7NotificationBucketName();
 
-const constructKey = ({
-  cxId,
-  patientId,
-  timestamp,
-  messageType,
-  messageCode,
-}: {
-  cxId: string;
-  patientId: string;
-  timestamp: string;
-  messageType: string;
-  messageCode: string;
-}) => {
-  return `${cxId}/${patientId}/${timestamp}_${messageType}_${messageCode}.hl7`;
-};
-
-const crypto = new Base64Scrambler(Config.getBase64ScramblerSecret());
-
-const unpackPidField = (pid: string) => {
-  const [cxString, patientString] = pid.split("_").map(s => crypto.unscramble(s));
-
-  const cxId = unpackUuid(cxString);
-  const patientId = unpackUuid(patientString);
-
-  return { cxId, patientId };
-};
-
 async function createHl7Server(logger: Logger): Promise<Hl7Server> {
+  const { log } = logger;
   const s3Utils = new S3Utils(Config.getAWSRegion());
 
   const server = new Hl7Server(connection => {
@@ -51,7 +24,7 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
 
     connection.addEventListener("message", async ({ message }) => {
       const timestamp = new Date().toISOString();
-      logger.log(
+      log(
         `${timestamp}> New Message from ${connection.socket.remoteAddress}:${connection.socket.remotePort}`
       );
 
@@ -61,33 +34,17 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
       }
 
       /**
-       * Avoid using message.toString() as it seems buggy and doesn't stringify every segment
+       * Avoid using message.toString() as its not stringifying every segment
        */
       const fullMessage = message.segments.map(s => s.toString()).join("\n");
       const { cxId, patientId } = unpackPidField(pid);
 
-      /**
-       * According to docs, the message type and code are in segment 9, but
-       * we've seen many sample ADTs with the message type and code in segment 8
-       *
-       * TODO(lucas|2854|2025-04-03): More advanced handling of different HL7 versions
-       */
-      const isAdtInPidSegment = (component: number) =>
-        message.getSegment("PID")?.getComponent(component, 1).startsWith("ADT");
-
-      let messageType: string | undefined;
-      let messageCode: string | undefined;
-      if (isAdtInPidSegment(9)) {
-        messageType = message.getSegment("PID")?.getComponent(9, 1) ?? "UNK";
-        messageCode = message.getSegment("PID")?.getComponent(9, 2) ?? "UNK";
-      } else if (isAdtInPidSegment(8)) {
-        messageType = message.getSegment("PID")?.getComponent(8, 1) ?? "UNK";
-        messageCode = message.getSegment("PID")?.getComponent(8, 2) ?? "UNK";
-      }
+      const messageType = message.getSegment("MSH")?.getComponent(9, 1) ?? "UNK";
+      const messageCode = message.getSegment("MSH")?.getComponent(9, 2) ?? "UNK";
 
       await s3Utils.uploadFile({
         bucket: bucketName,
-        key: constructKey({
+        key: constructS3Key({
           cxId,
           patientId,
           timestamp,

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -1,3 +1,6 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
 import { Hl7Server } from "@medplum/hl7";
 import { Hl7Message } from "@medplum/core";
 import { S3Utils } from "@metriport/core/external/aws/s3";
@@ -5,11 +8,8 @@ import { Config } from "@metriport/core/util/config";
 import type { Logger } from "@metriport/core/util/log";
 import { out } from "@metriport/core/util/log";
 import * as Sentry from "@sentry/node";
-import * as dotenv from "dotenv";
 import { initSentry } from "./sentry";
 import { buildS3Key, unpackPidField } from "./utils";
-
-dotenv.config();
 
 initSentry();
 
@@ -35,8 +35,6 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
   const { log } = logger;
 
   const server = new Hl7Server(connection => {
-    logger.log("Connection received");
-
     connection.addEventListener("message", async ({ message }) => {
       const timestamp = new Date().toISOString();
       log(

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -4,23 +4,45 @@ import { out } from "@metriport/core/util/log";
 import * as dotenv from "dotenv";
 import * as Sentry from "@sentry/node";
 import { initSentry } from "./sentry";
+import { S3Utils } from "@metriport/core/src/external/aws/s3";
+import { Config } from "@metriport/core/src/util/config";
 
 dotenv.config();
 
 initSentry();
 
 const MLLP_DEFAULT_PORT = 2575;
+const s3Utils = new S3Utils(Config.getAWSRegion());
+
+function generateS3KeyPrefix(message: Hl7Message) {
+  const messageType = message.get("MSH.9.1");
+  const triggerEvent = message.get("MSH.9.2");
+
+  const sendingFacility = message.get("MSH.4.1");
+
+  const timestampRaw = message.get("MSH.7.1");
+  const timestampDate = timestampRaw.substring(0, 8); // YYYYMMDD
+  const timestampHour = timestampRaw.substring(8, 12); // HHMM
+
+  const controlId = message.get("MSH.10");
+
+  return `${messageType}/${triggerEvent}/${sendingFacility}/${timestampDate}_${timestampHour}_${controlId}.hl7`;
+}
 
 async function createHl7Server(logger: Logger): Promise<Hl7Server> {
   const server = new Hl7Server(connection => {
     logger.log("Connection received");
 
-    connection.addEventListener("message", ({ message }) => {
+    connection.addEventListener("message", async ({ message }) => {
       logger.log(
         `## New Message from ${connection.socket.remoteAddress}:${connection.socket.remotePort} ##`
       );
-      // TODO(lucas|2757|2025-03-05): Write request log to S3
       // TODO(lucas|2758|2025-03-05): Enqueue message for pickup
+      await s3Utils.uploadFile({
+        bucket: "metriport-hl7v2-messages",
+        key: generateS3KeyPrefix(message),
+        file: Buffer.from(message.toString()),
+      });
       connection.send(message.buildAck());
     });
 

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -2,7 +2,7 @@ import { Hl7Server } from "@medplum/hl7";
 import type { Logger } from "@metriport/core/util/log";
 import { out } from "@metriport/core/util/log";
 import { unpackUuid } from "@metriport/core/util/pack-uuid";
-import { Base64Scrambler } from "@metriport/core/util/simple-scrambler";
+import { Base64Scrambler } from "@metriport/core/util/base64-scrambler";
 import * as dotenv from "dotenv";
 import * as Sentry from "@sentry/node";
 import { initSentry } from "./sentry";

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -6,7 +6,7 @@ import { out } from "@metriport/core/util/log";
 import * as Sentry from "@sentry/node";
 import * as dotenv from "dotenv";
 import { initSentry } from "./sentry";
-import { constructS3Key, unpackPidField } from "./utils";
+import { buildS3Key, unpackPidField } from "./utils";
 
 dotenv.config();
 
@@ -52,7 +52,7 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
 
       await s3Utils.uploadFile({
         bucket: bucketName,
-        key: constructS3Key({
+        key: buildS3Key({
           cxId,
           patientId,
           timestamp,

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -4,12 +4,12 @@ import { Config } from "@metriport/core/util/config";
 
 const crypto = new Base64Scrambler(Config.getBase64ScramblerSeed());
 
+const reformUuid = (shortId: string) => {
+  return unpackUuid(crypto.unscramble(shortId));
+};
+
 export const unpackPidField = (pid: string) => {
-  const [cxString, patientString] = pid.split("_").map(s => crypto.unscramble(s));
-
-  const cxId = unpackUuid(cxString);
-  const patientId = unpackUuid(patientString);
-
+  const [cxId, patientId] = pid.split("_").map(reformUuid);
   return { cxId, patientId };
 };
 

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -1,0 +1,30 @@
+import { unpackUuid } from "@metriport/core/util/pack-uuid";
+import { Base64Scrambler } from "@metriport/core/util/base64-scrambler";
+import { Config } from "@metriport/core/util/config";
+
+const crypto = new Base64Scrambler(Config.getBase64ScramblerSecret());
+
+export const unpackPidField = (pid: string) => {
+  const [cxString, patientString] = pid.split("_").map(s => crypto.unscramble(s));
+
+  const cxId = unpackUuid(cxString);
+  const patientId = unpackUuid(patientString);
+
+  return { cxId, patientId };
+};
+
+export const constructS3Key = ({
+  cxId,
+  patientId,
+  timestamp,
+  messageType,
+  messageCode,
+}: {
+  cxId: string;
+  patientId: string;
+  timestamp: string;
+  messageType: string;
+  messageCode: string;
+}) => {
+  return `${cxId}/${patientId}/${timestamp}_${messageType}_${messageCode}.hl7`;
+};

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -1,3 +1,6 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
 import { unpackUuid } from "@metriport/core/util/pack-uuid";
 import { Base64Scrambler } from "@metriport/core/util/base64-scrambler";
 import { Config } from "@metriport/core/util/config";

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -13,7 +13,7 @@ export const unpackPidField = (pid: string) => {
   return { cxId, patientId };
 };
 
-export const constructS3Key = ({
+export const buildS3Key = ({
   cxId,
   patientId,
   timestamp,

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -2,7 +2,7 @@ import { unpackUuid } from "@metriport/core/util/pack-uuid";
 import { Base64Scrambler } from "@metriport/core/util/base64-scrambler";
 import { Config } from "@metriport/core/util/config";
 
-const crypto = new Base64Scrambler(Config.getBase64ScramblerSeed());
+const crypto = new Base64Scrambler(Config.getHl7Base64ScramblerSeed());
 
 const reformUuid = (shortId: string) => {
   return unpackUuid(crypto.unscramble(shortId));

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -4,16 +4,20 @@ import { Config } from "@metriport/core/util/config";
 
 const crypto = new Base64Scrambler(Config.getHl7Base64ScramblerSeed());
 
-const reformUuid = (shortId: string) => {
+function reformUuid(shortId: string) {
   return unpackUuid(crypto.unscramble(shortId));
-};
+}
 
-export const unpackPidField = (pid: string) => {
+export function unpackPidField(pid: string | undefined) {
+  if (!pid) {
+    return { cxId: "UNK", patientId: "UNK" };
+  }
+
   const [cxId, patientId] = pid.split("_").map(reformUuid);
   return { cxId, patientId };
-};
+}
 
-export const buildS3Key = ({
+export function buildS3Key({
   cxId,
   patientId,
   timestamp,
@@ -25,6 +29,6 @@ export const buildS3Key = ({
   timestamp: string;
   messageType: string;
   messageCode: string;
-}) => {
+}) {
   return `${cxId}/${patientId}/${timestamp}_${messageType}_${messageCode}.hl7`;
-};
+}

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -2,7 +2,7 @@ import { unpackUuid } from "@metriport/core/util/pack-uuid";
 import { Base64Scrambler } from "@metriport/core/util/base64-scrambler";
 import { Config } from "@metriport/core/util/config";
 
-const crypto = new Base64Scrambler(Config.getBase64ScramblerSecret());
+const crypto = new Base64Scrambler(Config.getBase64ScramblerSeed());
 
 export const unpackPidField = (pid: string) => {
   const [cxString, patientString] = pid.split("_").map(s => crypto.unscramble(s));


### PR DESCRIPTION
Ticket: metriport/metriport-internal#2757

### Dependencies

- Upstream: Security utils in core -> https://github.com/metriport/metriport/pull/3596
- Upstream: Configs changes -> https://github.com/metriport/metriport-internal/pull/2852

### Description

This PR writes incoming HL7 messages out to S3 using the `cx_id/patient_id/ISO8601_MSGTYPE_MSGCODE.hl7` format.

### Testing

Have an end to end setup on my machine that passes ADT A01 messages to this server, and verified that the messages were being written to the staging s3 bucket.

### Release Plan

- [ ] Merge this
