### PR TITLE
2553 Remove old CQ directory table

### DIFF
--- a/packages/api/src/command/medical/admin/hie-overview.ts
+++ b/packages/api/src/command/medical/admin/hie-overview.ts
@@ -180,7 +180,7 @@ async function getCqDataFromDb(
     select p.cx_id, p.id, pdr.data as response_data, de.name as gateway_name
     from patient p
       left join patient_discovery_result pdr ON pdr.patient_id = p.id::uuid ${matchQuery}
-      left join cq_directory_entry de ON de.id = pdr.data->'gateway'->>'oid'
+      left join cq_directory_entry_view de ON de.id = pdr.data->'gateway'->>'oid'
     where p.id = :patientId
   `;
   const replacements = {

--- a/packages/api/src/sequelize/migrations/2025-04-03_00_drop-cq-directory-entry.ts
+++ b/packages/api/src/sequelize/migrations/2025-04-03_00_drop-cq-directory-entry.ts
@@ -1,0 +1,117 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+import * as shared from "../migrations-shared";
+
+const tableName = "cq_directory_entry";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.dropTable(tableName, { transaction });
+  });
+};
+
+// Note: this won't reintroduce the data, just recreate the table
+export const down: Migration = ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async transaction => {
+    await shared.createTable(
+      queryInterface,
+      tableName,
+      {
+        id: {
+          type: DataTypes.STRING,
+          primaryKey: true,
+          allowNull: false,
+        },
+        name: {
+          type: DataTypes.STRING,
+          allowNull: true,
+        },
+        urlXCPD: {
+          field: "url_xcpd",
+          type: DataTypes.STRING,
+          allowNull: true,
+        },
+        urlDQ: {
+          field: "url_dq",
+          type: DataTypes.STRING,
+          allowNull: true,
+        },
+        urlDR: {
+          field: "url_dr",
+          type: DataTypes.STRING,
+          allowNull: true,
+        },
+        lat: {
+          type: DataTypes.FLOAT,
+          allowNull: true,
+        },
+        lon: {
+          type: DataTypes.FLOAT,
+          allowNull: true,
+        },
+        point: {
+          type: "CUBE",
+          allowNull: true,
+        },
+        state: {
+          type: DataTypes.STRING,
+          allowNull: true,
+        },
+        data: {
+          type: DataTypes.JSONB,
+          allowNull: true,
+        },
+        lastUpdatedAtCQ: {
+          field: "last_updated_at_cq",
+          type: DataTypes.STRING,
+          allowNull: true,
+        },
+        createdAt: {
+          field: "created_at",
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
+        updatedAt: {
+          field: "updated_at",
+          type: DataTypes.DATE,
+          allowNull: false,
+          defaultValue: DataTypes.NOW,
+        },
+        version: {
+          type: DataTypes.INTEGER,
+          allowNull: false,
+          defaultValue: 0,
+        },
+        managingOrganization: {
+          field: "managing_organization",
+          type: DataTypes.STRING,
+          allowNull: true,
+        },
+        managingOrganizationId: {
+          field: "managing_organization_id",
+          type: DataTypes.STRING,
+          allowNull: true,
+        },
+        active: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+        },
+        addressLine: {
+          field: "address_line",
+          type: DataTypes.STRING,
+          allowNull: true,
+        },
+        city: {
+          type: DataTypes.STRING,
+          allowNull: true,
+        },
+        zip: {
+          type: DataTypes.STRING,
+          allowNull: true,
+        },
+      },
+      { transaction, addVersion: true }
+    );
+  });
+};

--- a/packages/utils/src/saml/pre-prod-tester.ts
+++ b/packages/utils/src/saml/pre-prod-tester.ts
@@ -138,7 +138,7 @@ async function getDrUrl(id: string): Promise<string> {
   const sequelize = initDbPool(sqlDBCreds);
   const query = `
     SELECT cde.url_dr
-    FROM cq_directory_entry cde
+    FROM cq_directory_entry_view cde
     WHERE cde.id = :id;
   `;
   try {


### PR DESCRIPTION
Ref. metriport/metriport-internal#2553

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3594
- Downstream: none

### Description

Remove the old CQ directory table.

### Testing

- Local
  - [x] migration get applied, reverted, re-applied
  - [x] table is removed
- Staging
  - [ ] table is removed
  - [ ] PD + DQ work
  - [ ] CQ dir rebuild works
- Sandbox
  - none
- Production
  - none

### Release Plan

- :warning: This contains a DB migration
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated backend data management processes to improve system stability and ensure smooth, recoverable updates. These enhancements help maintain overall data integrity and bolster the platform’s resilience, contributing to a more robust and reliable user experience.
  - Modified SQL queries to utilize `cq_directory_entry_view` instead of `cq_directory_entry`, impacting data retrieval processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->