### PR TITLE
fix(docs): point github link to metriport

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "Github",
-      "url": "https://github.com/mintlify/docs"
+      "url": "https://github.com/metriport/metriport"
     }
   ],
   "primaryTab": {


### PR DESCRIPTION
refs. metriport/metriport-internal#1040

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

None

### Description

Fixes link pointing to mintlify docs instead of our own repo

### Testing

None

### Release Plan

- [ ] Merge this
