### PR TITLE
1040 Add queue after FHIR converter

### DIFF
--- a/packages/api/src/command/medical/document/__tests__/document-query_calculateAndUpdateDocQuery.test.ts
+++ b/packages/api/src/command/medical/document/__tests__/document-query_calculateAndUpdateDocQuery.test.ts
@@ -73,12 +73,13 @@ describe("docQuery-conversionProgress", () => {
     });
   });
 
-  describe("getDocQueryProgress", () => {
+  describe("calculateConversionProgress", () => {
     const testIt = ({
       result,
       total,
       errors,
       successful,
+      count = 1,
       originalStatus,
       expectedStatus,
     }: {
@@ -86,6 +87,7 @@ describe("docQuery-conversionProgress", () => {
       total: number;
       errors?: number;
       successful?: number;
+      count?: number;
       originalStatus: DocumentQueryStatus;
       expectedStatus: DocumentQueryStatus;
     }): DocumentQueryProgress => {
@@ -96,17 +98,17 @@ describe("docQuery-conversionProgress", () => {
         }),
       });
 
-      const res = calculateConversionProgress({ patient, convertResult: result });
+      const res = calculateConversionProgress({ patient, convertResult: result, count });
 
       expect(res).toBeTruthy();
       expect(res.convert).toBeTruthy();
       expect(res.convert?.status).toEqual(expectedStatus);
       expect(res.convert?.total).toEqual(total);
       successful != null
-        ? expect(res.convert?.successful).toEqual(successful + (result === "success" ? 1 : 0))
+        ? expect(res.convert?.successful).toEqual(successful + (result === "success" ? count : 0))
         : expect(res.convert?.successful).toEqual(0);
       errors != null
-        ? expect(res.convert?.errors).toEqual(errors + (result === "failed" ? 1 : 0))
+        ? expect(res.convert?.errors).toEqual(errors + (result === "failed" ? count : 0))
         : expect(res.convert?.errors).toEqual(0);
       return res;
     };
@@ -117,17 +119,23 @@ describe("docQuery-conversionProgress", () => {
         total: 10,
         originalStatus: "processing" as const,
       };
-      it("success sets to processing when adding 1 success is lower than total", async () => {
+      it("sets to processing when adding 1 success is lower than total", async () => {
         testIt({ ...base, errors: 1, successful: 7, expectedStatus: "processing" });
       });
-      it("success sets to completed when adding 1 success matches total", async () => {
+      it("sets to completed when adding 1 success matches total", async () => {
         testIt({ ...base, errors: 1, successful: 8, expectedStatus: "completed" });
       });
-      it("success sets to completed when adding 1 success is higher than total", async () => {
+      it("sets to completed when adding 1 success is higher than total", async () => {
         testIt({ ...base, errors: 1, successful: 9, expectedStatus: "completed" });
       });
-      it("success sets to completed when no errors and adding 1 success matches total", async () => {
+      it("sets to completed when no errors and adding 1 success matches total", async () => {
         testIt({ ...base, errors: 0, successful: 9, expectedStatus: "completed" });
+      });
+      it("sets to processing when has 5 successful and no errors and adding 4 success", async () => {
+        testIt({ ...base, errors: 0, successful: 5, expectedStatus: "processing", count: 4 });
+      });
+      it("sets to completed when has 5 successful and no errors and adding 5 success", async () => {
+        testIt({ ...base, errors: 0, successful: 5, expectedStatus: "completed", count: 5 });
       });
     });
 
@@ -137,17 +145,23 @@ describe("docQuery-conversionProgress", () => {
         total: 10,
         originalStatus: "processing" as const,
       };
-      it("failed sets to processing when adding 1 success is lower than total", async () => {
+      it("sets to processing when adding 1 success is lower than total", async () => {
         testIt({ ...base, errors: 1, successful: 7, expectedStatus: "processing" });
       });
-      it("failed sets to completed when adding 1 success matches total", async () => {
+      it("sets to completed when adding 1 success matches total", async () => {
         testIt({ ...base, errors: 1, successful: 8, expectedStatus: "completed" });
       });
-      it("failed sets to completed when adding 1 success is higher than total", async () => {
+      it("sets to completed when adding 1 success is higher than total", async () => {
         testIt({ ...base, errors: 1, successful: 9, expectedStatus: "completed" });
       });
-      it("failed sets to completed when no errors and adding 1 success matches total", async () => {
+      it("sets to completed when no errors and adding 1 success matches total", async () => {
         testIt({ ...base, errors: 0, successful: 9, expectedStatus: "completed" });
+      });
+      it("sets to processing when has 5 successful and no errors and adding 4 failed", async () => {
+        testIt({ ...base, errors: 0, successful: 5, expectedStatus: "processing", count: 4 });
+      });
+      it("sets to completed when has 5 successful and no errors and adding 5 failed", async () => {
+        testIt({ ...base, errors: 0, successful: 5, expectedStatus: "completed", count: 5 });
       });
     });
 

--- a/packages/api/src/command/medical/document/document-conversion-status.ts
+++ b/packages/api/src/command/medical/document/document-conversion-status.ts
@@ -24,6 +24,7 @@ export async function calculateDocumentConversionStatus({
   source,
   convertResult,
   details,
+  count: countParam,
 }: {
   patientId: string;
   cxId: string;
@@ -32,14 +33,17 @@ export async function calculateDocumentConversionStatus({
   source?: string;
   convertResult: ConvertResult;
   details?: string;
+  count?: number;
 }) {
   const { log } = out(`Doc conversion status - patient ${patientId}, requestId ${requestId}`);
 
   const hasSource = isMedicalDataSource(source);
 
+  const count = countParam == undefined ? 1 : countParam;
+
   log(
     `Converted document ${docId} with status ${convertResult}, source: ${source}, ` +
-      `details: ${details}, result: ${JSON.stringify(convertResult)}`
+      `count: ${count}, details: ${details}, result: ${JSON.stringify(convertResult)}`
   );
 
   const patient = await getPatientOrFail({ id: patientId, cxId });
@@ -51,7 +55,7 @@ export async function calculateDocumentConversionStatus({
       patient: patient,
       type: "convert",
       progress: {
-        ...(convertResult === "success" ? { successful: 1 } : { errors: 1 }),
+        ...(convertResult === "success" ? { successful: count } : { errors: count }),
       },
       requestId,
       source,
@@ -123,6 +127,7 @@ export async function calculateDocumentConversionStatus({
     const expectedPatient = await updateConversionProgress({
       patient: { id: patientId, cxId },
       convertResult,
+      count,
     });
 
     const isConversionCompleted = isProgressStatusValid({

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -176,12 +176,14 @@ type UpdateResult = {
   patient: Pick<Patient, "id" | "cxId">;
   convertResult: ConvertResult;
   count?: number;
+  log?: typeof console.log;
 };
 
 export async function updateConversionProgress({
   patient: { id, cxId },
   convertResult,
   count,
+  log = out(`updateConversionProgress - patient ${id}, cxId ${cxId}`).log,
 }: UpdateResult): Promise<Patient> {
   const patientFilter = { id, cxId };
   return executeOnDBTx(PatientModel.prototype, async transaction => {
@@ -190,6 +192,9 @@ export async function updateConversionProgress({
       lock: true,
       transaction,
     });
+
+    const docQueryProgress = patient.data.documentQueryProgress;
+    log(`Status pre-update: ${JSON.stringify(docQueryProgress)}`);
 
     const documentQueryProgress = calculateConversionProgress({
       patient,

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -175,11 +175,13 @@ export const createQueryResponse = (
 type UpdateResult = {
   patient: Pick<Patient, "id" | "cxId">;
   convertResult: ConvertResult;
+  count?: number;
 };
 
 export async function updateConversionProgress({
   patient: { id, cxId },
   convertResult,
+  count,
 }: UpdateResult): Promise<Patient> {
   const patientFilter = { id, cxId };
   return executeOnDBTx(PatientModel.prototype, async transaction => {
@@ -192,6 +194,7 @@ export async function updateConversionProgress({
     const documentQueryProgress = calculateConversionProgress({
       patient,
       convertResult,
+      count,
     });
 
     const updatedPatient = {

--- a/packages/api/src/domain/medical/conversion-progress.ts
+++ b/packages/api/src/domain/medical/conversion-progress.ts
@@ -7,33 +7,46 @@ import { Patient } from "@metriport/core/domain/patient";
 export const convertResult = ["success", "failed"] as const;
 export type ConvertResult = (typeof convertResult)[number];
 
-export const calculateConversionProgress = ({
+export function calculateConversionProgress({
   patient,
   convertResult,
+  count,
 }: {
   patient: Pick<Patient, "id" | "cxId">;
   convertResult: ConvertResult;
+  count?: number;
 } & {
   patient: Pick<Patient, "data" | "id">;
-}): DocumentQueryProgress => {
+}): DocumentQueryProgress {
   const docQueryProgress = patient.data.documentQueryProgress ?? {};
 
-  const talliedDocQueryProgress = tallyDocQueryProgress(docQueryProgress, convertResult);
+  const talliedDocQueryProgress = tallyDocQueryProgress(docQueryProgress, convertResult, count);
 
   return talliedDocQueryProgress;
-};
+}
 
-export const tallyDocQueryProgress = (
+/**
+ * Tally the conversion progress for the given convert result and count.
+ *
+ * @param docQueryProgress - the current document query progress
+ * @param convertResult - the result of the conversion, either "success" or "failed"
+ * @param countParam - the amount of documents for the given result to add to the tally (optional,
+ *                     defaults to 1)
+ * @returns the updated document query progress
+ */
+export function tallyDocQueryProgress(
   docQueryProgress: DocumentQueryProgress,
-  convertResult: ConvertResult
-): DocumentQueryProgress => {
+  convertResult: ConvertResult,
+  countParam?: number
+): DocumentQueryProgress {
+  const count = countParam == undefined ? 1 : countParam;
   const totalToConvert = docQueryProgress?.convert?.total ?? 0;
 
   const successfulConvert = docQueryProgress?.convert?.successful ?? 0;
-  const successful = convertResult === "success" ? successfulConvert + 1 : successfulConvert;
+  const successful = convertResult === "success" ? successfulConvert + count : successfulConvert;
 
   const errorsConvert = docQueryProgress?.convert?.errors ?? 0;
-  const errors = convertResult === "failed" ? errorsConvert + 1 : errorsConvert;
+  const errors = convertResult === "failed" ? errorsConvert + count : errorsConvert;
 
   const status = getStatusFromProgress({ successful, errors, total: totalToConvert });
 
@@ -45,4 +58,4 @@ export const tallyDocQueryProgress = (
   };
 
   return docQueryProgress;
-};
+}

--- a/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
@@ -249,10 +249,7 @@ async function handleDocReferences(
             id: patientId,
             cxId,
           },
-          document: {
-            id: docRef.metriportId ?? "",
-            content: { mimeType: docRef.contentType ?? "" },
-          },
+          document: { id: docRef.metriportId ?? "" },
           s3FileName: docPath,
           s3BucketName: docLocation,
           requestId,

--- a/packages/api/src/external/fhir-converter/converter.ts
+++ b/packages/api/src/external/fhir-converter/converter.ts
@@ -37,7 +37,7 @@ export function isConvertible(mimeType?: string | undefined): boolean {
  */
 export async function convertCDAToFHIR(params: {
   patient: { cxId: string; id: string };
-  document: { id: string; content?: ContentMimeType };
+  document: { id: string };
   s3FileName: string;
   s3BucketName: string;
   template?: FHIRConverterCDATemplate;

--- a/packages/api/src/external/hie/__tests__/tally-doc-query-progress.test.ts
+++ b/packages/api/src/external/hie/__tests__/tally-doc-query-progress.test.ts
@@ -1,0 +1,161 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { Progress, ProgressType } from "@metriport/core/domain/document-query";
+import { PatientExternalData } from "@metriport/core/domain/patient";
+import { makePatient, makePatientData } from "@metriport/core/domain/__tests__/patient";
+import { MedicalDataSource } from "@metriport/core/external/index";
+import { v4 as uuidv4 } from "uuid";
+import { DynamicProgress, setHIETallyCount } from "../tally-doc-query-progress";
+
+describe("tallyDocQueryProgress", () => {
+  describe("setHIETallyCount", () => {
+    const testIt = ({
+      existingProgress,
+      inputProgress,
+      expectedProgress,
+      type = "convert",
+      source = MedicalDataSource.COMMONWELL,
+    }: {
+      existingProgress?: Progress;
+      inputProgress: DynamicProgress;
+      type?: ProgressType;
+      source?: MedicalDataSource;
+      expectedProgress: Progress;
+    }): PatientExternalData => {
+      const patient = makePatient({
+        id: uuidv4(),
+        data: makePatientData({
+          externalData: {
+            [source]: {
+              documentQueryProgress: {
+                [type]: existingProgress,
+              },
+            },
+          },
+        }),
+      });
+
+      const res = setHIETallyCount(patient, inputProgress, type, source);
+      const sourceData = res[source];
+      expect(sourceData).toBeTruthy();
+      expect(sourceData?.documentQueryProgress).toBeTruthy();
+      expect(sourceData?.documentQueryProgress?.[type]).toBeTruthy();
+      expect(sourceData?.documentQueryProgress?.[type]?.status).toEqual(expectedProgress.status);
+      expect(sourceData?.documentQueryProgress?.[type]?.total).toEqual(expectedProgress.total);
+      return res;
+    };
+
+    it("keeps processing when adding 1 success is lower than total", async () => {
+      const existingProgress: Progress = {
+        status: "processing",
+        total: 10,
+        errors: 0,
+        successful: 8,
+      };
+      const inputProgress = { successful: 1 };
+      const expectedProgress: Progress = {
+        status: "processing",
+        total: 10,
+        errors: 0,
+        successful: 1,
+      };
+      testIt({ existingProgress, inputProgress, expectedProgress });
+    });
+
+    it("sets to completed when adding 1 success is equal to total", async () => {
+      const existingProgress: Progress = {
+        status: "processing",
+        total: 10,
+        errors: 0,
+        successful: 9,
+      };
+      const inputProgress = { successful: 1 };
+      const expectedProgress: Progress = {
+        status: "completed",
+        total: 10,
+        errors: 0,
+        successful: 10,
+      };
+      testIt({ existingProgress, inputProgress, expectedProgress });
+    });
+
+    it("keeps processing when adding success with existing errors", async () => {
+      const existingProgress: Progress = {
+        status: "processing",
+        total: 10,
+        errors: 2,
+        successful: 5,
+      };
+      const inputProgress = { successful: 2 };
+      const expectedProgress: Progress = {
+        status: "processing",
+        total: 10,
+        errors: 2,
+        successful: 7,
+      };
+      testIt({ existingProgress, inputProgress, expectedProgress });
+    });
+
+    it("sets to completed when success + errors equals total", async () => {
+      const existingProgress: Progress = {
+        status: "processing",
+        total: 10,
+        errors: 3,
+        successful: 6,
+      };
+      const inputProgress = { successful: 1 };
+      const expectedProgress: Progress = {
+        status: "completed",
+        total: 10,
+        errors: 3,
+        successful: 7,
+      };
+      testIt({ existingProgress, inputProgress, expectedProgress });
+    });
+
+    it("handles multiple successes in input", async () => {
+      const existingProgress: Progress = {
+        status: "processing",
+        total: 10,
+        errors: 0,
+        successful: 5,
+      };
+      const inputProgress = { successful: 3 };
+      const expectedProgress: Progress = {
+        status: "processing",
+        total: 10,
+        errors: 0,
+        successful: 8,
+      };
+      testIt({ existingProgress, inputProgress, expectedProgress });
+    });
+
+    it("handles both success and errors in input", async () => {
+      const existingProgress: Progress = {
+        status: "processing",
+        total: 10,
+        errors: 1,
+        successful: 5,
+      };
+      const inputProgress = { successful: 2, errors: 2 };
+      const expectedProgress: Progress = {
+        status: "completed",
+        total: 10,
+        errors: 3,
+        successful: 7,
+      };
+      testIt({ existingProgress, inputProgress, expectedProgress });
+    });
+
+    it("handles empty existing progress", async () => {
+      const existingProgress = undefined;
+      const inputProgress = { successful: 1 };
+      const expectedProgress: Progress = {
+        status: "completed",
+        total: 0,
+        errors: 0,
+        successful: 1,
+      };
+      testIt({ existingProgress, inputProgress, expectedProgress });
+    });
+  });
+});

--- a/packages/api/src/external/hie/tally-doc-query-progress.ts
+++ b/packages/api/src/external/hie/tally-doc-query-progress.ts
@@ -10,7 +10,7 @@ import { getPatientOrFail } from "../../command/medical/patient/get-patient";
 import { processDocQueryProgressWebhook } from "../../command/medical/document/process-doc-query-webhook";
 import { aggregateAndSetHIEProgresses } from "./set-doc-query-progress";
 
-type DynamicProgress = Pick<Progress, "successful" | "errors">;
+export type DynamicProgress = Pick<Progress, "successful" | "errors">;
 
 export type TallyDocQueryProgress = {
   source: MedicalDataSource;
@@ -102,6 +102,7 @@ export function setHIETallyCount(
       ...sourceProgress[type],
       successful: sourceSuccessful + tallySuccessful,
       errors: sourceErrors + tallyErrors,
+      total: sourceTotal,
       status: getStatusFromProgress({
         successful: totalSuccessful,
         errors: totalErrors,

--- a/packages/api/src/routes/internal/medical/docs.ts
+++ b/packages/api/src/routes/internal/medical/docs.ts
@@ -144,6 +144,8 @@ router.post(
     const source = getFrom("query").optional("source", req);
     const details = getFrom("query").optional("details", req);
     const jobId = getFrom("query").optional("jobId", req);
+    const countRaw = getFrom("query").optional("count", req);
+    const count = countRaw ? parseInt(countRaw) : undefined;
     const convertResult = convertResultSchema.parse(status);
 
     // keeping the old logic for now, but we should avoid having these optional parameters that can
@@ -160,6 +162,7 @@ router.post(
       source,
       convertResult,
       details,
+      count,
     });
 
     return res.sendStatus(httpStatus.OK);

--- a/packages/core/src/command/conversion-result/__tests__/send-multiple-conversion-results.test.ts
+++ b/packages/core/src/command/conversion-result/__tests__/send-multiple-conversion-results.test.ts
@@ -1,0 +1,187 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { faker } from "@faker-js/faker";
+import { MedicalDataSource } from "../../../external";
+import { ConversionResultLocal } from "../conversion-result-local";
+import { sendConversionResults } from "../send-multiple-conversion-results";
+import { ConversionResult } from "../types";
+
+describe("sendConversionResults", () => {
+  const apiUrl = "https://api.metriport.com";
+  const cxId = faker.string.uuid();
+  const patientId = faker.string.uuid();
+  const mockResults: ConversionResult[] = [
+    { cxId, patientId, status: "success", source: MedicalDataSource.COMMONWELL },
+  ];
+  let notifyApi_mock: jest.SpyInstance;
+
+  beforeAll(() => {
+    notifyApi_mock = jest
+      .spyOn(ConversionResultLocal.prototype, "notifyApi")
+      .mockImplementation(() => Promise.resolve());
+  });
+  afterEach(() => {
+    notifyApi_mock.mockClear();
+  });
+
+  it("sends a single result with count", async () => {
+    const expectedResult = {
+      ...mockResults[0],
+      count: mockResults.length,
+    };
+    const res = await sendConversionResults({ results: mockResults, apiUrl });
+    expect(res).toEqual([expectedResult]);
+    expect(notifyApi_mock).toHaveBeenCalledWith(expectedResult, expect.any(Function));
+  });
+
+  it("groups multiple results for the same patient/source/status", async () => {
+    const multipleResults: ConversionResult[] = [
+      ...mockResults,
+      { cxId, patientId, status: "success", source: MedicalDataSource.COMMONWELL },
+      { cxId, patientId, status: "success", source: MedicalDataSource.COMMONWELL },
+    ];
+    const expectedResult = {
+      ...mockResults[0],
+      count: multipleResults.length,
+    };
+    const res = await sendConversionResults({ results: multipleResults, apiUrl });
+    expect(res).toEqual([expectedResult]);
+    expect(notifyApi_mock).toHaveBeenCalledTimes(1);
+    expect(notifyApi_mock).toHaveBeenCalledWith(
+      expect.objectContaining(expectedResult),
+      expect.any(Function)
+    );
+  });
+
+  it("handles multiple results for different patients", async () => {
+    const patient2Id = faker.string.uuid();
+    const multipleResults: ConversionResult[] = [
+      ...mockResults,
+      { cxId, patientId: patient2Id, status: "success", source: MedicalDataSource.COMMONWELL },
+    ];
+    const expectedResults = [
+      { ...multipleResults[0], count: 1 },
+      { ...multipleResults[1], count: 1 },
+    ];
+    const res = await sendConversionResults({ results: multipleResults, apiUrl });
+    expect(res).toEqual(expectedResults);
+    expect(notifyApi_mock).toHaveBeenCalledTimes(2);
+    expect(notifyApi_mock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining(multipleResults[0]),
+      expect.any(Function)
+    );
+    expect(notifyApi_mock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining(multipleResults[1]),
+      expect.any(Function)
+    );
+  });
+  it("handles API errors gracefully and returns the results that did not fail", async () => {
+    const multipleResults: ConversionResult[] = [
+      ...mockResults,
+      { cxId, patientId, status: "failed", source: MedicalDataSource.CAREQUALITY },
+    ];
+    const expectedResult = {
+      ...multipleResults[1],
+      count: 1,
+    };
+    notifyApi_mock.mockRejectedValueOnce(new Error("API Error"));
+    const res = await sendConversionResults({ results: multipleResults, apiUrl });
+    expect(res).toEqual([expectedResult]);
+    expect(notifyApi_mock).toHaveBeenCalledTimes(2);
+    expect(notifyApi_mock).toHaveBeenCalledWith(
+      expect.objectContaining(multipleResults[0]),
+      expect.any(Function)
+    );
+    expect(notifyApi_mock).toHaveBeenCalledWith(
+      expect.objectContaining(multipleResults[1]),
+      expect.any(Function)
+    );
+  });
+
+  it("returns empty array when no results are provided", async () => {
+    const res = await sendConversionResults({ results: [], apiUrl });
+    expect(res).toEqual([]);
+    expect(notifyApi_mock).not.toHaveBeenCalled();
+  });
+
+  it("groups results by different sources for the same patient", async () => {
+    const multipleResults: ConversionResult[] = [
+      { cxId, patientId, status: "success", source: MedicalDataSource.COMMONWELL },
+      { cxId, patientId, status: "success", source: MedicalDataSource.CAREQUALITY },
+    ];
+    const expectedResults = [
+      { ...multipleResults[0], count: 1 },
+      { ...multipleResults[1], count: 1 },
+    ];
+    const res = await sendConversionResults({ results: multipleResults, apiUrl });
+    expect(res).toEqual(expectedResults);
+    expect(notifyApi_mock).toHaveBeenCalledTimes(2);
+    expect(notifyApi_mock).toHaveBeenCalledWith(
+      expect.objectContaining(multipleResults[0]),
+      expect.any(Function)
+    );
+    expect(notifyApi_mock).toHaveBeenCalledWith(
+      expect.objectContaining(multipleResults[1]),
+      expect.any(Function)
+    );
+  });
+
+  it("groups results by different statuses for the same patient and source", async () => {
+    const multipleResults: ConversionResult[] = [
+      { cxId, patientId, status: "success", source: MedicalDataSource.COMMONWELL },
+      { cxId, patientId, status: "failed", source: MedicalDataSource.COMMONWELL },
+      { cxId, patientId, status: "success", source: MedicalDataSource.COMMONWELL },
+    ];
+    const expectedResults = [
+      { ...multipleResults[0], count: 2 },
+      { ...multipleResults[1], count: 1 },
+    ];
+    const res = await sendConversionResults({ results: multipleResults, apiUrl });
+    expect(res).toEqual(expectedResults);
+    expect(notifyApi_mock).toHaveBeenCalledTimes(2);
+    expect(notifyApi_mock).toHaveBeenCalledWith(
+      expect.objectContaining(multipleResults[0]),
+      expect.any(Function)
+    );
+    expect(notifyApi_mock).toHaveBeenCalledWith(
+      expect.objectContaining(multipleResults[1]),
+      expect.any(Function)
+    );
+  });
+
+  it("handles complex combinations of sources and statuses", async () => {
+    const multipleResults: ConversionResult[] = [
+      { cxId, patientId, status: "success", source: MedicalDataSource.COMMONWELL },
+      { cxId, patientId, status: "failed", source: MedicalDataSource.COMMONWELL },
+      { cxId, patientId, status: "success", source: MedicalDataSource.CAREQUALITY },
+      { cxId, patientId, status: "failed", source: MedicalDataSource.CAREQUALITY },
+      { cxId, patientId, status: "success", source: MedicalDataSource.COMMONWELL },
+    ];
+    const expectedResults = [
+      { ...multipleResults[0], count: 2 },
+      { ...multipleResults[1], count: 1 },
+      { ...multipleResults[2], count: 1 },
+      { ...multipleResults[3], count: 1 },
+    ];
+    const res = await sendConversionResults({ results: multipleResults, apiUrl });
+    expect(res).toEqual(expectedResults);
+    expect(notifyApi_mock).toHaveBeenCalledTimes(4);
+    expect(notifyApi_mock).toHaveBeenCalledWith(
+      expect.objectContaining(multipleResults[0]),
+      expect.any(Function)
+    );
+    expect(notifyApi_mock).toHaveBeenCalledWith(
+      expect.objectContaining(multipleResults[1]),
+      expect.any(Function)
+    );
+    expect(notifyApi_mock).toHaveBeenCalledWith(
+      expect.objectContaining(multipleResults[2]),
+      expect.any(Function)
+    );
+    expect(notifyApi_mock).toHaveBeenCalledWith(
+      expect.objectContaining(multipleResults[3]),
+      expect.any(Function)
+    );
+  });
+});

--- a/packages/core/src/command/conversion-result/conversion-result-cloud.ts
+++ b/packages/core/src/command/conversion-result/conversion-result-cloud.ts
@@ -1,5 +1,4 @@
 import { errorToString } from "@metriport/shared";
-import { createUuidFromText } from "@metriport/shared/common/uuid";
 import { SQSClient } from "../../external/aws/sqs";
 import { out } from "../../util/log";
 import { capture } from "../../util/notifications";
@@ -19,11 +18,7 @@ export class ConversionResultCloud implements ConversionResultHandler {
       : out(`notifyApi.cloud - cxId ${cxId} jobId ${jobId}`);
     try {
       const payload = JSON.stringify(params);
-      await this.sqsClient.sendMessageToQueue(this.conversionResultQueueUrl, payload, {
-        fifo: true,
-        messageDeduplicationId: createUuidFromText(payload),
-        messageGroupId: cxId,
-      });
+      await this.sqsClient.sendMessageToQueue(this.conversionResultQueueUrl, payload);
     } catch (error) {
       const msg = `Failure while processing conversion result @ ConversionResult`;
       log(`${msg}. Cause: ${errorToString(error)}`);

--- a/packages/core/src/command/conversion-result/conversion-result-cloud.ts
+++ b/packages/core/src/command/conversion-result/conversion-result-cloud.ts
@@ -1,0 +1,41 @@
+import { errorToString } from "@metriport/shared";
+import { createUuidFromText } from "@metriport/shared/common/uuid";
+import { SQSClient } from "../../external/aws/sqs";
+import { out } from "../../util/log";
+import { capture } from "../../util/notifications";
+import { ConversionResult, ConversionResultHandler } from "./types";
+
+export class ConversionResultCloud implements ConversionResultHandler {
+  private readonly sqsClient: SQSClient;
+
+  constructor(readonly region: string, private readonly conversionResultQueueUrl: string) {
+    this.sqsClient = new SQSClient({ region });
+  }
+
+  async notifyApi(params: ConversionResult, logParam?: typeof console.log): Promise<void> {
+    const { cxId, jobId } = params;
+    const { log } = logParam
+      ? { log: logParam }
+      : out(`notifyApi.cloud - cxId ${cxId} jobId ${jobId}`);
+    try {
+      const payload = JSON.stringify(params);
+      await this.sqsClient.sendMessageToQueue(this.conversionResultQueueUrl, payload, {
+        fifo: true,
+        messageDeduplicationId: createUuidFromText(payload),
+        messageGroupId: cxId,
+      });
+    } catch (error) {
+      const msg = `Failure while processing conversion result @ ConversionResult`;
+      log(`${msg}. Cause: ${errorToString(error)}`);
+      capture.error(msg, {
+        extra: {
+          cxId,
+          jobId,
+          context: "conversion-result-cloud.notifyApi",
+          error,
+        },
+      });
+      throw error;
+    }
+  }
+}

--- a/packages/core/src/command/conversion-result/conversion-result-cloud.ts
+++ b/packages/core/src/command/conversion-result/conversion-result-cloud.ts
@@ -1,7 +1,4 @@
-import { errorToString } from "@metriport/shared";
 import { SQSClient } from "../../external/aws/sqs";
-import { out } from "../../util/log";
-import { capture } from "../../util/notifications";
 import { ConversionResult, ConversionResultHandler } from "./types";
 
 export class ConversionResultCloud implements ConversionResultHandler {
@@ -11,26 +8,8 @@ export class ConversionResultCloud implements ConversionResultHandler {
     this.sqsClient = new SQSClient({ region });
   }
 
-  async notifyApi(params: ConversionResult, logParam?: typeof console.log): Promise<void> {
-    const { cxId, jobId } = params;
-    const { log } = logParam
-      ? { log: logParam }
-      : out(`notifyApi.cloud - cxId ${cxId} jobId ${jobId}`);
-    try {
-      const payload = JSON.stringify(params);
-      await this.sqsClient.sendMessageToQueue(this.conversionResultQueueUrl, payload);
-    } catch (error) {
-      const msg = `Failure while processing conversion result @ ConversionResult`;
-      log(`${msg}. Cause: ${errorToString(error)}`);
-      capture.error(msg, {
-        extra: {
-          cxId,
-          jobId,
-          context: "conversion-result-cloud.notifyApi",
-          error,
-        },
-      });
-      throw error;
-    }
+  async notifyApi(params: ConversionResult): Promise<void> {
+    const payload = JSON.stringify(params);
+    await this.sqsClient.sendMessageToQueue(this.conversionResultQueueUrl, payload);
   }
 }

--- a/packages/core/src/command/conversion-result/conversion-result-factory.ts
+++ b/packages/core/src/command/conversion-result/conversion-result-factory.ts
@@ -1,0 +1,15 @@
+import { getEnvVarOrFail } from "@metriport/shared";
+import { Config } from "../../util/config";
+import { ConversionResultHandler } from "./types";
+import { ConversionResultCloud } from "./conversion-result-cloud";
+import { ConversionResultLocal } from "./conversion-result-local";
+
+export function buildConversionResultHandler(): ConversionResultHandler {
+  if (Config.isDev()) {
+    const apiUrl = getEnvVarOrFail("API_URL");
+    return new ConversionResultLocal(apiUrl);
+  }
+  const region = getEnvVarOrFail("AWS_REGION");
+  const conversionResultQueueUrl = getEnvVarOrFail("CONVERSION_RESULT_QUEUE_URL");
+  return new ConversionResultCloud(region, conversionResultQueueUrl);
+}

--- a/packages/core/src/command/conversion-result/conversion-result-local.ts
+++ b/packages/core/src/command/conversion-result/conversion-result-local.ts
@@ -1,0 +1,27 @@
+import { executeWithNetworkRetries } from "@metriport/shared";
+import axios, { AxiosInstance } from "axios";
+import { out } from "../../util/log";
+import { ConversionResultHandler, ConversionResultWithCount } from "./types";
+
+const MAX_API_NOTIFICATION_ATTEMPTS = 5;
+
+export class ConversionResultLocal implements ConversionResultHandler {
+  private readonly api: AxiosInstance;
+  private readonly docProgressURL = `/internal/docs/conversion-status`;
+
+  constructor(readonly apiUrl: string) {
+    this.api = axios.create({ baseURL: apiUrl });
+  }
+
+  async notifyApi(params: ConversionResultWithCount, logParam?: typeof console.log): Promise<void> {
+    const { cxId, patientId, jobId } = params;
+    const { log } = logParam
+      ? { log: logParam }
+      : out(`notifyApi.local - cx ${cxId} patient ${patientId} job ${jobId}`);
+    log(`Notifying API on ${this.docProgressURL} w/ ${JSON.stringify(params)}`);
+    await executeWithNetworkRetries(() => this.api.post(this.docProgressURL, null, { params }), {
+      retryOnTimeout: true,
+      maxAttempts: MAX_API_NOTIFICATION_ATTEMPTS,
+    });
+  }
+}

--- a/packages/core/src/command/conversion-result/send-multiple-conversion-results.ts
+++ b/packages/core/src/command/conversion-result/send-multiple-conversion-results.ts
@@ -1,0 +1,64 @@
+import { errorToString, MetriportError } from "@metriport/shared";
+import { groupBy } from "lodash";
+import { out } from "../../util/log";
+import { capture } from "../../util/notifications";
+import { ConversionResult, ConversionResultWithCount } from "./types";
+import { ConversionResultLocal } from "./conversion-result-local";
+
+/**
+ * Sends multiple conversion result notifications to the API.
+ * Group them by patient and status, and send them as one request.
+ *
+ * @param requests - The requests to send.
+ * @param apiUrl - The URL of the API to send the requests to.
+ */
+export async function sendConversionResults({
+  results,
+  apiUrl,
+}: {
+  results: ConversionResult[];
+  apiUrl: string;
+}): Promise<ConversionResultWithCount[]> {
+  const conversionResultHandler = new ConversionResultLocal(apiUrl);
+  const resultsWithCount: ConversionResultWithCount[] = [];
+
+  // TODO group this by patientId only, with the count move to an array of source/status
+  const groupedByPatientId = groupBy(results, r => r.patientId + "|" + r.source + "|" + r.status);
+
+  for (const [patientStatus, requests] of Object.entries(groupedByPatientId)) {
+    const [patientId, source, status] = patientStatus.split("|");
+    const { log } = out(`patient ${patientId}, source ${source}, status ${status}`);
+
+    log(`${requests.length} requests to send as one`);
+
+    const firstRequest = requests[0];
+    if (!firstRequest) throw new MetriportError(`Programming error: missing first request`);
+
+    const request: ConversionResultWithCount = {
+      ...firstRequest,
+      count: requests.length,
+    };
+
+    try {
+      await conversionResultHandler.notifyApi(request, log);
+      resultsWithCount.push(request);
+    } catch (error) {
+      // Can't bubble up because we might have multiple patients, which mean multiple
+      // requests to the API, and we don't know which one was processed or failed.
+      // Bubbling up would send the message to DLQ and we can't reprocess it b/c of
+      // the above.
+      const msg = `Error processing conversion result notification`;
+      const extra = {
+        context: "conversion-result-notifier",
+        patientId,
+        status,
+        requests,
+        error,
+      };
+      log(`${msg}, error: ${errorToString(error)}, extra: ${JSON.stringify(extra)}`);
+      capture.error(msg, { extra });
+    }
+  }
+
+  return resultsWithCount;
+}

--- a/packages/core/src/command/conversion-result/send-multiple-conversion-results.ts
+++ b/packages/core/src/command/conversion-result/send-multiple-conversion-results.ts
@@ -75,5 +75,10 @@ function decodeResultKey(patientStatus: string): {
   status: string;
 } {
   const [patientId, source, status] = patientStatus.split(keySeparator);
+  if (!patientId || !source || !status) {
+    throw new MetriportError(`Invalid result key format`, undefined, {
+      patientStatus: JSON.stringify(patientStatus),
+    });
+  }
   return { patientId, source, status };
 }

--- a/packages/core/src/command/conversion-result/types.ts
+++ b/packages/core/src/command/conversion-result/types.ts
@@ -1,0 +1,17 @@
+export type ConversionResult = {
+  cxId: string;
+  patientId: string;
+  status: "success" | "failed";
+  details?: string | undefined;
+  jobId?: string | undefined;
+  /** The MedicalDataSource, or HIE name */
+  source?: string;
+};
+
+export type ConversionResultWithCount = ConversionResult & {
+  count?: number;
+};
+
+export interface ConversionResultHandler {
+  notifyApi(params: ConversionResult, log?: typeof console.log): Promise<void>;
+}

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -39,7 +39,6 @@ import * as cwEnhancedCoverageConnector from "./api-stack/cw-enhanced-coverage-c
 import { createScheduledDBMaintenance } from "./api-stack/db-maintenance";
 import { createDocQueryChecker } from "./api-stack/doc-query-checker";
 import * as documentUploader from "./api-stack/document-upload";
-import * as fhirConverterConnector from "./api-stack/fhir-converter-connector";
 import { createFHIRConverterService } from "./api-stack/fhir-converter-service";
 import { TerminologyServerNestedStack } from "./api-stack/terminology-server-service";
 import { EhrNestedStack } from "./ehr-nested-stack";
@@ -328,9 +327,10 @@ export class APIStack extends Stack {
       fhirToBundleLambda,
       fhirConverterConnector: {
         queue: fhirConverterQueue,
-        dlq: fhirConverterDLQ,
+        lambda: fhirConverterLambda,
         bucket: fhirConverterBucket,
       },
+      conversionResultNotifierLambda,
     } = new LambdasNestedStack(this, "LambdasNestedStack", {
       config: props.config,
       vpc: this.vpc,
@@ -560,22 +560,6 @@ export class APIStack extends Stack {
       resource: apiService.service.taskDefinition.taskRole,
     });
 
-    const fhirConverterLambda = fhirConverterConnector.createLambda({
-      envType: props.config.environmentType,
-      stack: this,
-      lambdaLayers,
-      vpc: this.vpc,
-      sourceQueue: fhirConverterQueue,
-      dlq: fhirConverterDLQ,
-      fhirConverterBucket,
-      medicalDocumentsBucket,
-      fhirServerUrl: props.config.fhirServerUrl,
-      termServerUrl: props.config.termServerUrl,
-      apiServiceDnsAddress: apiDirectUrl,
-      alarmSnsAction: slackNotification?.alarmAction,
-      featureFlagsTable,
-    });
-
     // Add ENV after the API service is created
     fhirToMedicalRecordLambda2?.addEnvironment("API_URL", `http://${apiDirectUrl}`);
     outboundPatientDiscoveryLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
@@ -586,13 +570,16 @@ export class APIStack extends Stack {
     patientImportQueryLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
     ehrSyncPatientLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
     elationLinkPatientLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
+    fhirConverterLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
+    conversionResultNotifierLambda.addEnvironment("API_URL", `http://${apiDirectUrl}`);
+
     // TODO move this to each place where it's used
     // Access grant for medical documents bucket
     sandboxSeedDataBucket &&
       sandboxSeedDataBucket.grantReadWrite(apiService.taskDefinition.taskRole);
     medicalDocumentsBucket.grantReadWrite(apiService.taskDefinition.taskRole);
     medicalDocumentsBucket.grantReadWrite(documentDownloaderLambda);
-    fhirConverterLambda && medicalDocumentsBucket.grantRead(fhirConverterLambda);
+    medicalDocumentsBucket.grantRead(fhirConverterLambda);
 
     createDocQueryChecker({
       lambdaLayers,

--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -37,7 +37,7 @@ function settings() {
   } = settingsFhirConverter();
   const lambdaTimeout = maxExecutionTimeout.minus(Duration.seconds(5));
   return {
-    connectorName: "FHIRConverter2",
+    connectorName: "FHIRConverter3",
     lambdaMemory: 1024,
     // Number of messages the lambda pull from SQS at once
     lambdaBatchSize: 1,

--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -7,6 +7,7 @@ import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { IQueue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
+import { EnvConfig } from "../../config/env-config";
 import { EnvType } from "../env-type";
 import { getConfig } from "../shared/config";
 import { createLambda as defaultCreateLambda } from "../shared/lambda";
@@ -18,6 +19,7 @@ export type FHIRConverterConnector = {
   queue: IQueue;
   dlq: IQueue;
   bucket: s3.IBucket;
+  lambda: Lambda;
 };
 
 /**
@@ -60,6 +62,77 @@ function settings() {
   };
 }
 
+/**
+ * Creates a FHIR Converter connector.
+ *
+ * It's receives messages to convert a CDA to a FHIR bundle in the SQS queue, which are then picked
+ * up by the FHIR Converter lambda.
+ *
+ * The lambda puts the converted FHIR bundle in an S3 bucket and notifies the OSS API via an SQS
+ * queue that a new document is ready to be processed.
+ *
+ * @param stack - The stack to create the connector in.
+ * @param vpc - The VPC to create the connector in.
+ * @param lambdaLayers - The lambda layers to use for the connector.
+ * @param envType - The environment type to use for the connector.
+ * @param alarmSnsAction - The SNS action to use for the connector.
+ * @param config - The config to use for the connector.
+ * @param medicalDocumentsBucket - The medical documents bucket to use for the connector.
+ * @param featureFlagsTable - The feature flags table to use for the connector.
+ * @param apiNotifierQueue - The API notifier queue to use for the connector.
+ *
+ * @returns The FHIR Converter connector.
+ */
+export function create({
+  stack,
+  vpc,
+  lambdaLayers,
+  envType,
+  alarmSnsAction,
+  config,
+  medicalDocumentsBucket,
+  featureFlagsTable,
+  apiNotifierQueue,
+}: {
+  stack: Construct;
+  vpc: IVpc;
+  lambdaLayers: LambdaLayers;
+  envType: EnvType;
+  alarmSnsAction?: SnsAction;
+  config: EnvConfig;
+  medicalDocumentsBucket: s3.IBucket;
+  featureFlagsTable: dynamodb.Table;
+  apiNotifierQueue: IQueue;
+}): FHIRConverterConnector {
+  const { queue, dlq, bucket } = createQueueAndBucket({
+    stack,
+    lambdaLayers,
+    envType,
+    alarmSnsAction,
+  });
+  const fhirConverterLambda = createLambda({
+    envType,
+    stack,
+    lambdaLayers,
+    vpc,
+    sourceQueue: queue,
+    dlq,
+    fhirConverterBucket: bucket,
+    medicalDocumentsBucket,
+    fhirServerUrl: config.fhirServerUrl,
+    termServerUrl: config.termServerUrl,
+    alarmSnsAction,
+    featureFlagsTable,
+    apiNotifierQueue,
+  });
+  return {
+    queue,
+    dlq,
+    bucket,
+    lambda: fhirConverterLambda,
+  };
+}
+
 export function createQueueAndBucket({
   stack,
   lambdaLayers,
@@ -70,7 +143,7 @@ export function createQueueAndBucket({
   lambdaLayers: LambdaLayers;
   envType: EnvType;
   alarmSnsAction?: SnsAction;
-}): FHIRConverterConnector {
+}): Omit<FHIRConverterConnector, "lambda"> {
   const config = getConfig();
   const {
     connectorName,
@@ -124,9 +197,9 @@ export function createLambda({
   medicalDocumentsBucket,
   fhirServerUrl,
   termServerUrl,
-  apiServiceDnsAddress,
   alarmSnsAction,
   featureFlagsTable,
+  apiNotifierQueue,
 }: {
   lambdaLayers: LambdaLayers;
   envType: EnvType;
@@ -138,9 +211,9 @@ export function createLambda({
   medicalDocumentsBucket: s3.IBucket;
   fhirServerUrl: string;
   termServerUrl?: string;
-  apiServiceDnsAddress: string;
   alarmSnsAction?: SnsAction;
   featureFlagsTable: dynamodb.Table;
+  apiNotifierQueue: IQueue;
 }): Lambda {
   const config = getConfig();
   const {
@@ -163,13 +236,13 @@ export function createLambda({
     envVars: {
       AXIOS_TIMEOUT_SECONDS: axiosTimeout.toSeconds().toString(),
       ...(config.lambdasSentryDSN ? { SENTRY_DSN: config.lambdasSentryDSN } : {}),
-      API_URL: `http://${apiServiceDnsAddress}`,
       FHIR_SERVER_URL: fhirServerUrl,
       ...(termServerUrl && { TERM_SERVER_URL: termServerUrl }),
       MEDICAL_DOCUMENTS_BUCKET_NAME: medicalDocumentsBucket.bucketName,
       QUEUE_URL: sourceQueue.queueUrl,
       DLQ_URL: dlq.queueUrl,
       CONVERSION_RESULT_BUCKET_NAME: fhirConverterBucket.bucketName,
+      CONVERSION_RESULT_QUEUE_URL: apiNotifierQueue.queueUrl,
       FEATURE_FLAGS_TABLE_NAME: featureFlagsTable.tableName,
     },
     timeout: lambdaTimeout,
@@ -190,6 +263,6 @@ export function createLambda({
   );
   provideAccessToQueue({ accessType: "both", queue: sourceQueue, resource: conversionLambda });
   provideAccessToQueue({ accessType: "send", queue: dlq, resource: conversionLambda });
-
+  provideAccessToQueue({ accessType: "send", queue: apiNotifierQueue, resource: conversionLambda });
   return conversionLambda;
 }

--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -37,7 +37,7 @@ function settings() {
   } = settingsFhirConverter();
   const lambdaTimeout = maxExecutionTimeout.minus(Duration.seconds(5));
   return {
-    connectorName: "FHIRConverter3",
+    connectorName: "FHIRConverter",
     lambdaMemory: 1024,
     // Number of messages the lambda pull from SQS at once
     lambdaBatchSize: 1,

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -5,9 +5,11 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Function as Lambda } from "aws-cdk-lib/aws-lambda";
+import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import * as rds from "aws-cdk-lib/aws-rds";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
+import { Queue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
 import { EnvConfig } from "../config/env-config";
 import * as fhirConverterConnector from "./api-stack/fhir-converter-connector";
@@ -17,6 +19,7 @@ import { createLambda, MAXIMUM_LAMBDA_TIMEOUT } from "./shared/lambda";
 import { LambdaLayers, setupLambdasLayers } from "./shared/lambda-layers";
 import { createScheduledLambda } from "./shared/lambda-scheduled";
 import { Secrets } from "./shared/secrets";
+import { createQueue } from "./shared/sqs";
 
 export const CDA_TO_VIS_TIMEOUT = Duration.minutes(15);
 
@@ -46,6 +49,7 @@ export class LambdasNestedStack extends NestedStack {
   readonly fhirToBundleLambda: lambda.Function;
   readonly fhirConverterConnector: FHIRConverterConnector;
   readonly acmCertificateMonitorLambda: Lambda;
+  readonly conversionResultNotifierLambda: lambda.Function;
 
   constructor(scope: Construct, id: string, props: LambdasNestedStackProps) {
     super(scope, id, props);
@@ -120,10 +124,23 @@ export class LambdasNestedStack extends NestedStack {
       maxPollingDuration: Duration.minutes(15),
     });
 
-    this.fhirConverterConnector = fhirConverterConnector.createQueueAndBucket({
+    const resultNotifierConnector = this.setupConversionResultNotifier({
+      vpc: props.vpc,
+      config: props.config,
+      alarmAction: props.alarmAction,
+    });
+    const conversionResultNotifierQueue = resultNotifierConnector.queue;
+    this.conversionResultNotifierLambda = resultNotifierConnector.lambda;
+
+    this.fhirConverterConnector = fhirConverterConnector.create({
       stack: this,
+      vpc: props.vpc,
       lambdaLayers: this.lambdaLayers,
       envType: props.config.environmentType,
+      config: props.config,
+      featureFlagsTable: props.featureFlagsTable,
+      medicalDocumentsBucket: props.medicalDocumentsBucket,
+      apiNotifierQueue: conversionResultNotifierQueue,
       alarmSnsAction: props.alarmAction,
     });
 
@@ -432,6 +449,76 @@ export class LambdasNestedStack extends NestedStack {
     dbCredsSecret.grantRead(outboundDocumentRetrievalLambda);
 
     return outboundDocumentRetrievalLambda;
+  }
+
+  private setupConversionResultNotifier({
+    vpc,
+    alarmAction,
+    config,
+  }: {
+    vpc: ec2.IVpc;
+    alarmAction: SnsAction | undefined;
+    config: EnvConfig;
+  }): { queue: Queue; lambda: Lambda } {
+    const name = "ConversionResultNotifier";
+    const { environmentType: envType, sentryDSN } = config;
+
+    const lambdaTimeout = Duration.minutes(5);
+    const settings = {
+      queue: {
+        maxReceiveCount: 1,
+        alarmMaxAgeOfOldestMessage: Duration.minutes(5),
+        maxMessageCountAlarmThreshold: 1_000,
+        visibilityTimeout: Duration.seconds(lambdaTimeout.toSeconds() * 2 + 1),
+      },
+      lambda: {
+        entry: "conversion-result-notifier",
+        memory: 256,
+        timeout: lambdaTimeout,
+      },
+      eventSource: {
+        batchSize: 500,
+        maxBatchingWindow: Duration.seconds(20),
+        maxConcurrency: 1,
+        // Partial batch response: https://docs.aws.amazon.com/prescriptive-guidance/latest/lambda-event-filtering-partial-batch-responses-for-sqs/welcome.html
+        reportBatchItemFailures: true,
+      },
+    };
+
+    const conversionResultQueue = createQueue({
+      stack: this,
+      name,
+      fifo: true,
+      contentBasedDeduplication: true,
+      visibilityTimeout: settings.queue.visibilityTimeout,
+      maxReceiveCount: settings.queue.maxReceiveCount,
+      createRetryLambda: false,
+      envType,
+      alarmSnsAction: alarmAction,
+      alarmMaxAgeOfOldestMessage: settings.queue.alarmMaxAgeOfOldestMessage,
+      maxMessageCountAlarmThreshold: settings.queue.maxMessageCountAlarmThreshold,
+    });
+
+    const conversionResultLambda = createLambda({
+      stack: this,
+      name,
+      entry: settings.lambda.entry,
+      envType,
+      envVars: {
+        // API_URL set on the api-stack after the OSS API is created
+        ...(sentryDSN ? { SENTRY_DSN: sentryDSN } : {}),
+      },
+      layers: [this.lambdaLayers.shared],
+      memory: settings.lambda.memory,
+      timeout: settings.lambda.timeout,
+      vpc,
+      alarmSnsAction: alarmAction,
+    });
+
+    conversionResultLambda.addEventSource(
+      new SqsEventSource(conversionResultQueue, settings.eventSource)
+    );
+    return { queue: conversionResultQueue, lambda: conversionResultLambda };
   }
 
   /** AKA, get consolidated lambda */

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -479,7 +479,7 @@ export class LambdasNestedStack extends NestedStack {
       eventSource: {
         batchSize: 500,
         maxBatchingWindow: Duration.seconds(20),
-        maxConcurrency: 1,
+        maxConcurrency: 2,
         // Partial batch response: https://docs.aws.amazon.com/prescriptive-guidance/latest/lambda-event-filtering-partial-batch-responses-for-sqs/welcome.html
         reportBatchItemFailures: true,
       },
@@ -488,8 +488,6 @@ export class LambdasNestedStack extends NestedStack {
     const conversionResultQueue = createQueue({
       stack: this,
       name,
-      fifo: true,
-      contentBasedDeduplication: true,
       visibilityTimeout: settings.queue.visibilityTimeout,
       maxReceiveCount: settings.queue.maxReceiveCount,
       createRetryLambda: false,

--- a/packages/infra/lib/shared/sqs.ts
+++ b/packages/infra/lib/shared/sqs.ts
@@ -34,7 +34,7 @@ export type QueueProps = (StandardQueueProps | FifoQueueProps) & {
   alarmMaxAgeOfOldestMessage?: Duration;
   createDLQ?: boolean | undefined;
   createRetryLambda?: boolean | undefined;
-  lambdaLayers: ILayerVersion[];
+  lambdaLayers?: ILayerVersion[];
   envType: EnvType;
   alarmMaxAgeOfOldestMessageDlq?: Duration;
 };

--- a/packages/lambdas/src/conversion-result-notifier.ts
+++ b/packages/lambdas/src/conversion-result-notifier.ts
@@ -1,0 +1,49 @@
+import { ConversionResult } from "@metriport/core/command/conversion-result/types";
+import { sendConversionResults } from "@metriport/core/command/conversion-result/send-multiple-conversion-results";
+import { getEnvVarOrFail, MetriportError } from "@metriport/shared";
+import * as Sentry from "@sentry/serverless";
+import { SQSEvent } from "aws-lambda";
+import { z } from "zod";
+import { capture } from "./shared/capture";
+import { getEnvOrFail } from "./shared/env";
+import { out } from "@metriport/core/util/log";
+// Keep this as early on the file as possible
+capture.init();
+
+const lambdaName = getEnvVarOrFail("AWS_LAMBDA_FUNCTION_NAME");
+const apiUrl = getEnvOrFail("API_URL");
+
+export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent) => {
+  const { log } = out(``);
+  log(`Running with ${event.Records.length} records`);
+  capture.setExtra({ lambdaName, event });
+
+  const records = event.Records;
+  if (!records || records.length < 1) {
+    log(`No records, discarding this event: ${JSON.stringify(event)}`);
+    return;
+  }
+  const parsedRecords = records.map(r => parseBody(r.body));
+  log(`Processing ${parsedRecords.length} records...`);
+
+  await sendConversionResults({ results: parsedRecords, apiUrl });
+
+  log(`Done`);
+});
+
+const processConversionResultSchema = z.object({
+  cxId: z.string(),
+  patientId: z.string(),
+  status: z.enum(["success", "failed"]),
+  details: z.string().optional(),
+  jobId: z.string().optional(),
+  source: z.string().optional(),
+});
+
+function parseBody(body?: unknown): ConversionResult {
+  if (!body) throw new MetriportError(`Missing message body`);
+  const bodyString = typeof body === "string" ? (body as string) : undefined;
+  if (!bodyString) throw new MetriportError(`Invalid body`);
+  const bodyAsJson = JSON.parse(bodyString);
+  return processConversionResultSchema.parse(bodyAsJson);
+}

--- a/packages/lambdas/src/shared/oss-api.ts
+++ b/packages/lambdas/src/shared/oss-api.ts
@@ -1,41 +1,17 @@
-import { CreateFeedback, executeWithNetworkRetries } from "@metriport/shared";
+import { CreateFeedback } from "@metriport/shared";
 import axios, { AxiosResponse } from "axios";
-import { Log } from "./log";
-
-const MAX_API_NOTIFICATION_ATTEMPTS = 5;
 
 const ossApi = axios.create();
 
-export type NotificationParams = {
-  cxId: string;
-  patientId: string;
-  status: "success" | "failed";
-  details?: string | undefined;
-  jobId: string | undefined;
-  /** The MedicalDataSource, or HIE name */
-  source?: string;
-};
-
 type OssApiClient = {
   internal: {
-    notifyApi(params: NotificationParams, log: Log): Promise<void>;
     createFeedback(params: CreateFeedback & { id: string }): Promise<AxiosResponse>;
   };
 };
 
 export function apiClient(apiURL: string): OssApiClient {
-  const docProgressURL = `${apiURL}/internal/docs/conversion-status`;
-
   function getCreateFeedbackUrl(id: string): string {
     return `${apiURL}/internal/feedback/${id}`;
-  }
-
-  async function notifyApi(params: NotificationParams, log: Log): Promise<void> {
-    log(`Notifying API on ${docProgressURL} w/ ${JSON.stringify(params)}`);
-    await executeWithNetworkRetries(() => ossApi.post(docProgressURL, null, { params }), {
-      retryOnTimeout: true,
-      maxAttempts: MAX_API_NOTIFICATION_ATTEMPTS,
-    });
   }
 
   async function createFeedback(params: CreateFeedback & { id: string }): Promise<AxiosResponse> {
@@ -45,7 +21,6 @@ export function apiClient(apiURL: string): OssApiClient {
 
   return {
     internal: {
-      notifyApi,
       createFeedback,
     },
   };

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -1,4 +1,5 @@
 import { Bundle, BundleEntry, Resource } from "@medplum/fhirtypes";
+import { buildConversionResultHandler } from "@metriport/core/command/conversion-result/conversion-result-factory";
 import { FeatureFlags } from "@metriport/core/command/feature-flags/ffs-on-dynamodb";
 import {
   FhirConverterParams,
@@ -20,21 +21,20 @@ import {
   storePreProcessedConversionResult,
   storePreprocessedPayloadInS3,
 } from "@metriport/core/domain/conversion/upload-conversion-steps";
-import { S3Utils, executeWithRetriesS3 } from "@metriport/core/external/aws/s3";
+import { executeWithRetriesS3, S3Utils } from "@metriport/core/external/aws/s3";
 import { partitionPayload } from "@metriport/core/external/cda/partition-payload";
 import { processAttachments } from "@metriport/core/external/cda/process-attachments";
 import { removeBase64PdfEntries } from "@metriport/core/external/cda/remove-b64";
 import { hydrate } from "@metriport/core/external/fhir/consolidated/hydrate";
 import { normalize } from "@metriport/core/external/fhir/consolidated/normalize";
 import { FHIR_APP_MIME_TYPE, TXT_MIME_TYPE } from "@metriport/core/util/mime";
-import { MetriportError, errorToString, executeWithNetworkRetries } from "@metriport/shared";
+import { errorToString, executeWithNetworkRetries, MetriportError } from "@metriport/shared";
 import { SQSEvent } from "aws-lambda";
 import axios from "axios";
 import { capture } from "./shared/capture";
 import { CloudWatchUtils, Metrics } from "./shared/cloudwatch";
 import { getEnvOrFail } from "./shared/env";
 import { Log, prefixedLog } from "./shared/log";
-import { apiClient } from "./shared/oss-api";
 
 // Keep this as early on the file as possible
 capture.init();
@@ -44,14 +44,16 @@ const lambdaName = getEnvOrFail("AWS_LAMBDA_FUNCTION_NAME");
 const region = getEnvOrFail("AWS_REGION");
 // Set by us
 const metricsNamespace = getEnvOrFail("METRICS_NAMESPACE");
-const apiUrl = getEnvOrFail("API_URL");
 const fhirUrl = getEnvOrFail("FHIR_SERVER_URL");
 const medicalDocumentsBucketName = getEnvOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
 const axiosTimeoutSeconds = Number(getEnvOrFail("AXIOS_TIMEOUT_SECONDS"));
 const conversionResultBucketName = getEnvOrFail("CONVERSION_RESULT_BUCKET_NAME");
 const featureFlagsTableName = getEnvOrFail("FEATURE_FLAGS_TABLE_NAME");
+
 // Call this before reading FFs
 FeatureFlags.init(region, featureFlagsTableName);
+
+const conversionResultHandler = buildConversionResultHandler();
 
 const s3Utils = new S3Utils(region);
 const cloudWatchUtils = new CloudWatchUtils(region, lambdaName, metricsNamespace);
@@ -63,7 +65,6 @@ const fhirConverter = axios.create({
     clarifyTimeoutError: true,
   },
 });
-const ossApi = apiClient(apiUrl);
 const LARGE_CHUNK_SIZE_IN_BYTES = 50_000_000;
 
 const HYDRATION_TIMEOUT_MS = 5_000;
@@ -142,7 +143,7 @@ export async function handler(event: SQSEvent) {
           log(
             `XML document is unstructured CDA with nonXMLBody, skipping... Filename: ${s3FileName}`
           );
-          await ossApi.internal.notifyApi({ ...lambdaParams, status: "failed" }, log);
+          await conversionResultHandler.notifyApi({ ...lambdaParams, status: "failed" }, log);
           continue;
         }
         const { documentContents: payloadNoB64, b64Attachments } =
@@ -173,7 +174,7 @@ export async function handler(event: SQSEvent) {
 
         if (!payloadClean.trim().length) {
           log(`XML document is empty, skipping... Filename: ${s3FileName}`);
-          await ossApi.internal.notifyApi({ ...lambdaParams, status: "failed" }, log);
+          await conversionResultHandler.notifyApi({ ...lambdaParams, status: "failed" }, log);
           continue;
         }
 
@@ -320,7 +321,7 @@ export async function handler(event: SQSEvent) {
 
         await cloudWatchUtils.reportMetrics(metrics);
       } catch (error) {
-        await ossApi.internal.notifyApi({ ...lambdaParams, status: "failed" }, log);
+        await conversionResultHandler.notifyApi({ ...lambdaParams, status: "failed" }, log);
         throw error;
       }
     }
@@ -465,8 +466,11 @@ async function sendConversionResult({
   );
 
   log(`Sending result info to the API`);
-  await ossApi.internal.notifyApi(
-    { cxId, patientId, jobId, source: medicalDataSource, status: "success" },
-    log
-  );
+  await conversionResultHandler.notifyApi({
+    cxId,
+    patientId,
+    jobId,
+    source: medicalDataSource,
+    status: "success",
+  });
 }

--- a/packages/utils/src/fhir-converter/s3-to-lambda.ts
+++ b/packages/utils/src/fhir-converter/s3-to-lambda.ts
@@ -1,0 +1,51 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import { Config } from "@metriport/core/util/config";
+import { sleep } from "@metriport/shared";
+import { v4 as uuidv4 } from "uuid";
+import { convertCDAToFHIR } from "../../../api/src/external/fhir-converter/converter";
+import { elapsedTimeAsStr } from "../shared/duration";
+
+/**
+ * This script is used to convert CDA files to FHIR using the FHIR Converter connector in the
+ * cloud. It sends messages to the SQS queue that the FHIR Converter lambda listens to.
+ * The files are expected to be in a S3 bucket.
+ *
+ * Set these on the environment variables:
+ * - FHIR_CONVERTER_QUEUE_URL
+ * - FHIR_CONVERTER_SERVER_URL
+ * - AWS_REGION
+ * - MEDICAL_DOCUMENTS_BUCKET_NAME
+ *
+ * Make sure to edit connector-factory.ts so it uses the "cloud" implementation.
+ */
+
+const cxId = "";
+const patientId = "";
+const fileNames: string[] = [];
+const bucket = Config.getMedicalDocumentsBucketName();
+
+async function main() {
+  await sleep(50); // Give some time to avoid mixing logs w/ Node's
+  const startedAt = Date.now();
+  console.log(`############## Started at ${new Date(startedAt).toISOString()} ##############`);
+
+  console.log(`Converting ${fileNames.length} files...`);
+
+  for (const key of fileNames) {
+    await convertCDAToFHIR({
+      patient: { cxId, id: patientId },
+      document: { id: uuidv4() },
+      s3FileName: key,
+      s3BucketName: bucket,
+      requestId: uuidv4(),
+    });
+  }
+
+  console.log(`>>>>>>> Done after ${elapsedTimeAsStr(startedAt)}`);
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

none

### Description

Add queue after FHIR converter - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1743701871418779?thread_ts=1743693474.848459&cid=C0616FCPAKZ).

Group messages by:
- patient ID
- source (HIE)
- status

We can later batch only by patient ID, but that would require more changes on the server (riskier) that I didn't want to tackle now.

### Testing

- Local
  - [x] compiles and unit test run
  - [x] branch to staging and...
  - [x] create new PT and DQ, convert more than one file, try to get them to be converted and batched/grouped together in one request - logs:
     - [FHIRConverter gets executed X times](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252FFHIRConverter3Lambda/log-events/2025$252F04$252F04$252F$255B$2524LATEST$255Dd33a77be7e6945b48a2baabdb8f707ec$3Fstart$3D1743808744284$26refEventId$3D38888234483477202744322629824967370889061541825508605952)
     - [Conversion result notifier gets executed twice, sends 3 requests to the API](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252FConversionResultNotifierLambda/log-events/2025$252F04$252F04$252F$255B$2524LATEST$255Dfee408aeeffb48ce9aea981485471ad7$3Fstart$3D1743808775517$26refEventId$3D38888235179996377530029582442311205563843361173982216192)
     - [API gets the requests and updates them accordingly](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/StagingAPIInfrastructureStack-APIFargateServiceTaskDefAPIServerLogGroup35E9518F-fDzCkr8Zml1k/log-events/APIFargateService$252FAPI-Server$252F09dbe95d69e14fb4b0ce20d462917900$3Fstart$3D1743808775544$26refEventId$3D38888235180598497650389909258063228506508673368711036928)
- Staging
  - [ ] DQ works + conversion
- Sandbox
  - none
- Production
  - [ ] monitor conversions for a few minutes, especially w/ bulk import ongoing

### Release Plan

- [ ] Merge this
- [ ] Update the prod dash so it references the new lambda/queue names _in addition to_ the old ones


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced document conversion progress tracking with a flexible count option, allowing more tailored progress updates.
  - Introduced automated conversion of clinical documents from CDA to FHIR, streamlining the workflow.
  - Implemented grouped and batched notifications for conversion results to ensure more reliable status reporting.
  - Added a new optional query parameter `count` to the `/conversion-status` endpoint.
  - Introduced a new AWS Lambda function for processing conversion results via SQS.
  - New test suite added for validating conversion result notifications.

- **Refactor**
  - Improved logging, error handling, and integration with external services to boost overall conversion process reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->