### PR TITLE
2620 Branch-to-staging deploy stacks in parallel

### DIFF
--- a/.github/workflows/_deploy-cdk.yml
+++ b/.github/workflows/_deploy-cdk.yml
@@ -16,22 +16,10 @@ on:
         required: true
         type: string
         description: "the environment we're deploying to, either 'staging', 'production', or 'sandbox'"
-      location_services_cdk_stack:
-        required: false
-        type: string
-        description: "the name of the Location Services CDK stack we're deploying"
-      secrets_cdk_stack:
-        required: true
-        type: string
-        description: "the name of the Secrets CDK stack we're deploying"
       cdk_stack:
         required: true
         type: string
         description: "the name of the CDK stack we're deploying"
-      ihe_stack:
-        required: false
-        type: string
-        description: "the name of the IHE CDK stack we're deploying"
       add_sentry_release:
         description: "the name of the CDK stack we're deploying"
         required: false
@@ -195,65 +183,8 @@ jobs:
           sourcemaps: metriport/packages/lambdas/dist
           projects: lambdas-oss
 
-      # Secrets Stack
-      - name: Diff Secrets CDK Stack
-        uses: metriport/deploy-with-cdk@master
-        with:
-          cdk_action: "diff"
-          cdk_version: "2.122.0"
-          cdk_stack: "${{ inputs.secrets_cdk_stack }}"
-          cdk_env: "${{ inputs.deploy_env }}"
-        env:
-          INPUT_PATH: "metriport/packages/infra"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
-      - name: Deploy Secrets CDK Stack
-        uses: metriport/deploy-with-cdk@master
-        with:
-          cdk_action: "deploy --verbose --require-approval never"
-          cdk_version: "2.122.0"
-          cdk_stack: "${{ inputs.secrets_cdk_stack }}"
-          cdk_env: "${{ inputs.deploy_env }}"
-        env:
-          INPUT_PATH: "metriport/packages/infra"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
-          METRIPORT_VERSION: ${{ github.sha }}
-
-      # Location Stack CDK DIFF
-      - name: Diff Location Services CDK stack
-        uses: metriport/deploy-with-cdk@master
-        if: inputs.location_services_cdk_stack != null
-        with:
-          cdk_action: "diff"
-          cdk_version: "2.122.0"
-          cdk_stack: "${{ inputs.location_services_cdk_stack }}"
-          cdk_env: "${{ inputs.deploy_env }}"
-        env:
-          INPUT_PATH: "metriport/packages/infra"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
-      # Location Stack DEPLOY
-      - name: Deploy Location Services CDK stack
-        uses: metriport/deploy-with-cdk@master
-        if: inputs.location_services_cdk_stack != null
-        with:
-          cdk_action: "deploy --verbose --require-approval never"
-          cdk_version: "2.122.0"
-          cdk_stack: "${{ inputs.location_services_cdk_stack }}"
-          cdk_env: "${{ inputs.deploy_env }}"
-        env:
-          INPUT_PATH: "metriport/packages/infra"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
-          METRIPORT_VERSION: ${{ github.sha }}
-
-      # API Stack
-      - name: Diff API Stack CDK
+      # CDK Stack
+      - name: Diff CDK Stack
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "diff"
@@ -265,41 +196,12 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
-      - name: Deploy API Stack CDK
+      - name: Deploy CDK Stack
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "deploy --verbose --require-approval never"
           cdk_version: "2.122.0"
           cdk_stack: "${{ inputs.cdk_stack }}"
-          cdk_env: "${{ inputs.deploy_env }}"
-        env:
-          INPUT_PATH: "metriport/packages/infra"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
-          METRIPORT_VERSION: ${{ github.sha }}
-
-      # IHE Stack
-      - name: Diff IHE Stack CDK
-        uses: metriport/deploy-with-cdk@master
-        if: inputs.ihe_stack != null
-        with:
-          cdk_action: "diff"
-          cdk_version: "2.122.0"
-          cdk_stack: "${{ inputs.ihe_stack }}"
-          cdk_env: "${{ inputs.deploy_env }}"
-        env:
-          INPUT_PATH: "metriport/packages/infra"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
-      - name: Deploy IHE Stack CDK
-        uses: metriport/deploy-with-cdk@master
-        if: inputs.ihe_stack != null
-        with:
-          cdk_action: "deploy --verbose --require-approval never"
-          cdk_version: "2.122.0"
-          cdk_stack: "${{ inputs.ihe_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
           INPUT_PATH: "metriport/packages/infra"

--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
     inputs:
       jobs_to_run:
-        description: 'Select jobs to run (comma-separated): api,mllp-server,infra-api-lambdas,redeploy-api-gw,e2e-tests'
+        description: "Select jobs to run (comma-separated, default 'all') - e.g.: api,infra-api-lambdas,mllp-server,infra-hl7-notification,secrets_cdk_stack,location_services_cdk_stack,ihe_stack,redeploy-api-gw,e2e-tests"
         required: true
-        default: 'api,mllp-server,infra-api-lambdas,redeploy-api-gw,e2e-tests'
+        default: "all"
         type: string
 
 jobs:
   api:
     # can't use contains(github.event.inputs.jobs_to_run, 'api') because this would trigger on 'redeploy-api-gw' or 'infra-api-lambdas'
-    if: contains(format(',{0},', github.event.inputs.jobs_to_run), ',api,')
+    if: contains(fromJSON('[",api,", ",all,"]'),format(',{0},', github.event.inputs.jobs_to_run))
     uses: ./.github/workflows/_deploy-api.yml
     with:
       deploy_env: "staging"
@@ -31,7 +31,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   mllp-server:
-    if: contains(github.event.inputs.jobs_to_run, 'mllp-server')
+    if: contains(fromJSON('["mllp-server", "all"]'), github.event.inputs.jobs_to_run)
     uses: ./.github/workflows/_deploy-mllp-server.yml
     with:
       deploy_env: "staging"
@@ -48,7 +48,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   infra-hl7-notification:
-    if: contains(github.event.inputs.jobs_to_run, 'infra-hl7-notification')
+    if: contains(fromJSON('["infra-hl7-notification", "all"]'), github.event.inputs.jobs_to_run)
     uses: ./.github/workflows/_deploy-hl7-notification-cdk.yml
     with:
       deploy_env: "staging"
@@ -65,15 +65,63 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   infra-api-lambdas:
-    if: contains(github.event.inputs.jobs_to_run, 'infra-api-lambdas')
+    if: contains(fromJSON('["infra-api-lambdas", "all"]'), github.event.inputs.jobs_to_run)
     uses: ./.github/workflows/_deploy-cdk.yml
     with:
       deploy_env: "staging"
       is-branch-to-staging: true
-      secrets_cdk_stack: ${{ vars.SECRET_STACK_NAME_STAGING }}
-      location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_STAGING }}
       cdk_stack: ${{ vars.API_STACK_NAME_STAGING }}
-      ihe_stack: ${{ vars.IHE_STACK_NAME }}
+      AWS_REGION: ${{ vars.API_REGION_STAGING }}
+    secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  secrets_cdk_stack:
+    if: contains(fromJSON('["secrets_cdk_stack", "all"]'), github.event.inputs.jobs_to_run)
+    uses: ./.github/workflows/_deploy-cdk.yml
+    with:
+      deploy_env: "staging"
+      is-branch-to-staging: true
+      cdk_stack: ${{ vars.SECRET_STACK_NAME_STAGING }}
+      AWS_REGION: ${{ vars.API_REGION_STAGING }}
+    secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  location_services_cdk_stack:
+    if: contains(fromJSON('["location_services_cdk_stack", "all"]'), github.event.inputs.jobs_to_run) && ${{ vars.LOCATION_SERVICES_STACK_NAME_STAGING }} != null
+    uses: ./.github/workflows/_deploy-cdk.yml
+    with:
+      deploy_env: "staging"
+      is-branch-to-staging: true
+      cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_STAGING }}
+      AWS_REGION: ${{ vars.API_REGION_STAGING }}
+    secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  ihe_stack:
+    if: contains(fromJSON('["ihe_stack", "all"]'), github.event.inputs.jobs_to_run) && ${{ vars.IHE_STACK_NAME }} != null
+    uses: ./.github/workflows/_deploy-cdk.yml
+    with:
+      deploy_env: "staging"
+      is-branch-to-staging: true
+      cdk_stack: ${{ vars.IHE_STACK_NAME }}
       AWS_REGION: ${{ vars.API_REGION_STAGING }}
     secrets:
       SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
@@ -85,7 +133,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   redeploy-api-gw:
-    if: contains(github.event.inputs.jobs_to_run, 'redeploy-api-gw')
+    if: contains(fromJSON('["redeploy-api-gw", "all"]'), github.event.inputs.jobs_to_run)
     uses: ./.github/workflows/_redeploy_api-gw.yml
     needs: [infra-api-lambdas]
     with:
@@ -100,7 +148,7 @@ jobs:
 
   e2e-tests:
     if: |
-      contains(github.event.inputs.jobs_to_run, 'e2e-tests') && 
+      contains(fromJSON('["e2e-tests", "all"]'), github.event.inputs.jobs_to_run) && 
       !failure() && 
       (needs.api.result == 'success' || needs.infra-api-lambdas.result == 'success' || needs.redeploy-api-gw.result == 'success')
     uses: ./.github/workflows/_e2e-tests.yml


### PR DESCRIPTION
Ref. metriport/metriport-internal#2620

### Dependencies

none

### Description

Branch-to-staging deploy stacks in parallel.

### Testing

- Local
  - none
- Staging
  - [ ] deploys changes in api
  - [ ] deploys changes in infra-api-lambdas
  - [ ] deploys changes in mllp-server
  - [ ] deploys changes in infra-hl7-notification
  - [ ] deploys changes in secrets_cdk_stack
  - [ ] deploys changes in location_services_cdk_stack
  - [ ] deploys changes in ihe_stack
- Sandbox
  - none
- Production
  - none

### Release Plan

- :warning: This changes CICD
- [ ] Merge this
- [ ] Apply the same changes to the workflows: deploy staging and prod


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined our automated deployment workflows by consolidating redundant steps, resulting in a simpler and more efficient update process.
  
- **New Features**
  - Enhanced staging deployment configurations and added new job conditions, leading to more reliable and scalable releases for a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->