### PR TITLE
1040 Keep original queue/dlq around for a while

### DIFF
--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -152,6 +152,22 @@ export function createQueueAndBucket({
     maxMessageCountAlarmThreshold,
     alarmMaxAgeOfOldestMessage,
   } = settings();
+  // TODO remove this after the release of the new ConversionResultNotifier connector (queue/lambda)
+  defaultCreateQueue({
+    stack,
+    name: "FHIRConverter2",
+    // To use FIFO we'd need to change the lambda code to set visibilityTimeout=0 on messages to be
+    // reprocessed, instead of re-enqueueing them (bc of messageDeduplicationId visibility of 5min)
+    fifo: false,
+    visibilityTimeout,
+    maxReceiveCount,
+    createRetryLambda: true,
+    lambdaLayers: [lambdaLayers.shared],
+    envType,
+    alarmSnsAction,
+    alarmMaxAgeOfOldestMessage,
+    maxMessageCountAlarmThreshold,
+  });
   const queue = defaultCreateQueue({
     stack,
     name: connectorName,
@@ -160,8 +176,6 @@ export function createQueueAndBucket({
     fifo: false,
     visibilityTimeout,
     maxReceiveCount,
-    createRetryLambda: true,
-    lambdaLayers: [lambdaLayers.shared],
     envType,
     alarmSnsAction,
     alarmMaxAgeOfOldestMessage,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

none

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3612
- Downstream: none

### Description

Keep original queue/DLQ around for a while - [context](https://metriport.slack.com/archives/C04CXLSAF7V/p1743870005939679?thread_ts=1743868192.128839&cid=C04CXLSAF7V).

### Testing

- Local
  - none
- Staging
  - [ ] FHIRConverter2Queue and FHIRConverter2DLQ are present
  - [ ] FHIRConverterQueue and FHIRConverterDLQ are present
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the internal background processing to enhance system reliability.
  - Adjusted the messaging queue setup to support a dual-processing mechanism, ensuring consistent and smooth operations without affecting user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->