### PR TITLE
1040 Send request ID to FHIRConverter

### DIFF
--- a/packages/api/src/external/fhir-converter/connector.ts
+++ b/packages/api/src/external/fhir-converter/connector.ts
@@ -13,7 +13,7 @@ export type FHIRConverterRequest = {
   template: string;
   unusedSegments: string;
   invalidAccess: string;
-  requestId?: string;
+  requestId: string;
   source?: MedicalDataSource;
 };
 

--- a/packages/api/src/external/fhir-converter/converter.ts
+++ b/packages/api/src/external/fhir-converter/converter.ts
@@ -47,7 +47,7 @@ export async function convertCDAToFHIR(params: {
   source?: MedicalDataSource;
 }): Promise<void> {
   const {
-    patient,
+    patient: patientParam,
     document,
     s3FileName,
     s3BucketName,
@@ -57,6 +57,11 @@ export async function convertCDAToFHIR(params: {
     requestId,
     source,
   } = params;
+  const patient = {
+    id: patientParam.id,
+    cxId: patientParam.cxId,
+  };
+
   const { log } = out(
     `convertCDAToFHIR, patientId ${patient.id}, requestId ${requestId}, docId ${document.id}`
   );


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/1040

### Dependencies

none

### Description

Send request ID to FHIRConverter - [context](https://metriport.slack.com/archives/C04CXLSAF7V/p1743892156445569?thread_ts=1743868192.128839&cid=C04CXLSAF7V)

### Testing

- Local
  - [x] Run script local that sends request ID, it gets processed by FHIRConverter and later by the API
- Staging
  - [ ] DQ + conversion works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a required request identifier for conversion requests to enable enhanced logging and improved traceability.
  - Improved logging to capture detailed configuration checks, ensuring clearer operational insights.

- **Refactor**
  - Streamlined patient information handling by encapsulating relevant fields for better clarity in data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->