### PR TITLE
fix(mllp-server): fix constant

### DIFF
--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -19,7 +19,7 @@ const s3Utils = new S3Utils(Config.getAWSRegion());
 
 const MESSAGE_TYPE_FIELD = 9;
 const MESSAGE_CODE_COMPONENT = 1;
-const TRIGGER_EVENT_COMPONENT = 1;
+const TRIGGER_EVENT_COMPONENT = 2;
 
 const IDENTIFIER_FIELD = 3;
 const IDENTIFIER_COMPONENT = 1;


### PR DESCRIPTION
refs. metriport/metriport-internal#2757

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

None

### Description

This fixes s3 key from being written out without an HL7 message code.

Bad:
`2025-04-07T00:18:45.488Z_ADT_ADT.hl7`

Good
`2025-04-07T00:18:45.488Z_ADT_A01.hl7` 

### Testing

Verified correct on local.

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated HL7 message processing to improve the extraction of trigger event data, ensuring more accurate handling of incoming messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->