### PR TITLE
feat(athena): appointment types + match on external id

### DIFF
--- a/docs/_snippets/patient-match-external-id.mdx
+++ b/docs/_snippets/patient-match-external-id.mdx
@@ -1,0 +1,9 @@
+<ParamField query="externalId" type="string">
+  The exact external identifier you're trying to match. For Athena external identifiers,
+  it must include the practice prefix (e.g. `a-12345.E-6789`).
+</ParamField>
+
+<ParamField query="source" type="string" optional>
+  If not included, Metriport will search along the custom external identifier submitted at patient create as `externalId`. 
+  If included, it must be `athenahealth`, `elation`, or `canvas`, and will filter along the respective EHR patient identifiers of Metriport patients.
+</ParamField>

--- a/docs/_snippets/patient-match-externalId.mdx
+++ b/docs/_snippets/patient-match-externalId.mdx
@@ -1,9 +1,0 @@
-<ParamField query="externalId" type="string">
-  The exact external ID you're trying to match. For Athena external IDs,
-  it must include the practice prefix (e.g. `a-12345.E-6789`).
-</ParamField>
-
-<ParamField query="source" type="string" optional>
-  If not included, Metriport will search along the custom exteranl ID field. If included, it must be
-  `athenahealth`, `elation`, or `canvas`, and will filter along the respective EHR patient IDs of Metriport patients.
-</ParamField>

--- a/docs/_snippets/patient-match-externalId.mdx
+++ b/docs/_snippets/patient-match-externalId.mdx
@@ -1,9 +1,9 @@
 <ParamField query="externalId" type="string">
-  The exact external ID you're trying to match. For AthenaHealth external IDs,
-  it must include the practice prefix (e.g. `a-12345.E-45678`).
+  The exact external ID you're trying to match. For Athena external IDs,
+  it must include the practice prefix (e.g. `a-12345.E-6789`).
 </ParamField>
 
 <ParamField query="source" type="string" optional>
-  If not included, Metriport will search along the custom exteranl ID field. If include, it must be
-  `athenahealth`, `elation`, or `canvas` and will filter along EHR IDs.
+  If not included, Metriport will search along the custom exteranl ID field. If included, it must be
+  `athenahealth`, `elation`, or `canvas`, and will filter along the respective EHR patient IDs of Metriport patients.
 </ParamField>

--- a/docs/_snippets/patient-match-externalId.mdx
+++ b/docs/_snippets/patient-match-externalId.mdx
@@ -1,0 +1,9 @@
+<ParamField query="externalId" type="string">
+  The exact external ID you're trying to match. For AthenaHealth external IDs,
+  it must include the practice prefix (e.g. `a-12345.E-45678`).
+</ParamField>
+
+<ParamField query="source" type="string" optional>
+  If not included, Metriport will search along the custom exteranl ID field. If include, it must be
+  `athenahealth`, `elation`, or `canvas` and will filter along EHR IDs.
+</ParamField>

--- a/docs/medical-api/api-reference/patient/match-patient-external-id.mdx
+++ b/docs/medical-api/api-reference/patient/match-patient-external-id.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Match Patient by External ID"
-description: "Searches for a Patient previously created in Metriport, based on External ID. Returns a 404 if the patient is not found."
+description: "Searches for a Patient previously created in Metriport, based on External Identifier. Returns a 404 if the patient is not found."
 api: "GET /medical/v1/patient/match/external-id"
 ---
 

--- a/docs/medical-api/api-reference/patient/match-patient-external-id.mdx
+++ b/docs/medical-api/api-reference/patient/match-patient-external-id.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Match Patient"
-description: "Searches for a Patient previously created in Metriport, based on external ID. Returns a 404 if the patient is not found."
+title: "Match Patient by External ID"
+description: "Searches for a Patient previously created in Metriport, based on External ID. Returns a 404 if the patient is not found."
 api: "GET /medical/v1/patient/match/external-id"
 ---
 
-## Body
+## Query Params
 
-<Snippet file="patient-match-externalId.mdx" />
+<Snippet file="patient-match-external-id.mdx" />
 
 ## Response
 

--- a/docs/medical-api/api-reference/patient/match-patient-externalId.mdx
+++ b/docs/medical-api/api-reference/patient/match-patient-externalId.mdx
@@ -1,0 +1,56 @@
+---
+title: "Match Patient"
+description: "Searches for a Patient previously created in Metriport, based on external ID. Returns a 404 if the patient is not found."
+api: "POST /medical/v1/patient/match/externalId"
+---
+
+## Body
+
+<Snippet file="patient-match-externalId.mdx" />
+
+## Response
+
+<Snippet file="patient-response.mdx" />
+
+<ResponseExample>
+
+```javascript Metriport SDK
+import { MetriportMedicalApi, USState } from "@metriport/api-sdk";
+
+const metriport = new MetriportMedicalApi("YOUR_API_KEY");
+
+const patient = await metriport.matchPatient(
+  {
+    firstName: "Jose",
+    lastName: "Juarez",
+    dob: "1951-05-05",
+    genderAtBirth: "M",
+    personalIdentifiers: [
+      {
+        type: "driversLicense",
+        state: USState.CA,
+        value: "51227265",
+      },
+    ],
+    address: [
+      {
+        zip: "12345",
+        city: "San Diego",
+        state: USState.CA,
+        country: "USA",
+        addressLine1: "Guadalajara Street",
+      },
+    ],
+    contact: [
+      {
+        phone: "1234567899",
+        email: "jose@domain.com",
+      },
+    ],
+  },
+);
+```
+
+</ResponseExample>
+
+<Snippet file="patient-response-json.mdx" />

--- a/docs/medical-api/api-reference/patient/match-patient-externalId.mdx
+++ b/docs/medical-api/api-reference/patient/match-patient-externalId.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Match Patient"
 description: "Searches for a Patient previously created in Metriport, based on external ID. Returns a 404 if the patient is not found."
-api: "POST /medical/v1/patient/match/externalId"
+api: "GET /medical/v1/patient/match/external-id"
 ---
 
 ## Body
@@ -19,36 +19,7 @@ import { MetriportMedicalApi, USState } from "@metriport/api-sdk";
 
 const metriport = new MetriportMedicalApi("YOUR_API_KEY");
 
-const patient = await metriport.matchPatient(
-  {
-    firstName: "Jose",
-    lastName: "Juarez",
-    dob: "1951-05-05",
-    genderAtBirth: "M",
-    personalIdentifiers: [
-      {
-        type: "driversLicense",
-        state: USState.CA,
-        value: "51227265",
-      },
-    ],
-    address: [
-      {
-        zip: "12345",
-        city: "San Diego",
-        state: USState.CA,
-        country: "USA",
-        addressLine1: "Guadalajara Street",
-      },
-    ],
-    contact: [
-      {
-        phone: "1234567899",
-        email: "jose@domain.com",
-      },
-    ],
-  },
-);
+const patient = await metriport.matchPatientByExternalId("1234567890");
 ```
 
 </ResponseExample>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -84,6 +84,7 @@
             "medical-api/api-reference/patient/get-patient",
             "medical-api/api-reference/patient/update-patient",
             "medical-api/api-reference/patient/match-patient",
+            "medical-api/api-reference/patient/match-patient-external-id",
             "medical-api/api-reference/patient/list-patients",
             "medical-api/api-reference/patient/delete-patient",
             "medical-api/api-reference/patient/hie-opt-out",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35410,7 +35410,7 @@
       }
     },
     "packages/api": {
-      "version": "1.25.3",
+      "version": "1.26.0-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -35494,12 +35494,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "14.12.3",
+      "version": "14.13.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.6.3",
-        "@metriport/shared": "^0.20.3",
+        "@metriport/commonwell-sdk": "^5.7.0-alpha.0",
+        "@metriport/shared": "^0.21.0-alpha.0",
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -35555,10 +35555,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.16.3",
+      "version": "1.17.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.17.3",
+        "@metriport/ihe-gateway-sdk": "^0.18.0-alpha.0",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -35572,7 +35572,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.4.5",
+      "version": "1.5.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -35596,10 +35596,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.24.3",
+      "version": "1.25.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.6.3",
+        "@metriport/commonwell-sdk": "^5.7.0-alpha.0",
         "axios": "^1.4.0",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -35638,10 +35638,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.22.3",
+      "version": "1.23.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.6.3",
+        "@metriport/commonwell-sdk": "^5.7.0-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -35673,10 +35673,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.6.3",
+      "version": "5.7.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.20.3",
+        "@metriport/shared": "^0.21.0-alpha.0",
         "axios": "^1.4.0",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -35724,7 +35724,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.22.3",
+      "version": "1.23.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -36948,17 +36948,17 @@
     "packages/core/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.17.3",
+      "version": "0.18.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.20.3",
+        "@metriport/shared": "^0.21.0-alpha.0",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.20.3",
+      "version": "1.21.0-alpha.0",
       "dependencies": {
         "@metriport/shared": "file:packages/shared",
         "aws-cdk-lib": "~2.133.0",
@@ -37011,7 +37011,7 @@
     },
     "packages/infra/packages/shared": {},
     "packages/mllp-server": {
-      "version": "0.1.3",
+      "version": "0.2.0-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@medplum/core": "^3.2.33",
@@ -37167,7 +37167,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.20.3",
+      "version": "0.21.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -37215,7 +37215,7 @@
       }
     },
     "packages/utils": {
-      "version": "1.23.3",
+      "version": "1.24.0-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.658.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "14.12.3",
+  "version": "14.13.0-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.6.3",
-    "@metriport/shared": "^0.20.3",
+    "@metriport/commonwell-sdk": "^5.7.0-alpha.0",
+    "@metriport/shared": "^0.21.0-alpha.0",
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -385,6 +385,28 @@ export class MetriportMedicalApi {
   }
 
   /**
+   * Searches for a patient previously created at Metriport, based on external ID.
+   *
+   * @return The patient if found.
+   */
+  async matchPatientByExternalId(
+    externalId: string,
+    source?: string
+  ): Promise<PatientDTO | undefined> {
+    try {
+      const resp = await this.api.post(`${PATIENT_URL}/match/externalId`, undefined, {
+        params: { externalId, source },
+      });
+      if (!resp.data) throw new Error(NO_DATA_MESSAGE);
+      return resp.data as PatientDTO;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      if (err.response?.status !== status.NOT_FOUND) throw err;
+      return undefined;
+    }
+  }
+
+  /**
    * Updates a patient at Metriport and at HIEs the patient is linked to.
    *
    * @param patient The patient data to be updated.

--- a/packages/api-sdk/src/medical/client/metriport.ts
+++ b/packages/api-sdk/src/medical/client/metriport.ts
@@ -394,7 +394,7 @@ export class MetriportMedicalApi {
     source?: string
   ): Promise<PatientDTO | undefined> {
     try {
-      const resp = await this.api.post(`${PATIENT_URL}/match/externalId`, undefined, {
+      const resp = await this.api.get(`${PATIENT_URL}/match/external-id`, {
         params: { externalId, source },
       });
       if (!resp.data) throw new Error(NO_DATA_MESSAGE);

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.25.3",
+  "version": "1.26.0-alpha.0",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/src/command/medical/patient/get-patient.ts
+++ b/packages/api/src/command/medical/patient/get-patient.ts
@@ -1,15 +1,15 @@
 import { Organization } from "@metriport/core/domain/organization";
 import { getStatesFromAddresses, Patient, PatientDemoData } from "@metriport/core/domain/patient";
 import { getPatientByDemo as getPatientByDemoMPI } from "@metriport/core/mpi/get-patient-by-demo";
-import { EhrSources, NotFoundError, USStateForAddress } from "@metriport/shared";
+import { NotFoundError, USStateForAddress } from "@metriport/shared";
 import { uniq } from "lodash";
 import { Op, QueryTypes, Transaction } from "sequelize";
 import { Facility } from "../../../domain/medical/facility";
-import { PatientSourceIdentifierMap } from "../../../domain/patient-mapping";
+import { PatientMappingSource, PatientSourceIdentifierMap } from "../../../domain/patient-mapping";
 import { PatientLoaderLocal } from "../../../models/helpers/patient-loader-local";
 import { PatientModel } from "../../../models/medical/patient";
 import { paginationSqlExpressions } from "../../../shared/sql";
-import { getSourceMapForPatient, getPatientMapping } from "../../mapping/patient";
+import { getPatientMapping, getSourceMapForPatient } from "../../mapping/patient";
 import { Pagination, sortForPagination } from "../../pagination";
 import { getFacilities } from "../facility/get-facility";
 import { getOrganizationOrFail } from "../organization/get-organization";
@@ -314,7 +314,7 @@ export async function getPatientByExternalId({
 }: {
   cxId: string;
   externalId: string;
-  source?: EhrSources;
+  source?: PatientMappingSource;
 }): Promise<PatientWithIdentifiers | undefined> {
   if (!source) {
     const patient = await PatientModel.findOne({ where: { cxId, externalId } });
@@ -326,8 +326,7 @@ export async function getPatientByExternalId({
     source,
   });
   if (!patientMap) return undefined;
-  const patient = await getPatientOrFail({ id: patientMap.patientId, cxId });
-  return await attachPatientIdentifiers(patient);
+  return await getPatientOrFail({ id: patientMap.patientId, cxId });
 }
 
 export async function attachPatientIdentifiers(patient: Patient): Promise<PatientWithIdentifiers> {

--- a/packages/api/src/routes/medical/patient-root.ts
+++ b/packages/api/src/routes/medical/patient-root.ts
@@ -191,10 +191,7 @@ router.get(
     const externalId = getFromQueryOrFail("externalId", req);
     const source = getFromQuery("source", req);
     if (source && !isPatientMappingSource(source)) {
-      throw new BadRequestError("Invalid source", undefined, {
-        externalId,
-        source,
-      });
+      throw new BadRequestError("Invalid source", undefined, { source });
     }
 
     const patient = await getPatientByExternalId({

--- a/packages/api/src/routes/medical/patient-root.ts
+++ b/packages/api/src/routes/medical/patient-root.ts
@@ -174,15 +174,15 @@ router.post(
 );
 
 /** ---------------------------------------------------------------------------
- * POST /patient/match/externalId
+ * POST /patient/match/external-id
  *
  * Searches for a patient previously created at Metriport, based on an external ID. Returns the matched patient, if it exists.
  *
  * @return The matched patient.
  * @throws NotFoundError if the patient does not exist.
  */
-router.post(
-  "/match",
+router.get(
+  "/match/external-id",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);

--- a/packages/api/src/routes/medical/patient-root.ts
+++ b/packages/api/src/routes/medical/patient-root.ts
@@ -176,7 +176,7 @@ router.post(
 );
 
 /** ---------------------------------------------------------------------------
- * POST /patient/match/external-id
+ * GET /patient/match/external-id
  *
  * Searches for a patient previously created at Metriport, based on an external ID. Returns the matched patient, if it exists.
  *

--- a/packages/api/src/routes/medical/patient-root.ts
+++ b/packages/api/src/routes/medical/patient-root.ts
@@ -5,7 +5,6 @@ import {
   PaginatedResponse,
   stringToBoolean,
 } from "@metriport/shared";
-import { EhrSources, isEhrSource } from "@metriport/shared/interface/external/ehr/source";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import { Request, Response } from "express";
@@ -22,6 +21,7 @@ import {
 import { createPatientImportJob } from "../../command/medical/patient/patient-import-create-job";
 import { Pagination } from "../../command/pagination";
 import { getSandboxPatientLimitForCx } from "../../domain/medical/get-patient-limit";
+import { isPatientMappingSource, PatientMappingSource } from "../../domain/patient-mapping";
 import { Config } from "../../shared/config";
 import { requestLogger } from "../helpers/request-logger";
 import { checkRateLimit } from "../middlewares/rate-limiting";
@@ -188,7 +188,7 @@ router.post(
     const cxId = getCxIdOrFail(req);
     const externalId = getFromQueryOrFail("externalId", req);
     const source = getFromQuery("source", req);
-    if (source && !isEhrSource(source)) {
+    if (source && !isPatientMappingSource(source)) {
       throw new BadRequestError("Invalid source", undefined, {
         externalId,
         source,
@@ -198,7 +198,7 @@ router.post(
     const patient = await getPatientByExternalId({
       cxId,
       externalId,
-      ...(source ? { source: source as EhrSources } : {}),
+      ...(source ? { source: source as PatientMappingSource } : {}),
     });
 
     if (patient) return res.status(httpStatus.OK).json(dtoFromModel(patient));

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.16.3",
+  "version": "1.17.0-alpha.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.17.3",
+    "@metriport/ihe-gateway-sdk": "^0.18.0-alpha.0",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.4.5",
+  "version": "1.5.0-alpha.0",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.24.3",
+  "version": "1.25.0-alpha.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.6.3",
+    "@metriport/commonwell-sdk": "^5.7.0-alpha.0",
     "axios": "^1.4.0",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.22.3",
+  "version": "1.23.0-alpha.0",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.6.3",
+    "@metriport/commonwell-sdk": "^5.7.0-alpha.0",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.6.3",
+  "version": "5.7.0-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.20.3",
+    "@metriport/shared": "^0.21.0-alpha.0",
     "axios": "^1.4.0",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.22.3",
+  "version": "1.23.0-alpha.0",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.17.3",
+  "version": "0.18.0-alpha.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.20.3",
+    "@metriport/shared": "^0.21.0-alpha.0",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.20.3",
+  "version": "1.21.0-alpha.0",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mllp-server",
-  "version": "0.1.3",
+  "version": "0.2.0-alpha.0",
   "description": "MLLP server that reads HL7 messages off of a raw tcp connection",
   "main": "app.js",
   "private": true,
@@ -28,8 +28,8 @@
   },
   "homepage": "https://github.com/metriport/metriport#readme",
   "dependencies": {
-    "@medplum/hl7": "^3.2.33",
     "@medplum/core": "^3.2.33",
+    "@medplum/hl7": "^3.2.33",
     "@metriport/core": "file:packages/core",
     "@metriport/shared": "file:packages/shared",
     "@sentry/cli": "^2.42.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.20.3",
+  "version": "0.21.0-alpha.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/src/interface/external/ehr/athenahealth/cx-mapping.ts
+++ b/packages/shared/src/interface/external/ehr/athenahealth/cx-mapping.ts
@@ -4,5 +4,6 @@ export const athenaSecondaryMappingsSchema = z.object({
   departmentIds: z.string().array(),
   webhookAppointmentDisabled: z.boolean().optional(),
   backgroundAppointmentsDisabled: z.boolean().optional(),
+  appointmentTypesFilter: z.string().array().optional(),
 });
 export type AthenaSecondaryMappings = z.infer<typeof athenaSecondaryMappingsSchema>;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.23.3",
+  "version": "1.24.0-alpha.0",
   "description": "",
   "main": "mock-webhook.js",
   "private": true,


### PR DESCRIPTION
Ref: #2894 

### Description

- adding match endpoint along external ID that supports both exact matching the existing custom external ID + source based matching on EHR external IDs
- adding in appointment type filtering as a general Athena feature

### Testing

- Local
  - [x] new match endpoint works for generic external ID + EHR external IDs
  - [x] new match endpoint works from sdk
  - [x] backend appointments task runs with new appointment type filteirng
  - [x] docs look good
- Staging
  - [ ] new match endpoint works for generic external ID + EHR external IDs
  - [ ] backend appointments task runs with new appointment type filteirng
  - [ ] docs look good
- Sandbox
  - [ ] N/A
- Production
  - [ ] new match endpoint works for generic external ID + EHR external IDs
  - [ ] backend appointments task runs with new appointment type filteirng
  - [ ] docs look good

### Release Plan

- [x] Release NPM packages
- [ ] Throttle background task lambda for athena until target CXs can be updated
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new capability to search and retrieve patient details using an external identifier, expanding patient lookup options.
	- Enhanced appointment handling with flexible filtering options to improve data accuracy.

- **Documentation**
	- Updated the API reference with a dedicated section covering patient matching by external ID, including detailed query parameter examples and usage guidelines.
	- Added documentation for the new endpoint `/patient/match/external-id` to assist developers with usage examples.
	- Included new parameters in the documentation for the patient match functionality to clarify usage.
	- Added a new entry in the API reference for the patient match by external ID endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->