### PR TITLE
1040 Single query for list patients

### DIFF
--- a/packages/api/src/command/mapping/patient.ts
+++ b/packages/api/src/command/mapping/patient.ts
@@ -73,22 +73,18 @@ export async function deleteAllPatientMappings({
 
 export const defaultSources = [EhrSources.athena, EhrSources.canvas, EhrSources.elation];
 
-export async function getSourceMapForPatient({
-  cxId,
-  patientId,
+export function getSourceMapForPatient({
+  mappings,
   sources = defaultSources,
 }: {
-  cxId: string;
-  patientId: string;
+  mappings: PatientMapping[];
   sources?: string[];
-}): Promise<PatientSourceIdentifierMap | undefined> {
-  const mappings = await PatientMappingModel.findAll({
-    where: { cxId, patientId, ...(sources ? { source: sources } : undefined) },
-    order: [["createdAt", "ASC"]],
-  });
+}): PatientSourceIdentifierMap | undefined {
   const sourceMap = mappings.reduce((acc, mapping) => {
-    const { source, externalId } = mapping.dataValues;
-    acc[source] = [...(acc[source] || []), parseExternalId(source, externalId)];
+    const { source, externalId } = mapping;
+    if (sources.includes(source)) {
+      acc[source] = [...(acc[source] || []), parseExternalId(source, externalId)];
+    }
     return acc;
   }, {} as PatientSourceIdentifierMap);
   return Object.keys(sourceMap).length > 0 ? sourceMap : undefined;

--- a/packages/api/src/command/mapping/patient.ts
+++ b/packages/api/src/command/mapping/patient.ts
@@ -1,6 +1,8 @@
+import { Patient } from "@metriport/core/domain/patient";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { NotFoundError } from "@metriport/shared";
 import { EhrSources } from "@metriport/shared/interface/external/ehr/source";
+import { Transaction } from "sequelize";
 import {
   PatientMapping,
   PatientMappingPerSource,
@@ -57,6 +59,18 @@ export async function getPatientMappingOrFail({
     throw new NotFoundError("PatientMapping not found", undefined, { cxId, externalId, source });
   }
   return mapping;
+}
+
+export async function getPatientMappings(
+  { cxId, id: patientId }: Pick<Patient, "id" | "cxId">,
+  transaction?: Transaction
+): Promise<PatientMapping[]> {
+  const mappings = await PatientMappingModel.findAll({
+    where: { cxId, patientId },
+    order: [["createdAt", "ASC"]],
+    transaction,
+  });
+  return mappings.map(m => m.dataValues);
 }
 
 export async function deleteAllPatientMappings({

--- a/packages/api/src/command/medical/patient/create-patient.ts
+++ b/packages/api/src/command/medical/patient/create-patient.ts
@@ -14,7 +14,7 @@ import { runInitialPatientDiscoveryAcrossHies } from "../../../external/hie/run-
 import { PatientModel } from "../../../models/medical/patient";
 import { getFacilityOrFail } from "../facility/get-facility";
 import { addCoordinatesToAddresses } from "./add-coordinates";
-import { PatientWithIdentifiers, attachPatientIdentifiers, getPatientByDemo } from "./get-patient";
+import { attachPatientIdentifiers, getPatientByDemo, PatientWithIdentifiers } from "./get-patient";
 import { createPatientSettings } from "./settings/create-patient-settings";
 import { sanitize, validate } from "./shared";
 
@@ -104,7 +104,6 @@ export async function createPatient({
       forceCommonwell,
     }).catch(processAsyncError("runInitialPatientDiscoveryAcrossHies"));
   }
-  // why do we need to do this here, since the pt has just been created?
   const patientWithIdentifiers = await attachPatientIdentifiers(newPatient.dataValues);
   return patientWithIdentifiers;
 }

--- a/packages/api/src/command/medical/patient/create-patient.ts
+++ b/packages/api/src/command/medical/patient/create-patient.ts
@@ -104,6 +104,7 @@ export async function createPatient({
       forceCommonwell,
     }).catch(processAsyncError("runInitialPatientDiscoveryAcrossHies"));
   }
+  // why do we need to do this here, since the pt has just been created?
   const patientWithIdentifiers = await attachPatientIdentifiers(newPatient.dataValues);
   return patientWithIdentifiers;
 }

--- a/packages/api/src/command/medical/patient/get-patient.ts
+++ b/packages/api/src/command/medical/patient/get-patient.ts
@@ -5,9 +5,10 @@ import { NotFoundError, USStateForAddress } from "@metriport/shared";
 import { uniq } from "lodash";
 import { Op, QueryTypes, Transaction } from "sequelize";
 import { Facility } from "../../../domain/medical/facility";
-import { PatientSourceIdentifierMap } from "../../../domain/patient-mapping";
+import { PatientMapping, PatientSourceIdentifierMap } from "../../../domain/patient-mapping";
 import { PatientLoaderLocal } from "../../../models/helpers/patient-loader-local";
 import { PatientModel } from "../../../models/medical/patient";
+import { PatientMappingModel, rawToDomain } from "../../../models/patient-mapping";
 import { paginationSqlExpressions } from "../../../shared/sql";
 import { getSourceMapForPatient } from "../../mapping/patient";
 import { Pagination, sortForPagination } from "../../pagination";
@@ -18,6 +19,9 @@ import { sanitize, validate } from "./shared";
 export type PatientMatchCmd = PatientDemoData & { cxId: string };
 
 export type PatientWithIdentifiers = Patient & { additionalIds?: PatientSourceIdentifierMap };
+
+const aliasReplacement = "<patient-alias>";
+const mappingsAlias = "mappings";
 
 export async function matchPatient(
   patient: PatientMatchCmd
@@ -61,15 +65,15 @@ export async function getPatients({
    * If/when we move to Sequelize v7 we can replace the raw query with ORM:
    * https://sequelize.org/docs/v7/querying/operators/#tsquery-matching-operator
    */
-  const queryFTS = getPatientsSharedQueryUntilFTS(
-    "*",
+  const { query: queryFTS, patientAlias } = getPatientsSharedQueryUntilFTS(
+    `${aliasReplacement}.*`,
     facilityId,
     patientIds,
     fullTextSearchFilters
   );
 
   const { query: paginationQueryExpression, replacements: paginationReplacements } =
-    paginationSqlExpressions(pagination);
+    paginationSqlExpressions(pagination, patientAlias);
   const queryFinal = queryFTS + paginationQueryExpression;
 
   const patients = await sequelize.query(queryFinal, {
@@ -83,9 +87,21 @@ export async function getPatients({
     type: QueryTypes.SELECT,
   });
 
-  const patientsWithIdentifiers = await Promise.all(
-    patients.map(patient => attachPatientIdentifiers(patient.dataValues))
+  const patientAndMappings: { patient: Patient; mappings: PatientMapping[] }[] = patients.map(p => {
+    const patient = p.dataValues;
+    const mappingsRaw: [] = (patient as any)[mappingsAlias] as []; //eslint-disable-line @typescript-eslint/no-explicit-any
+    return {
+      patient,
+      mappings: mappingsRaw.map(rawToDomain),
+    };
+  });
+  const patientsWithIdentifiers: PatientWithIdentifiers[] = await Promise.all(
+    patientAndMappings.map(pm => {
+      const additionalIds = getSourceMapForPatient({ mappings: pm.mappings });
+      return { ...pm.patient, additionalIds };
+    })
   );
+
   const sortedPatients = sortForPagination(patientsWithIdentifiers, pagination);
   return sortedPatients;
 }
@@ -104,8 +120,8 @@ export async function getPatientsCount({
   const sequelize = PatientModel.sequelize;
   if (!sequelize) throw new Error("Sequelize not found");
 
-  const queryFTS = getPatientsSharedQueryUntilFTS(
-    "count(id)",
+  const { query: queryFTS } = getPatientsSharedQueryUntilFTS(
+    `count(${aliasReplacement}.id)`,
     facilityId,
     patientIds,
     fullTextSearchFilters
@@ -128,27 +144,47 @@ function getPatientsSharedQueryUntilFTS(
   facilityId?: string,
   patientIds?: string[],
   fullTextSearchFilters?: string
-): string {
-  const querySelect = `SELECT ${selectColumns} FROM ${PatientModel.tableName} WHERE cx_id = :cxId `;
+): { query: string; patientAlias: string } {
+  const alias = "p";
+  const querySelect = `SELECT ${selectColumns.replace(aliasReplacement, alias)}, 
+  COALESCE(
+    jsonb_agg(
+      CASE WHEN pm.id IS NOT NULL 
+      THEN jsonb_build_object(
+        'id', pm.id,
+        'external_id', pm.external_id,
+        'source', pm.source,
+        'created_at', pm.created_at,
+        'updated_at', pm.updated_at,
+        'version', pm.version
+      )
+      ELSE NULL END
+    ) FILTER (WHERE pm.id IS NOT NULL),
+    '[]'::jsonb
+  ) as ${mappingsAlias}
+  FROM ${PatientModel.tableName} ${alias}
+  LEFT OUTER JOIN ${PatientMappingModel.tableName} pm ON ${alias}.id = pm.patient_id
+  WHERE ${alias}.cx_id = :cxId`;
 
   const queryFacility =
-    querySelect + (facilityId ? ` AND facility_ids::text[] && :facilityIds::text[]` : "");
+    querySelect + (facilityId ? ` AND ${alias}.facility_ids::text[] && :facilityIds::text[]` : "");
 
-  const queryPatientIds = queryFacility + (patientIds ? ` AND id IN (:patientIds)` : "");
+  const queryPatientIds = queryFacility + (patientIds ? ` AND ${alias}.id IN (:patientIds)` : "");
 
   const queryFTS =
     queryPatientIds +
     (fullTextSearchFilters
       ? ` AND (
-        search_criteria @@ websearch_to_tsquery('english', :filters) 
-        OR external_id ilike '%' || :filters || '%'
-        OR id = :filters
-        OR id IN (SELECT patient_id FROM patient_mapping WHERE cx_id = :cxId and external_id ilike '%' || :filters || '%')
-        OR facility_ids && (SELECT array_agg(id) FROM facility WHERE cx_id = :cxId and (data->>'name' ilike '%' || :filters || '%' or id = :filters))
+        ${alias}.search_criteria @@ websearch_to_tsquery('english', :filters) 
+        OR ${alias}.external_id ilike '%' || :filters || '%'
+        OR ${alias}.id = :filters
+        OR ${alias}.id IN (SELECT patient_id FROM patient_mapping WHERE cx_id = :cxId and external_id ilike '%' || :filters || '%')
+        OR ${alias}.facility_ids && (SELECT array_agg(id) FROM facility WHERE cx_id = :cxId and (data->>'name' ilike '%' || :filters || '%' or id = :filters))
       )`
       : "");
 
-  return queryFTS;
+  const query = queryFTS + ` GROUP BY ${alias}.id `;
+  return { query, patientAlias: alias };
 }
 
 function getPatientsSharedReplacements(
@@ -239,7 +275,7 @@ export async function getPatient({
     transaction,
     lock,
   });
-  return patient ? await attachPatientIdentifiers(patient.dataValues) : undefined;
+  return patient ? await attachPatientIdentifiers(patient.dataValues, transaction) : undefined;
 }
 
 /**
@@ -307,11 +343,19 @@ export async function getPatientStates({
   return uniq(nonUniqueStates);
 }
 
-export async function attachPatientIdentifiers(patient: Patient): Promise<PatientWithIdentifiers> {
-  const additionalIds = await getSourceMapForPatient({
-    cxId: patient.cxId,
-    patientId: patient.id,
+/**
+ * @deprecated Let's join this in the DB while querying the patient
+ */
+export async function attachPatientIdentifiers(
+  patient: Patient,
+  transaction?: Transaction
+): Promise<PatientWithIdentifiers> {
+  const mappings = await PatientMappingModel.findAll({
+    where: { cxId: patient.cxId, patientId: patient.id },
+    order: [["createdAt", "ASC"]],
+    transaction,
   });
+  const additionalIds = getSourceMapForPatient({ mappings });
   return {
     ...patient,
     ...(additionalIds ? { additionalIds } : {}),

--- a/packages/api/src/command/medical/patient/get-patient.ts
+++ b/packages/api/src/command/medical/patient/get-patient.ts
@@ -10,7 +10,7 @@ import { PatientLoaderLocal } from "../../../models/helpers/patient-loader-local
 import { PatientModel } from "../../../models/medical/patient";
 import { PatientMappingModel, rawToDomain } from "../../../models/patient-mapping";
 import { paginationSqlExpressions } from "../../../shared/sql";
-import { getSourceMapForPatient } from "../../mapping/patient";
+import { getPatientMappings, getSourceMapForPatient } from "../../mapping/patient";
 import { Pagination, sortForPagination } from "../../pagination";
 import { getFacilities } from "../facility/get-facility";
 import { getOrganizationOrFail } from "../organization/get-organization";
@@ -348,11 +348,7 @@ export async function attachPatientIdentifiers(
   patient: Patient,
   transaction?: Transaction
 ): Promise<PatientWithIdentifiers> {
-  const mappings = await PatientMappingModel.findAll({
-    where: { cxId: patient.cxId, patientId: patient.id },
-    order: [["createdAt", "ASC"]],
-    transaction,
-  });
+  const mappings = await getPatientMappings(patient, transaction);
   const additionalIds = getSourceMapForPatient({ mappings });
   return {
     ...patient,

--- a/packages/api/src/command/medical/patient/get-patient.ts
+++ b/packages/api/src/command/medical/patient/get-patient.ts
@@ -342,7 +342,9 @@ export async function getPatientStates({
 }
 
 /**
- * @deprecated Let's join this in the DB while querying the patient
+ * Attaches the patient identifiers from the mappings table to the patient object.
+ *
+ * NOTE: avoid using this function, instead join this column in the DB while querying the patient
  */
 export async function attachPatientIdentifiers(
   patient: Patient,

--- a/packages/api/src/command/medical/patient/get-patient.ts
+++ b/packages/api/src/command/medical/patient/get-patient.ts
@@ -95,12 +95,10 @@ export async function getPatients({
       mappings: mappingsRaw.map(rawToDomain),
     };
   });
-  const patientsWithIdentifiers: PatientWithIdentifiers[] = await Promise.all(
-    patientAndMappings.map(pm => {
-      const additionalIds = getSourceMapForPatient({ mappings: pm.mappings });
-      return { ...pm.patient, additionalIds };
-    })
-  );
+  const patientsWithIdentifiers: PatientWithIdentifiers[] = patientAndMappings.map(pm => {
+    const additionalIds = getSourceMapForPatient({ mappings: pm.mappings });
+    return { ...pm.patient, additionalIds };
+  });
 
   const sortedPatients = sortForPagination(patientsWithIdentifiers, pagination);
   return sortedPatients;

--- a/packages/api/src/models/_default.ts
+++ b/packages/api/src/models/_default.ts
@@ -70,7 +70,7 @@ export abstract class BaseModel<T extends Model<any, any>>
         type: DataTypes.VIRTUAL,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         get<T extends Model<any, any>>(this: BaseModel<T>): string {
-          return Util.md5(this.id + "_" + this.version);
+          return generateETag(this.id, this.version);
         },
       },
     };
@@ -97,4 +97,8 @@ export function normalizeString<T extends string | null | undefined>(
   maxLength = MAX_VARCHAR_LENGTH
 ): T {
   return value != null ? limitStringLength(value, maxLength) : value;
+}
+
+export function generateETag(id: string, version: number): string {
+  return Util.md5(id + "_" + version);
 }

--- a/packages/api/src/models/patient-mapping.ts
+++ b/packages/api/src/models/patient-mapping.ts
@@ -58,6 +58,8 @@ export function rawToDomain(raw: Record<string, string>): PatientMapping {
   if (versionRaw == undefined) {
     throw new MetriportError("version is required to create a patient mapping");
   }
+  const version = parseInt(versionRaw);
+  if (isNaN(version)) throw new MetriportError("version must be a number");
   const id = raw[patientMappingColumnNames.id];
   const obj: PatientMapping = {
     id,
@@ -67,7 +69,7 @@ export function rawToDomain(raw: Record<string, string>): PatientMapping {
     cxId: raw[patientMappingColumnNames.cxId],
     createdAt: new Date(createdAtRaw),
     updatedAt: new Date(updatedAtRaw),
-    eTag: generateETag(id, parseInt(versionRaw)),
+    eTag: generateETag(id, version),
   };
   return obj;
 }

--- a/packages/api/src/routes/medical/patient-root.ts
+++ b/packages/api/src/routes/medical/patient-root.ts
@@ -1,4 +1,5 @@
 import { demographicsSchema, patientCreateSchema } from "@metriport/api-sdk";
+import { out } from "@metriport/core/util/log";
 import { NotFoundError, PaginatedResponse, stringToBoolean } from "@metriport/shared";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
@@ -113,6 +114,7 @@ router.get(
 
     // TODO 483 remove this (and respected conditional) once pagination is fully rolled out
     if (!isPaginated(req)) {
+      out(`List patients - cx ${cxId}`).log(`Running without pagination`);
       const patients = await getPatients({ cxId, facilityId: facilityId, fullTextSearchFilters });
       const patientsData = patients.map(dtoFromModel);
       return res.status(httpStatus.OK).json({ patients: patientsData });

--- a/packages/api/src/shared/sql.ts
+++ b/packages/api/src/shared/sql.ts
@@ -2,13 +2,15 @@ import { Pagination } from "../command/pagination";
 
 const defaultPageSize = 50;
 
-export const paginationSqlExpressions = (pagination: Pagination | undefined) => {
+export const paginationSqlExpressions = (pagination: Pagination | undefined, alias?: string) => {
+  const aliasParsed = alias ? `${alias}.` : "";
+
   const { toItem, fromItem } = pagination ?? {};
-  const toItemStr = toItem ? ` AND id >= :toItem` : "";
-  const fromItemStr = fromItem ? ` AND id <= :fromItem` : "";
+  const toItemStr = toItem ? ` AND ${aliasParsed}id >= :toItem` : "";
+  const fromItemStr = fromItem ? ` AND ${aliasParsed}id <= :fromItem` : "";
   const queryPagination = " " + [toItemStr, fromItemStr].filter(Boolean).join("");
 
-  const queryOrder = queryPagination + " ORDER BY id " + (toItem ? "ASC" : "DESC");
+  const queryOrder = queryPagination + ` ORDER BY ${aliasParsed}id ` + (toItem ? "ASC" : "DESC");
 
   const { count } = pagination ?? {};
   const query = queryOrder + (count ? ` LIMIT :count` : "");


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Single query for list patients - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1744032812880729?thread_ts=1741293023.098159&cid=C04T256DQPQ)

### Testing

- Local
  - [x] lists patients with pagination
  - [x] lists patients without pagination
  - [x] includes mappings on the result payload
- Staging
  - [ ] lists patients with pagination
  - [ ] lists patients without pagination
  - [ ] Dash displays additional IDs
- Sandbox
  - none
- Production
  - [ ] monitor the platform for 5min
  - [ ] list pts for bulk import w/o erros

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new function for converting raw records into structured patient mappings with validation checks.
  - Enhanced SQL query generation to support dynamic aliasing for improved flexibility.
  - Added a new method for retrieving patient mappings based on specified criteria.

- **Refactor**
  - Streamlined patient data processing and retrieval for improved accuracy and consistency.
  - Optimized query construction to enhance performance and efficiency.
  - Modularized eTag generation logic for better maintainability.

- **Chore**
  - Added diagnostic logging for enhanced monitoring of data retrieval without pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->