### PR TITLE
PATCH RELEASE Adjust DDB capacity unit alarm

### DIFF
--- a/packages/infra/lib/feature-flags-nested-stack.ts
+++ b/packages/infra/lib/feature-flags-nested-stack.ts
@@ -22,9 +22,14 @@ function getSettings(props: FeatureFlagsNestedStackProps) {
     dynamoReplicationRegions: isProd(props.config) ? ["us-east-1"] : ["ca-central-1"],
     dynamoReplicationTimeout: Duration.hours(3),
     dynamoPointInTimeRecovery: true,
-    consumedWriteCapacityUnitsAlarmThreshold: isProd(props.config) ? 100 : 10,
+    // BOTH: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html
+    // Starts w/ 4,000 writes/s
+    // Also see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/metrics-dimensions.html#ConsumedWriteCapacityUnits
+    consumedWriteCapacityUnitsAlarmThreshold: isProd(props.config) ? 200_000 : 50_000,
     consumedWriteCapacityUnitsAlarmPeriod: 1,
-    consumedReadCapacityUnitsAlarmThreshold: isProd(props.config) ? 5000 : 100,
+    // Starts w/ 12,000 reads/s
+    // Also see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/metrics-dimensions.html#ConsumedReadCapacityUnits
+    consumedReadCapacityUnitsAlarmThreshold: isProd(props.config) ? 600_000 : 150_000,
     consumedReadCapacityUnitsAlarmPeriod: 2,
   };
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Dependencies

none

### Description

Adjust FFs DDB capacity unit alarm - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1744063264565649?thread_ts=1744058189.069079&cid=C04T256DQPQ)

[Metrics for reference](https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#metricsV2?graph=~(metrics~(~(~(expression~'m1*2f60~label~'read*2fs~id~'e1~period~60))~(~(expression~'m2*2f60~label~'write*2fs~id~'e2~yAxis~'right~period~60))~(~'AWS*2fDynamoDB~'ConsumedReadCapacityUnits~'TableName~'APIInfrastructureStack-FeatureFlagsNestedStackFeatureFlagsNestedStackResourceC9FC68AC-1JFAKNPXQHGRA-FeatureFlagsC2AFA789-1WDQYCPSFP4YE~(id~'m1~visible~false))~(~'.~'ConsumedWriteCapacityUnits~'.~'.~(yAxis~'right~id~'m2~visible~false)))~view~'timeSeries~stacked~false~region~'us-west-1~start~'-PT72H~end~'P0D~stat~'Sum~period~60)&query=~'*7bAWS*2fDynamoDB*2cTableName*7d*20feature*20capacity).

### Testing

none

### Release Plan

- :warning: Points to `master`
- [ ] RELEASE this
- [ ] Alarm threshold updated for write and read consumed capacity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated capacity alarm thresholds to improve monitoring accuracy in both production and non-production settings.
- **Documentation**
	- Added contextual notes to clarify the updated monitoring parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->