### PR TITLE
fix(infra): fix api url for lambda

### DIFF
--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -703,6 +703,7 @@ export class LambdasNestedStack extends NestedStack {
       envType,
       envVars: {
         BUCKET_NAME: hl7v2RosterBucket.bucketName,
+        API_URL: config.loadBalancerDnsName,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
       layers: [lambdaLayers.shared],

--- a/packages/utils/src/hl7v2-notifications/create-hl7v2-patient-roster.ts
+++ b/packages/utils/src/hl7v2-notifications/create-hl7v2-patient-roster.ts
@@ -49,7 +49,7 @@ async function playground() {
       .invoke({
         FunctionName: lambdaName,
         InvocationType: "RequestResponse",
-        Payload: config,
+        Payload: JSON.stringify(config),
       })
       .promise();
 


### PR DESCRIPTION
refs. metriport/metriport-internal#2791

### Description
- Use internal api url for the lambda 
- Fix payload passing to the lambda on the script

### Testing
- Same as here - https://github.com/metriport/metriport/pull/3629

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced backend connectivity by introducing a dynamic API endpoint configuration that improves how the system locates its services.
  - Improved AWS Lambda invocations by ensuring configuration data is properly serialized as JSON, leading to more reliable data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->