### PR TITLE
fix(api): fixing a bug on pagination

### DIFF
--- a/packages/api/src/routes/internal/medical/patient.ts
+++ b/packages/api/src/routes/internal/medical/patient.ts
@@ -169,6 +169,7 @@ router.get(
         // There's no use for calculating the actual number of subscribers for this route
         return Promise.resolve(-1);
       },
+      isInternal: true,
     });
 
     const response: PaginatedResponse<Hl7v2Subscriber, "patients"> = {

--- a/packages/api/src/routes/internal/medical/patient.ts
+++ b/packages/api/src/routes/internal/medical/patient.ts
@@ -13,6 +13,7 @@ import {
   validHl7v2Subscriptions,
 } from "@metriport/core/domain/patient-settings";
 import { MedicalDataSource } from "@metriport/core/external/index";
+import { Config } from "@metriport/core/util/config";
 import { processAsyncError } from "@metriport/core/util/error/shared";
 import { out } from "@metriport/core/util/log";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
@@ -169,7 +170,7 @@ router.get(
         // There's no use for calculating the actual number of subscribers for this route
         return Promise.resolve(-1);
       },
-      isInternal: true,
+      hostUrl: Config.getApiLoadBalancerAddress(),
     });
 
     const response: PaginatedResponse<Hl7v2Subscriber, "patients"> = {

--- a/packages/api/src/routes/pagination.ts
+++ b/packages/api/src/routes/pagination.ts
@@ -152,7 +152,6 @@ function getPaginationUrl(
     }
   }
 
-  console.log("IS INTERNAL IS", isInternal);
   if ("_reconstructedRoute" in req) {
     return getHostUrl(isInternal) + req._reconstructedRoute + "?" + params.toString();
   }


### PR DESCRIPTION
refs. metriport/metriport-internal#2791

### Description
- Fixing a bug on pagination, constructing the proper URL for consecutive requests on internal routes

### Testing

- Local
  - [ ] Run internal GET hl7 subscribers route
  - [ ] Run public GET patient route
- Staging
  - [ ] Run internal GET hl7 subscribers route
  - [ ] Run public GET patient route

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced API routing to support context-aware pagination and URL generation to better distinguish between internal and external requests.
  - Introduced a new optional `hostUrl` parameter for improved request handling in pagination.

- **Chores**
  - Updated documentation for the `paginated` function to include new parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->