### PR TITLE
feat(mllp-server): add posthog analytics to mllp-server

### DIFF
--- a/packages/core/src/external/analytics/posthog.ts
+++ b/packages/core/src/external/analytics/posthog.ts
@@ -14,6 +14,7 @@ export interface EventMessageV1 extends IdentifyMessageV1 {
   groups?: Record<string, string | number>; // Mapping of group type to group id
   sendFeatureFlags?: boolean;
   timestamp?: Date;
+  platform?: string;
 }
 
 const defaultPostHogApiKey = Config.getPostHogApiKey();
@@ -29,7 +30,7 @@ export function analytics(params: EventMessageV1, postApiKey?: string): PostHog 
   params.properties = {
     ...(params.properties ? { ...params.properties } : undefined),
     environment: Config.getEnvType(),
-    platform: "oss-api",
+    platform: params.platform ?? "oss-api",
   };
   params.groups = { [groupType]: params.distinctId };
   posthog.capture(params);
@@ -62,6 +63,7 @@ export enum EventTypes {
   fhirDeduplication = "fhirDeduplication",
   fhirNormalization = "fhirNormalization",
   fhirHydration = "fhirHydration",
+  hl7NotificationReceived = "hl7NotificationReceived",
   consolidatedQuery = "consolidatedQuery",
   inboundPatientDiscovery = "inbound.patientDiscovery",
   inboundDocumentQuery = "inbound.documentQuery",

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -20,6 +20,8 @@ import type { Logger } from "@metriport/core/util/log";
 import { out } from "@metriport/core/util/log";
 import { initSentry } from "./sentry";
 import { withErrorHandling } from "./utils";
+import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
+
 initSentry();
 
 const MLLP_DEFAULT_PORT = 2575;
@@ -79,6 +81,18 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
           }),
           file: Buffer.from(asString(message)),
           contentType: "text/plain",
+        });
+
+        analytics({
+          distinctId: cxId,
+          event: EventTypes.hl7NotificationReceived,
+          properties: {
+            cxId,
+            patientId,
+            messageCode,
+            triggerEvent,
+            platform: "mllp-server",
+          },
         });
       }, logger)
     );


### PR DESCRIPTION
refs. metriport/metriport-internal#2876

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

Ticket: metriport/metriport-internal#2876

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3576

### Description

This PR tracks HL7 message types and codes in posthog by cxid and patient id.

### Testing

- [x] Verified that message appears in posthog ([link](https://us.posthog.com/project/68199/activity/explore#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.triggerEvent%22%2C%22properties.messageCode%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%22-24h%22%2C%22modifiers%22%3A%7B%22usePresortedEventsTable%22%3Atrue%7D%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D))

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tracking for HL7 notification events, allowing for improved analytics on message handling within the MLLP server.
- **Chores**
  - Enhanced analytics event data by including platform information for more detailed reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->