### PR TITLE
api: restricting dob year to 1900 & over only

### DIFF
--- a/packages/shared/src/common/date.ts
+++ b/packages/shared/src/common/date.ts
@@ -65,7 +65,17 @@ export function elapsedTimeFromNow(
 }
 
 export function buildDayjs(date?: ConfigType, format?: string, strict?: boolean): dayjs.Dayjs {
-  return dayjs.utc(date, format, strict);
+  const dayjsObj = dayjs.utc(date, format, strict);
+  
+  // Only check for years less than 1900 if we have a valid date
+  if (date !== undefined && dayjsObj.isValid() && dayjsObj.year() < 1900) {
+    throw new BadRequestError(
+      `Date year cannot be less than 1900`,
+      undefined,
+      { date: typeof date === 'object' ? dayjsObj.format() : date, year: dayjsObj.year() }
+    );
+  }
+  return dayjsObj;
 }
 
 export function sortDate(


### PR DESCRIPTION
Ticket: #3212 

### Description

- Restricting the birth year to 1900 and over only
- If the user enters the year under 1900, the new logic will throw an error

### Testing

- Local
  - [ ] Created a script locally w/ multiple test cases

### Release Plan

- Release in the package
- Merge this