### PR TITLE
Local npm package for driver license verification

### DIFF
--- a/packages/shared/src/validators/driver-license/__tests__/index.test.ts
+++ b/packages/shared/src/validators/driver-license/__tests__/index.test.ts
@@ -1,0 +1,104 @@
+import { isValid, getMatches } from "../index";
+import { ValidationMatch } from "../interfaces";
+
+describe("driver-license-validator", () => {
+  describe("isValid", () => {
+    it("should return true for valid driver license numbers", () => {
+      expect(isValid("A1234567")).toBe(true);
+      expect(isValid("123456789")).toBe(true);
+      expect(isValid("AB12345")).toBe(true);
+      expect(isValid("1234567")).toBe(true);
+    });
+
+    it("should return false for invalid driver license numbers", () => {
+      expect(isValid("")).toBe(false);
+      expect(isValid("invalid_dl")).toBe(false);
+      expect(isValid("AB@123")).toBe(false); // Invalid characters
+      expect(isValid("ABCDEFGHIJKLM")).toBe(false); // Invalid format
+    });
+
+    it("should filter by country", () => {
+      expect(isValid("A1234567", { country: "CA" })).toBe(false);
+      expect(isValid("A123456789", { country: "CA" })).toBe(true);
+    });
+
+    it("should filter by state", () => {
+      expect(isValid("A1234567", { states: "CA" })).toBe(true);
+      expect(isValid("A1234567", { states: "TX" })).toBe(false);
+      expect(isValid("A1234567", { states: ["CA", "NY"] })).toBe(true);
+    });
+
+    it("should respect ignoreCase option", () => {
+      expect(isValid("a1234567")).toBe(false);
+      expect(isValid("a1234567", { ignoreCase: true })).toBe(true);
+    });
+
+    // Massachusetts driver's license formats
+    it("should validate Massachusetts driver's license formats", () => {
+      // Test the "SA + 7 numbers" format (2 letters followed by 7 numbers)
+      expect(isValid("SA1234567", { states: "MA" })).toBe(true);
+      expect(isValid("S12345678", { states: "MA" })).toBe(true);
+      expect(isValid("123456789", { states: "MA" })).toBe(true);
+      expect(isValid("S123456", { states: "MA" })).toBe(false); // Invalid format for MA
+    });
+  });
+
+  describe("getMatches", () => {
+    it("should return matching formats for valid driver license numbers", () => {
+      const matches = getMatches("A1234567");
+      expect(matches).not.toBeNull();
+      
+      if (matches) {
+        expect(Array.isArray(matches)).toBe(true);
+        expect(matches.length).toBeGreaterThan(0);
+        
+        const caMatch = matches.find(m => m.state === "CA");
+        expect(caMatch).toBeDefined();
+        if (caMatch) {
+          expect(caMatch.description).toBe("1 letter followed by 7 numbers");
+        }
+      }
+    });
+
+    it("should return null for invalid driver license numbers", () => {
+      expect(getMatches("invalid_dl")).toBeNull();
+    });
+
+    it("should filter matches by country", () => {
+      const matches = getMatches("A123456789", { country: "CA" });
+      expect(matches).not.toBeNull();
+      
+      if (matches) {
+        matches.forEach(match => {
+          expect(["AB", "BC", "MB", "NB", "NL", "NT", "NS", "NU", "ON", "PE", "QC", "SK", "YT"]).toContain(match.state);
+        });
+      }
+    });
+
+    it("should filter matches by state", () => {
+      const matches = getMatches("A1234567", { states: "CA" });
+      expect(matches).not.toBeNull();
+      
+      if (matches) {
+        expect(matches.length).toBe(1);
+        
+        const firstMatch = matches[0] as ValidationMatch;
+        expect(firstMatch.state).toBe("CA");
+      }
+      
+      const multiMatches = getMatches("A1234567", { states: ["CA", "NY"] });
+      expect(multiMatches).not.toBeNull();
+      
+      if (multiMatches) {
+        expect(multiMatches.length).toBe(2);
+        
+        const stateList = multiMatches.map(m => m.state).sort();
+        expect(stateList).toEqual(["CA", "NY"]);
+      }
+    });
+
+    it("should throw an error for invalid state", () => {
+      expect(() => getMatches("A1234567", { states: "XX" })).toThrow();
+    });
+  });
+});

--- a/packages/shared/src/validators/driver-license/ca-dl.ts
+++ b/packages/shared/src/validators/driver-license/ca-dl.ts
@@ -1,0 +1,85 @@
+import { CountryFormats } from './interfaces';
+
+/**
+ * Canada driver license formats.
+ */
+export const CA_DL: CountryFormats = {
+  AB: [
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  BC: [
+    {
+      regex: /^[0-9]{7}$/,
+      description: '7 numbers',
+    },
+  ],
+  MB: [
+    {
+      regex: /^[A-Z0-9]{12}$/,
+      description: 'any combination of letters or numbers for a total of 12 characters',
+    },
+  ],
+  NB: [
+    {
+      regex: /^[0-9]{5,7}$/,
+      description: '5-7 numbers',
+    },
+  ],
+  NL: [
+    {
+      regex: /^[A-Z]{1}[0-9]{9}$/,
+      description: '1 letter followed by 9 numbers',
+    },
+  ],
+  NT: [
+    {
+      regex: /^[0-9]{6}$/,
+      description: '6 numbers',
+    },
+  ],
+  NS: [
+    {
+      regex: /^[A-Z]{5}[0-9]{9}$/,
+      description: '5 letters followed by 9 numbers',
+    },
+  ],
+  NU: [
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  ON: [
+    {
+      regex: /^[A-Z]{1}[0-9]{14}$/,
+      description: '1 letter followed by 14 numbers',
+    },
+  ],
+  PE: [
+    {
+      regex: /^[0-9]{5,6}$/,
+      description: '5-6 numbers',
+    },
+  ],
+  QC: [
+    {
+      regex: /^[A-Z]{1}[0-9]{12}$/,
+      description: '1 letter followed by 12 numbers',
+    },
+  ],
+  SK: [
+    {
+      regex: /^[0-9]{8}$/,
+      description: '8 numbers',
+    },
+  ],
+  YT: [
+    {
+      regex: /^[0-9]{10}$/,
+      description: '10 numbers',
+    },
+  ],
+};

--- a/packages/shared/src/validators/driver-license/index.ts
+++ b/packages/shared/src/validators/driver-license/index.ts
@@ -1,6 +1,7 @@
-import { US_DL } from './us-dl';
-import { CA_DL } from './ca-dl';
-import { ValidateOptions, ValidationMatch } from './interfaces';
+import { US_DL } from "./us-dl";
+import { CA_DL } from "./ca-dl";
+import { ValidateOptions, ValidationMatch } from "./interfaces";
+import { MetriportError } from "../../error/metriport-error";
 
 /**
  * Supported countries.
@@ -34,17 +35,17 @@ export function getMatches(dl: string, options: ValidateOptions = {}) {
     return null;
   }
 
-  const country = options.country || 'US';
+  const country = options.country || "US";
   const countryFormats = COUNTRIES[country];
 
   if (!countryFormats) {
-    throw new Error(`Country ${country} not supported`);
+    throw new MetriportError(`Country ${country} not supported`, undefined, { country });
   }
 
   // Filter by state if provided
   let states: string[] = [];
   if (options.states) {
-    if (typeof options.states === 'string') {
+    if (typeof options.states === "string") {
       states = [options.states];
     } else {
       states = options.states;
@@ -53,7 +54,10 @@ export function getMatches(dl: string, options: ValidateOptions = {}) {
     // Validate states
     for (const state of states) {
       if (!countryFormats[state]) {
-        throw new Error(`State ${state} not supported for country ${country}`);
+        throw new MetriportError(`State ${state} not supported for country ${country}`, undefined, {
+          state,
+          country,
+        });
       }
     }
   } else {
@@ -66,14 +70,12 @@ export function getMatches(dl: string, options: ValidateOptions = {}) {
   // Check each state
   for (const state of states) {
     const stateFormats = countryFormats[state];
-    
+
     if (!stateFormats) continue;
 
     // Check each format for the state
     for (const format of stateFormats) {
-      const regex = options.ignoreCase
-        ? new RegExp(format.regex.source, 'i')
-        : format.regex;
+      const regex = options.ignoreCase ? new RegExp(format.regex.source, "i") : format.regex;
 
       if (regex.test(dl)) {
         matches.push({

--- a/packages/shared/src/validators/driver-license/index.ts
+++ b/packages/shared/src/validators/driver-license/index.ts
@@ -1,0 +1,89 @@
+import { US_DL } from './us-dl';
+import { CA_DL } from './ca-dl';
+import { ValidateOptions, ValidationMatch } from './interfaces';
+
+/**
+ * Supported countries.
+ */
+const COUNTRIES = {
+  US: US_DL,
+  CA: CA_DL,
+};
+
+/**
+ * Validates if a driver license number is valid.
+ *
+ * @param dl Driver license number
+ * @param options Validation options
+ * @returns True if valid, false otherwise
+ */
+export function isValid(dl: string, options: ValidateOptions = {}) {
+  const result = getMatches(dl, options);
+  return result !== null && result.length > 0;
+}
+
+/**
+ * Gets all matching formats for a driver license number.
+ *
+ * @param dl Driver license number
+ * @param options Validation options
+ * @returns Array of matching formats or null if no matches
+ */
+export function getMatches(dl: string, options: ValidateOptions = {}) {
+  if (!dl) {
+    return null;
+  }
+
+  const country = options.country || 'US';
+  const countryFormats = COUNTRIES[country];
+
+  if (!countryFormats) {
+    throw new Error(`Country ${country} not supported`);
+  }
+
+  // Filter by state if provided
+  let states: string[] = [];
+  if (options.states) {
+    if (typeof options.states === 'string') {
+      states = [options.states];
+    } else {
+      states = options.states;
+    }
+
+    // Validate states
+    for (const state of states) {
+      if (!countryFormats[state]) {
+        throw new Error(`State ${state} not supported for country ${country}`);
+      }
+    }
+  } else {
+    // Use all states if not specified
+    states = Object.keys(countryFormats);
+  }
+
+  const matches: ValidationMatch[] = [];
+
+  // Check each state
+  for (const state of states) {
+    const stateFormats = countryFormats[state];
+    
+    if (!stateFormats) continue;
+
+    // Check each format for the state
+    for (const format of stateFormats) {
+      const regex = options.ignoreCase
+        ? new RegExp(format.regex.source, 'i')
+        : format.regex;
+
+      if (regex.test(dl)) {
+        matches.push({
+          state,
+          description: format.description,
+        });
+        break; // Found a match for this state, move to next state
+      }
+    }
+  }
+
+  return matches.length > 0 ? matches : null;
+}

--- a/packages/shared/src/validators/driver-license/interfaces.ts
+++ b/packages/shared/src/validators/driver-license/interfaces.ts
@@ -24,13 +24,13 @@ export interface ValidationMatch {
 /**
  * Supported country codes.
  */
-export type countryCode = 'US' | 'CA';
+export type CountryCode = 'US' | 'CA';
 
 /**
  * Validate options.
  */
 export interface ValidateOptions {
-  country?: countryCode;
+  country?: CountryCode;
   states?: string | string[];
   ignoreCase?: boolean;
 }

--- a/packages/shared/src/validators/driver-license/interfaces.ts
+++ b/packages/shared/src/validators/driver-license/interfaces.ts
@@ -1,0 +1,36 @@
+/**
+ * Country formats.
+ */
+export interface CountryFormats {
+  [index: string]: DriverLicenseFormat[];
+}
+
+/**
+ * Driver license format.
+ */
+export interface DriverLicenseFormat {
+  regex: RegExp;
+  description: string;
+}
+
+/**
+ * Validation match results.
+ */
+export interface ValidationMatch {
+  state: string;
+  description: string;
+}
+
+/**
+ * Supported country codes.
+ */
+export type CountyCode = 'US' | 'CA';
+
+/**
+ * Validate options.
+ */
+export interface ValidateOptions {
+  country?: CountyCode;
+  states?: string | string[];
+  ignoreCase?: boolean;
+}

--- a/packages/shared/src/validators/driver-license/interfaces.ts
+++ b/packages/shared/src/validators/driver-license/interfaces.ts
@@ -24,13 +24,13 @@ export interface ValidationMatch {
 /**
  * Supported country codes.
  */
-export type CountyCode = 'US' | 'CA';
+export type countryCode = 'US' | 'CA';
 
 /**
  * Validate options.
  */
 export interface ValidateOptions {
-  country?: CountyCode;
+  country?: countryCode;
   states?: string | string[];
   ignoreCase?: boolean;
 }

--- a/packages/shared/src/validators/driver-license/us-dl.ts
+++ b/packages/shared/src/validators/driver-license/us-dl.ts
@@ -1,0 +1,469 @@
+import { CountryFormats } from './interfaces';
+
+/**
+ * USA driver license formats.
+ */
+export const US_DL: CountryFormats = {
+  AL: [
+    {
+      regex: /^[0-9]{1,8}$/,
+      description: '1-8 numbers',
+    },
+  ],
+  AK: [
+    {
+      regex: /^[0-9]{1,7}$/,
+      description: '1-7 numbers',
+    },
+  ],
+  AZ: [
+    {
+      regex: /^[A-Z]{1}[0-9]{8,9}$/,
+      description: '1 letter followed by 8-9 numbers',
+    },
+    {
+      regex: /^[A-Z]{2}[0-9]{2,5}$/,
+      description: '2 letters followed by 2-5 numbers',
+    },
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  AR: [
+    {
+      regex: /^[0-9]{4,9}$/,
+      description: '4-9 numbers',
+    },
+  ],
+  CA: [
+    {
+      regex: /^[A-Z]{1}[0-9]{7}$/,
+      description: '1 letter followed by 7 numbers',
+    },
+  ],
+  CO: [
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+    {
+      regex: /^[A-Z]{1}[0-9]{3,6}$/,
+      description: '1 letter followed by 3-6 numbers',
+    },
+    {
+      regex: /^[A-Z]{2}[0-9]{2,5}$/,
+      description: '2 letters followed by 2-5 numbers',
+    },
+  ],
+  CT: [
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  DE: [
+    {
+      regex: /^[0-9]{1,7}$/,
+      description: '1-7 numbers',
+    },
+  ],
+  DC: [
+    {
+      regex: /^[0-9]{7}$/,
+      description: '7 numbers',
+    },
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  FL: [
+    {
+      regex: /^[A-Z]{1}[0-9]{12}$/,
+      description: '1 letter followed by 12 numbers',
+    },
+  ],
+  GA: [
+    {
+      regex: /^[0-9]{7,9}$/,
+      description: '7-9 numbers',
+    },
+  ],
+  HI: [
+    {
+      regex: /^[A-Z]{1}[0-9]{8}$/,
+      description: '1 letter followed by 8 numbers',
+    },
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  ID: [
+    {
+      regex: /^[A-Z]{2}[0-9]{6}[A-Z]{1}$/,
+      description: '2 letters followed by 6 numbers followed by 1 letter',
+    },
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  IL: [
+    {
+      regex: /^[A-Z]{1}[0-9]{11,12}$/,
+      description: '1 letter followed by 11-12 numbers',
+    },
+  ],
+  IN: [
+    {
+      regex: /^[A-Z]{1}[0-9]{9}$/,
+      description: '1 letter followed by 9 numbers',
+    },
+    {
+      regex: /^[0-9]{9,10}$/,
+      description: '9-10 numbers',
+    },
+  ],
+  IA: [
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+    {
+      regex: /^[0-9]{3}[A-Z]{2}[0-9]{4}$/,
+      description: '3 numbers followed by 2 letters followed by 4 numbers',
+    },
+  ],
+  KS: [
+    {
+      regex: /^([A-Z]{1}[0-9]{1}){2}[A-Z]{1}$/,
+      description: '1 letter then 1 number then 1 letter then 1 number then 1 letter',
+    },
+    {
+      regex: /^[A-Z]{1}[0-9]{8}$/,
+      description: '1 letter followed by 8 numbers',
+    },
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  KY: [
+    {
+      regex: /^[A-Z]{1}[0-9]{8,9}$/,
+      description: '1 letter followed by 8-9 numbers',
+    },
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  LA: [
+    {
+      regex: /^[0-9]{1,9}$/,
+      description: '1-9 numbers',
+    },
+  ],
+  ME: [
+    {
+      regex: /^[0-9]{7}$/,
+      description: '7 numbers',
+    },
+    {
+      regex: /^[0-9]{7}[A-Z]{1}$/,
+      description: '7 numbers followed by 1 letter',
+    },
+    {
+      regex: /^[0-9]{8}$/,
+      description: '8 numbers',
+    },
+  ],
+  MD: [
+    {
+      regex: /^[A-Z]{1}[0-9]{12}$/,
+      description: '1 letter followed by 12 numbers',
+    },
+  ],
+  MA: [
+    {
+      regex: /^[A-Z]{1}[0-9]{8}$/,
+      description: '1 letter followed by 8 numbers',
+    },
+    {
+      regex: /^[A-Z]{2}[0-9]{7}$/,
+      description: '2 letters followed by 7 numbers',
+    },
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  MI: [
+    {
+      regex: /^[A-Z]{1}[0-9]{10}$/,
+      description: '1 letter followed by 10 numbers',
+    },
+    {
+      regex: /^[A-Z]{1}[0-9]{12}$/,
+      description: '1 letter followed by 12 numbers',
+    },
+  ],
+  MN: [
+    {
+      regex: /^[A-Z]{1}[0-9]{12}$/,
+      description: '1 letter followed by 12 numbers',
+    },
+  ],
+  MS: [
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  MO: [
+    {
+      regex: /^[A-Z]{1}[0-9]{5,9}$/,
+      description: '1 letter followed by 5-9 numbers',
+    },
+    {
+      regex: /^[A-Z]{1}[0-9]{6}[R]$/,
+      description: '1 letter followed by 6 numbers followed by "R"',
+    },
+    {
+      regex: /^[0-9]{8}[A-Z]{2}$/,
+      description: '8 numbers followed by 2 letters',
+    },
+    {
+      regex: /^[0-9]{9}[A-Z]{1}$/,
+      description: '9 numbers followed by 1 letter',
+    },
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  MT: [
+    {
+      regex: /^[A-Z]{1}[0-9]{8}$/,
+      description: '1 letter followed by 8 numbers',
+    },
+    {
+      regex: /^[0-9]{13}$/,
+      description: '13 numbers',
+    },
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+    {
+      regex: /^[0-9]{14}$/,
+      description: '14 numbers',
+    },
+  ],
+  NE: [
+    {
+      regex: /^[A-Z]{1}[0-9]{6,8}$/,
+      description: '1 letter followed by 6-8 numbers',
+    },
+  ],
+  NV: [
+    {
+      regex: /^[0-9]{9,10}$/,
+      description: '9-10 numbers',
+    },
+    {
+      regex: /^[0-9]{12}$/,
+      description: '12 numbers',
+    },
+    {
+      regex: /^[X]{1}[0-9]{8}$/,
+      description: '"X" followed by 8 numbers',
+    },
+  ],
+  NH: [
+    {
+      regex: /^[0-9]{2}[A-Z]{3}[0-9]{5}$/,
+      description: '2 numbers followed by 3 letters followed by 5 numbers',
+    },
+  ],
+  NJ: [
+    {
+      regex: /^[A-Z]{1}[0-9]{14}$/,
+      description: '1 letter followed by 14 numbers',
+    },
+  ],
+  NM: [
+    {
+      regex: /^[0-9]{8,9}$/,
+      description: '8-9 numbers',
+    },
+  ],
+  NY: [
+    {
+      regex: /^[A-Z]{1}[0-9]{7}$/,
+      description: '1 letter followed by 7 numbers',
+    },
+    {
+      regex: /^[A-Z]{1}[0-9]{18}$/,
+      description: '1 letter followed by 18 numbers',
+    },
+    {
+      regex: /^[0-9]{8,9}$/,
+      description: '8-9 numbers',
+    },
+    {
+      regex: /^[0-9]{16}$/,
+      description: '16 numbers',
+    },
+    {
+      regex: /^[A-Z]{8}$/,
+      description: '8 letters',
+    },
+  ],
+  NC: [
+    {
+      regex: /^[0-9]{1,12}$/,
+      description: '1-12 numbers',
+    },
+  ],
+  ND: [
+    {
+      regex: /^[A-Z]{3}[0-9]{6}$/,
+      description: '3 letters followed by 6 numbers',
+    },
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  OH: [
+    {
+      regex: /^[A-Z]{1}[0-9]{4,8}$/,
+      description: '1 letter followed by 4-8 numbers',
+    },
+    {
+      regex: /^[A-Z]{2}[0-9]{3,7}$/,
+      description: '2 letters followed by 3-7 numbers',
+    },
+    {
+      regex: /^[0-9]{8}$/,
+      description: '8 numbers',
+    },
+  ],
+  OK: [
+    {
+      regex: /^[A-Z]{1}[0-9]{9}$/,
+      description: '1 letter followed by 9 numbers',
+    },
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  OR: [
+    {
+      regex: /^[0-9]{1,9}$/,
+      description: '1-9 numbers',
+    },
+  ],
+  PA: [
+    {
+      regex: /^[0-9]{8}$/,
+      description: '8 numbers',
+    },
+  ],
+  RI: [
+    {
+      regex: /^[0-9]{7}$/,
+      description: '7 numbers',
+    },
+    {
+      regex: /^[A-Z]{1}[0-9]{6}$/,
+      description: '1 letter followed by 6 numbers',
+    },
+  ],
+  SC: [
+    {
+      regex: /^[0-9]{5,11}$/,
+      description: '5-11 numbers',
+    },
+  ],
+  SD: [
+    {
+      regex: /^[0-9]{6,10}$/,
+      description: '6-10 numbers',
+    },
+    {
+      regex: /^[0-9]{12}$/,
+      description: '12 numbers',
+    },
+  ],
+  TN: [
+    {
+      regex: /^[0-9]{7,9}$/,
+      description: '7-9 numbers',
+    },
+  ],
+  TX: [
+    {
+      regex: /^[0-9]{7,8}$/,
+      description: '7-8 numbers',
+    },
+  ],
+  UT: [
+    {
+      regex: /^[0-9]{4,10}$/,
+      description: '4-10 numbers',
+    },
+  ],
+  VT: [
+    {
+      regex: /^[0-9]{8}$/,
+      description: '8 numbers',
+    },
+    {
+      regex: /^[0-9]{7}[A]$/,
+      description: '7 numbers followed by "A"',
+    },
+  ],
+  VA: [
+    {
+      regex: /^[A-Z]{1}[0-9]{8,11}$/,
+      description: '1 letter followed by 8-11 numbers',
+    },
+    {
+      regex: /^[0-9]{9}$/,
+      description: '9 numbers',
+    },
+  ],
+  WA: [
+    {
+      regex: /^(?=.{12}$)[A-Z]{1,7}[A-Z0-9\\*]{4,11}$/,
+      description: '1-7 letters followed by any combination of letters, numbers, or "*" for a total of 12 characters',
+    },
+  ],
+  WV: [
+    {
+      regex: /^[0-9]{7}$/,
+      description: '7 numbers',
+    },
+    {
+      regex: /^[A-Z]{1,2}[0-9]{5,6}$/,
+      description: '1-2 letters followed by 5-6 numbers',
+    },
+  ],
+  WI: [
+    {
+      regex: /^[A-Z]{1}[0-9]{13}$/,
+      description: '1 letter followed by 13 numbers',
+    },
+  ],
+  WY: [
+    {
+      regex: /^[0-9]{9,10}$/,
+      description: '9-10 numbers',
+    },
+  ],
+};


### PR DESCRIPTION
Ticket: #1990

### Description
- Creating a localized version of the npm library `driver-license-validator`
- Adding support for Massachusetts DLs (SA + 7 numbers format) as the original library did not support that
- The original library hadn't been updated in over 3 years. Building the library locally would diffuse any security risks

### Testing
- Local
  - Tested the implementation using localized unit tests

### Release Plan

- [ ] Release NPM packages: `metriport/shared`
- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced driver license validation supporting U.S. and Canadian formats.
	- Added flexible filtering by country and state along with case sensitivity options.
- **Tests**
	- Implemented a comprehensive test suite covering various valid formats, matching criteria, and error scenarios to ensure robust functionality.
- **Interfaces**
	- Added new interfaces and types for better structure and validation options related to driver license formats.
- **Constants**
	- Defined constants for Canadian and U.S. driver license formats to facilitate validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->