### PR TITLE
PATCH get link oid

### DIFF
--- a/packages/api/src/external/commonwell/shared.ts
+++ b/packages/api/src/external/commonwell/shared.ts
@@ -118,6 +118,5 @@ function isCommonwellEnabledForPatient(patient: Patient): boolean {
 }
 
 export function getLinkOid(link: CwLink): string | undefined {
-  return link.patient?.details.identifier?.find(identifier => identifier.assigner !== "Commonwell")
-    ?.system;
+  return link.patient?.identifier?.find(identifier => identifier.assigner !== "Commonwell")?.system;
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Dependencies

- Upstream: none
- Downstream: none

### Description

- Issue with unlinking where we were removing all links in cw and it was because when we went to get oid it was finding in the wrong place and always undefined.

### Testing

- Local
  - [x] Filters out CW link
- Production
  - [ ] Filters out CW link


### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the system’s internal process for retrieving patient identifiers to enhance overall data handling efficiency.
	- These behind-the-scenes improvements help maintain smooth and reliable functionality, ensuring users continue to experience consistent performance with no noticeable changes to their current workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->