### PR TITLE
1040 Add network retries to CW requests

### DIFF
--- a/packages/api/src/external/commonwell/admin/find-patient-duplicates.ts
+++ b/packages/api/src/external/commonwell/admin/find-patient-duplicates.ts
@@ -5,6 +5,7 @@ import {
   Person,
 } from "@metriport/commonwell-sdk";
 import { Patient } from "@metriport/core/domain/patient";
+import { executeWithRetriesCw } from "@metriport/core/external/commonwell/shared";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import { sleepRandom } from "@metriport/shared";
@@ -117,7 +118,10 @@ export async function findDuplicatedPersonsByPatient(
     const { queryMeta, cwPatientId, cwPersonId: storedPersonId } = cwAccess;
     commonWell = cwAccess.commonWell;
 
-    const respSearch = await commonWell.searchPersonByPatientDemo(queryMeta, cwPatientId);
+    const cwApi: CommonWellAPI = commonWell; // makes the compiler happy inside executeWithRetriesCw
+    const respSearch = await executeWithRetriesCw(() =>
+      cwApi.searchPersonByPatientDemo(queryMeta, cwPatientId)
+    );
 
     const persons = respSearch._embedded?.person
       ? respSearch._embedded.person.flatMap(p => (p && getPersonId(p) ? p : []))

--- a/packages/api/src/external/commonwell/admin/recreate-patients-at-hies.ts
+++ b/packages/api/src/external/commonwell/admin/recreate-patients-at-hies.ts
@@ -2,6 +2,7 @@ import { CommonWellAPI, organizationQueryMeta } from "@metriport/commonwell-sdk"
 import { isCWEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { addOidPrefix } from "@metriport/core/domain/oid";
 import { Patient } from "@metriport/core/domain/patient";
+import { executeWithRetriesCw } from "@metriport/core/external/commonwell/shared";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import { groupBy } from "lodash";
@@ -149,7 +150,8 @@ export async function recreatePatientAtCW(
 
       // remove old patient
       log(`Deleting old patient from CW...`);
-      await commonWell.deletePatient(queryMeta, originalCWPatientId);
+      const cwApi: CommonWellAPI = commonWell; // makes the compiler happy inside executeWithRetriesCw
+      await executeWithRetriesCw(() => cwApi.deletePatient(queryMeta, originalCWPatientId));
     }
 
     return { originalCWPatientId, newCWPatientId };

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -16,6 +16,7 @@ import { addOidPrefix } from "@metriport/core/domain/oid";
 import { Patient } from "@metriport/core/domain/patient";
 import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
 import { DownloadResult } from "@metriport/core/external/commonwell/document/document-downloader";
+import { executeWithRetriesCw } from "@metriport/core/external/commonwell/shared";
 import { MedicalDataSource } from "@metriport/core/external/index";
 import { processAsyncError } from "@metriport/core/util/error/shared";
 import { out } from "@metriport/core/util/log";
@@ -313,7 +314,9 @@ export async function internalGetDocuments({
   const cwErrs: OperationOutcome[] = [];
   const queryStart = Date.now();
   try {
-    const queryResponse = await commonWell.queryDocumentsFull(queryMeta, cwData.patientId);
+    const queryResponse = await executeWithRetriesCw(() =>
+      commonWell.queryDocumentsFull(queryMeta, cwData.patientId)
+    );
     reportDocQueryMetric(queryStart);
     debug(`resp queryDocumentsFull: ${JSON.stringify(queryResponse)}`);
 

--- a/packages/api/src/external/commonwell/link/get.ts
+++ b/packages/api/src/external/commonwell/link/get.ts
@@ -16,6 +16,7 @@ import { AdditionalInfo } from "@metriport/commonwell-sdk/common/commonwell-erro
 import { isCWEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { addOidPrefix } from "@metriport/core/domain/oid";
 import { Patient } from "@metriport/core/domain/patient";
+import { executeWithRetriesCw } from "@metriport/core/external/commonwell/shared";
 import { errorToString } from "@metriport/core/util/error/shared";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
@@ -269,7 +270,9 @@ async function findNetworkLinks(
   if (!patientCWData) return undefined;
   const { log } = out("cw.findNetworkLinks");
 
-  const respLinks = await commonWell.getNetworkLinks(queryMeta, patientCWData.patientId);
+  const respLinks = await executeWithRetriesCw(() =>
+    commonWell.getNetworkLinks(queryMeta, patientCWData.patientId)
+  );
   const allLinks = respLinks._embedded.networkLink
     ? respLinks._embedded.networkLink.flatMap(filterTruthy)
     : [];

--- a/packages/api/src/external/commonwell/organization.ts
+++ b/packages/api/src/external/commonwell/organization.ts
@@ -3,6 +3,7 @@ import { isEnhancedCoverageEnabledForCx } from "@metriport/core/command/feature-
 import { OID_PREFIX } from "@metriport/core/domain/oid";
 import { Organization, OrgType } from "@metriport/core/domain/organization";
 import { getOrgsByPrio } from "@metriport/core/external/commonwell/cq-bridge/get-orgs";
+import { executeWithRetriesCw } from "@metriport/core/external/commonwell/shared";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import { errorToString, NotFoundError, USState } from "@metriport/shared";
@@ -97,7 +98,7 @@ export async function get(orgOid: string): Promise<CWSdkOrganization | undefined
 
   const commonWell = makeCommonWellAPI(Config.getCWMemberOrgName(), Config.getCWMemberOID());
   try {
-    const resp = await commonWell.getOneOrg(metriportQueryMeta, cwId);
+    const resp = await executeWithRetriesCw(() => commonWell.getOneOrg(metriportQueryMeta, cwId));
     debug(`resp getOneOrg: `, JSON.stringify(resp));
     return resp;
   } catch (error) {
@@ -159,10 +160,8 @@ export async function update(cxId: string, org: CWOrganization, isObo = false): 
 
   const commonWell = makeCommonWellAPI(Config.getCWMemberOrgName(), Config.getCWMemberOID());
   try {
-    const resp = await commonWell.updateOrg(
-      metriportQueryMeta,
-      commonwellOrg,
-      commonwellOrg.organizationId
+    const resp = await executeWithRetriesCw(() =>
+      commonWell.updateOrg(metriportQueryMeta, commonwellOrg, commonwellOrg.organizationId)
     );
     debug(`resp updateOrg: `, JSON.stringify(resp));
     //eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/api/src/external/hie/validate-patient-links.ts
+++ b/packages/api/src/external/hie/validate-patient-links.ts
@@ -1,10 +1,10 @@
+import { isStrictMatchingAlgorithmEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { PatientData } from "@metriport/core/domain/patient";
 import { epicMatchingAlgorithm, strictMatchingAlgorithm } from "@metriport/core/mpi/match-patients";
-import { isStrictMatchingAlgorithmEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
+import { CQLink } from "../carequality/cq-patient-data";
+import { cqLinkToPatientData } from "../carequality/shared";
 import { CwLink } from "../commonwell/cw-patient-data";
 import { cwLinkToPatientData } from "../commonwell/link/shared";
-import { cqLinkToPatientData } from "../carequality/shared";
-import { CQLink } from "../carequality/cq-patient-data";
 
 const SIMILARITY_THRESHOLD = 8.5;
 

--- a/packages/core/src/external/commonwell/document/document-downloader-local.ts
+++ b/packages/core/src/external/commonwell/document/document-downloader-local.ts
@@ -13,6 +13,7 @@ import { detectFileType, isContentTypeAccepted } from "../../../util/file-type";
 import { out } from "../../../util/log";
 import { isMimeTypeXML } from "../../../util/mime";
 import { makeS3Client, S3Utils } from "../../aws/s3";
+import { executeWithRetriesCw } from "../shared";
 import {
   Document,
   DocumentDownloader,
@@ -291,9 +292,8 @@ export class DocumentDownloaderLocal extends DocumentDownloader {
     stream: stream.Writable;
   }): Promise<void> {
     try {
-      await executeWithNetworkRetries(
-        () => this.cwApi.retrieveDocument(this.cwQueryMeta, location, stream),
-        { retryOnTimeout: true, maxAttempts: 5, initialDelay: 500 }
+      await executeWithRetriesCw(() =>
+        this.cwApi.retrieveDocument(this.cwQueryMeta, location, stream)
       );
     } catch (error) {
       const { details, code, status } = getNetworkErrorDetails(error);

--- a/packages/core/src/external/commonwell/shared.ts
+++ b/packages/core/src/external/commonwell/shared.ts
@@ -1,0 +1,13 @@
+import { executeWithNetworkRetries, ExecuteWithNetworkRetriesOptions } from "@metriport/shared";
+
+export async function executeWithRetriesCw<T>(
+  fn: () => Promise<T>,
+  options?: Partial<ExecuteWithNetworkRetriesOptions>
+): Promise<T> {
+  const defaultOptions: Partial<ExecuteWithNetworkRetriesOptions> = {
+    retryOnTimeout: true,
+    initialDelay: 500,
+    maxAttempts: 5,
+  };
+  return executeWithNetworkRetries(fn, { ...defaultOptions, ...options });
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Add network retries to most requests to CW.

Context is that we constantly have networking errors from CW. This makes the integration more reliable and results in less work for us on the ops side.

### Testing

...WIP

- Local
  - [ ] 
- Staging
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Sandbox
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Production
  - [ ] _testing step 1_
  - [ ] _testing step 2_

_[Release PRs:]_

Check each PR.

### Release Plan

_[How does the changes on this PR impact/interact with the existing environment (database, configs, secrets, FFs, api contracts, etc.)?
Consider creating 2+ PRs if we need to ship those changes in a staged way]_

_[This is the release plan for production]_

_[You should execute the exact same steps when releasing to staging to validate it works]_

_[Add and remove items below accordingly]_

- :warning: Points to `master`
- :warning: This contains a DB migration
- [ ] Maintenance window scheduled/created at Checkly (if needed)
- [ ] Execute this on <env1>, <env2>
  - [ ] _step1_
  - [ ] _step2_
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (deprecates a feature that needs to be communicated with customers)
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (introduce a feature that would be useful customers)
- [ ] Upstream dependencies are met/released
- [ ] Release NPM packages
- [ ] Fern Definition Updated
- [ ] Release Fern SDKs
- [ ] FFs have been set in Staging, Production, and Sandbox
- [ ] No dependencies between API and Infra that will cause errors during deployment
- [ ] _[action n-1]_
- [ ] _[action n]_
- [ ] Merge this
