### PR TITLE
1040 Add a make NPI util

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,7 +36,8 @@
     "uuidv7": "ts-node src/make-uuidv7",
     "cda-to-html": "ts-node --files src/customer-requests/cda-to-html.ts",
     "saml-server": "ts-node src/saml/saml-server",
-    "load-test": "artillery run ./src/terminology/load-test.yml"
+    "load-test": "artillery run ./src/terminology/load-test.yml",
+    "npi": "ts-node src/facility/make-npi"
   },
   "keywords": [],
   "author": "",

--- a/packages/utils/src/facility/make-npi.ts
+++ b/packages/utils/src/facility/make-npi.ts
@@ -1,0 +1,15 @@
+import { makeNPI } from "@metriport/shared/common/__tests__/npi";
+
+/**
+ * Generate 10 random NPI numbers and print them to the console.
+ *
+ * Run with:
+ * > npm run make-npi
+ */
+export function main() {
+  for (let i = 0; i < 10; i++) {
+    console.log(makeNPI());
+  }
+}
+
+main();


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

none

### Description

Add a utility to generate mock NPI numbers for testing purposes.

### Testing

- Local
  - [x] Generates 10 random NPIs
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new command that generates and displays 10 random National Provider Identifier (NPI) numbers in the console for quick data testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->