### PR TITLE
PATCH: Downgrade invalid links

### DIFF
--- a/packages/api/src/command/hie/unlink-patient-from-organization.ts
+++ b/packages/api/src/command/hie/unlink-patient-from-organization.ts
@@ -351,7 +351,7 @@ async function findAndInvalidateLinks(
       );
     }
 
-    await Promise.all([
+    await Promise.allSettled([
       createOrUpdateInvalidLinks({ id: patientId, cxId, invalidLinks }),
       updateCQPatientData({ id: patientId, cxId, cqLinksToInvalidate: invalidLinks.carequality }),
       updateCwPatientData({ id: patientId, cxId, cwLinksToInvalidate: invalidLinks.commonwell }),

--- a/packages/api/src/command/hie/unlink-patient-from-organization.ts
+++ b/packages/api/src/command/hie/unlink-patient-from-organization.ts
@@ -329,7 +329,10 @@ async function findAndInvalidateLinks(
 
     const patient = await getPatientOrFail({ cxId, id: patientId });
     const cwAccess = await getCWAccessForPatient(patient);
-    if (cwAccess.error != null) throw new MetriportError(cwAccess.error);
+    if (cwAccess.error != null)
+      throw new MetriportError("Error invalidating CW link", undefined, {
+        reason: cwAccess.error,
+      });
     const { commonWell, queryMeta } = cwAccess;
 
     const downgradeRequests: Promise<NetworkLink>[] = [];


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

Ticket: #_[ticket-number]_

### Dependencies

- Upstream: none
- Downstream: none

### Description

- Need to downgrade links so dont get documents from those documents

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced validation and access verification steps during patient unlinking.
	- Introduced automatic management of network connection adjustments in unlink operations.
	- Improved error handling and logging ensure a more robust, consistent unlinking process for smoother operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->