### PR TITLE
feat: modifying the utility function to better handle < 1900 years

### DIFF
--- a/packages/shared/src/common/__tests__/date.test.ts
+++ b/packages/shared/src/common/__tests__/date.test.ts
@@ -11,6 +11,23 @@ describe("shared date functions", () => {
       expect(isValidISODate("2024-12-18T03:50:00.006Z")).toEqual(true);
       expect(isValidISODate("2024-12-18T04:18:01.263Z")).toEqual(true);
     });
+
+    it("returns false for non-ISO format dates", () => {
+      expect(isValidISODate("12/25/2023")).toBe(false);
+      expect(isValidISODate("25-12-2023")).toBe(false);
+      expect(isValidISODate("2023.12.25")).toBe(false);
+      expect(isValidISODate("Dec 25, 2023")).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isValidISODate("")).toBe(false);
+    });
+
+    it("returns false for invalid dates", () => {
+      expect(isValidISODate("2023-13-01")).toBe(false);
+      expect(isValidISODate("2023-12-32")).toBe(false);
+      expect(isValidISODate("not-a-date")).toBe(false);
+    });
   });
 
   describe("validateIsPastOrPresentSafe", () => {
@@ -46,11 +63,8 @@ describe("validateDateIsAfter1900", () => {
     expect(validateDateIsAfter1900("1900-01-01")).toBe(true);
   });
 
-  it("returns false for 0007-01-01", () => {
+  it("returns false for dates with years less than 1000", () => {
     expect(validateDateIsAfter1900("0007-01-01")).toBe(false);
-  });
-
-  it("returns false for 0014-01-01", () => {
     expect(validateDateIsAfter1900("0014-01-01")).toBe(false);
   });
 });

--- a/packages/shared/src/common/__tests__/date.test.ts
+++ b/packages/shared/src/common/__tests__/date.test.ts
@@ -45,6 +45,14 @@ describe("validateDateIsAfter1900", () => {
   it("returns true for 1900-01-01", () => {
     expect(validateDateIsAfter1900("1900-01-01")).toBe(true);
   });
+
+  it("returns false for 0007-01-01", () => {
+    expect(validateDateIsAfter1900("0007-01-01")).toBe(false);
+  });
+
+  it("returns false for 0014-01-01", () => {
+    expect(validateDateIsAfter1900("0014-01-01")).toBe(false);
+  });
 });
 
 describe("buildDayjsFromCompactDate", () => {

--- a/packages/shared/src/common/date.ts
+++ b/packages/shared/src/common/date.ts
@@ -9,7 +9,8 @@ export const ISO_DATE = "YYYY-MM-DD";
 
 /** @see https://day.js.org/docs/en/parse/is-valid  */
 export function isValidISODate(date: string): boolean {
-  return buildDayjs(date, ISO_DATE, true).isValid();
+  const isoRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/; // Matches dates like: 2023-12-18T03:50:00.123Z
+  return isoRegex.test(date) && dayjs.utc(date, ISO_DATE, true).isValid();
 }
 
 function isValidISODateOptional(date: string | undefined | null): boolean {

--- a/packages/shared/src/common/date.ts
+++ b/packages/shared/src/common/date.ts
@@ -32,9 +32,8 @@ export function validateIsPastOrPresentSafe(date: string): boolean {
 }
 
 export function validateDateIsAfter1900(date: string): boolean {
-  const dateToCheck = buildDayjs(date);
-  const year1900 = buildDayjs("1900-01-01");
-  return dateToCheck.isSame(year1900) || dateToCheck.isAfter(year1900);
+  const yearToCheck = date.split("-")[0];
+  return Number(yearToCheck) >= 1900;
 }
 
 export function validateDateRange(start: string, end: string): boolean {

--- a/packages/shared/src/common/date.ts
+++ b/packages/shared/src/common/date.ts
@@ -17,7 +17,13 @@ function isValidISODateOptional(date: string | undefined | null): boolean {
 }
 
 export function validateDateOfBirth(date: string): boolean {
-  return validateIsPastOrPresent(date) && validateDateIsAfter1900(date);
+  const parsedDate = buildDayjs(date);
+  if (!parsedDate.isValid()) return false;
+
+  return (
+    validateIsPastOrPresent(parsedDate.format(ISO_DATE)) &&
+    validateDateIsAfter1900(parsedDate.format(ISO_DATE))
+  );
 }
 
 export function validateIsPastOrPresent(date: string): boolean {


### PR DESCRIPTION
Ticket: #3212 

### Description

- Restricting the birth year to 1900 and over only
- If the user enters the year under 1900, the new logic will throw an error

### Testing

- Local
  - [ ] Unit tests

### Release Plan

- Release in the package
- Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved date validation to more accurately identify valid ISO 8601 date formats and reject invalid or incorrectly formatted dates.
	- Enhanced validation to ensure dates of birth are properly checked for validity and for being after the year 1900.

- **Tests**
	- Added comprehensive test cases for date validation functions, covering a wider range of invalid and non-ISO date formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->