### PR TITLE
PATCH RELEASE Don't log details on CW inbound

### DIFF
--- a/packages/api/src/external/commonwell/proxy/cw-process-request.ts
+++ b/packages/api/src/external/commonwell/proxy/cw-process-request.ts
@@ -47,11 +47,11 @@ const allowedQueryParams = ["status", "date", "_summary"];
  */
 export async function processRequest(req: Request): Promise<Bundle<Resource>> {
   const { cxId, patientId } = await getPatientAndCxFromRequest(req);
-  const { log } = out(`${proxyPrefix} request - cxId ${cxId}, patient ${patientId}`);
+  const { log, debug } = out(`${proxyPrefix} request - cxId ${cxId}, patient ${patientId}`);
   log(`ORIGINAL URL: ${req.url}`);
   const { resource, count, params } = fromHttpRequestToFHIR(req);
 
-  log(`UPDATED resource: ${resource} / count : ${count} / params: ${params.toString()}`);
+  debug(`UPDATED resource: ${resource} / count : ${count} / params: ${params.toString()}`);
 
   const patient = await getPatientOrFail({ id: patientId, cxId });
   const organization = await getOrganizationOrFail({ cxId });
@@ -73,11 +73,7 @@ export async function processRequest(req: Request): Promise<Bundle<Resource>> {
   }
 
   const bundle = prepareBundle([patientResource, ...docRefs], params);
-  log(
-    `Responding to CW (cx ${cxId} / patient ${patientId}): ${
-      bundle.entry?.length
-    } resources - ${JSON.stringify(bundle)}`
-  );
+  log(`Responding to CW (cx ${cxId} / patient ${patientId}): ${bundle.entry?.length} resources`);
   return bundle;
 }
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Dependencies

none

### Description

Don't log details on CW inbound - [context](https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#logsV2:log-groups/log-group/APIInfrastructureStack-APIFargateServiceTaskDefAPIServerLogGroup35E9518F-7A2oRfufKv3Z/log-events/APIFargateService$252FAPI-Server$252Fb7dcb4471c3e4c9ca4654a50450e3868$3Fstart$3D1744655004888$26refEventId$3D38907106725578561369375905278133032124222879801053413379).

### Testing

none

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined diagnostic messaging to provide clearer insights during system operations. End users will experience the same consistent functionality while these behind‑the‑scenes refinements improve monitoring and maintenance efforts. Overall, the update contributes to a more robust system with no noticeable impact on external features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->