### PR TITLE
fix(shared): add nicer timer util

### DIFF
--- a/packages/shared/src/common/timer.ts
+++ b/packages/shared/src/common/timer.ts
@@ -1,0 +1,9 @@
+import { elapsedTimeFromNow } from "./date";
+
+export function initTimer() {
+  const startedAt = new Date();
+  return {
+    getStartedAt: () => startedAt,
+    getElapsedTime: () => elapsedTimeFromNow(startedAt),
+  };
+}


### PR DESCRIPTION
refs. metriport/metriport-internal#0000

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>


### Dependencies

Nonw

### Description

A nicer timer util. Use as follows

```
const { getElapsedTime } = initTimer()
// do stuff part 1
// ...
log(`Doing  stuff p1 took ${getElapsedTime()} ms`)

// do stuff part 2
// ...
log(`Doing  stuff p2 took ${getElapsedTime()} ms`)
```

### Testing

None

### Release Plan

- [ ] Merge this
