### PR TITLE
fix(core): hooking up the coding normalization to the flow

### DIFF
--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-coding.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-coding.test.ts
@@ -70,7 +70,6 @@ describe("normalizeCodeableConcept", () => {
     const normalized = normalizeCodeableConcept(concept);
     expect(normalized.coding).toHaveLength(1);
     expect(normalized.coding?.[0]).toEqual({ system: CPT_URL, code: "456", display: "Cpt Term" });
-    expect(normalized.coding?.[1]).toEqual({ system: SNOMED_URL });
   });
 
   it("should not set text if highest priority coding has no display", () => {

--- a/packages/core/src/external/fhir/normalization/coding.ts
+++ b/packages/core/src/external/fhir/normalization/coding.ts
@@ -46,7 +46,9 @@ function normalizeResource(resource: Resource): void {
 export function normalizeCodeableConcept(concept: CodeableConcept): CodeableConcept {
   if (!concept.coding) return concept;
   const codings = concept.coding;
-  const filteredCodings = codings.length > 1 ? codings.filter(isValidCoding) : codings;
+  const normalizedCodings = codings.flatMap(normalizeCoding);
+  const filteredCodings =
+    normalizedCodings.length > 1 ? normalizedCodings.filter(isValidCoding) : normalizedCodings;
   const sortedCodings = [...filteredCodings].sort((a, b) => rankCoding(a) - rankCoding(b));
   const replacementText = sortedCodings.find(c => c.display && isUsefulDisplay(c.display))?.display;
 


### PR DESCRIPTION
refs. metriport/metriport-internal#2837

### Description
- The coding normalization function wasn't actually hooked up to the flow 🤦‍♂️ 

### Testing

- Local
  - [x] Run on patient data  and confirm results
- Production
  - [ ] Reprocess some patients that had issues


### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of multiple codings within codeable concepts to ensure more consistent normalization and filtering.
	- Enhanced processing of codings with empty codes to better preserve or filter entries based on display presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->