### PR TITLE
1040 Remove unused FHIRConverter Queue and DLQ

### DIFF
--- a/packages/infra/lib/api-stack/fhir-converter-connector.ts
+++ b/packages/infra/lib/api-stack/fhir-converter-connector.ts
@@ -106,7 +106,6 @@ export function create({
 }): FHIRConverterConnector {
   const { queue, dlq, bucket } = createQueueAndBucket({
     stack,
-    lambdaLayers,
     envType,
     alarmSnsAction,
   });
@@ -135,12 +134,10 @@ export function create({
 
 export function createQueueAndBucket({
   stack,
-  lambdaLayers,
   envType,
   alarmSnsAction,
 }: {
   stack: Construct;
-  lambdaLayers: LambdaLayers;
   envType: EnvType;
   alarmSnsAction?: SnsAction;
 }): Omit<FHIRConverterConnector, "lambda"> {
@@ -152,22 +149,6 @@ export function createQueueAndBucket({
     maxMessageCountAlarmThreshold,
     alarmMaxAgeOfOldestMessage,
   } = settings();
-  // TODO remove this after the release of the new ConversionResultNotifier connector (queue/lambda)
-  defaultCreateQueue({
-    stack,
-    name: "FHIRConverter2",
-    // To use FIFO we'd need to change the lambda code to set visibilityTimeout=0 on messages to be
-    // reprocessed, instead of re-enqueueing them (bc of messageDeduplicationId visibility of 5min)
-    fifo: false,
-    visibilityTimeout,
-    maxReceiveCount,
-    createRetryLambda: true,
-    lambdaLayers: [lambdaLayers.shared],
-    envType,
-    alarmSnsAction,
-    alarmMaxAgeOfOldestMessage,
-    maxMessageCountAlarmThreshold,
-  });
   const queue = defaultCreateQueue({
     stack,
     name: connectorName,


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3611
- Downstream: none

### Description

Remove unused FHIRConverter Queue and DLQ. See upstream's release plan.

### Testing

- Local
  - none
- Staging
  - [ ] FHIRConverter2Queue and FHIRConverter2DLQ removed
  - [ ] FHIRConverter2_Retry_Lambda removed
  - [ ] FHIRConverterQueue and FHIRConverterDLQ still there
  - [ ] FHIR conversion works
- Sandbox
  - none
- Production
  - [ ] FHIRConverter2Queue and FHIRConverter2DLQ removed
  - [ ] FHIRConverter2_Retry_Lambda removed
  - [ ] FHIRConverterQueue and FHIRConverterDLQ still there

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified queue and bucket creation logic by removing obsolete parameters and unused code. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->