### PR TITLE
fix(core): using hl7 formatted message timestamp + adding message id

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/encounter.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/encounter.ts
@@ -1,15 +1,15 @@
 import { Hl7Message } from "@medplum/core";
 import { Coding, Encounter, Resource } from "@medplum/fhirtypes";
 import { buildPatientReference } from "../../../../external/fhir/shared/references";
-import { Hl7MessageIdentifier, getHl7MessageIdentifierOrFail } from "../msh";
+import { Hl7MessageIdentifier, getHl7MessageTypeIdentifierOrFail } from "../msh";
 import { getAdmitReason } from "./condition";
 import { getLocationFromAdt } from "./location";
 import { DEFAULT_ENCOUNTER_CLASS, adtToFhirEncounterClassMap, isAdtPatientClass } from "./mappings";
 import { getParticipantsFromAdt } from "./practitioner";
-import { createEncounterId, getPatientClassCode, getEncounterPeriod } from "./utils";
+import { createEncounterId, getEncounterPeriod, getPatientClassCode } from "./utils";
 
 export function mapEncounterAndRelatedResources(adt: Hl7Message, patientId: string): Resource[] {
-  const msgIdentifier = getHl7MessageIdentifierOrFail(adt);
+  const msgIdentifier = getHl7MessageTypeIdentifierOrFail(adt);
   const status = getPatientStatus(msgIdentifier);
   const encounterClass = getEncounterClass(adt);
   const period = getEncounterPeriod(adt);

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/encounter.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/encounter.ts
@@ -1,7 +1,7 @@
 import { Hl7Message } from "@medplum/core";
 import { Coding, Encounter, Resource } from "@medplum/fhirtypes";
 import { buildPatientReference } from "../../../../external/fhir/shared/references";
-import { Hl7MessageIdentifier, getHl7MessageTypeIdentifierOrFail } from "../msh";
+import { Hl7MessageType, getHl7MessageTypeOrFail } from "../msh";
 import { getAdmitReason } from "./condition";
 import { getLocationFromAdt } from "./location";
 import { DEFAULT_ENCOUNTER_CLASS, adtToFhirEncounterClassMap, isAdtPatientClass } from "./mappings";
@@ -9,8 +9,8 @@ import { getParticipantsFromAdt } from "./practitioner";
 import { createEncounterId, getEncounterPeriod, getPatientClassCode } from "./utils";
 
 export function mapEncounterAndRelatedResources(adt: Hl7Message, patientId: string): Resource[] {
-  const msgIdentifier = getHl7MessageTypeIdentifierOrFail(adt);
-  const status = getPatientStatus(msgIdentifier);
+  const msgType = getHl7MessageTypeOrFail(adt);
+  const status = getPatientStatus(msgType);
   const encounterClass = getEncounterClass(adt);
   const period = getEncounterPeriod(adt);
   const participants = getParticipantsFromAdt(adt);
@@ -53,7 +53,7 @@ export function mapEncounterAndRelatedResources(adt: Hl7Message, patientId: stri
  *
  * @see {@link https://hl7.org/fhir/R4/valueset-encounter-status.html}
  */
-function getPatientStatus(messageType: Hl7MessageIdentifier): NonNullable<Encounter["status"]> {
+function getPatientStatus(messageType: Hl7MessageType): NonNullable<Encounter["status"]> {
   switch (messageType.triggerEvent) {
     case "A01":
       return "in-progress";

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/utils.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/utils.ts
@@ -9,7 +9,6 @@ import {
   getOptionalValueFromSegment,
   getSegmentByNameOrFail,
   mapHl7SystemNameToSystemUrl,
-  unpackPidFieldOrFail,
 } from "../shared";
 import { buildConditionCoding } from "./condition";
 
@@ -118,10 +117,4 @@ export function createEncounterId(adt: Hl7Message, patientId: string) {
   }
 
   return uuidv7();
-}
-
-export function getPatientIdsOrFail(msg: Hl7Message): { cxId: string; patientId: string } {
-  const pid = getSegmentByNameOrFail(msg, "PID");
-  const idComponent = pid.getComponent(3, 1);
-  return unpackPidFieldOrFail(idComponent);
 }

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
@@ -6,7 +6,7 @@ import { BundleWithEntry, buildBundleFromResources } from "../../../external/fhi
 import { buildDocIdFhirExtension } from "../../../external/fhir/shared/extensions/doc-id-extension";
 import { capture, out } from "../../../util";
 import { mapEncounterAndRelatedResources } from "./adt/encounter";
-import { getHl7MessageTypeIdentifierOrFail } from "./msh";
+import { getHl7MessageTypeOrFail } from "./msh";
 import { buildHl7MessageFileKey } from "./shared";
 
 export type Hl7ToFhirParams = {
@@ -31,18 +31,18 @@ export function convertHl7v2MessageToFhir({
   log("Beginning conversion.");
 
   const startedAt = new Date();
-  const msgIdentifier = getHl7MessageTypeIdentifierOrFail(hl7Message);
+  const msgType = getHl7MessageTypeOrFail(hl7Message);
 
   const filePath = buildHl7MessageFileKey({
     cxId,
     patientId,
     timestamp: timestampString,
     messageId,
-    messageType: msgIdentifier.triggerEvent,
-    messageCode: msgIdentifier.messageType,
+    messageType: msgType.triggerEvent,
+    messageCode: msgType.messageType,
   });
 
-  if (msgIdentifier.messageType === "ADT") {
+  if (msgType.messageType === "ADT") {
     const resources = mapEncounterAndRelatedResources(hl7Message, patientId);
     const bundle = buildBundleFromResources({ type: "collection", resources });
     const duration = elapsedTimeFromNow(startedAt);
@@ -52,12 +52,12 @@ export function convertHl7v2MessageToFhir({
   }
 
   const msg = "HL7 message type isn't supported";
-  log(`${msg} ${msgIdentifier.messageType}. Skipping conversion.`);
+  log(`${msg} ${msgType.messageType}. Skipping conversion.`);
 
   const extraProps = {
     patientId,
     cxId,
-    messageType: JSON.stringify(msgIdentifier),
+    messageType: JSON.stringify(msgType),
   };
 
   capture.message(msg, {

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
@@ -38,8 +38,8 @@ export function convertHl7v2MessageToFhir({
     patientId,
     timestamp: timestampString,
     messageId,
-    messageType: msgType.triggerEvent,
-    messageCode: msgType.messageType,
+    messageType: msgType.messageType,
+    messageCode: msgType.triggerEvent,
   });
 
   if (msgType.messageType === "ADT") {

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh.ts
@@ -1,10 +1,12 @@
 import { Hl7Message } from "@medplum/core";
 import { MetriportError } from "@metriport/shared";
 import {
+  formatDateToHl7,
   getOptionalValueFromMessage,
   getOptionalValueFromSegment,
   getSegmentByNameOrFail,
 } from "./shared";
+import { createUuidFromText } from "@metriport/shared/common/uuid";
 
 const MSH_9_MESSAGE_TYPE = 9;
 
@@ -36,6 +38,10 @@ export function getMessageDatetime(msg: Hl7Message): string | undefined {
   return getOptionalValueFromMessage(msg, "MSH", 7, 1);
 }
 
-export function getMessageUniqueIdentifier(msg: Hl7Message): string | undefined {
-  return getOptionalValueFromMessage(msg, "MSH", 10, 1);
+export function getOrCreateMessageDatetime(msg: Hl7Message): string {
+  return getMessageDatetime(msg) ?? formatDateToHl7(new Date());
+}
+
+export function getMessageUniqueIdentifier(msg: Hl7Message): string {
+  return getOptionalValueFromMessage(msg, "MSH", 10, 1) ?? createUuidFromText(msg.toString());
 }

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh.ts
@@ -8,12 +8,12 @@ import {
 
 const MSH_9_MESSAGE_TYPE = 9;
 
-export type Hl7MessageIdentifier = {
+export type Hl7MessageType = {
   messageType: string;
   triggerEvent: string;
 };
 
-export function getHl7MessageTypeIdentifierOrFail(hl7Message: Hl7Message): Hl7MessageIdentifier {
+export function getHl7MessageTypeOrFail(hl7Message: Hl7Message): Hl7MessageType {
   const mshSegment = getSegmentByNameOrFail(hl7Message, "MSH");
   const messageType = getOptionalValueFromSegment(mshSegment, MSH_9_MESSAGE_TYPE, 1);
   const triggerEvent = getOptionalValueFromSegment(mshSegment, MSH_9_MESSAGE_TYPE, 2);

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh.ts
@@ -13,7 +13,7 @@ export type Hl7MessageIdentifier = {
   triggerEvent: string;
 };
 
-export function getHl7MessageIdentifierOrFail(hl7Message: Hl7Message): Hl7MessageIdentifier {
+export function getHl7MessageTypeIdentifierOrFail(hl7Message: Hl7Message): Hl7MessageIdentifier {
   const mshSegment = getSegmentByNameOrFail(hl7Message, "MSH");
   const messageType = getOptionalValueFromSegment(mshSegment, MSH_9_MESSAGE_TYPE, 1);
   const triggerEvent = getOptionalValueFromSegment(mshSegment, MSH_9_MESSAGE_TYPE, 2);
@@ -34,4 +34,8 @@ export function getHl7MessageIdentifierOrFail(hl7Message: Hl7Message): Hl7Messag
 
 export function getMessageDatetime(msg: Hl7Message): string | undefined {
   return getOptionalValueFromMessage(msg, "MSH", 7, 1);
+}
+
+export function getMessageUniqueIdentifier(msg: Hl7Message): string | undefined {
+  return getOptionalValueFromMessage(msg, "MSH", 10, 1);
 }

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -4,7 +4,7 @@ dotenv.config();
 import { Hl7Message } from "@medplum/core";
 import { Hl7Server } from "@medplum/hl7";
 import {
-  getHl7MessageTypeIdentifierOrFail,
+  getHl7MessageTypeOrFail,
   getMessageDatetime,
   getMessageUniqueIdentifier,
 } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh";
@@ -50,12 +50,12 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
 
         const { cxId, patientId } = getPatientIdsOrFail(message);
 
-        const msgIdentifier = getHl7MessageTypeIdentifierOrFail(message);
+        const msgType = getHl7MessageTypeOrFail(message);
         Sentry.setExtras({
           cxId,
           patientId,
-          messageType: msgIdentifier.messageType,
-          messageCode: msgIdentifier.triggerEvent,
+          messageType: msgType.messageType,
+          messageCode: msgType.triggerEvent,
         });
 
         // TODO(lucas|2758|2025-03-05): Enqueue message for pickup
@@ -70,8 +70,8 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
               patientId,
               timestamp,
               messageId,
-              messageType: msgIdentifier.messageType,
-              messageCode: msgIdentifier.triggerEvent,
+              messageType: msgType.messageType,
+              messageCode: msgType.triggerEvent,
             }),
             file: Buffer.from(asString(message)),
             contentType: "text/plain",

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -22,22 +22,6 @@ export function unpackPidField(pid: string | undefined) {
   return { cxId, patientId };
 }
 
-export function buildS3Key({
-  cxId,
-  patientId,
-  timestamp,
-  messageType,
-  messageCode,
-}: {
-  cxId: string;
-  patientId: string;
-  timestamp: string;
-  messageType: string;
-  messageCode: string;
-}) {
-  return `${cxId}/${patientId}/${timestamp}_${messageType}_${messageCode}.hl7`;
-}
-
 export function withErrorHandling<T>(
   handler: (data: T) => void,
   logger: Logger

--- a/packages/utils/src/hl7v2-notifications/convert-adt-to-fhir-local-example.ts
+++ b/packages/utils/src/hl7v2-notifications/convert-adt-to-fhir-local-example.ts
@@ -4,11 +4,18 @@ dotenv.config();
 // keep that ^ on top
 import { Hl7Message } from "@medplum/core";
 import { convertHl7v2MessageToFhir } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index";
-import { getMessageDatetime } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh";
-import { getPatientIdsOrFail } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/utils";
+import {
+  getMessageDatetime,
+  getMessageUniqueIdentifier,
+} from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh";
+import {
+  formatDateToHl7,
+  getPatientIdsOrFail,
+} from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
 import { errorToString } from "@metriport/shared";
 import fs from "fs";
-import { initRunsFolder, buildGetDirPathInside } from "../shared/folder";
+import { buildGetDirPathInside, initRunsFolder } from "../shared/folder";
+import { uuidv7 } from "../shared/uuid-v7";
 
 /**
  * Converts HL7v2 ADT messages to FHIR Bundle and saves them to a file.
@@ -49,7 +56,8 @@ async function convertAdtToFhir() {
     console.log(
       new Date().toISOString().split(".")[0].replace(/-/g, "").replace("T", "").replace(/:/g, "")
     );
-    const timestamp = getMessageDatetime(hl7Message);
+    const timestamp = getMessageDatetime(hl7Message) ?? formatDateToHl7(new Date());
+    const messageId = getMessageUniqueIdentifier(hl7Message) ?? uuidv7();
 
     try {
       const { cxId, patientId } = getPatientIdsOrFail(hl7Message);
@@ -57,7 +65,8 @@ async function convertAdtToFhir() {
         hl7Message,
         cxId,
         patientId,
-        timestampString: timestamp ?? Date.now().toString(),
+        messageId,
+        timestampString: timestamp,
       });
 
       if (!fs.existsSync(outputFolder)) {

--- a/packages/utils/src/hl7v2-notifications/convert-adt-to-fhir-local-example.ts
+++ b/packages/utils/src/hl7v2-notifications/convert-adt-to-fhir-local-example.ts
@@ -5,17 +5,13 @@ dotenv.config();
 import { Hl7Message } from "@medplum/core";
 import { convertHl7v2MessageToFhir } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index";
 import {
-  getMessageDatetime,
   getMessageUniqueIdentifier,
+  getOrCreateMessageDatetime,
 } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh";
-import {
-  formatDateToHl7,
-  getPatientIdsOrFail,
-} from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
+import { getCxIdAndPatientIdOrFail } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
 import { errorToString } from "@metriport/shared";
 import fs from "fs";
 import { buildGetDirPathInside, initRunsFolder } from "../shared/folder";
-import { uuidv7 } from "../shared/uuid-v7";
 
 /**
  * Converts HL7v2 ADT messages to FHIR Bundle and saves them to a file.
@@ -56,11 +52,11 @@ async function convertAdtToFhir() {
     console.log(
       new Date().toISOString().split(".")[0].replace(/-/g, "").replace("T", "").replace(/:/g, "")
     );
-    const timestamp = getMessageDatetime(hl7Message) ?? formatDateToHl7(new Date());
-    const messageId = getMessageUniqueIdentifier(hl7Message) ?? uuidv7();
+    const timestamp = getOrCreateMessageDatetime(hl7Message);
+    const messageId = getMessageUniqueIdentifier(hl7Message);
 
     try {
-      const { cxId, patientId } = getPatientIdsOrFail(hl7Message);
+      const { cxId, patientId } = getCxIdAndPatientIdOrFail(hl7Message);
       const bundle = convertHl7v2MessageToFhir({
         hl7Message,
         cxId,


### PR DESCRIPTION
refs. metriport/metriport-internal#2883

### Description
- HL7 msg timestamp now uses the timestamp from the message itself 
- HL7 msgs saved with the message ID from the message itself
- Minor bug fixes

### Testing

- Local
  - [ ] TBD
- Production
  - [ ] Monitor in prod

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for including a unique message ID in HL7-to-FHIR conversion and file naming.
  - Introduced new utilities for extracting unique message identifiers and formatting HL7-compliant timestamps.
  - Added local patient ID extraction utility for improved message processing.

- **Refactor**
  - Updated parameter structures and function signatures to include message ID and improve metadata handling.
  - Enhanced logic for extracting patient and message information, with improved fallback mechanisms.
  - Modified how document ID extensions are added within message bundles for better compliance.

- **Chores**
  - Removed unused utility functions and streamlined imports for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->