### PR TITLE
ENG-98 Update commitlint and readme.md to support Linear

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Ticket: #_[ticket-number]_
+Issue: https://linear.app/metriport/issue/ENG-xxx
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ Scope is optional, and we can use one of these, or empty (no scope):
 - docs
 - ... (usually subdirectories of `./packages`)
 
-The footer should have the ticket number supporting the commit:
+The footer should have the issue number supporting the commit:
 
 ```
 ...
-Ref: #<ticket-number>
+Ref: #<issue-number>
 ```
 
 #### Commitizen

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,10 +1,17 @@
 /*global module*/
 module.exports = {
-    // Resolve and load @commitlint/config-conventional from node_modules. Referenced packages must be installed
-    extends: ["@commitlint/config-conventional"],
-    // Any rules defined here will override rules from @commitlint/config-conventional
-    rules: {
-        "footer-empty": [2, "never"],
+  // Resolve and load @commitlint/config-conventional from node_modules. Referenced packages must be installed
+  extends: ["@commitlint/config-conventional"],
+  // Any rules defined here will override rules from @commitlint/config-conventional
+  rules: {
+    "footer-empty": [2, "never"],
+    "footer-leading-blank": [2, "always"],
+    "references-empty": [2, "never"],
+  },
+  parserPreset: {
+    parserOpts: {
+      issuePrefixes: ["Part of ENG-", "Fixes ENG-"],
     },
-    ignores: [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
+  },
+  ignores: [message => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
 };


### PR DESCRIPTION
Ticket: https://linear.app/metriport/issue/ENG-98

### Dependencies

none

### Description

Update commitlint, readme.md, and PR template to support Linear.

### Testing

- Local
  - [ ] commits are replicated to/linked in Linear
  - [ ] PR is linked in Linear
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
