### PR TITLE
ENG-98 Add issue list to release PRs on PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,10 @@
+_[Release PRs:]_
+
+Issues:
+
+- https://linear.app/metriport/issue/ENG-xxx
+- https://linear.app/metriport/issue/ENG-xxx
+
 ### Dependencies
 
 - Upstream: _[this PR points to another PR or depends on its release]_

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -10,7 +10,7 @@ module.exports = {
   },
   parserPreset: {
     parserOpts: {
-      issuePrefixes: ["Part of ENG-", "Fixes ENG-"],
+      issuePrefixes: ["Ref ENG-", "References ENG-", "Part of ENG-", "Fixes ENG-", "Closes ENG-"],
     },
   },
   ignores: [message => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -10,7 +10,14 @@ module.exports = {
   },
   parserPreset: {
     parserOpts: {
-      issuePrefixes: ["Ref ENG-", "References ENG-", "Part of ENG-", "Fixes ENG-", "Closes ENG-"],
+      issuePrefixes: [
+        " #", // TODO REMOVE THIS ASAP, this is a temporary fix to allow commitlint to work with existing commits that reference GH issues
+        "Ref ENG-",
+        "References ENG-",
+        "Part of ENG-",
+        "Fixes ENG-",
+        "Closes ENG-",
+      ],
     },
   },
   ignores: [message => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3684
- Downstream: none

### Description

Testing merging PR and not closing the Linear issue - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1744928196424799?thread_ts=1744910005.927949&cid=C04DMKE9DME)

### Testing

none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the pull request template to include a new section for release PRs, allowing users to list related issues.

- **Chores**
  - Expanded the accepted commit message prefixes to support "Ref ENG-", "References ENG-", "Closes ENG-", and a temporary " #" prefix in addition to existing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->