### PR TITLE
feat(docs): adding a page on condition chronicity

### DIFF
--- a/docs/medical-api/fhir/extensions/chronicity.mdx
+++ b/docs/medical-api/fhir/extensions/chronicity.mdx
@@ -1,0 +1,64 @@
+---
+title: "Condition Chronicity"
+description: "Indicates whether a medical condition is chronic or not."
+---
+
+The chronicity extension is used in FHIR Condition resources to specify whether a medical condition is chronic.
+
+## Properties
+
+Example extension:
+
+```json
+{
+  "url": "http://hl7.org/fhir/StructureDefinition/condition-related",
+  "valueCoding": {
+    "code": "C",
+    "display": "Chronic",
+    "system": "https://public.metriport.com/fhir/StructureDefinition/condition-chronicity.json"
+  }
+}
+```
+
+<Tip>
+  You can use the value of the `valueString` property as
+  input to the [Get Document URL
+  endpoint](/medical-api/api-reference/document/get-document)
+  to download the C-CDA Document from which the FHIR
+  Resource was derived from.
+</Tip>
+
+<ResponseField name="url" type="string" required>
+  The URL of this extension's JSON structure specification.
+</ResponseField>
+
+<ResponseField name="valueCoding" type="object" required>
+  Contains the chronicity classification of the condition.
+</ResponseField>
+
+<ResponseField
+  name="valueCoding.code"
+  type="string"
+  required
+>
+  The code indicating chronicity status. Currently supports:
+  - "C" for Chronic 
+  - "NC" for Not-Chronic 
+  - "U" for Unknown
+</ResponseField>
+
+<ResponseField
+  name="valueCoding.display"
+  type="string"
+  required
+>
+  The human-readable display text for the chronicity status.
+</ResponseField>
+
+<ResponseField
+  name="valueCoding.system"
+  type="string"
+  required
+>
+  The system that defines the chronicity codes.
+</ResponseField>

--- a/docs/medical-api/fhir/overview.mdx
+++ b/docs/medical-api/fhir/overview.mdx
@@ -131,5 +131,4 @@ may be relevant to their specific implementation.
 Extensions can be available under the `extension` property on any FHIR Resource, and also
 have their own [specification for data they can contain](/medical-api/fhir/data-types/extension).
 
-For example, Metriport introduces a [Document ID extension](/medical-api/fhir/extensions/doc-id) that allows you to get the C-CDA Document ID
-for which any given FHIR Resource is derived from.
+For example, Metriport introduces a [Condition Chronicity Extension](/medical-api/fhir/extensions/chronicity) inside FHIR Condition resources to specify whether the underlying medical condition is chronic.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -236,7 +236,10 @@
         {
           "group": "Extensions",
           "icon": "asterisk",
-          "pages": ["medical-api/fhir/extensions/doc-id"]
+          "pages": [
+            "medical-api/fhir/extensions/doc-id",
+            "medical-api/fhir/extensions/chronicity"
+          ]
         }
       ]
     },


### PR DESCRIPTION
Part of ENG-127

### Description
- Added a page for FHIR Condition chronicity extension
- Small update on FHIR Overview page

### Screenshots
<img width="1168" alt="Screenshot 2025-04-17 at 4 33 20 PM" src="https://github.com/user-attachments/assets/9ebd03fc-e682-48ce-bde1-db857e5a10bd" />
<img width="508" alt="Screenshot 2025-04-17 at 4 33 57 PM" src="https://github.com/user-attachments/assets/057a8d93-42bf-4e37-be4a-6b8f9c6b27ca" />

### Testing

- Local
  - [x] Ran mintlify locally and posted screenshots
- Production
  - [ ] Confirm the updates look good 


### Release Plan
- [ ] Merge this
