### PR TITLE
feat(utils): split WH and recreate consolidated

### DIFF
--- a/packages/api/src/command/medical/document/document-conversion-status.ts
+++ b/packages/api/src/command/medical/document/document-conversion-status.ts
@@ -14,6 +14,7 @@ import { getCWData } from "../../../external/commonwell/patient";
 import { tallyDocQueryProgress } from "../../../external/hie/tally-doc-query-progress";
 import { recreateConsolidated } from "../patient/consolidated-recreate";
 import { updateConversionProgress } from "./document-query";
+import { MAPIWebhookStatus, processPatientDocumentRequest } from "./document-webhook";
 import { processDocQueryProgressWebhook } from "./process-doc-query-webhook";
 
 export async function calculateDocumentConversionStatus({
@@ -145,10 +146,15 @@ export async function calculateDocumentConversionStatus({
       await recreateConsolidated({
         patient: expectedPatient,
         context: "calculate-no-source",
-        ...recreateConsolidatedOnCompleteParams({
-          patient: expectedPatient,
-          requestId,
-        }),
+        onCompleteFinal: async () => {
+          processPatientDocumentRequest(
+            cxId,
+            patientId,
+            "medical.document-conversion",
+            MAPIWebhookStatus.completed,
+            ""
+          );
+        },
       });
     }
   }

--- a/packages/api/src/command/medical/patient/consolidated-recreate.ts
+++ b/packages/api/src/command/medical/patient/consolidated-recreate.ts
@@ -13,7 +13,8 @@ import { getConsolidated } from "../patient/consolidated-get";
  * @param patient - The patient to recreate the consolidated bundle for.
  * @param organization - The organization to recreate the consolidated bundle for.
  * @param conversionType - The conversion type to use when converting to consolidatd.
- * @param onComplete - Optional callback to run after the consolidated bundle is recreated.
+ * @param onCompleteSuccess - Optional callback to run after the consolidated bundle is recreated.
+ * @param onCompleteFinal - Optional callback to at the end of the process.
  * @param context - Optional context to log.
  */
 export async function recreateConsolidated({

--- a/packages/api/src/command/medical/patient/consolidated-recreate.ts
+++ b/packages/api/src/command/medical/patient/consolidated-recreate.ts
@@ -13,16 +13,21 @@ import { getConsolidated } from "../patient/consolidated-get";
  * @param patient - The patient to recreate the consolidated bundle for.
  * @param organization - The organization to recreate the consolidated bundle for.
  * @param conversionType - The conversion type to use when converting to consolidatd.
+ * @param onComplete - Optional callback to run after the consolidated bundle is recreated.
  * @param context - Optional context to log.
  */
 export async function recreateConsolidated({
   patient,
   conversionType,
   context,
+  onCompleteSuccess,
+  onCompleteFinal,
 }: {
   patient: Patient;
   conversionType?: ConsolidationConversionType;
   context?: string;
+  onCompleteSuccess?: () => Promise<void>;
+  onCompleteFinal?: () => Promise<void>;
 }): Promise<void> {
   const { log } = out(`${context ? context + " " : ""}recreateConsolidated - pt ${patient.id}`);
   try {
@@ -35,7 +40,13 @@ export async function recreateConsolidated({
   }
   try {
     await getConsolidated({ patient, conversionType });
+    if (onCompleteSuccess) {
+      await onCompleteSuccess();
+    }
   } catch (err) {
     processAsyncError(`Post-DQ getConsolidated`, log)(err);
+  }
+  if (onCompleteFinal) {
+    await onCompleteFinal();
   }
 }

--- a/packages/api/src/domain/medical/conversion-progress.ts
+++ b/packages/api/src/domain/medical/conversion-progress.ts
@@ -20,7 +20,11 @@ export function calculateConversionProgress({
 }): DocumentQueryProgress {
   const docQueryProgress = patient.data.documentQueryProgress ?? {};
 
-  const talliedDocQueryProgress = tallyDocQueryProgress(docQueryProgress, convertResult, count);
+  const talliedDocQueryProgress = tallyDocQueryProgressOnCounts(
+    docQueryProgress,
+    convertResult,
+    count
+  );
 
   return talliedDocQueryProgress;
 }
@@ -34,7 +38,7 @@ export function calculateConversionProgress({
  *                     defaults to 1)
  * @returns the updated document query progress
  */
-export function tallyDocQueryProgress(
+function tallyDocQueryProgressOnCounts(
   docQueryProgress: DocumentQueryProgress,
   convertResult: ConvertResult,
   countParam?: number

--- a/packages/api/src/domain/medical/conversion-progress.ts
+++ b/packages/api/src/domain/medical/conversion-progress.ts
@@ -20,7 +20,7 @@ export function calculateConversionProgress({
 }): DocumentQueryProgress {
   const docQueryProgress = patient.data.documentQueryProgress ?? {};
 
-  const talliedDocQueryProgress = tallyDocQueryProgressOnCounts(
+  const talliedDocQueryProgress = tallyDocQueryProgressWithCount(
     docQueryProgress,
     convertResult,
     count
@@ -38,7 +38,7 @@ export function calculateConversionProgress({
  *                     defaults to 1)
  * @returns the updated document query progress
  */
-function tallyDocQueryProgressOnCounts(
+function tallyDocQueryProgressWithCount(
   docQueryProgress: DocumentQueryProgress,
   convertResult: ConvertResult,
   countParam?: number

--- a/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-retrieval-resps.ts
@@ -13,7 +13,7 @@ import { convertCDAToFHIR, isConvertible } from "../../fhir-converter/converter"
 import { DocumentReferenceWithId } from "../../fhir/document";
 import { upsertDocumentsToFHIRServer } from "../../fhir/document/save-document-reference";
 import { setDocQueryProgress } from "../../hie/set-doc-query-progress";
-import { tallyDocQueryProgress } from "../../hie/tally-doc-query-progress";
+import { tallyDocQueryProgressAndProcessWebhook } from "../../hie/tally-doc-query-progress";
 import { getCQDirectoryEntryOrFail } from "../command/cq-directory/get-cq-directory-entry";
 import { formatDate } from "../shared";
 import {
@@ -168,7 +168,7 @@ export async function processOutboundDocumentRetrievalResps({
       });
     }
 
-    await tallyDocQueryProgress({
+    await tallyDocQueryProgressAndProcessWebhook({
       patient: { id: patientId, cxId: cxId },
       progress: {
         successful: successDocsRetrievedCount,

--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -49,7 +49,7 @@ import { buildInterrupt } from "../../hie/reset-doc-query-progress";
 import { scheduleDocQuery } from "../../hie/schedule-document-query";
 import { setDocQueryProgress } from "../../hie/set-doc-query-progress";
 import { setDocQueryStartAt } from "../../hie/set-doc-query-start";
-import { tallyDocQueryProgress } from "../../hie/tally-doc-query-progress";
+import { tallyDocQueryProgressAndProcessWebhook } from "../../hie/tally-doc-query-progress";
 import { makeCommonWellAPI } from "../api";
 import { groupCWErrors } from "../error-categories";
 import { getCWData, update } from "../patient";
@@ -715,7 +715,7 @@ async function downloadDocsAndUpsertFHIR({
             processFhirResponse(patient, doc.id, fhir);
           }
 
-          await tallyDocQueryProgress({
+          await tallyDocQueryProgressAndProcessWebhook({
             patient: { id: patient.id, cxId: patient.cxId },
             progress: {
               successful: 1,
@@ -727,7 +727,7 @@ async function downloadDocsAndUpsertFHIR({
 
           return fhirDocRef;
         } catch (error) {
-          await tallyDocQueryProgress({
+          await tallyDocQueryProgressAndProcessWebhook({
             patient: { id: patient.id, cxId: patient.cxId },
             progress: {
               errors: 1,

--- a/packages/api/src/external/hie/tally-doc-query-progress.ts
+++ b/packages/api/src/external/hie/tally-doc-query-progress.ts
@@ -72,14 +72,31 @@ export async function tallyDocQueryProgress({
     return updatedPatient;
   });
 
-  await processDocQueryProgressWebhook({
-    patient,
-    documentQueryProgress: patient.data.documentQueryProgress,
-    requestId,
-    progressType: type,
-  });
-
   return patient;
+}
+
+export async function tallyDocQueryProgressAndProcessWebhook({
+  patient: { id, cxId },
+  requestId,
+  progress,
+  type,
+  source,
+}: TallyDocQueryProgress): Promise<void> {
+  const updatedPatient = await tallyDocQueryProgress({
+    patient: { id, cxId },
+    requestId,
+    progress,
+    type,
+    source,
+  });
+  if (updatedPatient.data.documentQueryProgress) {
+    await processDocQueryProgressWebhook({
+      patient: updatedPatient,
+      documentQueryProgress: updatedPatient.data.documentQueryProgress,
+      requestId,
+      progressType: type,
+    });
+  }
 }
 
 export function setHIETallyCount(


### PR DESCRIPTION
Ref: #1040

### Description

- split process WH from tallyDocQueryProgress
- regroup in a new method
- re-name duplicate name method
- adding exit conditions to recreate consolidated

### Testing

- Local
  - [ ] conversion webhook is sent after consolidated finishes
- Staging
  - [ ] conversion webhook is sent after consolidated finishes
- Sandbox
  - [ ] N/A
- Production
 - [ ] conversion webhook is sent after consolidated finishes

### Release Plan

- [ ] Merge this
