### PR TITLE
ENG-191 Only load the bundle when converting

### DIFF
--- a/packages/api/src/command/medical/patient/consolidated-recreate.ts
+++ b/packages/api/src/command/medical/patient/consolidated-recreate.ts
@@ -7,7 +7,7 @@ import { processAsyncError } from "@metriport/core/util/error/shared";
 import { out } from "@metriport/core/util/log";
 import { ResourceDiffDirection } from "@metriport/shared/interface/external/ehr/resource-diff";
 import { createResourceDiffBundles } from "../../../external/ehr/create-resource-diff-bundles";
-import { getConsolidated } from "../patient/consolidated-get";
+import { getConsolidated } from "./consolidated-get";
 
 /**
  * Recreates the consolidated bundle for a patient.

--- a/packages/api/src/command/medical/patient/convert-fhir-bundle.ts
+++ b/packages/api/src/command/medical/patient/convert-fhir-bundle.ts
@@ -11,6 +11,7 @@ import {
   createSandboxMRSummaryFileName,
 } from "@metriport/core/domain/medical-record-summary";
 import { Patient } from "@metriport/core/domain/patient";
+import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
 import { getLambdaResultPayload, makeLambdaClient } from "@metriport/core/external/aws/lambda";
 import { makeS3Client, S3Utils } from "@metriport/core/external/aws/s3";
 import { out } from "@metriport/core/util";
@@ -80,6 +81,16 @@ export async function handleBundleToMedicalRecord({
     newBundle.entry = [];
     newBundle.total = 0;
   }
+
+  analytics({
+    distinctId: patient.cxId,
+    event: EventTypes.consolidatedQuery,
+    properties: {
+      patientId: patient.id,
+      conversionType,
+      resourceCount: newBundle.entry?.length,
+    },
+  });
   return newBundle;
 }
 

--- a/packages/api/src/command/medical/patient/convert-fhir-bundle.ts
+++ b/packages/api/src/command/medical/patient/convert-fhir-bundle.ts
@@ -10,11 +10,12 @@ import {
   createMRSummaryFileName,
   createSandboxMRSummaryFileName,
 } from "@metriport/core/domain/medical-record-summary";
-import { Patient } from "@metriport/core/domain/patient";
+import { getConsolidatedQueryByRequestId, Patient } from "@metriport/core/domain/patient";
 import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
 import { getLambdaResultPayload, makeLambdaClient } from "@metriport/core/external/aws/lambda";
 import { makeS3Client, S3Utils } from "@metriport/core/external/aws/s3";
 import { out } from "@metriport/core/util";
+import { elapsedTimeFromNow } from "@metriport/shared/common/date";
 import { SearchSetBundle } from "@metriport/shared/medical";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
@@ -40,6 +41,7 @@ export const emptyMetaProp = "na";
 export async function handleBundleToMedicalRecord({
   bundle,
   patient,
+  requestId,
   resources,
   dateFrom,
   dateTo,
@@ -47,6 +49,7 @@ export async function handleBundleToMedicalRecord({
 }: {
   bundle: Bundle<Resource>;
   patient: Pick<Patient, "id" | "cxId" | "data">;
+  requestId?: string;
   resources?: ResourceTypeForConsolidation[];
   dateFrom?: string;
   dateTo?: string;
@@ -82,12 +85,14 @@ export async function handleBundleToMedicalRecord({
     newBundle.total = 0;
   }
 
+  const currentConsolidatedProgress = getConsolidatedQueryByRequestId(patient, requestId);
   analytics({
     distinctId: patient.cxId,
     event: EventTypes.consolidatedQuery,
     properties: {
       patientId: patient.id,
       conversionType,
+      duration: elapsedTimeFromNow(currentConsolidatedProgress?.startedAt),
       resourceCount: newBundle.entry?.length,
     },
   });

--- a/packages/core/src/domain/patient.ts
+++ b/packages/core/src/domain/patient.ts
@@ -124,3 +124,10 @@ export function createDriversLicensePersonalIdentifier(
   };
   return personalIdentifier;
 }
+
+export function getConsolidatedQueryByRequestId(
+  patient: Pick<Patient, "data">,
+  requestId: string | undefined
+): ConsolidatedQuery | undefined {
+  return patient.data.consolidatedQueries?.find(q => q.requestId === requestId);
+}


### PR DESCRIPTION
### Dependencies

none

### Description

Only load the bundle upon recreate consolidated when converting (creating a MR).

### Testing

- Local
  - none
- Staging
  - [ ] trigger DQ, consolidated gets updated at the end
  - [ ] trigger DQ, ask for MR in PDF, it gets generated
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added telemetry reporting for consolidated query processing to enhance analytics.
  - Introduced support for request-specific tracking in patient consolidation queries.
- **Bug Fixes**
  - Improved the reliability of patient consolidation retrieval, ensuring correct handling when no conversion type is specified.
- **Chores**
  - Removed obsolete analytics tracking and parameters from consolidation retrieval to streamline processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->