### PR TITLE
ENG-140 Validate IDs are UUID on CQ processInboundDq

### DIFF
--- a/packages/core/src/external/carequality/dq/__tests__/utils.test.ts
+++ b/packages/core/src/external/carequality/dq/__tests__/utils.test.ts
@@ -1,0 +1,65 @@
+import { faker } from "@faker-js/faker";
+import { stringToBase64 } from "../../../../util/base64";
+import { XDSUnknownPatientId } from "../../error";
+import { decodePatientId } from "../utils";
+
+describe("decodePatientId", () => {
+  it("parses cxId and patientId from the base64'd ID pair in the right order", () => {
+    const cxId = faker.string.uuid();
+    const patientId = faker.string.uuid();
+    const idPair = stringToBase64(`${cxId}/${patientId}`);
+    const result = decodePatientId(idPair);
+    expect(result).toBeTruthy();
+    expect(result.cxId).toBe(cxId);
+    expect(result.patientId).toBe(patientId);
+  });
+
+  it("throws when cxId and patientId are merged but not base64'd", () => {
+    const cxId = faker.string.uuid();
+    const patientId = faker.string.uuid();
+    const idPair = `${cxId}/${patientId}`;
+    expect(() => decodePatientId(idPair)).toThrow(XDSUnknownPatientId);
+  });
+
+  it("throws when cxId is not a valid UUID", () => {
+    const cxId = faker.lorem.word();
+    const patientId = faker.string.uuid();
+    const idPair = stringToBase64(`${cxId}/${patientId}`);
+    expect(() => decodePatientId(idPair)).toThrow(XDSUnknownPatientId);
+  });
+
+  it("throws when patientId is not a valid UUID", () => {
+    const cxId = faker.string.uuid();
+    const patientId = faker.lorem.word();
+    const idPair = stringToBase64(`${cxId}/${patientId}`);
+    expect(() => decodePatientId(idPair)).toThrow(XDSUnknownPatientId);
+  });
+
+  it("throws when missing separator", () => {
+    const cxId = faker.string.uuid();
+    const patientId = faker.string.uuid();
+    const idPair = stringToBase64(`${cxId}${patientId}`);
+    expect(() => decodePatientId(idPair)).toThrow(XDSUnknownPatientId);
+  });
+
+  it("throws when missing cxId", () => {
+    const patientId = faker.string.uuid();
+    const idPair = stringToBase64(`/${patientId}`);
+    expect(() => decodePatientId(idPair)).toThrow(XDSUnknownPatientId);
+  });
+
+  it("throws when missing patientId", () => {
+    const cxId = faker.string.uuid();
+    const idPair = stringToBase64(`${cxId}/`);
+    expect(() => decodePatientId(idPair)).toThrow(XDSUnknownPatientId);
+  });
+
+  it("throws when cxId and patientId are empty strings", () => {
+    const idPair = stringToBase64(`/`);
+    expect(() => decodePatientId(idPair)).toThrow(XDSUnknownPatientId);
+  });
+
+  it("throws when input string is empty", () => {
+    expect(() => decodePatientId("")).toThrow(XDSUnknownPatientId);
+  });
+});

--- a/packages/core/src/external/carequality/dq/process-inbound-dq.ts
+++ b/packages/core/src/external/carequality/dq/process-inbound-dq.ts
@@ -2,12 +2,7 @@ import { InboundDocumentQueryReq, InboundDocumentQueryResp } from "@metriport/ih
 import { ensureCcdExists } from "../../../shareback/ensure-ccd-exists";
 import { getMetadataDocumentContents } from "../../../shareback/metadata/get-metadata-xml";
 import { out } from "../../../util/log";
-import {
-  IHEGatewayError,
-  XDSRegistryError,
-  XDSUnknownPatientId,
-  constructDQErrorResponse,
-} from "../error";
+import { constructDQErrorResponse, IHEGatewayError, XDSRegistryError } from "../error";
 import { validateBasePayload } from "../shared";
 import { decodePatientId } from "./utils";
 
@@ -16,12 +11,9 @@ export async function processInboundDq(
 ): Promise<InboundDocumentQueryResp> {
   try {
     validateBasePayload(payload);
-    const id_pair = decodePatientId(payload.externalGatewayPatient.id);
 
-    if (!id_pair) {
-      throw new XDSUnknownPatientId("Patient ID is not valid");
-    }
-    const { cxId, id: patientId } = id_pair;
+    const id_pair = decodePatientId(payload.externalGatewayPatient.id);
+    const { cxId, patientId } = id_pair;
     const { log } = out(`Inbound DQ: ${cxId}, patientId: ${patientId}`);
 
     await ensureCcdExists({ cxId, patientId, log });

--- a/packages/core/src/external/carequality/dq/utils.ts
+++ b/packages/core/src/external/carequality/dq/utils.ts
@@ -1,12 +1,13 @@
+import { isValidUuid } from "../../../util/uuid-v7";
 import { XDSUnknownPatientId } from "../error";
 import { extractPatientUniqueId } from "../shared";
 
-export function decodePatientId(patientIdB64: string): { cxId: string; id: string } | undefined {
+export function decodePatientId(patientIdB64: string): { cxId: string; patientId: string } {
   const decodedString = extractPatientUniqueId(patientIdB64);
-  const [cxId, id] = decodedString.split("/");
+  const [cxId, patientId] = decodedString.split("/");
 
-  if (!cxId || !id) {
+  if (!cxId || !patientId || !isValidUuid(cxId) || !isValidUuid(patientId)) {
     throw new XDSUnknownPatientId("Patient ID is not valid");
   }
-  return { cxId, id };
+  return { cxId, patientId };
 }

--- a/packages/core/src/util/__tests__/validate-uuid.test.ts
+++ b/packages/core/src/util/__tests__/validate-uuid.test.ts
@@ -1,4 +1,4 @@
-import { isValidUuid, uuidv7 } from "../uuid-v7";
+import { isValidUuid, uuidv4, uuidv7 } from "../uuid-v7";
 
 const validUuid = "01902d03-8560-78ef-9566-f0b133de4a65";
 const allNumberValidUuid = "01902203-8560-7821-9566-202133224111";
@@ -20,10 +20,21 @@ describe("isValidUuid", () => {
     expect(isValidUuid(idWithUnexpectedCharacters)).toBe(false);
   });
 
-  it("should validate uuids created with uuidv7()", () => {
-    for (let i = 0; i < 100; i++) {
+  describe("uuidv7", () => {
+    for (let i = 0; i < 10; i++) {
       const id = uuidv7();
-      expect(isValidUuid(id)).toBe(true);
+      it("should validate uuidv7 " + id, () => {
+        expect(isValidUuid(id)).toBe(true);
+      });
+    }
+  });
+
+  describe("uuidv4", () => {
+    for (let i = 0; i < 10; i++) {
+      const id = uuidv4();
+      it("should validate uuidv4 " + id, () => {
+        expect(isValidUuid(id)).toBe(true);
+      });
     }
   });
 });


### PR DESCRIPTION
### Dependencies

none

### Description

Validate IDs are UUID on CQ `processInboundDq()` - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1745251386834939?thread_ts=1744231772.562539&cid=C04T256DQPQ).

### Testing

- Local
  - [x] unit tests
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for patient ID decoding, ensuring both components are valid UUIDs and updating error handling for malformed inputs.

- **Tests**
  - Added comprehensive tests for patient ID decoding, covering valid and invalid scenarios.
  - Enhanced UUID validation tests to include both UUIDv4 and UUIDv7 formats with more granular test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->