### PR TITLE
feat(infra): add bucketname var to webhook sender

### DIFF
--- a/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
+++ b/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
@@ -5,7 +5,7 @@ import { Function as Lambda } from "aws-cdk-lib/aws-lambda";
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
-import { EnvConfig } from "../config/env-config";
+import { EnvConfigNonSandbox } from "../config/env-config";
 import { EnvType } from "./env-type";
 import { createLambda } from "./shared/lambda";
 import { LambdaLayers } from "./shared/lambda-layers";
@@ -42,7 +42,7 @@ function settings() {
 }
 
 interface Hl7NotificationWebhookSenderNestedStackProps extends NestedStackProps {
-  config: EnvConfig;
+  config: EnvConfigNonSandbox;
   vpc: ec2.IVpc;
   alarmAction?: SnsAction;
   lambdaLayers: LambdaLayers;
@@ -70,9 +70,9 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
   }
 
   private setupHl7NotificationWebhookSenderLambda(ownProps: {
-    lambdaLayers: LambdaLayers;
     vpc: ec2.IVpc;
     envType: EnvType;
+    lambdaLayers: LambdaLayers;
     sentryDsn: string | undefined;
     alarmAction: SnsAction | undefined;
     outgoingHl7NotificationBucket: s3.Bucket;
@@ -109,6 +109,7 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
       alarmSnsAction: alarmAction,
       envVars: {
         // API_URL set on the api-stack after the OSS API is created
+        HL7_OUTGOING_MESSAGE_BUCKET_NAME: outgoingHl7NotificationBucket.bucketName,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
     });


### PR DESCRIPTION
refs. metriport/metriport-internal#2758

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

- Release this PR fixes: https://github.com/metriport/metriport/pull/3693

### Description

Bucketname env variable to write messages out to s3 was missing
(Also simple type improvement)

### Testing

None, going to check on staging since change is very small

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new environment variable enabling outgoing HL7 messages to be stored in a dedicated bucket.

- **Chores**
  - Updated environment configuration handling for improved deployment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->