### PR TITLE
build: flexible team prefix on commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -8,22 +8,6 @@ module.exports = {
     "footer-leading-blank": [2, "always"],
     "references-empty": [2, "never"],
   },
-  parserPreset: {
-    parserOpts: {
-      issuePrefixes: [
-        " #", // TODO REMOVE THIS ASAP, this is a temporary fix to allow commitlint to work with existing commits that reference GH issues
-        "Ref ENG-",
-        "References ENG-",
-        "Part of ENG-",
-        "Fixes ENG-",
-        "Closes ENG-",
-        "Ref CS-",
-        "References CS-",
-        "Part of CS-",
-        "Fixes CS-",
-        "Closes CS-",
-      ],
-    },
-  },
+  parserPreset: "./commitlint.parserPreset",
   ignores: [message => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
 };

--- a/commitlint.parserPreset.js
+++ b/commitlint.parserPreset.js
@@ -1,0 +1,16 @@
+const teams = ["ENG", "OPS", "CS", "MKT", "SLS"];
+
+const prefixes = ["Ref", "References", "Part of", "Fixes", "Closes"];
+
+const issuePrefixes = [
+  " #", // TODO REMOVE THIS ASAP, this is a temporary fix to allow commitlint to work with existing commits that reference GH issues
+  ...prefixes.flatMap(prefix => {
+    return teams.map(team => `${prefix} ${team}-`);
+  }),
+];
+
+module.exports = {
+  parserOpts: {
+    issuePrefixes,
+  },
+};


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/2902
- Downstream: none

### Description

Make the team prefix for Linear more flexible on commitlint rules.

### Testing

- Local
  - [ ] commit msg w/ CS team works
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to reference an external file for commit message parsing rules.
  - Introduced a new configuration file to manage custom issue prefixes for commit messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->