### PR TITLE
ENG-210 Patch xml-crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35354,9 +35354,9 @@
       }
     },
     "node_modules/xml-crypto": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.0.tgz",
-      "integrity": "sha512-L3RgnkaDrHaYcCnoENv4Idzt1ZRj5U1z1BDH98QdDTQfssScx8adgxhd9qwyYo+E3fXbQZjEQH7aiXHLVgxGvw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.1.1.tgz",
+      "integrity": "sha512-ni6H4Xnd5zvpDKvevmFmmKNojF2cAoTcioeSasICsDTkF0pjqS/PlHsMCLjiruH0N6iVa3OCBMHRLwRfcUPo2g==",
       "dependencies": {
         "@xmldom/is-dom-node": "^1.0.1",
         "@xmldom/xmldom": "^0.8.10",
@@ -35874,7 +35874,7 @@
         "sequelize": "^6.37.1",
         "ssh2-sftp-client": "^9.0.4",
         "whatwg-mimetype": "^4.0.0",
-        "xml-crypto": "^6.0.0",
+        "xml-crypto": "^6.0.1",
         "xml2js": "^0.6.2",
         "xmldom": "^0.6.0",
         "zod-to-json-schema": "3.22.5"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -142,7 +142,7 @@
     "sequelize": "^6.37.1",
     "ssh2-sftp-client": "^9.0.4",
     "whatwg-mimetype": "^4.0.0",
-    "xml-crypto": "^6.0.0",
+    "xml-crypto": "^6.0.1",
     "xml2js": "^0.6.2",
     "xmldom": "^0.6.0",
     "zod-to-json-schema": "3.22.5"

--- a/packages/lambdas/package-lock.json
+++ b/packages/lambdas/package-lock.json
@@ -46,7 +46,7 @@
         "ssh2-sftp-client": "^9.0.4",
         "uuid": "^9.0.0",
         "whatwg-mimetype": "^4.0.0",
-        "xml-crypto": "^6.0.0",
+        "xml-crypto": "^6.0.1",
         "xml2js": "^0.6.2",
         "xmldom": "^0.6.0",
         "zod": "^3.22.4"
@@ -14272,9 +14272,9 @@
       }
     },
     "node_modules/xml-crypto": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.0.tgz",
-      "integrity": "sha512-L3RgnkaDrHaYcCnoENv4Idzt1ZRj5U1z1BDH98QdDTQfssScx8adgxhd9qwyYo+E3fXbQZjEQH7aiXHLVgxGvw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.1.1.tgz",
+      "integrity": "sha512-ni6H4Xnd5zvpDKvevmFmmKNojF2cAoTcioeSasICsDTkF0pjqS/PlHsMCLjiruH0N6iVa3OCBMHRLwRfcUPo2g==",
       "dependencies": {
         "@xmldom/is-dom-node": "^1.0.1",
         "@xmldom/xmldom": "^0.8.10",

--- a/packages/lambdas/package.json
+++ b/packages/lambdas/package.json
@@ -61,7 +61,7 @@
     "ssh2-sftp-client": "^9.0.4",
     "uuid": "^9.0.0",
     "whatwg-mimetype": "^4.0.0",
-    "xml-crypto": "^6.0.0",
+    "xml-crypto": "^6.0.1",
     "xml2js": "^0.6.2",
     "xmldom": "^0.6.0",
     "zod": "^3.22.4"


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-210/update-xml-crypto

### Dependencies

- related: https://github.com/metriport/metriport-internal/pull/2688

### Description

Patch `xml-crypto`.

### Testing

- Local (branch to staging)
  - [x] monorepo builds
  - [x] unit tests related to xml-crypto pass
- Staging
  - none
- Sandbox
  - none
- Production
  - [ ] monitor a couple of DQs

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the "xml-crypto" dependency to version 6.0.1 for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->