### PR TITLE
Dependabot#103 Require semver>=5.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "packages/utils"
       ],
       "dependencies": {
+        "semver": ">=5.7.2",
         "sharp": "^0.33.5"
       },
       "devDependencies": {
@@ -35558,6 +35559,7 @@
         "pg-hstore": "^2.3.4",
         "posthog-node": "^3.3.0",
         "reflect-metadata": "^0.1.13",
+        "semver": ">=5.7.2",
         "sequelize": "^6.31.0",
         "simple-oauth2": "^5.0.0",
         "ts-essentials": "^9.3.0",
@@ -35611,6 +35613,7 @@
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
+        "semver": ">=5.7.2",
         "zod": "^3.22.1"
       },
       "devDependencies": {
@@ -35871,6 +35874,7 @@
         "pkijs": "^3.0.16",
         "playwright": "1.39.0",
         "pvutils": "^1.1.3",
+        "semver": ">=5.7.2",
         "sequelize": "^6.37.1",
         "ssh2-sftp-client": "^9.0.4",
         "whatwg-mimetype": "^4.0.0",
@@ -37305,6 +37309,7 @@
         "fast-xml-parser": "^4.4.1",
         "http-status": "~1.7.0",
         "lodash": "^4.17.21",
+        "semver": ">=5.7.2",
         "zod": "^3.22.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "semver": ">=5.7.2"
   }
 }

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -63,6 +63,7 @@
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",
+    "semver": ">=5.7.2",
     "zod": "^3.22.1"
   },
   "devDependencies": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -64,6 +64,7 @@
     "pg-hstore": "^2.3.4",
     "posthog-node": "^3.3.0",
     "reflect-metadata": "^0.1.13",
+    "semver": ">=5.7.2",
     "sequelize": "^6.31.0",
     "simple-oauth2": "^5.0.0",
     "ts-essentials": "^9.3.0",

--- a/packages/connect-widget/package.json
+++ b/packages/connect-widget/package.json
@@ -60,6 +60,7 @@
     "react-icons": "^3.11.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "^5.0.1",
+    "semver": ">=5.7.2",
     "ts-jest": "^29.1.1",
     "web-vitals": "^2.1.4"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -139,6 +139,7 @@
     "pkijs": "^3.0.16",
     "playwright": "1.39.0",
     "pvutils": "^1.1.3",
+    "semver": ">=5.7.2",
     "sequelize": "^6.37.1",
     "ssh2-sftp-client": "^9.0.4",
     "whatwg-mimetype": "^4.0.0",

--- a/packages/lambdas/package-lock.json
+++ b/packages/lambdas/package-lock.json
@@ -42,6 +42,7 @@
         "pkijs": "^3.0.16",
         "posthog-node": "^4.0.1",
         "pvutils": "^1.1.3",
+        "semver": ">=5.7.2",
         "sequelize": "^6.37.1",
         "ssh2-sftp-client": "^9.0.4",
         "uuid": "^9.0.0",

--- a/packages/lambdas/package.json
+++ b/packages/lambdas/package.json
@@ -57,6 +57,7 @@
     "pkijs": "^3.0.16",
     "posthog-node": "^4.0.1",
     "pvutils": "^1.1.3",
+    "semver": ">=5.7.2",
     "sequelize": "^6.37.1",
     "ssh2-sftp-client": "^9.0.4",
     "uuid": "^9.0.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -85,6 +85,7 @@
     "fast-xml-parser": "^4.4.1",
     "http-status": "~1.7.0",
     "lodash": "^4.17.21",
+    "semver": ">=5.7.2",
     "zod": "^3.22.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Issues:

- https://github.com/metriport/metriport/security/dependabot/103

### Dependencies

none

### Description

Require `semver` >= `5.7.2`

### Testing

- Local
  - none
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added the semver package as a new dependency across multiple packages to enhance version management. No changes to user-facing features or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->