### PR TITLE
fix(lambdas): remove phi from log

### DIFF
--- a/packages/lambdas/src/hl7-notification-webhook-sender.ts
+++ b/packages/lambdas/src/hl7-notification-webhook-sender.ts
@@ -21,7 +21,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent): Pro
   }
 
   const log = prefixedLog(lambdaName);
-  log(`Parsing body: ${params.body}`);
+  log("Parsing body");
   const parsedBody = parseBody(params.body);
   const { cxId, patientId } = parsedBody;
 


### PR DESCRIPTION
refs. metriport/metriport-internal#2758

Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

None

### Description

Removes PHI that would be logged to cloudwatch

### Testing

Verified potential phi being written to logs in staging, fix is trivial

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated logging to no longer display message body content before parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->