### PR TITLE
feat(canvas): patch duration

### DIFF
--- a/packages/infra/lib/ehr-nested-stack.ts
+++ b/packages/infra/lib/ehr-nested-stack.ts
@@ -91,9 +91,8 @@ function settings(): {
     },
     waitTime: waitTimeStartResourceDiff,
   };
-  const ComputeResourceDiffBundlesLambdaTimeout = waitTimeComputeResourceDiff.plus(
-    Duration.minutes(5)
-  );
+  // Skip adding the wait time to the lambda timeout because it's already sub 1 second
+  const ComputeResourceDiffBundlesLambdaTimeout = Duration.minutes(5);
   const computeResourceDiffBundles: QueueAndLambdaSettings = {
     name: "EhrComputeResourceDiffBundles",
     entry: "ehr-compute-resource-diff-bundles",


### PR DESCRIPTION
Ref: ENG-47

Ref: #1040

Issues:

- https://linear.app/metriport/issue/ENG-47

### Description

- make lambda timeout a even number of seconds

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the timeout setting for a background process to streamline its configuration and improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->