### PR TITLE
feat(canvas): patch removing coverage resources

### DIFF
--- a/packages/core/src/external/ehr/canvas/index.ts
+++ b/packages/core/src/external/ehr/canvas/index.ts
@@ -59,7 +59,6 @@ export type CanvasEnv = string;
 export const supportedCanvasDiffResources = [
   "AllergyIntolerance",
   "Condition",
-  "Coverage",
   "DiagnosticReport",
   "Encounter",
   "MedicationStatement",


### PR DESCRIPTION
Ref: ENG-47

Ref: #1040

Issues:

- https://linear.app/metriport/issue/ENG-47

### Description

- coverage isn't being fetched properly

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed support for the "Coverage" resource type in Canvas resource diff operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->