### PR TITLE
PATCH: Be able to update org biz type

### DIFF
--- a/packages/api/src/command/medical/organization/update-organization.ts
+++ b/packages/api/src/command/medical/organization/update-organization.ts
@@ -6,8 +6,7 @@ import { validateVersionForUpdate } from "../../../models/_default";
 import { BaseUpdateCmdWithCustomer } from "../base-update-command";
 import { getOrganizationOrFail } from "./get-organization";
 
-export type OrganizationUpdateCmd = BaseUpdateCmdWithCustomer &
-  Partial<Omit<OrganizationCreate, "type">>;
+export type OrganizationUpdateCmd = BaseUpdateCmdWithCustomer & Partial<OrganizationCreate>;
 
 export async function updateOrganization({
   id,
@@ -18,6 +17,7 @@ export async function updateOrganization({
   cqActive,
   cwApproved,
   cwActive,
+  type,
 }: OrganizationUpdateCmd): Promise<OrganizationModel> {
   const org = await getOrganizationOrFail({ id, cxId });
   validateVersionForUpdate(org, eTag);
@@ -27,6 +27,7 @@ export async function updateOrganization({
     cwActive,
     cqApproved,
     cwApproved,
+    type,
   });
 
   const fhirOrg = toFHIR(updatedOrg);


### PR DESCRIPTION
Part of cs-127

Issues:

- https://linear.app/metriport/issue/CS-127

### Dependencies

- Upstream: none
- Downstream: none

### Description

- Updates org biz type to change from obo to non obo

### Testing

- Production
  - [ ] Updates org biz type

_[Release PRs:]_

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users can now update the organization type when editing organization details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->