### PR TITLE
fix(deps): move posthog dep to core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30822,14 +30822,26 @@
       }
     },
     "node_modules/posthog-node": {
-      "version": "3.3.0",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-4.14.0.tgz",
+      "integrity": "sha512-PitSiuxGiVFl0ItuhIfi3Sq1tcaMU4vlbPu1wv0qufTJGDjWthOOr4vYfFIs1xkbJFOQcfGczMXkr44kX5TDDg==",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.2",
-        "rusha": "^0.8.14"
+        "axios": "^1.8.2"
       },
       "engines": {
         "node": ">=15.0.0"
+      }
+    },
+    "node_modules/posthog-node/node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -32403,10 +32415,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/rusha": {
-      "version": "0.8.14",
-      "license": "MIT"
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
@@ -35556,7 +35564,6 @@
         "oauth-signature": "^1.5.0",
         "pg": "^8.8.0",
         "pg-hstore": "^2.3.4",
-        "posthog-node": "^3.3.0",
         "reflect-metadata": "^0.1.13",
         "sequelize": "^6.31.0",
         "simple-oauth2": "^5.0.0",
@@ -35871,6 +35878,7 @@
         "pg": "^8.11.3",
         "pkijs": "^3.0.16",
         "playwright": "1.39.0",
+        "posthog-node": "^4.0.1",
         "pvutils": "^1.1.3",
         "sequelize": "^6.37.1",
         "ssh2-sftp-client": "^9.0.4",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -62,7 +62,6 @@
     "oauth-signature": "^1.5.0",
     "pg": "^8.8.0",
     "pg-hstore": "^2.3.4",
-    "posthog-node": "^3.3.0",
     "reflect-metadata": "^0.1.13",
     "sequelize": "^6.31.0",
     "simple-oauth2": "^5.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -139,6 +139,7 @@
     "pg": "^8.11.3",
     "pkijs": "^3.0.16",
     "playwright": "1.39.0",
+    "posthog-node": "^4.0.1",
     "pvutils": "^1.1.3",
     "sequelize": "^6.37.1",
     "ssh2-sftp-client": "^9.0.4",

--- a/packages/lambdas/package.json
+++ b/packages/lambdas/package.json
@@ -55,7 +55,6 @@
     "node-fetch": "^2.6.12",
     "pg": "^8.11.3",
     "pkijs": "^3.0.16",
-    "posthog-node": "^4.0.1",
     "pvutils": "^1.1.3",
     "sequelize": "^6.37.1",
     "ssh2-sftp-client": "^9.0.4",


### PR DESCRIPTION
Fixes ENG-169

### Dependencies

- Downstream: https://github.com/metriport/metriport/pull/3719

### Description

See ticket below for context.

To make this change it requires standardizing downsteam packages to a single version of posthog-node. I verified that posthog-node v4 does not have any breaking changes that would break OSS's usages. 

Changelog: https://github.com/PostHog/posthog-js-lite/blob/main/posthog-node/CHANGELOG.md#400---2024-03-18

### Testing

install deps, build, and test all pass without error

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management for "posthog-node" across multiple packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->