### PR TITLE
2876 add posthog env vars to hl7 infra

### DIFF
--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -128,7 +128,7 @@ type EnvConfigBase = {
   iheParsedResponsesBucketName: string;
   iheRequestsBucketName: string;
   fhirConverterBucketName?: string;
-  analyticsSecretNames?: {
+  analyticsSecretNames: {
     POST_HOG_API_KEY_SECRET: string;
   };
   locationService?: {

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -44,6 +44,9 @@ export const config: EnvConfigNonSandbox = {
   },
   dashUrl: "https://url-of-your-dashboard.com",
   ehrDashUrl: "https://url-of-your-ehr-dashboard.com",
+  analyticsSecretNames: {
+    POST_HOG_API_KEY_SECRET: "your-posthog-api-key-secret",
+  },
   fhirToMedicalLambda: {
     nodeRuntimeArn: "arn:aws:lambda:<region>::runtime:<id>",
   },

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -381,6 +381,7 @@ export class APIStack extends Stack {
           vpc: this.vpc,
           alarmAction: slackNotification?.alarmAction,
           outgoingHl7NotificationBucket,
+          secrets,
         }
       );
 

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -123,7 +123,10 @@ export class MllpStack extends cdk.NestedStack {
 
     fargateService.taskDefinition.addContainer("MllpServer", {
       image: ecs.ContainerImage.fromEcrRepository(ecrRepo, "latest"),
-      secrets: secretsToECS(buildSecrets(this, props.config.hl7Notification.secrets)),
+      secrets: secretsToECS({
+        ...buildSecrets(this, props.config.hl7Notification.secrets),
+        ...buildSecrets(this, props.config.analyticsSecretNames),
+      }),
       environment: {
         NODE_ENV: "production",
         ENV_TYPE: props.config.environmentType,

--- a/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
+++ b/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
@@ -60,6 +60,12 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
 
     this.terminationProtection = true;
 
+    const analyticsSecret =
+      props.secrets[props.config.analyticsSecretNames.POST_HOG_API_KEY_SECRET];
+    if (!analyticsSecret) {
+      throw new Error("Analytics secret is required");
+    }
+
     const setup = this.setupHl7NotificationWebhookSenderLambda({
       lambdaLayers: props.lambdaLayers,
       vpc: props.vpc,
@@ -67,7 +73,7 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
       sentryDsn: props.config.lambdasSentryDSN,
       alarmAction: props.alarmAction,
       outgoingHl7NotificationBucket: props.outgoingHl7NotificationBucket,
-      analyticsSecret: props.secrets[props.config.analyticsSecretNames.POST_HOG_API_KEY_SECRET],
+      analyticsSecret,
     });
 
     this.lambda = setup.lambda;

--- a/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
+++ b/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
@@ -60,8 +60,7 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
 
     this.terminationProtection = true;
 
-    const analyticsSecret =
-      props.secrets[props.config.analyticsSecretNames.POST_HOG_API_KEY_SECRET];
+    const analyticsSecret = props.secrets["POST_HOG_API_KEY_SECRET"];
     if (!analyticsSecret) {
       throw new Error("Analytics secret is required");
     }

--- a/packages/infra/lib/ihe-stack.ts
+++ b/packages/infra/lib/ihe-stack.ts
@@ -160,7 +160,7 @@ export class IHEStack extends Stack {
 
     const lambdaLayers = setupLambdasLayers(this, true);
 
-    const posthogSecretName = props.config.analyticsSecretNames?.POST_HOG_API_KEY_SECRET;
+    const posthogSecretName = props.config.analyticsSecretNames.POST_HOG_API_KEY_SECRET;
 
     const iheRequestsBucket = s3.Bucket.fromBucketName(
       this,

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -72,11 +72,9 @@ export class SecretsStack extends Stack {
       }
     }
 
-    if (props.config.analyticsSecretNames) {
-      for (const secretName of Object.values(props.config.analyticsSecretNames)) {
-        const secret = makeSecret(secretName);
-        logSecretInfo(this, secret, secretName);
-      }
+    for (const secretName of Object.values(props.config.analyticsSecretNames)) {
+      const secret = makeSecret(secretName);
+      logSecretInfo(this, secret, secretName);
     }
 
     if (!isSandbox(props.config)) {

--- a/packages/infra/lib/shared/secrets.ts
+++ b/packages/infra/lib/shared/secrets.ts
@@ -20,7 +20,7 @@ export function getSecrets(scope: Construct, config: EnvConfig): Secrets {
     ...(config.carequality?.secretNames
       ? buildSecrets(scope, config.carequality.secretNames)
       : undefined),
-    ...(config.analyticsSecretNames ? buildSecrets(scope, config.analyticsSecretNames) : undefined),
+    ...buildSecrets(scope, config.analyticsSecretNames),
     ...(config.canvas?.secretNames ? buildSecrets(scope, config.canvas.secretNames) : undefined),
     ...(config.ehrIntegration?.athenaHealth.secrets
       ? buildSecrets(scope, config.ehrIntegration.athenaHealth.secrets)


### PR DESCRIPTION
Issues:

- https://github.com/metriport/metriport-internal/issues/2876

### Dependencies

None

### Description

This adds the post hog api key environment variable to
- the MLLP server 
- the hl7 webhook sender lambda 

It starts logging the trigger event code to posthog and preps the webhook sender to start logging key metrics about ADT data in the future.

### Testing

Verified MLLP server is writing events out via branch-to-staging: see [link to staging posthog activity
](https://us.posthog.com/project/68198/activity/explore)

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for managing analytics-related secrets, including integration of a new analytics API key secret into the infrastructure configuration and deployment.

- **Refactor**
  - Updated configuration requirements to always include analytics secret names, ensuring consistent access to analytics secrets across all relevant services.
  - Improved secret handling by removing conditional checks and enforcing the presence of analytics secrets throughout the infrastructure setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->