### PR TITLE
build: PCP AI summary

### DIFF
--- a/packages/core/src/command/ai-brief/create.ts
+++ b/packages/core/src/command/ai-brief/create.ts
@@ -7,9 +7,15 @@ import { errorToString } from "@metriport/shared";
 import { elapsedTimeFromNow } from "@metriport/shared/common/date";
 import { LLMChain, MapReduceDocumentsChain, StuffDocumentsChain } from "langchain/chains";
 import { EventTypes, analytics } from "../../external/analytics/posthog";
+import { isPcpVisitAiSummaryFeatureFlagEnabledForCx } from "../feature-flags/domain-ffs";
 import { BedrockChat } from "../../external/langchain/bedrock";
 import { out } from "../../util";
 import { documentVariableName, mainSummaryPrompt, refinedSummaryPrompt } from "./prompts";
+import {
+  documentVariableName as pcpVisitDocumentVariableName,
+  mainSummaryPrompt as pcpVisitMainSummaryPrompt,
+  refinedSummaryPrompt as pcpVisitRefinedSummaryPrompt,
+} from "./pcp-visit-prompt";
 
 const CHUNK_SIZE = 100_000;
 const CHUNK_OVERLAP = 1000;
@@ -29,6 +35,10 @@ export async function summarizeFilteredBundleWithAI(
   const { log } = out(`summarizeFilteredBundleWithAI - cxId ${cxId}, patientId ${patientId}`);
   // filter out historical data
   try {
+    const { documentVariable, mainPrompt, refinedPrompt } = await getInputsForAiBriefGeneration(
+      cxId
+    );
+
     // TODO: #2510 - experiment with different splitters
     const textSplitter = new RecursiveCharacterTextSplitter({
       chunkSize: CHUNK_SIZE,
@@ -57,25 +67,25 @@ export async function summarizeFilteredBundleWithAI(
       ],
     });
 
-    const SUMMARY_PROMPT = PromptTemplate.fromTemplate(mainSummaryPrompt);
+    const SUMMARY_PROMPT = PromptTemplate.fromTemplate(mainPrompt);
     const summaryChain = new LLMChain({
       llm: llmSummary as any, // eslint-disable-line @typescript-eslint/no-explicit-any
       prompt: SUMMARY_PROMPT as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     });
 
-    const SUMMARY_PROMPT_REFINED = PromptTemplate.fromTemplate(refinedSummaryPrompt);
+    const SUMMARY_PROMPT_REFINED = PromptTemplate.fromTemplate(refinedPrompt);
     const summaryChainRefined = new StuffDocumentsChain({
       llmChain: new LLMChain({
         llm: llmSummary as any, // eslint-disable-line @typescript-eslint/no-explicit-any
         prompt: SUMMARY_PROMPT_REFINED as any, // eslint-disable-line @typescript-eslint/no-explicit-any
       }),
-      documentVariableName,
+      documentVariableName: documentVariable,
     });
 
     const mapReduce = new MapReduceDocumentsChain({
       llmChain: summaryChain,
       combineDocumentChain: summaryChainRefined,
-      documentVariableName,
+      documentVariableName: documentVariable,
       verbose: false,
     });
 
@@ -110,6 +120,28 @@ export async function summarizeFilteredBundleWithAI(
     // Intentionally not throwing the error to avoid breaking the MR Summary generation flow
     throw err;
   }
+}
+
+async function getInputsForAiBriefGeneration(cxId: string): Promise<{
+  mainPrompt: string;
+  refinedPrompt: string;
+  documentVariable: string;
+}> {
+  const isPcpVisit = await isPcpVisitAiSummaryFeatureFlagEnabledForCx(cxId);
+
+  if (isPcpVisit) {
+    return {
+      mainPrompt: pcpVisitMainSummaryPrompt,
+      refinedPrompt: pcpVisitRefinedSummaryPrompt,
+      documentVariable: pcpVisitDocumentVariableName,
+    };
+  }
+
+  return {
+    mainPrompt: mainSummaryPrompt,
+    refinedPrompt: refinedSummaryPrompt,
+    documentVariable: documentVariableName,
+  };
 }
 
 function calculateCostsBasedOnTokens(totalTokens: { input: number; output: number }): {

--- a/packages/core/src/command/ai-brief/pcp-visit-prompt.ts
+++ b/packages/core/src/command/ai-brief/pcp-visit-prompt.ts
@@ -1,0 +1,97 @@
+const todaysDate = new Date().toISOString().split("T")[0];
+const systemPrompt =
+  "You are a medical record reviewer and your task is to extract key information from a patient's medical chart.";
+
+export const documentVariableName = "text";
+
+const instructions = `
+Instructions:
+1. Review the patient medical records and format the output as follows:
+    Most recent Primary Care Provider (PCP) visit (Date: [date]):
+    PCP Name: [name], [credentials] [specialty]
+
+    Medical / Problem List: [comma separated list of conditions]
+    Medication List: [comma separated list of medications]
+    Note: Only include MD, DO, NP, PA visits to the specialty of Family Medicine, Internal Medicine or OB/GYN.
+    If PCP visit isn't available, use History of Present Illness (HPI) visit instead
+
+    Most recent height (Date: [date]): [value] in
+    Most recent weight (Date: [date]): [value] lbs
+    Most Recent BMI ([date]): [value]
+
+    Qualifying Conditions: [Comma separated list of conditions with their most recent diagnosis date]
+    Disqualifying Conditions: [Comma separated list of conditions with their most recent diagnosis date]
+    Qualifying Medications: [Comma separated list of medications with their recent fill date]
+    Disqualifying Medications: [Comma separated list of medications with their recent fill date]
+
+List of qualifying conditions:
+- High blood pressure or hypertension
+- High cholesterol or Hyperlipidemia/Dyslipidemia
+- Type 2 Diabetes Sleep Apnea or OSA
+- Polycystic ovarian syndrome (PCOS)
+- Fatty Liver, Hepatic Steatosis, or Non-alcoholic fatty liver disease (NAFLD)*
+- Prediabetes Insulin Resistance*
+- Coronary Artery Disease (Heart Disease, History of MI/Heart Attack > 6 months, etc.)*
+- Infertility
+
+List of disqualifying conditions:
+- Current pregnancy or currently breastfeeding
+- Active cancer or cancer treatment in the last 6 months Active drug or alcohol abuse
+- CKD Stage 4 or higher (eGFR <29) or kidney transplant
+- Active hepatitis or liver disease (fatty liver does not apply)
+- Heart attack / stroke / any heart condition that limits daily activity in last 6 months
+- Serious uncontrolled mental health conditions: mental health conditions if there is evidence of uncontrolled symptoms or inpatient hospitalization
+
+List of qualifying medications:
+- Alli or Xenical (orlistat)
+- Bupropion Contrave (naltrexone-bupropion)
+- Diethylpropion
+- Metformin
+- Mounjaro (tirzepatide)
+- Naltrexone
+- Ozempic (semaglutide)
+- Phentermine (Lomaira)
+- Qsymia (phentermine + topiramate ER)
+- Rybelsus (oral semaglutide)
+- Saxenda (liraglutide)
+- Topiramate Trulicity (dulaglutide)
+- Victoza (liraglutide)
+- Wegovy (semaglutide)
+- Zonisamide
+
+List of disqualifying medications:
+- Daily use of oral steroid meds equivalent or higher than prednisone 20 mg twice daily (not including inhalers)
+`;
+
+export const mainSummaryPrompt = `
+${systemPrompt}
+
+Today's date is ${todaysDate}.
+Review the patient medical records:
+--------
+{${documentVariableName}}
+--------
+${instructions}
+
+If any of the above information is not present, do not include it in the summary.
+Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided.
+
+SUMMARY:
+`;
+
+export const refinedSummaryPrompt = `
+${systemPrompt}
+
+Today's date is ${todaysDate}.
+Here are the previous summaries written by you of sections of the patient's medical history:
+--------
+{${documentVariableName}}
+--------
+
+Combine these summaries into a single, comprehensive summary.
+Use these ${instructions}.
+
+Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided.
+
+SUMMARY:
+`;

--- a/packages/core/src/command/feature-flags/domain-ffs.ts
+++ b/packages/core/src/command/feature-flags/domain-ffs.ts
@@ -232,3 +232,11 @@ export async function isDermFeatureFlagEnabledForCx(cxId: string): Promise<boole
   const cxIdsWithDermEnabled = await getCxsWithDermFeatureFlag();
   return cxIdsWithDermEnabled.some(i => i === cxId);
 }
+
+export async function getCxsWithPcpVisitAiSummaryFeatureFlag(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithPcpVisitAiSummaryFeatureFlag");
+}
+export async function isPcpVisitAiSummaryFeatureFlagEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithPcpVisitAiSummaryEnabled = await getCxsWithPcpVisitAiSummaryFeatureFlag();
+  return cxIdsWithPcpVisitAiSummaryEnabled.some(i => i === cxId);
+}

--- a/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
+++ b/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
@@ -57,6 +57,7 @@ export const initialFeatureFlags: FeatureFlagDatastore = {
   e2eCxIds: { enabled: false, values: [] },
   commonwellFeatureFlag: { enabled: false },
   carequalityFeatureFlag: { enabled: false },
+  cxsWithPcpVisitAiSummaryFeatureFlag: { enabled: false, values: [] },
 };
 
 /**

--- a/packages/core/src/command/feature-flags/types.ts
+++ b/packages/core/src/command/feature-flags/types.ts
@@ -34,6 +34,7 @@ export const cxBasedFFsSchema = z.object({
   cxsWithStalePatientUpdateEnabled: ffStringValuesSchema,
   cxsWithStrictMatchingAlgorithm: ffStringValuesSchema,
   cxsWithAthenaCustomFieldsEnabled: ffStringValuesSchema,
+  cxsWithPcpVisitAiSummaryFeatureFlag: ffStringValuesSchema,
 });
 export type CxBasedFFsSchema = z.infer<typeof cxBasedFFsSchema>;
 


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/CS-188

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/2910

### Description

- Enable Custom PCP AI sumamry

### Testing

- Local
  - [x] PCP Visi Summaryt is rendered
- Staging
  - [ ] PCP Visi Summaryt is rendered
- Production
  - [ ] PCP Visi Summaryt is rendered


Check each PR.

### Release Plan

- [ ] FFs have been set in Staging, Production, and Sandbox
- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a feature flag to enable a specialized AI summary for Primary Care Provider (PCP) visits, allowing select customers to receive enhanced clinical summaries.
  - Added new AI prompt templates that extract and format key PCP visit details, including provider information, medical/problem lists, medications, and relevant clinical data.
- **Chores**
  - Updated internal feature flag management to support the new PCP visit AI summary capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->