### PR TITLE
fix(infra): fix undefined batch size

### DIFF
--- a/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
+++ b/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
@@ -20,7 +20,6 @@ function settings() {
     lambda: {
       memory: 1024 as const,
       timeout,
-      reportBatchItemFailures: true,
     },
     queue: {
       alarmMaxAgeOfOldestMessage: Duration.minutes(5),

--- a/packages/infra/lib/shared/settings.ts
+++ b/packages/infra/lib/shared/settings.ts
@@ -7,12 +7,8 @@ export type QueueAndLambdaSettings = {
   entry: string;
   lambda: {
     memory: 512 | 1024 | 2048 | 4096;
-    /** Number of messages the lambda pull from SQS at once  */
-    batchSize?: number;
     /** How long can the lambda run for, max is 900 seconds (15 minutes)  */
     timeout: Duration;
-    /** Partial batch response: https://docs.aws.amazon.com/prescriptive-guidance/latest/lambda-event-filtering-partial-batch-responses-for-sqs/welcome.html */
-    reportBatchItemFailures?: boolean;
     reservedConcurrentExecutions?: number;
   };
   queue: {
@@ -26,7 +22,9 @@ export type QueueAndLambdaSettings = {
     createRetryLambda: boolean;
   };
   eventSource: {
+    /** Number of messages the lambda pull from SQS at once  */
     batchSize: number;
+    /** Partial batch response: https://docs.aws.amazon.com/prescriptive-guidance/latest/lambda-event-filtering-partial-batch-responses-for-sqs/welcome.html */
     reportBatchItemFailures: boolean;
     maxConcurrency?: number;
     maxBatchingWindow?: Duration;

--- a/packages/lambdas/src/shared/sqs.ts
+++ b/packages/lambdas/src/shared/sqs.ts
@@ -71,7 +71,6 @@ export function getSingleMessageOrFail(
     const msg = "Got more than one message from SQS";
     capture.error(msg, {
       extra: {
-        event,
         context: lambdaName,
         additional: `This lambda is supposed to run w/ only 1 message per batch, got ${records.length}`,
       },


### PR DESCRIPTION
metriport/metriport-internal#1040

Ref: ENG-176
Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

Issues:

- https://linear.app/metriport/issue/ENG-176/fix-undefined-batchsize-in-patient-import-infra

### Dependencies

None

### Description

Patient import was getting passed undefined for batch size due to a refactor where types weren't set correctly, and the code change wasn't tested :( 

See slack thread: https://metriport.slack.com/archives/C04T256DQPQ/p1745540667295649

### Testing

None

### Release Plan

- [ ] Merge this
- [ ] Verify that batch size for patient import lambda is set to 1 in staging


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined configuration handling for Lambda and SQS event sources, grouping related settings and improving maintainability.
  - Adjusted internal error reporting to exclude event details from error logs.

- **Style**
  - Updated type definitions to consolidate and clarify configuration options for event sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->