### PR TITLE
fix(api): fix wh ff boolean condition

### DIFF
--- a/packages/api/src/command/medical/patient/hl7-fhir-webhook.ts
+++ b/packages/api/src/command/medical/patient/hl7-fhir-webhook.ts
@@ -47,7 +47,7 @@ export async function processHl7FhirBundleWebhook({
       },
     };
 
-    if (await isHl7NotificationWebhookFeatureFlagEnabledForCx(cxId)) {
+    if (!(await isHl7NotificationWebhookFeatureFlagEnabledForCx(cxId))) {
       log(`WH FF disabled. Not sending it...`);
       await createWebhookRequest({
         cxId,


### PR DESCRIPTION
metriport/metriport-internal#1040

Ref: ENG-89
Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

None

### Description

Fixes the HL7 notification webhook send FF so that the FF must be on for a CX for them to receive a webhook.

### Testing

- [ ] Something

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the behavior of the HL7 notification webhook feature flag, ensuring webhooks are only sent when the feature is enabled for the relevant context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->