### PR TITLE
fix(infra): lambda to have read permission on s3

### DIFF
--- a/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
+++ b/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
@@ -114,7 +114,7 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
       },
     });
 
-    outgoingHl7NotificationBucket.grantWrite(lambda);
+    outgoingHl7NotificationBucket.grantReadWrite(lambda);
     lambda.addEventSource(new SqsEventSource(queue, eventSourceSettings));
 
     new CfnOutput(this, "Hl7NotificationWebhookSenderQueueArn", {


### PR DESCRIPTION
Part of ENG-89

Issues:

- https://linear.app/metriport/issue/ENG-89

### Description
- Adding the s3 bucket read permission to the hl7 webhook sender lambda

### Testing

- Staging
  - [x] Make sure the signed URL in the WH payload works
- Production
  - [ ] Confirm the payload looks good

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated permissions to allow Lambda functions both read and write access to outgoing HL7 notification files in the storage bucket.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->