### PR TITLE
2330 Patient import optional on finishSinglePatientImport

### DIFF
--- a/packages/api/src/command/medical/patient/patient-import/finish-single-patient.ts
+++ b/packages/api/src/command/medical/patient/patient-import/finish-single-patient.ts
@@ -12,7 +12,7 @@ import {
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import { tryToFinishPatientImportJob } from "./finish-job";
-import { getPatientImportByRequestIdOrFail } from "./get-mapping-and-import";
+import { getPatientImportByRequestId } from "./get-mapping-and-import";
 
 dayjs.extend(duration);
 
@@ -47,11 +47,16 @@ export async function finishSinglePatientImport({
   log(`Finishing import for patient, status ${status}`);
 
   try {
-    const patientImportAndMapping = await getPatientImportByRequestIdOrFail({
+    const patientImportAndMapping = await getPatientImportByRequestId({
       cxId,
       patientId,
       dataPipelineRequestId,
     });
+    if (!patientImportAndMapping) {
+      // TODO 2330 Remove this on v2
+      log(`Patient import and mapping not found, skipping`);
+      return;
+    }
     const { job: patientImport, mapping } = patientImportAndMapping;
     const jobId = patientImport.id;
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#2330

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3412
- Downstream: none

### Description

Patient import optional on `finishSinglePatientImport()` - [context](https://metriport.slack.com/archives/C04T5Q9JHFX/p1745864447858269?thread_ts=1744292288.639309&cid=C04T5Q9JHFX).

### Testing

- Local
  - none
- Staging
  - [ ] Regular DQ doesn't trigger alert
  - [ ] Bulk import completes
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing patient import data to prevent errors and provide clearer feedback when data is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->