### PR TITLE
chore(release): publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35674,16 +35674,11 @@
       "license": "MIT",
       "dependencies": {
         "@metriport/ihe-gateway-sdk": "^0.19.1",
-        "@metriport/shared": "^0.8.0"
+        "@metriport/shared": "^0.23.1"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
       }
-    },
-    "packages/carequality-cert-runner/node_modules/@metriport/shared": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@metriport/shared/-/shared-0.8.0.tgz",
-      "integrity": "sha512-V4t0pHP9SHkxxfLhZSsS7yfjLSn1HoYwO8zN3QUJwpbX9cDxbeO8FvqiMlQ3wGBOeShJbzEsFeWBmW9dGTzzZw=="
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35526,7 +35526,7 @@
       }
     },
     "packages/api": {
-      "version": "1.27.1-alpha.0",
+      "version": "1.27.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.338.0",
@@ -35609,12 +35609,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "14.14.1-alpha.0",
+      "version": "14.14.1",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.8.1-alpha.0",
-        "@metriport/shared": "^0.23.1-alpha.0",
+        "@metriport/commonwell-sdk": "^5.8.1",
+        "@metriport/shared": "^0.23.1",
         "axios": "^1.4.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -35670,10 +35670,10 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.18.1-alpha.0",
+      "version": "1.18.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.19.1-alpha.0",
+        "@metriport/ihe-gateway-sdk": "^0.19.1",
         "@metriport/shared": "^0.8.0"
       },
       "bin": {
@@ -35687,7 +35687,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.6.1-alpha.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -35711,10 +35711,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.26.1-alpha.0",
+      "version": "1.26.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.8.1-alpha.0",
+        "@metriport/commonwell-sdk": "^5.8.1",
         "axios": "^1.4.0",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -35753,10 +35753,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.24.1-alpha.0",
+      "version": "1.24.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.8.1-alpha.0",
+        "@metriport/commonwell-sdk": "^5.8.1",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -35788,10 +35788,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.8.1-alpha.0",
+      "version": "5.8.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.23.1-alpha.0",
+        "@metriport/shared": "^0.23.1",
         "axios": "^1.4.0",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -35839,7 +35839,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.24.1-alpha.0",
+      "version": "1.24.1",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -37084,17 +37084,17 @@
     "packages/core/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.19.1-alpha.0",
+      "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.23.1-alpha.0",
+        "@metriport/shared": "^0.23.1",
         "axios": "^1.6.0",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.22.1-alpha.0",
+      "version": "1.22.1",
       "dependencies": {
         "@metriport/shared": "file:packages/shared",
         "aws-cdk-lib": "~2.133.0",
@@ -37147,7 +37147,7 @@
     },
     "packages/infra/packages/shared": {},
     "packages/mllp-server": {
-      "version": "0.3.1-alpha.0",
+      "version": "0.3.1",
       "license": "ISC",
       "dependencies": {
         "@medplum/core": "^3.2.33",
@@ -37303,7 +37303,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.23.1-alpha.0",
+      "version": "0.23.1",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -37351,7 +37351,7 @@
       }
     },
     "packages/utils": {
-      "version": "1.25.1-alpha.0",
+      "version": "1.25.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.658.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "14.14.1-alpha.0",
+  "version": "14.14.1",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.8.1-alpha.0",
-    "@metriport/shared": "^0.23.1-alpha.0",
+    "@metriport/commonwell-sdk": "^5.8.1",
+    "@metriport/shared": "^0.23.1",
     "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.27.1-alpha.0",
+  "version": "1.27.1",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.18.1-alpha.0",
+  "version": "1.18.1",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.19.1-alpha.0",
+    "@metriport/ihe-gateway-sdk": "^0.19.1",
     "@metriport/shared": "^0.8.0"
   }
 }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -42,6 +42,6 @@
   },
   "dependencies": {
     "@metriport/ihe-gateway-sdk": "^0.19.1",
-    "@metriport/shared": "^0.8.0"
+    "@metriport/shared": "^0.23.1"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.6.1-alpha.0",
+  "version": "1.6.1",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.26.1-alpha.0",
+  "version": "1.26.1",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.8.1-alpha.0",
+    "@metriport/commonwell-sdk": "^5.8.1",
     "axios": "^1.4.0",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.24.1-alpha.0",
+  "version": "1.24.1",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.8.1-alpha.0",
+    "@metriport/commonwell-sdk": "^5.8.1",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.8.1-alpha.0",
+  "version": "5.8.1",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.23.1-alpha.0",
+    "@metriport/shared": "^0.23.1",
     "axios": "^1.4.0",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.24.1-alpha.0",
+  "version": "1.24.1",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.19.1-alpha.0",
+  "version": "0.19.1",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.23.1-alpha.0",
+    "@metriport/shared": "^0.23.1",
     "axios": "^1.6.0",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.22.1-alpha.0",
+  "version": "1.22.1",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mllp-server",
-  "version": "0.3.1-alpha.0",
+  "version": "0.3.1",
   "description": "MLLP server that reads HL7 messages off of a raw tcp connection",
   "main": "app.js",
   "private": true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.23.1-alpha.0",
+  "version": "0.23.1",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.25.1-alpha.0",
+  "version": "1.25.1",
   "description": "",
   "private": true,
   "scripts": {

--- a/samples/typescript-express/package-lock.json
+++ b/samples/typescript-express/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@metriport/api-sdk": "^14.14.0-alpha.0",
-        "@metriport/shared": "^0.23.0-alpha.0",
+        "@metriport/shared": "^0.23.1",
         "express": "^4.19.2"
       },
       "devDependencies": {
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@metriport/shared": {
-      "version": "0.23.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@metriport/shared/-/shared-0.23.0-alpha.0.tgz",
-      "integrity": "sha512-4uhtJkIsbiEpTADqUBsDbFDY203L6Okw5f5KYEGbcSgW3n4m+CaOSD8CvADj5OwOaMiertYpQJaxV84Aw8fOFQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@metriport/shared/-/shared-0.23.1.tgz",
+      "integrity": "sha512-ZMkxOPbj4usrg8fP/freDRrnMS5DsW7vhwSmaIPz5KZshdzZ2AJDuLozEIf/JGHzLV8Xw+GcFJ1tz10120DxpQ==",
       "dependencies": {
         "@medplum/core": "^2.2.10",
         "axios": "^1.4.0",

--- a/samples/typescript-express/package.json
+++ b/samples/typescript-express/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "@metriport/api-sdk": "^14.14.0-alpha.0",
-    "@metriport/shared": "^0.23.1-alpha.0",
+    "@metriport/shared": "^0.23.1",
     "express": "^4.19.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Ref: #000

 - api@1.27.1
 - @metriport/api-sdk@14.14.1
 - @metriport/carequality-cert-runner@1.18.1
 - @metriport/carequality-sdk@1.6.1
 - @metriport/commonwell-cert-runner@1.26.1
 - @metriport/commonwell-jwt-maker@1.24.1
 - @metriport/commonwell-sdk@5.8.1
 - @metriport/core@1.24.1
 - @metriport/ihe-gateway-sdk@0.19.1
 - infrastructure@1.22.1
 - mllp-server@0.3.1
 - @metriport/shared@0.23.1
 - utils@1.25.1

Related to https://github.com/metriport/metriport/pull/3412


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated multiple packages and dependencies from pre-release alpha versions to stable release versions across the platform. No changes to features, functionality, or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->