### PR TITLE
Dependabot#399 Require axios version across the whole monorepo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "packages/utils"
       ],
       "dependencies": {
+        "axios": ">=1.8.2",
         "semver": ">=5.7.2",
         "sharp": "^0.33.5"
       },
@@ -10536,7 +10537,10 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.22.6",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -18314,9 +18318,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -18324,11 +18328,14 @@
       }
     },
     "node_modules/axios-retry": {
-      "version": "3.9.1",
-      "license": "Apache-2.0",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
         "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
       }
     },
     "node_modules/b4a": {
@@ -23394,6 +23401,17 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.22.tgz",
       "integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw==",
       "peer": true
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/axios": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/ibm-cloud-sdk-core/node_modules/camelcase": {
       "version": "6.3.0",
@@ -30834,17 +30852,6 @@
         "node": ">=15.0.0"
       }
     },
-    "node_modules/posthog-node/node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -31874,7 +31881,10 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -35636,16 +35646,6 @@
         "typescript": "^4.9.5"
       }
     },
-    "packages/api-sdk/node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "packages/api/node_modules/@metriport/api-sdk": {
       "resolved": "packages/api/packages/api-sdk",
       "link": true
@@ -35675,16 +35675,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/api/node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "packages/api/packages/api-sdk": {},
     "packages/api/packages/carequality-sdk": {},
     "packages/api/packages/commonwell-sdk": {},
@@ -35709,7 +35699,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
-        "axios-retry": "^3.1.9",
+        "axios-retry": "^4.5.0",
         "zod": "^3.22.1"
       },
       "devDependencies": {
@@ -35725,16 +35715,6 @@
         "ts-essentials": "^9.3.1",
         "ts-jest": "29.1.1",
         "typescript": "^4.9.5"
-      }
-    },
-    "packages/carequality-sdk/node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/commonwell-cert-runner": {
@@ -35771,16 +35751,6 @@
       "version": "18.16.19",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/commonwell-cert-runner/node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "packages/commonwell-cert-runner/node_modules/commander": {
       "version": "9.5.0",
@@ -35860,16 +35830,6 @@
       "version": "18.16.19",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/commonwell-sdk/node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "packages/commonwell-sdk/node_modules/jsonwebtoken": {
       "version": "9.0.1",
@@ -37141,16 +37101,6 @@
         "zod": "^3.22.1"
       }
     },
-    "packages/ihe-gateway-sdk/node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "packages/infra": {
       "name": "infrastructure",
       "version": "1.22.1",
@@ -37387,16 +37337,6 @@
         "ts-essentials": "^9.3.1",
         "ts-jest": "29.1.1",
         "typescript": "^4.9.5"
-      }
-    },
-    "packages/shared/node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/shared/node_modules/fast-xml-parser": {
@@ -39687,16 +39627,6 @@
       },
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "packages/utils/node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/utils/node_modules/buffer": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
       "path": "@commitlint/cz-commitlint"
     }
   },
+  "dependencies": {
+    "axios": ">=1.8.2",
+    "sharp": "^0.33.5",
+    "semver": ">=5.7.2"
+  },
   "devDependencies": {
     "@commitlint/cli": "^17.4.2",
     "@commitlint/config-conventional": "^17.4.2",
@@ -80,9 +85,5 @@
     "lint-staged": "^13.1.0",
     "mintlify": "^4.0.307",
     "typescript": "^4.9.5"
-  },
-  "dependencies": {
-    "sharp": "^0.33.5",
-    "semver": ">=5.7.2"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "axios": "^1.8.2",
-    "axios-retry": "^3.1.9",
+    "axios-retry": "^4.5.0",
     "zod": "^3.22.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Issues:

- https://github.com/metriport/metriport/security/dependabot/399

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3706
- Downstream: none

### Description

Require axios version across the whole monorepo - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1745937017580299)

### Testing

- Local
  - [x] The monorepo builds successfully
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated and reorganized dependencies in the main package configuration for improved clarity.
  - Added "axios" as a runtime dependency.
  - Updated "axios-retry" to the latest version in the carequality-sdk package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->