### PR TITLE
ENG-84 Move count consolidated to a lambda

### DIFF
--- a/packages/api/src/command/medical/patient/get-patient.ts
+++ b/packages/api/src/command/medical/patient/get-patient.ts
@@ -377,11 +377,12 @@ export async function getPatientByExternalId({
 }): Promise<PatientWithIdentifiers | undefined> {
   if (!source) {
     const patients = await PatientModel.findAll({ where: { cxId, externalId } });
-    if (patients.length < 1) return undefined;
     if (patients.length > 1) {
       throw new BadRequestError(`Found multiple patients with external ID ${externalId}`);
     }
-    return await attachPatientIdentifiers(patients[0].dataValues);
+    const patient = patients[0];
+    if (!patient) return undefined;
+    return await attachPatientIdentifiers(patient.dataValues);
   }
   const patientMapping = await getPatientMapping({
     cxId,

--- a/packages/api/src/external/fhir/patient/count-resources-shared.ts
+++ b/packages/api/src/external/fhir/patient/count-resources-shared.ts
@@ -1,8 +1,0 @@
-import { ResourceTypeForConsolidation } from "@metriport/api-sdk";
-
-export type ResourceCount = {
-  total: number;
-  resources: {
-    [key in ResourceTypeForConsolidation]?: number;
-  };
-};

--- a/packages/api/src/external/fhir/patient/count-resources.ts
+++ b/packages/api/src/external/fhir/patient/count-resources.ts
@@ -1,7 +1,7 @@
 import { ResourceTypeForConsolidation } from "@metriport/api-sdk";
+import { ConsolidatedCounterResponse } from "@metriport/core/command/consolidated/consolidated-counter";
 import { Patient } from "@metriport/core/domain/patient";
 import { countResourcesOnS3 } from "./count-resources-on-s3";
-import { ResourceCount } from "./count-resources-shared";
 
 export type CountResourcesParams = {
   patient: Pick<Patient, "cxId" | "id">;
@@ -16,6 +16,6 @@ export async function countResources({
   resources = [],
   dateFrom,
   dateTo,
-}: CountResourcesParams): Promise<ResourceCount> {
+}: CountResourcesParams): Promise<ConsolidatedCounterResponse> {
   return countResourcesOnS3({ patient, resources, dateFrom, dateTo });
 }

--- a/packages/core/src/command/consolidated/consolidated-counter-factory.ts
+++ b/packages/core/src/command/consolidated/consolidated-counter-factory.ts
@@ -1,0 +1,11 @@
+import { Config } from "../../util/config";
+import { ConsolidatedCounter } from "./consolidated-counter";
+import { ConsolidatedCounterLambda } from "./consolidated-counter-lambda";
+import { ConsolidatedCounterImpl } from "./consolidated-counter-impl";
+
+export function buildConsolidatedCountConnector(): ConsolidatedCounter {
+  if (Config.isDev()) {
+    return new ConsolidatedCounterImpl();
+  }
+  return new ConsolidatedCounterLambda();
+}

--- a/packages/core/src/command/consolidated/consolidated-counter-impl.ts
+++ b/packages/core/src/command/consolidated/consolidated-counter-impl.ts
@@ -1,0 +1,32 @@
+import { countBy } from "lodash";
+import { out } from "../../util/log";
+import {
+  ConsolidatedCounter,
+  ConsolidatedCounterRequest,
+  ConsolidatedCounterResponse,
+} from "./consolidated-counter";
+import { getConsolidatedFromS3 } from "./consolidated-filter";
+
+export class ConsolidatedCounterImpl implements ConsolidatedCounter {
+  async execute(params: ConsolidatedCounterRequest): Promise<ConsolidatedCounterResponse> {
+    const { patient, resources, dateFrom, dateTo } = params;
+    const { log } = out(`ConsolidatedCounterImpl - cx ${patient.cxId}, pt ${patient.id}`);
+
+    const res = await getConsolidatedFromS3({
+      cxId: patient.cxId,
+      patient,
+      resources,
+      dateFrom,
+      dateTo,
+    });
+    const resultingResources = (res.entry ?? []).flatMap(e => (e && e.resource ? e.resource : []));
+
+    const counted = countBy(resultingResources, r => r.resourceType);
+    log(`Counted ${resultingResources.length} resources`);
+
+    return {
+      total: resultingResources.length,
+      resources: counted,
+    };
+  }
+}

--- a/packages/core/src/command/consolidated/consolidated-counter-lambda.ts
+++ b/packages/core/src/command/consolidated/consolidated-counter-lambda.ts
@@ -1,0 +1,36 @@
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import { getLambdaResultPayload, makeLambdaClient } from "../../external/aws/lambda";
+import { Config } from "../../util/config";
+import {
+  ConsolidatedCounter,
+  ConsolidatedCounterRequest,
+  ConsolidatedCounterResponse,
+} from "./consolidated-counter";
+
+dayjs.extend(duration);
+
+export const lambdaExecutionTimeout = dayjs.duration(15, "minutes").add(2, "seconds");
+
+export class ConsolidatedCounterLambda implements ConsolidatedCounter {
+  readonly lambdaClient: AWS.Lambda;
+  constructor(
+    region = Config.getAWSRegion(),
+    private readonly lambdaName = Config.getFHIRtoBundleCountLambdaName()
+  ) {
+    this.lambdaClient = makeLambdaClient(region, lambdaExecutionTimeout.asMilliseconds());
+  }
+
+  async execute(params: ConsolidatedCounterRequest): Promise<ConsolidatedCounterResponse> {
+    const result = await this.lambdaClient
+      .invoke({
+        FunctionName: this.lambdaName,
+        InvocationType: "RequestResponse",
+        Payload: JSON.stringify(params),
+      })
+      .promise();
+    const resultPayload = getLambdaResultPayload({ result, lambdaName: this.lambdaName });
+    const response = JSON.parse(resultPayload) as ConsolidatedCounterResponse;
+    return response;
+  }
+}

--- a/packages/core/src/command/consolidated/consolidated-counter.ts
+++ b/packages/core/src/command/consolidated/consolidated-counter.ts
@@ -1,0 +1,15 @@
+import { ResourceTypeForConsolidation } from "@metriport/api-sdk";
+import { ConsolidatedSnapshotRequest } from "./get-snapshot";
+
+export type ConsolidatedCounterRequest = ConsolidatedSnapshotRequest;
+
+export type ConsolidatedCounterResponse = {
+  total: number;
+  resources: {
+    [key in ResourceTypeForConsolidation]?: number;
+  };
+};
+
+export interface ConsolidatedCounter {
+  execute(params: ConsolidatedCounterRequest): Promise<ConsolidatedCounterResponse>;
+}

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -131,6 +131,9 @@ export class Config {
   static getFHIRtoBundleLambdaName(): string {
     return getEnvVarOrFail("FHIR_TO_BUNDLE_LAMBDA_NAME");
   }
+  static getFHIRtoBundleCountLambdaName(): string {
+    return getEnvVarOrFail("FHIR_TO_BUNDLE_COUNT_LAMBDA_NAME");
+  }
 
   static getBedrockRegion(): string | undefined {
     return getEnvVar("BEDROCK_REGION");

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -347,6 +347,7 @@ export class APIStack extends Stack {
       outboundDocumentQueryLambda,
       outboundDocumentRetrievalLambda,
       fhirToBundleLambda,
+      fhirToBundleCountLambda,
       fhirConverterConnector: {
         queue: fhirConverterQueue,
         lambda: fhirConverterLambda,
@@ -549,6 +550,7 @@ export class APIStack extends Stack {
       fhirToMedicalRecordLambda2,
       fhirToCdaConverterLambda,
       fhirToBundleLambda,
+      fhirToBundleCountLambda,
       rateLimitTable,
       searchIngestionQueue: ccdaSearchQueue,
       searchEndpoint: ccdaSearchDomain.domainEndpoint,
@@ -623,6 +625,7 @@ export class APIStack extends Stack {
       outboundDocumentQueryLambda,
       outboundDocumentRetrievalLambda,
       fhirToBundleLambda,
+      fhirToBundleCountLambda,
       hl7v2RosterUploadLambda,
       hl7NotificationWebhookSenderLambda,
       patientImportCreateLambda,

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -43,7 +43,6 @@ interface LambdasNestedStackProps extends NestedStackProps {
 type GenericConsolidatedLambdaProps = {
   name: string;
   entry: string;
-  memory: number;
   lambdaLayers: LambdaLayers;
   vpc: ec2.IVpc;
   bundleBucket: s3.IBucket;
@@ -577,7 +576,6 @@ export class LambdasNestedStack extends NestedStack {
       ...params,
       name: "FhirToBundle",
       entry: "fhir-to-bundle",
-      memory: 4096,
     });
   }
   private setupFhirBundleCountLambda(params: ConsolidatedLambdaProps): Lambda {
@@ -585,14 +583,12 @@ export class LambdasNestedStack extends NestedStack {
       ...params,
       name: "FhirToBundleCount",
       entry: "fhir-to-bundle-count",
-      memory: 2048,
     });
   }
 
   private setupGenericConsolidatedLambda({
     name,
     entry,
-    memory,
     lambdaLayers,
     vpc,
     fhirServerUrl,
@@ -628,7 +624,7 @@ export class LambdasNestedStack extends NestedStack {
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
       layers: [lambdaLayers.shared, lambdaLayers.langchain],
-      memory,
+      memory: 6144,
       timeout: lambdaTimeout,
       isEnableInsights: true,
       vpc,

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -636,7 +636,7 @@ export class LambdasNestedStack extends NestedStack {
 
     featureFlagsTable.grantReadData(theLambda);
 
-    addBedrockPolicyToLambda(theLambda);
+    if (bedrock) addBedrockPolicyToLambda(theLambda);
 
     return theLambda;
   }

--- a/packages/infra/lib/shared/bedrock.ts
+++ b/packages/infra/lib/shared/bedrock.ts
@@ -1,0 +1,15 @@
+import * as iam from "aws-cdk-lib/aws-iam";
+import { Function as Lambda } from "aws-cdk-lib/aws-lambda";
+
+export const defaultBedrockPolicyStatement = new iam.PolicyStatement({
+  actions: ["bedrock:InvokeModel"],
+  resources: [
+    `arn:aws:bedrock:*:*:foundation-model/*`,
+    `arn:aws:bedrock:*:*:inference-profile/*`,
+    `arn:aws:bedrock:*:*:application-inference-profile/*`,
+  ],
+});
+
+export function addBedrockPolicyToLambda(lambda: Lambda) {
+  lambda.addToRolePolicy(defaultBedrockPolicyStatement);
+}

--- a/packages/infra/lib/shared/lambda-layers.ts
+++ b/packages/infra/lib/shared/lambda-layers.ts
@@ -22,12 +22,14 @@ export function setupLambdasLayers(stack: Stack, prefixStackName = false): Lambd
       layerVersionName: `${prefix}LambdaNodeModules`,
       code: Code.fromAsset("../lambdas/layers/shared/shared-layer.zip"),
     }),
+    /** @deprecated use wkHtmlToPdf instead */
     chromium: new LayerVersion(stack, `${prefix}Chromium-layer`, {
       layerVersionName: `${prefix}Chromium-layer`,
       compatibleRuntimes: [Runtime.NODEJS_16_X],
       code: Code.fromAsset("../lambdas/layers/chromium"),
       description: "Adds chromium to the lambda",
     }),
+    /** @deprecated use wkHtmlToPdf instead */
     dig: new LayerVersion(stack, `${prefix}Dig-layer`, {
       layerVersionName: `${prefix}Dig-layer`,
       compatibleRuntimes: [Runtime.NODEJS_16_X],

--- a/packages/lambdas/src/fhir-to-bundle-count.ts
+++ b/packages/lambdas/src/fhir-to-bundle-count.ts
@@ -1,0 +1,47 @@
+import {
+  ConsolidatedCounterRequest,
+  ConsolidatedCounterResponse,
+} from "@metriport/core/command/consolidated/consolidated-counter";
+import { ConsolidatedCounterImpl } from "@metriport/core/command/consolidated/consolidated-counter-impl";
+import { FeatureFlags } from "@metriport/core/command/feature-flags/ffs-on-dynamodb";
+import { out } from "@metriport/core/util/log";
+import { errorToString } from "@metriport/shared";
+import { capture } from "./shared/capture";
+import { getEnvOrFail } from "./shared/env";
+
+// Keep this as early on the file as possible
+capture.init();
+
+// Automatically set by AWS
+const region = getEnvOrFail("AWS_REGION");
+// Set by us
+const featureFlagsTableName = getEnvOrFail("FEATURE_FLAGS_TABLE_NAME");
+
+// Call this before reading FFs
+FeatureFlags.init(region, featureFlagsTableName);
+
+export async function handler(
+  params: ConsolidatedCounterRequest
+): Promise<ConsolidatedCounterResponse> {
+  const { patient, requestId, resources, dateFrom, dateTo } = params;
+  const normalizedParams = {
+    patientId: patient.id,
+    cxId: patient.cxId,
+    requestId,
+    dateFrom,
+    dateTo,
+    resources,
+  };
+  capture.setExtra(normalizedParams);
+  const { log } = out(`cx ${patient.cxId}, patient ${patient.id}, req ${requestId}`);
+  try {
+    log(`Running with dateFrom: ${dateFrom}, dateTo: ${dateTo}, resources: ${resources}}`);
+    const conn = new ConsolidatedCounterImpl();
+    const result = await conn.execute(params);
+    return result;
+  } catch (error) {
+    const msg = "Failed to count consolidated resources";
+    log(`${msg} - params: ${JSON.stringify(normalizedParams)} - error: ${errorToString(error)}`);
+    throw error;
+  }
+}


### PR DESCRIPTION
### Dependencies

none

### Description

Move count consolidated to a lambda.

### Testing

- Local
  - [x] Count consolidated counts resources (local impl)
- Local (branch to staging)
  - [x] Count consolidated counts resources (cloud impl)
- Staging
  - [ ] Count consolidated counts resources
- Sandbox
  - none
- Production
  - [ ] Count consolidated counts resources

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new AWS Lambda function for consolidated FHIR resource counting.
  - Added infrastructure and configuration support for the new FHIR resource count Lambda.
- **Refactor**
  - Unified and streamlined FHIR resource counting logic with a new consolidated counting interface.
  - Updated resource counting endpoints to return a consolidated response format.
- **Chores**
  - Added reusable IAM policy and helper to manage Bedrock model invocation permissions across Lambdas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->