### PR TITLE
ENG-196 Update terminology's package-lock.json

### DIFF
--- a/packages/terminology/package-lock.json
+++ b/packages/terminology/package-lock.json
@@ -14,7 +14,7 @@
         "@medplum/fhirtypes": "^3.2.5",
         "@metriport/shared": "^0.12.2",
         "aws-sdk": "^2.1243.0",
-        "axios": "^1.7.3",
+        "axios": "^1.8.2",
         "dayjs": "^1.11.9",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -3209,9 +3209,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
-      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3706
- Downstream: none

### Description

 - [context](https://github.com/metriport/metriport/security/dependabot?q=is%3Aopen+package%3Aaxios+manifest%3Apackages%2Fterminology%2Fpackage-lock.json+has%3Apatch)

### Testing

none

### Release Plan

- [ ] Merge this
