### PR TITLE
build: add hba1c and cbc panel

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-bmi.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-bmi.ts
@@ -1621,6 +1621,7 @@ function createObservationLaboratorySection(
   ]);
 
   const hba1cPanels = findPanelsWithHba1c(diagnosticReports, observations, includedPanels);
+  const latestHba1cPanels = hba1cPanels.slice(0, 2);
 
   const allPanels = [
     ...latestBasicPanels.map(p => ({ type: "Basic Metabolic Panel", panel: p })),
@@ -1628,7 +1629,7 @@ function createObservationLaboratorySection(
     ...latestLipidPanels.map(p => ({ type: "Lipid Panel", panel: p })),
     ...latestThyroidPanels.map(p => ({ type: "Thyroid", panel: p })),
     ...latestCbcPanels.map(p => ({ type: "Complete Blood Count", panel: p })),
-    ...hba1cPanels.map(p => ({ type: "HbA1c Panel", panel: p })),
+    ...latestHba1cPanels.map(p => ({ type: "HbA1c Panel", panel: p })),
   ]
     .sort((a, b) => {
       const dateA = a.panel.effectiveDateTime || a.panel.effectivePeriod?.start || "";
@@ -1672,8 +1673,7 @@ function findPanelsWithHba1c(
       const dateA = a.effectiveDateTime || a.effectivePeriod?.start || "";
       const dateB = b.effectiveDateTime || b.effectivePeriod?.start || "";
       return dayjs(dateB).diff(dayjs(dateA));
-    })
-    .slice(0, 2);
+    });
 }
 
 function findMetabolicPanels(

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-bmi.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-bmi.ts
@@ -1612,7 +1612,6 @@ function createObservationLaboratorySection(
   const latestThyroidPanels = thyroidPanels.slice(0, 2);
   const latestCbcPanels = cbcPanels.slice(0, 2);
 
-  // Get all panels that were already included
   const includedPanels = new Set([
     ...latestBasicPanels,
     ...latestComprehensivePanels,
@@ -1621,7 +1620,6 @@ function createObservationLaboratorySection(
     ...latestCbcPanels,
   ]);
 
-  // Find panels containing HbA1c results
   const hba1cPanels = findPanelsWithHba1c(diagnosticReports, observations, includedPanels);
 
   const allPanels = [


### PR DESCRIPTION
Part of cs-263

Issues:

- https://linear.app/metriport/issue/CS-127

### Dependencies

- Upstream: none
- Downstream: none

### Description

- Customer wanted to changes to how the lab panels were generated

[Context](https://metriport.slack.com/archives/C079QBLE78E/p1745611111621379)

### Testing

- Local
  - [ ] Test that is renders as expected
- Staging
  - [ ]Test that is renders as expected
- Production
  - [ ] Test that is renders as expected

_[Release PRs:]_

Check each PR.

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Laboratory results now display Complete Blood Count (CBC) panels and HbA1c panels as distinct, labeled entries.
  - The two most recent CBC and HbA1c panels are shown alongside other panel types in the laboratory section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->