### PR TITLE
ENG-226 Set max ECS task count when restarting API

### DIFF
--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -57,8 +57,8 @@ function getEnvSpecificSettings(config: EnvConfig): EnvSpecificSettings {
       desiredTaskCount: 12,
       maxTaskCount: 20,
       memoryLimitMiB: 4096,
-      maxHealthyPercent: 120,
-      minHealthyPercent: 80,
+      maxHealthyPercent: 160,
+      minHealthyPercent: 70,
     };
   }
   if (isSandbox(config)) {


### PR DESCRIPTION
### Dependencies

none

### Description

Set max ECS task count when restarting API to 160% - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1746059536983809)

### Testing

- Local
  - none
- Staging
  - none
- Sandbox
  - none
- Production
  - [ ] ECS Service update to 160% max and 70% min task count

### Release Plan

- [ ] Merge this
