### PR TITLE
External 3769

### DIFF
--- a/docs/medical-api/getting-started/webhooks.mdx
+++ b/docs/medical-api/getting-started/webhooks.mdx
@@ -55,7 +55,7 @@ Avoid parsing the request body before generating the signature - it could result
 different signature that's enough to invalidate it.
 
 Here's an example of how you can do this in Node.js - see the full sample code
-[here](https://github.com/metriport/metriport/blob/develop/samples/typescript-express/mock-webhook.ts):
+[here](https://github.com/metriport/metriport/blob/develop/samples/typescript-express/src/mock-webhook.ts):
 
 <Snippet file="webhook-signature-validation.mdx" />
 


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3769
- Downstream: none

### Description

Merging https://github.com/metriport/metriport/pull/3769 into `develop`. This fixes an incorrect link in the WH section of the docs.

No update on the UI, so no screenshots 📸 .

### Testing

- Local
  - [ ] updated link opens the correct file on GH
- Staging
  - none
- Sandbox
  - none
- Production
  - [ ] updated link opens the correct file on GH

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the URL link to the Node.js webhook signature validation sample code in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->