### PR TITLE
PATCH RELEASE ENG-244 Api max task count to 24

### DIFF
--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -55,7 +55,7 @@ function getEnvSpecificSettings(config: EnvConfig): EnvSpecificSettings {
   if (isProd(config)) {
     return {
       desiredTaskCount: 12,
-      maxTaskCount: 20,
+      maxTaskCount: 24,
       memoryLimitMiB: 4096,
       maxHealthyPercent: 160,
       minHealthyPercent: 70,
@@ -536,12 +536,12 @@ export function createAPIService({
   scaling.scaleOnCpuUtilization("autoscale_cpu", {
     targetUtilizationPercent: 10,
     scaleInCooldown: Duration.minutes(2),
-    scaleOutCooldown: Duration.seconds(30),
+    scaleOutCooldown: Duration.minutes(1),
   });
   scaling.scaleOnMemoryUtilization("autoscale_mem", {
     targetUtilizationPercent: 20,
     scaleInCooldown: Duration.minutes(2),
-    scaleOutCooldown: Duration.seconds(30),
+    scaleOutCooldown: Duration.minutes(1),
   });
 
   return {

--- a/packages/infra/lib/shared/rds.ts
+++ b/packages/infra/lib/shared/rds.ts
@@ -9,7 +9,7 @@ import { mbToBytes } from "../shared/util";
 const DEFAULT_MIN_LOCAL_STORAGE_MB_ALARM = 10_000;
 const DB_CONN_ALARM_THRESHOLD = 0.8;
 
-function getMaxPostgresConnections(maxAcu: number): number {
+export function getMaxPostgresConnections(maxAcu: number): number {
   if (maxAcu < 4) return 189;
   if (maxAcu < 8) return 823;
   if (maxAcu < 16) return 1_669;
@@ -95,7 +95,7 @@ export function addDBClusterPerformanceAlarms(
     treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
   });
 
-  const maxConnectionsPerInstance =
+  const thresholdAlarmOpenConnectionsPerDbInstance =
     DB_CONN_ALARM_THRESHOLD * getMaxPostgresConnections(dbConfig.maxCapacity);
 
   dbCluster.instanceIdentifiers.forEach((instanceId, index) => {
@@ -108,7 +108,7 @@ export function addDBClusterPerformanceAlarms(
         period: cdk.Duration.minutes(1),
       }),
       name: `DatabaseConnectionsAlarm-${index + 1}`,
-      threshold: maxConnectionsPerInstance,
+      threshold: thresholdAlarmOpenConnectionsPerDbInstance,
       evaluationPeriods: 2,
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/2924
- Downstream: none

### Description

Api max task count to 24.

### Testing

Check each PR.

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Increased the maximum number of tasks for the production environment.
	- Adjusted the cooldown period for scaling up resources to improve autoscaling behavior.
	- Enhanced database connection management with improved validation and alarm thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->