### PR TITLE
PATCH RELEASE ENG-244 Adj max ecs task on sandbox

### DIFF
--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -65,7 +65,7 @@ function getEnvSpecificSettings(config: EnvConfig): EnvSpecificSettings {
   if (isSandbox(config)) {
     return {
       desiredTaskCount: 2,
-      maxTaskCount: 10,
+      maxTaskCount: 8,
       memoryLimitMiB: 2048,
       maxHealthyPercent: 200,
       minHealthyPercent: 50,


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-244

### Dependencies

- Upstream:
  - https://github.com/metriport/metriport/pull/3777
  - https://github.com/metriport/metriport-internal/pull/2926
- Downstream: none

### Description

Adj max ecs task on sandbox

### Testing

### Release Plan

- :warning: Points to `master`
- [ ] Merge upstream
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced the maximum number of concurrent tasks allowed in the sandbox environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->