### PR TITLE
feat: updating schema to pass Zod validation on patient info

### DIFF
--- a/packages/shared/src/interface/external/ehr/patient.ts
+++ b/packages/shared/src/interface/external/ehr/patient.ts
@@ -8,9 +8,10 @@ const address = z.object({
   country: z.string().optional(),
 });
 
-const telecome = z.object({
+const telecom = z.object({
   value: z.string().optional(),
   system: z.enum(["phone", "email"]).optional(),
+  use: z.enum(["home", "mobile", "old", "temp", "work"]).optional(),
 });
 
 const name = z.object({
@@ -23,7 +24,7 @@ export const patientSchema = z.object({
   name: name.array().optional(),
   address: address.array().optional(),
   birthDate: z.string(),
-  telecom: telecome.array().optional(),
+  telecom: telecom.array().optional(),
 });
 
 export type Patient = z.infer<typeof patientSchema>;


### PR DESCRIPTION
refs. metriport/metriport-internal#1853

Issues:
- https://linear.app/metriport/issue/ENG-180/canvas-400-on-zod-parsing

### Dependencies
- No dependencies

### Description

Fixed a validation error occurring when syncing patient data from Canvas EHR. The issue was in the patient schema definition where the `telecom` field was missing the `use` property, which is a standard field in FHIR patient records. 

Changes made:
1. Added the `use` field to the telecom schema with proper FHIR-compliant validation
2. Fixed a naming inconsistency in the schema (renamed `telecome` to `telecom`)

This resolves the 500 errors seen in production with the error message:

`telecom -> 0 -> use must be set to one of: home, mobile, old, temp, work (type=value_error)`

### Testing

- Local
  - [x] Created and ran test scripts to verify:
    - Valid telecom data with proper `use` values now passes validation
    - The exact error scenario from production now works correctly

- Staging
  - [ ] Test the changes by calling the API endpoint

### Release Plan
This is a simple schema update that should be backward compatible with existing data. 
- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the patient contact information field to ensure accurate data handling.

- **New Features**
  - Added an optional field to patient contact information, allowing specification of the contact method type (e.g., home, mobile, work, etc.).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->