### PR TITLE
PATCH RELEASE Always add permission to bedrock on FHIR Converter

### DIFF
--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -636,7 +636,8 @@ export class LambdasNestedStack extends NestedStack {
 
     featureFlagsTable.grantReadData(theLambda);
 
-    if (bedrock) addBedrockPolicyToLambda(theLambda);
+    // Always add the bedrock policy to the lambda, regardless of whether bedrock is defined or not
+    addBedrockPolicyToLambda(theLambda);
 
     return theLambda;
   }


### PR DESCRIPTION
Ref metriport/metriport-internal#799

### Dependencies

none

### Description

Always add permission to bedrock on FHIR Converter - [context](https://metriport.slack.com/archives/C07MUUHVCAX/p1746464845378099?thread_ts=1746226281.087459&cid=C07MUUHVCAX)

### Testing

none

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated internal configuration to always attach the Bedrock policy to Lambda functions. No visible changes to end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->