### PR TITLE
ENG-41 Include Patient and regular doc ref and CCDA search on semantic search's result

### DIFF
--- a/packages/core/src/external/opensearch/semantic/search.ts
+++ b/packages/core/src/external/opensearch/semantic/search.ts
@@ -2,7 +2,9 @@ import { SearchSetBundle } from "@metriport/shared/medical";
 import { Patient } from "../../../domain/patient";
 import { out } from "../../../util";
 import { Config } from "../../../util/config";
-import { OpenSearchSemanticSearcherDirect } from "./semantic-searcher-direct";
+import { DocumentReferenceWithId } from "../../fhir/document/document-reference";
+import { searchDocuments } from "../search-documents";
+import { OpenSearchSemanticSearcherDirect, SearchResult } from "./semantic-searcher-direct";
 import { getConsolidated } from "./shared";
 
 /**
@@ -23,9 +25,10 @@ export async function searchSemantic({
   log(`Getting consolidated and searching OS...`);
   const startedAt = Date.now();
 
-  const [consolidated, searchResults] = await Promise.all([
+  const [consolidated, searchResults, docRefResults] = await Promise.all([
     getConsolidated({ patient }),
-    searchOpenSearch({ query, cxId: patient.cxId, patientId: patient.id, maxNumberOfResults }),
+    searchOpenSearch({ cxId: patient.cxId, patientId: patient.id, query, maxNumberOfResults }),
+    searchDocuments({ cxId: patient.cxId, patientId: patient.id, contentFilter: query }),
   ]);
   const elapsedTime = Date.now() - startedAt;
   log(
@@ -38,19 +41,39 @@ export async function searchSemantic({
       const resourceId = entry.resource?.id;
       const resourceType = entry.resource?.resourceType;
       if (!resourceId || !resourceType) return false;
-      return searchResults.some(
-        r => r.resourceId === resourceId && r.resourceType === resourceType
+      return (
+        isInSemanticResults(searchResults, resourceId, resourceType) ||
+        isInDocRefResults(docRefResults, resourceId, resourceType)
       );
     }) ?? [];
 
-  log(`Done, returning ${filteredResources.length} filtered resources...`);
+  const sliced = filteredResources.slice(0, maxNumberOfResults);
+
+  log(`Done, returning ${sliced.length} filtered resources...`);
 
   return {
     resourceType: "Bundle",
     type: "searchset",
-    entry: filteredResources,
-    total: filteredResources.length,
+    total: sliced.length,
+    entry: sliced,
   };
+}
+
+function isInSemanticResults(
+  searchResults: SearchResult[],
+  resourceId: string,
+  resourceType: string
+) {
+  return searchResults.some(r => r.resourceId === resourceId && r.resourceType === resourceType);
+}
+
+function isInDocRefResults(
+  docRefResults: DocumentReferenceWithId[],
+  resourceId: string,
+  resourceType: string
+) {
+  if (resourceType !== "DocumentReference") return false;
+  return docRefResults.some(r => r.id === resourceId);
 }
 
 async function searchOpenSearch({


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3792
- Downstream: none

### Description

Include Patient and regular doc ref and CCDA search on semantic search's result.

### Testing

- Local
  - [x] semantic search works
- Staging
  - [ ] semantic search includes CCDAs and doc refs
- Sandbox
  - [ ] semantic search includes CCDAs and doc refs
- Production
  - none

### Release Plan

- [ ] Merge upstream
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved input validation for search results, ensuring requests outside the allowed range return an error.
- **New Features**
	- Enhanced search functionality to combine semantic search and document reference results, providing more comprehensive and relevant results.
- **Refactor**
	- Updated filtering logic to deliver more accurate search bundles and counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->