### PR TITLE
ENG-41 Limit semantic results based on similarity threshold

### DIFF
--- a/packages/api/src/routes/medical/patient.ts
+++ b/packages/api/src/routes/medical/patient.ts
@@ -182,7 +182,20 @@ router.get(
   })
 );
 
-// TODO eng-41 document this
+/**
+ * GET /patient/:id/consolidated/search
+ *
+ * Runs a semantic search on a patient's consolidated data and return the
+ * resources that match the query.
+ *
+ * Also includes DocumentResources that match the query lexically, using the
+ * document search (GET /document)
+ *
+ * @param req.cxId The customer ID.
+ * @param req.param.id The ID of the patient whose data is to be returned.
+ * @param req.query.query The query to search for.
+ * @param req.query.similarityThreshold The similarity threshold to use for the semantic search.
+ */
 router.get(
   "/consolidated/search",
   requestLogger,
@@ -195,9 +208,11 @@ router.get(
     const { patient } = getPatientInfoOrFail(req);
     const queryParam = getFrom("query").optional("query", req);
     const query = queryParam ? queryParam.trim() : undefined;
+    const similarityParam = getFrom("query").optional("similarityThreshold", req);
+    const similarityThreshold = similarityParam ? parseFloat(similarityParam) : undefined;
 
     const result = query
-      ? await searchSemantic({ patient, query })
+      ? await searchSemantic({ patient, query, similarityThreshold })
       : await getConsolidatedPatientData({ patient });
 
     return res.status(status.OK).json(result);

--- a/packages/core/src/external/opensearch/semantic/hybrid-search.ts
+++ b/packages/core/src/external/opensearch/semantic/hybrid-search.ts
@@ -12,13 +12,13 @@ export type HybridSearchParams = {
  * Generates a hybrid search query that combines lexical and neural search with filters
  * for cxId and patientId. This ensures both search methods respect the same filtering criteria.
  */
-export const createHybridSearchQuery = ({
+export function createHybridSearchQuery({
   query,
   cxId,
   patientId,
   modelId,
   k = 5,
-}: HybridSearchParams) => {
+}: HybridSearchParams) {
   const absoluteFilters = [
     {
       term: { cxId },
@@ -29,7 +29,8 @@ export const createHybridSearchQuery = ({
   ];
   return {
     _source: {
-      exclude: ["content_embedding"],
+      // removes these from the response
+      exclude: ["content_embedding", contentFieldName],
     },
     size: k,
     query: {
@@ -70,4 +71,4 @@ export const createHybridSearchQuery = ({
       },
     },
   };
-};
+}

--- a/packages/core/src/external/opensearch/semantic/ingest.ts
+++ b/packages/core/src/external/opensearch/semantic/ingest.ts
@@ -24,17 +24,17 @@ export async function ingestSemantic({ patient }: { patient: Patient }) {
     settings: { logLevel: "info" },
   });
 
-  // TODO eng-41 Figure out how to do this in bulk, chunking to the limit of items per bulk
   const startedAt = Date.now();
-  for (const resource of convertedResources) {
-    await ingestor.ingest({
-      cxId: patient.cxId,
-      patientId: patient.id,
-      resourceType: resource.type,
-      resourceId: resource.id,
-      content: resource.text,
-    });
-  }
+  const resources = convertedResources.map(resource => ({
+    resourceType: resource.type,
+    resourceId: resource.id,
+    content: resource.text,
+  }));
+  await ingestor.ingestBulk({
+    cxId: patient.cxId,
+    patientId: patient.id,
+    resources,
+  });
   const elapsedTime = Date.now() - startedAt;
 
   log(`Ingested ${convertedResources.length} resources in ${elapsedTime} ms`);

--- a/packages/core/src/external/opensearch/semantic/semantic-searcher-direct.ts
+++ b/packages/core/src/external/opensearch/semantic/semantic-searcher-direct.ts
@@ -1,17 +1,29 @@
+import { BadRequestError } from "@metriport/shared";
 import { Client } from "@opensearch-project/opensearch";
-import { contentFieldName } from "..";
 import { out } from "../../../util";
-import { OpenSearchFileSearcherConfig, SearchRequest } from "../file-searcher";
+import { OpenSearchFileSearcherConfig } from "../file-searcher";
 import { IngestRequest } from "../text-ingestor-direct";
 import { createHybridSearchQuery } from "./hybrid-search";
+
+const defaultSimilarityThreshold = 0.2;
+const defaultNumberOfResults = 100;
 
 export type OpenSearchSemanticSearcherDirectConfig = OpenSearchFileSearcherConfig & {
   endpoint: string;
   username: string;
   password: string;
   modelId: string;
-  /** From 0 to 10_000, optional, defaults to 10 */
+};
+
+export type SearchRequest = {
+  cxId: string;
+  patientId: string;
+  // https://www.elastic.co/guide/en/elasticsearch/reference/8.5/query-dsl-query-string-query.html#_boolean_operators
+  query: string;
+  /** From 0 to 10_000, optional, defaults to 100 */
   maxNumberOfResults?: number | undefined;
+  /** From 0 to 1, optional, defaults to 0.2 */
+  similarityThreshold?: number | undefined;
 };
 
 export type SearchResult = Omit<IngestRequest, "content">;
@@ -33,10 +45,18 @@ export type OpenSearchResponse = {
 export class OpenSearchSemanticSearcherDirect {
   constructor(readonly config: OpenSearchSemanticSearcherDirectConfig) {}
 
-  async search(req: SearchRequest): Promise<SearchResult[]> {
-    const { indexName, endpoint, username, password, modelId, maxNumberOfResults } = this.config;
-    const { cxId, patientId, query } = req;
+  async search({
+    cxId,
+    patientId,
+    query,
+    maxNumberOfResults = defaultNumberOfResults,
+    similarityThreshold = defaultSimilarityThreshold,
+  }: SearchRequest): Promise<SearchResult[]> {
+    const { indexName, endpoint, username, password, modelId } = this.config;
     const { log, debug } = out(`OpenSearchSemanticSearcherDirect - cx ${cxId}, pt ${patientId}`);
+
+    this.validateMaxNumberOfResults(maxNumberOfResults);
+    this.validateSimilarityThreshold(similarityThreshold);
 
     const auth = { username, password };
     const client = new Client({ node: endpoint, auth });
@@ -51,27 +71,45 @@ export class OpenSearchSemanticSearcherDirect {
     });
 
     const response = (
-      await client.search(
-        {
-          index: indexName,
-          body: queryPayload,
-        },
-        {
-          querystring: {
-            // removes the "content" from the response
-            filter_path: `-hits.hits._source.${contentFieldName}`,
-          },
-        }
-      )
+      await client.search({
+        index: indexName,
+        body: queryPayload,
+      })
     ).body as OpenSearchResponse;
     // TODO eng-41 Remove this
     debug(`Response: `, () => JSON.stringify(response));
 
     const items = response.hits.hits ?? [];
-
     log(`Successfully searched, got ${items.length} results`);
 
-    return this.mapResult(items);
+    const filteredItems = items.filter(item => item._score >= similarityThreshold);
+    if (filteredItems.length !== items.length) {
+      log(
+        `Filtered ${
+          items.length - filteredItems.length
+        } results due to similarity threshold (${similarityThreshold})`
+      );
+    }
+
+    return this.mapResult(filteredItems);
+  }
+
+  private validateMaxNumberOfResults(maxNumberOfResults: number) {
+    if (maxNumberOfResults > 10_000) {
+      throw new BadRequestError("maxNumberOfResults cannot be greater than 10_000");
+    }
+    if (maxNumberOfResults < 1) {
+      throw new BadRequestError("maxNumberOfResults cannot be less than 1");
+    }
+  }
+
+  private validateSimilarityThreshold(similarityThreshold: number) {
+    if (similarityThreshold > 1) {
+      throw new BadRequestError("similarityThreshold cannot be greater than 1");
+    }
+    if (similarityThreshold <= 0) {
+      throw new BadRequestError("similarityThreshold cannot be less than or equal to 0");
+    }
   }
 
   private mapResult(input: OpenSearchResponseHit[]): SearchResult[] {

--- a/packages/core/src/external/opensearch/text-ingestor-direct.ts
+++ b/packages/core/src/external/opensearch/text-ingestor-direct.ts
@@ -2,12 +2,25 @@ import { emptyFunction } from "@metriport/shared";
 import { Client } from "@opensearch-project/opensearch";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
+import { chunk } from "lodash";
 import { out } from "../../util/log";
+import { capture } from "../../util/notifications";
 import { contentFieldName, OpenSearchIngestorConfig } from "./index";
 
 dayjs.extend(duration);
 
 const DEFAULT_INGESTION_TIMEOUT = dayjs.duration(20, "seconds").asMilliseconds();
+const DEFAULT_BULK_INGESTION_TIMEOUT = dayjs.duration(1, "minute").asMilliseconds();
+
+/**
+ * Didn't find a good reference for OpenSearch, so using Elasticsearch's reference:
+ * https://www.elastic.co/guide/en/elasticsearch/guide/current/bulk.html#_how_big_is_too_big
+ * "A good bulk size to start playing with is around 5-15MB in size."
+ * During tests, resources were 99.9% of the time under 250 Bytes.
+ * 5MB / 250 Bytes = 20_000
+ */
+// const bulkChunkSize = 10_000;
+const bulkChunkSize = 200;
 
 export type IngestRequest = {
   cxId: string;
@@ -15,6 +28,11 @@ export type IngestRequest = {
   resourceType: string;
   resourceId: string;
   [contentFieldName]: string;
+};
+export type IngestBulkRequest = {
+  cxId: string;
+  patientId: string;
+  resources: Omit<IngestRequest, "cxId" | "patientId">[];
 };
 
 export type OpenSearchFileIngestorDirectSettings = {
@@ -67,13 +85,12 @@ export class OpenSearchTextIngestorDirect {
       resourceId,
       content,
     };
-    // TODO eng-41 Useful so we can hit it directly, like a cache?
-    const entryId = `${cxId}_${patientId}_${resourceId}`;
+    const entryId = getEntryId(cxId, patientId, resourceId);
 
     log(`Ingesting resource ${resourceType} ${resourceId} into index ${indexName}...`);
     const startedAt = Date.now();
     // upsert
-    const response = await client.update(
+    const response = await client.index(
       {
         index: indexName,
         id: entryId,
@@ -86,6 +103,92 @@ export class OpenSearchTextIngestorDirect {
     debug(`Response: `, () => JSON.stringify(response.body));
   }
 
+  async ingestBulk({ cxId, patientId, resources }: IngestBulkRequest): Promise<void> {
+    const defaultLogger = out(`ingestBulk - ${cxId} - ${patientId}`);
+    const { log } = this.getLog(defaultLogger);
+
+    const { indexName } = this.config;
+    const auth = { username: this.username, password: this.password };
+    const client = new Client({ node: this.endpoint, auth });
+
+    log(`Ingesting ${resources.length} resources into index ${indexName}...`);
+    const startedAt = Date.now();
+
+    const chunks = chunk(resources, bulkChunkSize);
+    const errors: string[] = [];
+    for (const chunk of chunks) {
+      const { errors: chunkErrors } = await this.ingestBulkInternal({
+        cxId,
+        patientId,
+        resources: chunk,
+        indexName,
+        client,
+      });
+      errors.push(...chunkErrors);
+    }
+
+    const time = Date.now() - startedAt;
+    log(
+      `Bulk ingested ${resources.length} resources in ${time} milliseconds, ${errors.length} errors`
+    );
+    if (errors.length > 0) {
+      const errorsToCapture = errors.slice(0, 20);
+      log(`Errors (${errors.length}): `, () => JSON.stringify(errorsToCapture));
+      capture.error("Errors ingesting resources into OpenSearch", {
+        extra: { cxId, patientId, errors: errorsToCapture },
+      });
+    }
+  }
+
+  private async ingestBulkInternal({
+    cxId,
+    patientId,
+    resources,
+    indexName,
+    client,
+  }: IngestBulkRequest & {
+    indexName: string;
+    client: Client;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }): Promise<{ errors: any[] }> {
+    const defaultLogger = out(`...ingestBulkInternal - ${cxId} - ${patientId}`);
+    const { debug } = this.getLog(defaultLogger);
+
+    const operation = "index";
+
+    debug(`Ingesting ${resources.length} resources into index ${indexName}...`);
+    const startedAt = Date.now();
+
+    const bulkBody = resources.flatMap(resource => {
+      const entryId = getEntryId(cxId, patientId, resource.resourceId);
+      const document: IngestRequest = {
+        cxId,
+        patientId,
+        resourceType: resource.resourceType,
+        resourceId: resource.resourceId,
+        content: resource.content,
+      };
+      const cmd = { [operation]: { _id: entryId } };
+      return [cmd, document];
+    });
+
+    const response = await client.bulk(
+      { index: indexName, body: bulkBody },
+      { requestTimeout: DEFAULT_BULK_INGESTION_TIMEOUT }
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const errors = response.body.items.flatMap((item: any) =>
+      item[operation].status > 299 ? item[operation].error.reason : []
+    );
+
+    const time = Date.now() - startedAt;
+    debug(
+      `Bulk ${operation}ed ${resources.length} resources in ${time} ms, ${errors.length} errors`
+    );
+
+    return { errors };
+  }
+
   private getLog(defaultLogger: ReturnType<typeof out>): ReturnType<typeof out> {
     if (this.settings.logLevel === "none") return { debug: emptyFunction, log: emptyFunction };
     return {
@@ -93,4 +196,9 @@ export class OpenSearchTextIngestorDirect {
       log: defaultLogger.log,
     };
   }
+}
+
+// TODO eng-41 Useful so we can hit it directly, like a cache?
+function getEntryId(cxId: string, patientId: string, resourceId: string): string {
+  return `${cxId}_${patientId}_${resourceId}`;
 }

--- a/packages/utils/src/open-search/semantic-search.ts
+++ b/packages/utils/src/open-search/semantic-search.ts
@@ -45,6 +45,7 @@ async function main() {
     patient,
     query: searchQuery,
     maxNumberOfResults: 1_234,
+    similarityThreshold: 0.2,
   });
   const searchResultIds = searchResult.entry?.map(r => r.resource?.id) ?? [];
   console.log("Search result: ", searchResultIds.join(", "));


### PR DESCRIPTION
### Dependencies

- Upstream: 
- Downstream: none

### Description

Limit semantic results based on similarity threshold.

Add bulk ingestion (still script based to be triggered).

### Testing

- Local
  - [x] Semantic search limits resources to 20% similarity
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional similarity threshold when performing semantic searches, allowing users to fine-tune search result relevance.
  - Introduced bulk ingestion for semantic and text resources, improving the speed and efficiency of data processing.

- **Bug Fixes**
  - Improved validation and error handling for search parameters, ensuring input values are within allowed ranges.

- **Documentation**
  - Enhanced endpoint documentation with detailed descriptions of parameters and behaviors for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->