### PR TITLE
fix(repo): unify aws-cdk dep across repo

### DIFF
--- a/.github/workflows/_deploy-cdk.yml
+++ b/.github/workflows/_deploy-cdk.yml
@@ -200,7 +200,7 @@ jobs:
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "diff"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "${{ inputs.secrets_cdk_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
@@ -212,7 +212,7 @@ jobs:
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "deploy --verbose --require-approval never"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "${{ inputs.secrets_cdk_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
@@ -228,7 +228,7 @@ jobs:
         if: inputs.location_services_cdk_stack != null
         with:
           cdk_action: "diff"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "${{ inputs.location_services_cdk_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
@@ -242,7 +242,7 @@ jobs:
         if: inputs.location_services_cdk_stack != null
         with:
           cdk_action: "deploy --verbose --require-approval never"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "${{ inputs.location_services_cdk_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
@@ -257,7 +257,7 @@ jobs:
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "diff"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "${{ inputs.cdk_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
@@ -269,7 +269,7 @@ jobs:
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "deploy --verbose --require-approval never"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "${{ inputs.cdk_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
@@ -285,7 +285,7 @@ jobs:
         if: inputs.ihe_stack != null
         with:
           cdk_action: "diff"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "${{ inputs.ihe_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
@@ -298,7 +298,7 @@ jobs:
         if: inputs.ihe_stack != null
         with:
           cdk_action: "deploy --verbose --require-approval never"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "${{ inputs.ihe_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:

--- a/.github/workflows/_deploy-hl7-notification-cdk.yml
+++ b/.github/workflows/_deploy-hl7-notification-cdk.yml
@@ -130,7 +130,7 @@ jobs:
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "diff"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "${{ inputs.secrets_cdk_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
@@ -142,7 +142,7 @@ jobs:
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "deploy --verbose --require-approval never"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "${{ inputs.secrets_cdk_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
@@ -157,7 +157,7 @@ jobs:
         if: inputs.hl7_notification_stack != null
         with:
           cdk_action: "diff"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "${{ inputs.hl7_notification_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
@@ -170,7 +170,7 @@ jobs:
         if: inputs.hl7_notification_stack != null
         with:
           cdk_action: "deploy --verbose --require-approval never"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "${{ inputs.hl7_notification_stack }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:

--- a/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
+++ b/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
@@ -103,7 +103,7 @@ jobs:
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "deploy --verbose --require-approval never"
-          cdk_version: "2.122.0"
+          cdk_version: "2.133.0"
           cdk_stack: "VpnStack-${{ inputs.partner_name }}"
           cdk_env: "${{ inputs.deploy_env }}"
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@tsconfig/recommended": "^1.0.2",
         "@typescript-eslint/eslint-plugin": "^5.48.2",
         "@typescript-eslint/parser": "^5.48.2",
+        "aws-cdk": "~2.133.0",
         "commitizen": "^4.3.0",
         "eslint": "^8.32.0",
         "eslint-config-prettier": "^8.6.0",
@@ -17902,6 +17903,7 @@
       "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.133.0.tgz",
       "integrity": "sha512-EwH8VgQQ8ODeMwjE3p+WhbcbWNkCbvuJJl+Py9IB5znGf7GwLcEmOu4YWBsBGPVu41SXbSAf36twMBrJytCFZA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
   },
   "dependencies": {
     "axios": ">=1.8.2",
-    "sharp": "^0.33.5",
-    "semver": ">=5.7.2"
+    "semver": ">=5.7.2",
+    "sharp": "^0.33.5"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.4.2",
@@ -77,6 +77,7 @@
     "@tsconfig/recommended": "^1.0.2",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",
+    "aws-cdk": "~2.133.0",
     "commitizen": "^4.3.0",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",


### PR DESCRIPTION
metriport/metriport-internal#1040

Ref: ENG-263
Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-263

### Dependencies

None

### Description

packages/infra/package.json uses "~2.133.0" as its dependency.

Let's install aws-cdk at the mono repo level to create a clear default version for cli use. This also means we really should be using a consistent version in our gh actions workflows.

### Testing

?

### Release Plan

- [ ] Merge this
