### PR TITLE
Eng 265 cq rebuild heartbeat

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory.ts
@@ -3,7 +3,7 @@ import { sendHeartbeatToMonitoringService } from "@metriport/core/external/monit
 import { capture, executeAsynchronously } from "@metriport/core/util";
 import { out } from "@metriport/core/util/log";
 import { initDbPool } from "@metriport/core/util/sequelize";
-import { errorToString, getEnvVar, sleep } from "@metriport/shared";
+import { errorToString, sleep } from "@metriport/shared";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import { Config } from "../../../../shared/config";
@@ -26,7 +26,7 @@ dayjs.extend(duration);
 const BATCH_SIZE = 5_000;
 const parallelQueriesToGetManagingOrg = 20;
 const SLEEP_TIME = dayjs.duration({ milliseconds: 750 });
-const heartbeatUrl = getEnvVar("CQ_DIR_REBUILD_HEARTBEAT_URL");
+const heartbeatUrl = Config.getCqDirRebuildHeartbeatUrl();
 
 const dbCreds = Config.getDBCreds();
 const sequelize = initDbPool(dbCreds, {

--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -141,9 +141,6 @@ export async function processOutboundDocumentQueryResps({
     await storeInitDocRefInFHIR(docsToDownload, cxId, patientId, log);
 
     const outboundDocumentQueryResults = await replaceDqUrlWithDrUrl({
-      patientId,
-      requestId,
-      cxId,
       responsesWithDocsToDownload,
       log,
     });
@@ -348,15 +345,9 @@ async function addMetriportDocRefID({
 }
 
 async function replaceDqUrlWithDrUrl({
-  patientId,
-  requestId,
-  cxId,
   responsesWithDocsToDownload,
   log,
 }: {
-  patientId: string;
-  requestId: string;
-  cxId: string;
   responsesWithDocsToDownload: OutboundDocumentQueryResp[];
   log: typeof console.log;
 }): Promise<OutboundDocumentQueryResp[]> {
@@ -370,15 +361,6 @@ async function replaceDqUrlWithDrUrl({
       if (!gateway) {
         const msg = `Gateway not found - Doc Retrieval`;
         log(`${msg}: ${outboundDocumentQueryResp.gateway.homeCommunityId} skipping...`);
-        capture.message(msg, {
-          extra: {
-            context: `cq.dq.getCQDirectoryEntry`,
-            patientId,
-            requestId,
-            cxId,
-            gateway: outboundDocumentQueryResp.gateway,
-          },
-        });
         return;
       } else if (!gateway.urlDR) {
         log(`Gateway ${gateway.id} has no DR URL, skipping...`);

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -129,15 +129,6 @@ export async function getDocumentsFromCQ({
       if (!gateway) {
         const msg = `Gateway not found - Doc Query`;
         log(`${msg}: ${patientLink.oid} skipping...`);
-        capture.message(msg, {
-          extra: {
-            context: `cq.pd.getCQDirectoryEntry`,
-            patientId,
-            requestId,
-            cxId,
-            gateway: patientLink,
-          },
-        });
         return;
       } else if (!gateway.urlDQ) {
         log(`Gateway ${gateway.id} has no DQ URL, skipping...`);

--- a/packages/api/src/external/commonwell/organization.ts
+++ b/packages/api/src/external/commonwell/organization.ts
@@ -5,8 +5,8 @@ import { Organization, OrgType } from "@metriport/core/domain/organization";
 import { getOrgsByPrio } from "@metriport/core/external/commonwell/cq-bridge/get-orgs";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
-import { errorToString, NotFoundError, USState } from "@metriport/shared";
-import { Config, getEnvVarOrFail } from "../../shared/config";
+import { errorToString, getEnvVarOrFail, NotFoundError, USState } from "@metriport/shared";
+import { Config } from "../../shared/config";
 import {
   getCertificate,
   makeCommonWellAPI,

--- a/packages/api/src/models/db-dev.ts
+++ b/packages/api/src/models/db-dev.ts
@@ -1,8 +1,7 @@
 import { partitionKey, sortKey } from "@metriport/core/command/feature-flags/ffs-on-dynamodb";
-import { rateLimitPartitionKey } from "@metriport/shared";
+import { getEnvVarOrFail, rateLimitPartitionKey } from "@metriport/shared";
 import * as AWS from "aws-sdk";
 import { allowMapiAccess } from "../command/medical/mapi-access";
-import { getEnvVarOrFail } from "../shared/config";
 import { docTableNames } from "./db";
 
 //Checks if the table exists in the db

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -1,17 +1,5 @@
 import { Config as CoreConfig } from "@metriport/core/util/config";
-import {
-  getEnvVar as coreGetEnvVar,
-  getEnvVarOrFail as coreGetEnvVarOrFail,
-} from "@metriport/core/util/env-var";
-
-/**
- * @deprecated Use core's version instead
- */
-export const getEnvVar = (varName: string): string | undefined => coreGetEnvVar(varName);
-/**
- * @deprecated Use core's version instead
- */
-export const getEnvVarOrFail = (varName: string): string => coreGetEnvVarOrFail(varName);
+import { getEnvVar, getEnvVarOrFail } from "@metriport/shared";
 
 export class Config {
   // env config
@@ -362,5 +350,9 @@ export class Config {
 
   static getRateLimitTableName(): string | undefined {
     return getEnvVar("RATE_LIMIT_TABLE_NAME");
+  }
+
+  static getCqDirRebuildHeartbeatUrl() {
+    return getEnvVar("CQ_DIR_REBUILD_HEARTBEAT_URL");
   }
 }

--- a/packages/core/src/external/monitoring/heartbeat.ts
+++ b/packages/core/src/external/monitoring/heartbeat.ts
@@ -1,0 +1,11 @@
+import { executeWithNetworkRetries } from "@metriport/shared";
+import axios from "axios";
+
+/**
+ * Notifies our monitoring service that the service ran successfully.
+ */
+export async function sendHeartbeatToMonitoringService(url: string): Promise<void> {
+  await executeWithNetworkRetries(async () => {
+    await axios.post(url);
+  });
+}

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -238,6 +238,7 @@ type EnvConfigBase = {
   };
   cqDirectoryRebuilder?: {
     scheduleExpressions: string | string[];
+    heartbeatUrl?: string;
   };
   ehrIntegration?: {
     athenaHealth: {

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -365,6 +365,9 @@ export function createAPIService({
             DASH_URL: props.config.dashUrl,
             EHR_DASH_URL: props.config.ehrDashUrl,
           }),
+          ...(props.config.cqDirectoryRebuilder?.heartbeatUrl && {
+            CQ_DIR_REBUILD_HEARTBEAT_URL: props.config.cqDirectoryRebuilder.heartbeatUrl,
+          }),
         },
       },
       healthCheckGracePeriod: Duration.seconds(60),

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -689,7 +689,7 @@ export class LambdasNestedStack extends NestedStack {
     const acmCertificateMonitorLambda = createScheduledLambda({
       stack: this,
       layers: [lambdaLayers.shared],
-      name: "AcmCertificateMonitor",
+      name: "ScheduledAcmCertificateMonitor",
       entry: "acm-cert-monitor",
       vpc,
       memory: 256,

--- a/packages/lambdas/src/acm-cert-monitor.ts
+++ b/packages/lambdas/src/acm-cert-monitor.ts
@@ -1,7 +1,7 @@
 import { checkExpiringCertificates } from "@metriport/core/external/aws/acm-cert-monitor";
-import { executeWithNetworkRetries, getEnvVarOrFail } from "@metriport/shared";
+import { sendHeartbeatToMonitoringService } from "@metriport/core/external/monitoring/heartbeat";
+import { getEnvVarOrFail } from "@metriport/shared";
 import * as Sentry from "@sentry/serverless";
-import axios from "axios";
 import { capture } from "./shared/capture";
 
 // Keep this as early on the file as possible
@@ -19,16 +19,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(async () => {
 
   await checkExpiringCertificates(notificationUrl);
 
-  await sendHeartbeatToMonitoringService();
+  await sendHeartbeatToMonitoringService(heartbeatUrl);
 
   console.log(`Done.`);
 });
-
-/**
- * Notifies our monitoring service that this lambda ran successfully.
- */
-async function sendHeartbeatToMonitoringService() {
-  await executeWithNetworkRetries(async () => {
-    await axios.post(heartbeatUrl);
-  });
-}

--- a/packages/utils/src/carequality/patient-discovery-statistics.ts
+++ b/packages/utils/src/carequality/patient-discovery-statistics.ts
@@ -2,7 +2,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 // keep that ^ on top
 import { getXcpdStatisticsForPatient } from "@metriport/core/external/carequality/pd/get-xcpd-statistics";
-import { getEnvVarOrFail } from "../../../api/src/shared/config";
+import { getEnvVarOrFail } from "@metriport/shared";
 
 const apiUrl = getEnvVarOrFail("API_URL");
 const cxId = getEnvVarOrFail("CX_ID");

--- a/packages/utils/src/cda-converter/cda-conversion-testing-script.ts
+++ b/packages/utils/src/cda-converter/cda-conversion-testing-script.ts
@@ -4,10 +4,10 @@ dotenv.config();
 import { Bundle } from "@medplum/fhirtypes";
 import { generateCdaFromFhirBundle } from "@metriport/core/fhir-to-cda/cda-generators";
 import { splitBundleByCompositions } from "@metriport/core/fhir-to-cda/composition-splitter";
+import { getEnvVarOrFail } from "@metriport/shared";
 import axios, { AxiosInstance } from "axios";
 import fs from "fs";
 import path from "path";
-import { getEnvVarOrFail } from "../../../api/src/shared/config";
 
 /**
  * The objective of these tests are to test two things:

--- a/packages/utils/src/hl7v2-notifications/create-hl7v2-patient-roster.ts
+++ b/packages/utils/src/hl7v2-notifications/create-hl7v2-patient-roster.ts
@@ -1,15 +1,10 @@
 import * as dotenv from "dotenv";
 dotenv.config();
 // keep that ^ on top
-import {
-  HieConfig,
-  Hl7v2RosterConfig,
-  // SftpConfig,
-} from "@metriport/core/command/hl7v2-subscriptions/types";
-import { makeLambdaClient } from "@metriport/core/external/aws/lambda";
-import { USState } from "@metriport/shared";
-import { getEnvVarOrFail } from "../../../api/src/shared/config";
+import { HieConfig, Hl7v2RosterConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
 import { Hl7v2Subscription } from "@metriport/core/domain/patient-settings";
+import { makeLambdaClient } from "@metriport/core/external/aws/lambda";
+import { getEnvVarOrFail, USState } from "@metriport/shared";
 
 const region = getEnvVarOrFail("AWS_REGION");
 const lambdaName = getEnvVarOrFail("HL7V2_ROSTER_UPLOAD_LAMBDA_NAME");


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/2948
- Downstream: none

### Description

Add heartbeat monitor for CQ directory rebuild.

Additionally, remove the alert when the CQ gateway can't be found upon DQ/DR - [context](https://metriport.slack.com/archives/C065BLRBUDQ/p1746706660995339).

### Testing

see upstream

### Release Plan

- [x] Merge upstream
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a heartbeat notification mechanism to monitor the successful rebuilding of the Carequality directory.
  - Added support for a configurable heartbeat URL in environment settings.

- **Refactor**
  - Centralized the heartbeat notification logic into a shared module for improved maintainability.
  - Updated Lambda functions to use the new shared heartbeat notification mechanism.
  - Renamed a scheduled Lambda function for clarity.

- **Bug Fixes**
  - Improved logging to ensure success messages are only shown after all steps complete successfully.

- **Chores**
  - Updated environment and configuration handling to support the new heartbeat feature.
  - Cleaned up imports and removed deprecated environment variable helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->