### PR TITLE
ENG-41 Adj OS bulk import error handling

### DIFF
--- a/packages/core/src/external/opensearch/bulk.ts
+++ b/packages/core/src/external/opensearch/bulk.ts
@@ -1,26 +1,66 @@
 import { ApiResponse } from "@opensearch-project/opensearch";
-import { isTrue } from "@metriport/shared";
+
 export type BulkOperation = "index" | "create" | "update" | "delete";
 
-export function getErrorsFromBulkResponse(
+type RawBulkResponseErrorBody = {
+  errors: boolean;
+  items: RawBulkResponseErrorItem[];
+};
+type RawBulkResponseErrorItem = Record<BulkOperation, RawBulkResponseErrorItemForOperation>;
+type RawBulkResponseErrorItemForOperation = {
+  error: { reason: string; type: string; index: string };
+  status: number;
+};
+
+export type BulkResponseErrorItem = {
+  index: string;
+  operation: BulkOperation;
+  status: number;
+  type: string;
+  reason: string;
+};
+
+export type OnBulkItemError = (error: BulkResponseErrorItem) => void;
+
+/**
+ * Gets the errors from a bulk response.
+ *
+ * @param response - The response from the bulk operation.
+ * @param operation - The operation to get the errors for.
+ * @param onItemError - The function to call for each item error, optional. Defaults to `bulkResponseErrorToString`.
+ * @returns The errors from the bulk response.
+ */
+export function getCountErrorsFromBulkResponse(
   response: ApiResponse<Record<string, any>, unknown>, // eslint-disable-line @typescript-eslint/no-explicit-any
-  operation: BulkOperation
-): string[] {
-  if (!isTrue(response.body.errors)) return [];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return response.body.items.flatMap((item: any) => {
-    if (item[operation].status > 299) {
-      return bulkResponseErrorToString(item, operation) ?? [];
+  operation: BulkOperation,
+  onItemError?: OnBulkItemError
+): number {
+  const body = response.body as RawBulkResponseErrorBody;
+  if (!body.errors) return 0;
+  let errorCount = 0;
+  body.items.forEach(item => {
+    const itemOp = item[operation];
+    if (itemOp && itemOp.status > 299) {
+      errorCount++;
+      onItemError?.({
+        index: itemOp.error.index,
+        operation,
+        status: itemOp.status,
+        type: itemOp.error.type,
+        reason: itemOp.error.reason,
+      });
     }
-    return [];
   });
+  return errorCount;
 }
 
 export function bulkResponseErrorToString(
-  singleItem: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  singleItem: RawBulkResponseErrorItem,
   operation: BulkOperation
 ): string | undefined {
-  const errorAsAny = singleItem[operation].error;
+  const itemOp = singleItem[operation];
+  if (!itemOp) return undefined;
+  const errorAsAny = itemOp.error?.reason;
   if (!errorAsAny) return undefined;
   return typeof errorAsAny === "string" ? errorAsAny : JSON.stringify(errorAsAny);
 }

--- a/packages/core/src/external/opensearch/bulk.ts
+++ b/packages/core/src/external/opensearch/bulk.ts
@@ -30,15 +30,15 @@ export type OnBulkItemError = (error: BulkResponseErrorItem) => void;
  * @param onItemError - The function to call for each item error, optional. Defaults to `bulkResponseErrorToString`.
  * @returns The errors from the bulk response.
  */
-export function getCountErrorsFromBulkResponse(
+export function processErrorsFromBulkResponse(
   response: ApiResponse<Record<string, any>, unknown>, // eslint-disable-line @typescript-eslint/no-explicit-any
   operation: BulkOperation,
   onItemError?: OnBulkItemError
 ): number {
   const body = response.body as RawBulkResponseErrorBody;
-  if (!body.errors) return 0;
+  if (!body?.errors) return 0;
   let errorCount = 0;
-  body.items.forEach(item => {
+  body.items?.forEach(item => {
     const itemOp = item[operation];
     if (itemOp && itemOp.status > 299) {
       errorCount++;

--- a/packages/core/src/external/opensearch/bulk.ts
+++ b/packages/core/src/external/opensearch/bulk.ts
@@ -1,0 +1,26 @@
+import { ApiResponse } from "@opensearch-project/opensearch";
+import { isTrue } from "@metriport/shared";
+export type BulkOperation = "index" | "create" | "update" | "delete";
+
+export function getErrorsFromBulkResponse(
+  response: ApiResponse<Record<string, any>, unknown>, // eslint-disable-line @typescript-eslint/no-explicit-any
+  operation: BulkOperation
+): string[] {
+  if (!isTrue(response.body.errors)) return [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return response.body.items.flatMap((item: any) => {
+    if (item[operation].status > 299) {
+      return bulkResponseErrorToString(item, operation) ?? [];
+    }
+    return [];
+  });
+}
+
+export function bulkResponseErrorToString(
+  singleItem: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  operation: BulkOperation
+): string | undefined {
+  const errorAsAny = singleItem[operation].error;
+  if (!errorAsAny) return undefined;
+  return typeof errorAsAny === "string" ? errorAsAny : JSON.stringify(errorAsAny);
+}

--- a/packages/core/src/external/opensearch/semantic/ingest.ts
+++ b/packages/core/src/external/opensearch/semantic/ingest.ts
@@ -2,6 +2,7 @@ import { Patient } from "../../../domain/patient";
 import { out } from "../../../util";
 import { Config } from "../../../util/config";
 import { bundleToString, FhirResourceToText } from "../../fhir/export/string/bundle-to-string";
+import { OnBulkItemError } from "../bulk";
 import { OpenSearchTextIngestorDirect } from "../text-ingestor-direct";
 import { getConsolidated } from "./shared";
 
@@ -10,7 +11,13 @@ import { getConsolidated } from "./shared";
  *
  * @param patient The patient to ingest.
  */
-export async function ingestSemantic({ patient }: { patient: Patient }) {
+export async function ingestSemantic({
+  patient,
+  onItemError,
+}: {
+  patient: Patient;
+  onItemError?: OnBulkItemError;
+}) {
   const { log } = out(`ingestSemantic - cx ${patient.cxId}, pt ${patient.id}`);
 
   const convertedResources = await getConsolidatedAsText({ patient });
@@ -34,6 +41,7 @@ export async function ingestSemantic({ patient }: { patient: Patient }) {
     cxId: patient.cxId,
     patientId: patient.id,
     resources,
+    onItemError,
   });
   const elapsedTime = Date.now() - startedAt;
 

--- a/packages/core/src/external/opensearch/text-ingestor-direct.ts
+++ b/packages/core/src/external/opensearch/text-ingestor-direct.ts
@@ -8,7 +8,7 @@ import { capture } from "../../util/notifications";
 import {
   BulkOperation,
   BulkResponseErrorItem,
-  getCountErrorsFromBulkResponse,
+  processErrorsFromBulkResponse,
   OnBulkItemError,
 } from "./bulk";
 import { contentFieldName, OpenSearchIngestorConfig } from "./index";
@@ -188,7 +188,7 @@ export class OpenSearchTextIngestorDirect {
     );
     const time = Date.now() - startedAt;
 
-    const errorCount = getCountErrorsFromBulkResponse(response, operation, onItemError);
+    const errorCount = processErrorsFromBulkResponse(response, operation, onItemError);
     debug(`${operation}ed ${resources.length} resources in ${time} ms, ${errorCount} errors`);
 
     return errorCount;

--- a/packages/core/src/external/opensearch/text-ingestor-direct.ts
+++ b/packages/core/src/external/opensearch/text-ingestor-direct.ts
@@ -5,13 +5,19 @@ import duration from "dayjs/plugin/duration";
 import { chunk } from "lodash";
 import { out } from "../../util/log";
 import { capture } from "../../util/notifications";
-import { getErrorsFromBulkResponse } from "./bulk";
+import {
+  BulkOperation,
+  BulkResponseErrorItem,
+  getCountErrorsFromBulkResponse,
+  OnBulkItemError,
+} from "./bulk";
 import { contentFieldName, OpenSearchIngestorConfig } from "./index";
 
 dayjs.extend(duration);
 
 const DEFAULT_INGESTION_TIMEOUT = dayjs.duration(20, "seconds").asMilliseconds();
 const DEFAULT_BULK_INGESTION_TIMEOUT = dayjs.duration(2, "minute").asMilliseconds();
+const MAX_BULK_RETRIES = 3;
 
 /**
  * Didn't find a good reference for OpenSearch, so using Elasticsearch's reference:
@@ -25,6 +31,8 @@ const bulkChunkSize = 10_000;
 export type IngestRequest = {
   cxId: string;
   patientId: string;
+} & IngestRequestResource;
+export type IngestRequestResource = {
   resourceType: string;
   resourceId: string;
   [contentFieldName]: string;
@@ -32,7 +40,8 @@ export type IngestRequest = {
 export type IngestBulkRequest = {
   cxId: string;
   patientId: string;
-  resources: Omit<IngestRequest, "cxId" | "patientId">[];
+  resources: IngestRequestResource[];
+  onItemError?: OnBulkItemError | undefined;
 };
 
 export type OpenSearchFileIngestorDirectSettings = {
@@ -103,7 +112,16 @@ export class OpenSearchTextIngestorDirect {
     debug(`Response: `, () => JSON.stringify(response.body));
   }
 
-  async ingestBulk({ cxId, patientId, resources }: IngestBulkRequest): Promise<void> {
+  /**
+   * Ingests resources into OpenSearch in bulk.
+   *
+   * @param cxId - The cxId of the resources to ingest.
+   * @param patientId - The patientId of the resources to ingest.
+   * @param resources - The resources to ingest.
+   * @param onItemError - The function to call for each item error, optional. See buildOnItemError()
+   *                      for the default implementation.
+   */
+  async ingestBulk({ cxId, patientId, resources, onItemError }: IngestBulkRequest): Promise<void> {
     const defaultLogger = out(`ingestBulk - ${cxId} - ${patientId}`);
     const { log } = this.getLog(defaultLogger);
 
@@ -114,30 +132,26 @@ export class OpenSearchTextIngestorDirect {
     log(`Ingesting ${resources.length} resources into index ${indexName}...`);
     const startedAt = Date.now();
 
+    let errorCount = 0;
+    const errors: Map<string, number> = new Map();
+    const _onItemError = onItemError ?? buildOnItemError(errors);
+
     const chunks = chunk(resources, bulkChunkSize);
-    const errors: string[] = [];
     for (const resourceChunk of chunks) {
-      const { errors: chunkErrors } = await this.ingestBulkInternal({
+      const errorCountChunk = await this.ingestBulkInternal({
         cxId,
         patientId,
         resources: resourceChunk,
         indexName,
         client,
+        onItemError: _onItemError,
       });
-      errors.push(...chunkErrors);
+      errorCount += errorCountChunk;
     }
 
     const time = Date.now() - startedAt;
-    log(
-      `Bulk ingested ${resources.length} resources in ${time} milliseconds, ${errors.length} errors`
-    );
-    if (errors.length > 0) {
-      const errorsToCapture = errors.slice(0, 20);
-      log(`Errors (${errors.length}): `, () => JSON.stringify(errorsToCapture));
-      capture.error("Errors ingesting resources into OpenSearch", {
-        extra: { cxId, patientId, errors: errorsToCapture },
-      });
-    }
+    log(`Ingested ${resources.length} resources in ${time} ms, ${errorCount} errors`);
+    if (errors.size > 0) captureErrors({ cxId, patientId, errors, log });
   }
 
   private async ingestBulkInternal({
@@ -146,44 +160,38 @@ export class OpenSearchTextIngestorDirect {
     resources,
     indexName,
     client,
+    onItemError,
   }: IngestBulkRequest & {
     indexName: string;
     client: Client;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  }): Promise<{ errors: any[] }> {
+  }): Promise<number> {
     const defaultLogger = out(`...ingestBulkInternal - ${cxId} - ${patientId}`);
     const { debug } = this.getLog(defaultLogger);
 
     const operation = "index";
 
     debug(`Ingesting ${resources.length} resources into index ${indexName}...`);
-    const startedAt = Date.now();
 
-    const bulkBody = resources.flatMap(resource => {
-      const entryId = getEntryId(cxId, patientId, resource.resourceId);
-      const document: IngestRequest = {
+    const bulkRequest = resources.flatMap(resource =>
+      resourceToBulkRequest({
         cxId,
         patientId,
-        resourceType: resource.resourceType,
-        resourceId: resource.resourceId,
-        content: resource.content,
-      };
-      const cmd = { [operation]: { _id: entryId } };
-      return [cmd, document];
-    });
+        resource,
+        operation,
+      })
+    );
 
+    const startedAt = Date.now();
     const response = await client.bulk(
-      { index: indexName, body: bulkBody },
-      { requestTimeout: DEFAULT_BULK_INGESTION_TIMEOUT }
+      { index: indexName, body: bulkRequest },
+      { requestTimeout: DEFAULT_BULK_INGESTION_TIMEOUT, maxRetries: MAX_BULK_RETRIES }
     );
-    const errors = getErrorsFromBulkResponse(response, operation);
-
     const time = Date.now() - startedAt;
-    debug(
-      `Bulk ${operation}ed ${resources.length} resources in ${time} ms, ${errors.length} errors`
-    );
 
-    return { errors };
+    const errorCount = getCountErrorsFromBulkResponse(response, operation, onItemError);
+    debug(`${operation}ed ${resources.length} resources in ${time} ms, ${errorCount} errors`);
+
+    return errorCount;
   }
 
   private getLog(defaultLogger: ReturnType<typeof out>): ReturnType<typeof out> {
@@ -195,7 +203,70 @@ export class OpenSearchTextIngestorDirect {
   }
 }
 
-// TODO eng-41 Useful so we can hit it directly, like a cache?
+function resourceToBulkRequest({
+  cxId,
+  patientId,
+  resource,
+  operation,
+}: {
+  cxId: string;
+  patientId: string;
+  resource: IngestRequestResource;
+  operation: BulkOperation;
+}) {
+  const entryId = getEntryId(cxId, patientId, resource.resourceId);
+  const document: IngestRequest = {
+    cxId,
+    patientId,
+    resourceType: resource.resourceType,
+    resourceId: resource.resourceId,
+    content: resource.content,
+  };
+  const cmd = { [operation]: { _id: entryId } };
+  return [cmd, document];
+}
+
+/**
+ * Builds the ID for an OpenSearch entry.
+ *
+ * @param cxId - The cxId of the resource.
+ * @param patientId - The patientId of the resource.
+ * @param resourceId - The resourceId of the resource.
+ * @returns The ID for the OpenSearch entry.
+ */
 function getEntryId(cxId: string, patientId: string, resourceId: string): string {
   return `${cxId}_${patientId}_${resourceId}`;
+}
+
+/**
+ * Builds a function that will add the error to the list if it doesn't already exist.
+ *
+ * NOTE: Assumes all requeests are for the same index and operation!
+ *
+ * @param errors - The list of errors to add to.
+ * @returns A function that will add the error to the list if it doesn't already exist.
+ */
+function buildOnItemError(errors: Map<string, number>): OnBulkItemError {
+  return (error: BulkResponseErrorItem) => {
+    const count = errors.get(error.type) ?? 0;
+    errors.set(error.type, count + 1);
+  };
+}
+
+function captureErrors({
+  cxId,
+  patientId,
+  errors,
+  log,
+}: {
+  cxId: string;
+  patientId: string;
+  errors: Map<string, number>;
+  log: typeof console.log;
+}) {
+  const errorMapToObj = Object.fromEntries(errors.entries());
+  log(`Errors: `, () => JSON.stringify(errorMapToObj));
+  capture.error("Errors ingesting resources into OpenSearch", {
+    extra: { cxId, patientId, countPerErrorType: JSON.stringify(errorMapToObj, null, 2) },
+  });
 }

--- a/packages/utils/src/open-search/semantic-ingest.ts
+++ b/packages/utils/src/open-search/semantic-ingest.ts
@@ -3,17 +3,27 @@ dotenv.config();
 // keep that ^ on top
 import { MetriportMedicalApi } from "@metriport/api-sdk";
 import { getDomainFromDTO } from "@metriport/core/command/patient-loader-metriport-api";
+import { BulkResponseErrorItem } from "@metriport/core/external/opensearch/bulk";
 import { ingestSemantic } from "@metriport/core/external/opensearch/semantic/ingest";
 import { sleep } from "@metriport/core/util/sleep";
 import { getEnvVarOrFail } from "@metriport/shared";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
+import fs from "fs";
 import { elapsedTimeAsStr } from "../shared/duration";
+import { buildGetDirPathInside, initRunsFolder } from "../shared/folder";
+import { initSentry } from "../shared/sentry";
 
 dayjs.extend(duration);
 
 /**
  * Script to ingest a patient's consolidated resources into OpenSearch for semantic search.
+ *
+ * Stores the individual errors to ingest resources into a NDJSON in the `./runs/semantic-ingest` folder.
+ *
+ * Usage:
+ * - set the env vars
+ * - run with: `ts-node src/open-search/semantic-ingest.ts`
  */
 
 const patientId = getEnvVarOrFail("PATIENT_ID");
@@ -26,18 +36,28 @@ const metriportAPI = new MetriportMedicalApi(apiKey, {
   timeout: 120_000,
 });
 
+const outputFolderName = `semantic-ingest`;
+initRunsFolder(outputFolderName);
+const getFolderName = buildGetDirPathInside(outputFolderName);
+const outputFilePrefix = getFolderName(`${cxId}_${patientId}`);
+const outputFilePath = outputFilePrefix + ".ndjson";
+
 async function main() {
   await sleep(50); // Give some time to avoid mixing logs w/ Node's
   const startedAt = Date.now();
-
+  initSentry();
   console.log("Running test ingestion...");
 
   const patientDto = await metriportAPI.getPatient(patientId);
   const patient = getDomainFromDTO(patientDto, cxId);
 
-  await ingestSemantic({ patient });
+  await ingestSemantic({ patient, onItemError });
 
   console.log(`>>> Done in ${elapsedTimeAsStr(startedAt)}`);
+}
+
+function onItemError(error: BulkResponseErrorItem) {
+  fs.appendFileSync(outputFilePath, `${JSON.stringify(error)}\n`);
 }
 
 if (require.main === module) {

--- a/packages/utils/src/open-search/semantic-text-from-consolidated.ts
+++ b/packages/utils/src/open-search/semantic-text-from-consolidated.ts
@@ -24,7 +24,6 @@ const apiUrl = getEnvVarOrFail("API_URL");
 const cxId = getEnvVarOrFail("CX_ID");
 
 const outputRootFolderName = `semantic-text-from-consolidated`;
-const getFolderName = buildGetDirPathInside(outputRootFolderName);
 
 const metriportAPI = new MetriportMedicalApi(apiKey, {
   baseAddress: apiUrl,
@@ -34,6 +33,10 @@ const metriportAPI = new MetriportMedicalApi(apiKey, {
 async function main() {
   await sleep(50); // Give some time to avoid mixing logs w/ Node's
   const startedAt = Date.now();
+  initRunsFolder(outputRootFolderName);
+  const getFolderName = buildGetDirPathInside(outputRootFolderName);
+  const outputFilePrefix = getFolderName(`${cxId}_${patientId}`);
+  const outputFilePath = outputFilePrefix + ".csv";
 
   console.log("Getting consolidated resources as text...");
 
@@ -45,9 +48,6 @@ async function main() {
   const headers = ["id", "type", "text"];
   const resourcesAsCsv = [headers, ...resources.map(r => [r.id, r.type, `"${r.text}"`])].join("\n");
 
-  const outputFilePrefix = getFolderName(`${cxId}_${patientId}`);
-  initRunsFolder(outputFilePrefix);
-  const outputFilePath = outputFilePrefix + ".csv";
   fs.writeFileSync(outputFilePath, resourcesAsCsv);
 
   console.log(`>>> Done in ${elapsedTimeAsStr(startedAt)}`);

--- a/packages/utils/src/shared/sentry.ts
+++ b/packages/utils/src/shared/sentry.ts
@@ -1,0 +1,23 @@
+import { getEnvType, getEnvVar } from "@metriport/shared";
+import * as Sentry from "@sentry/node";
+
+const sentryDsn = getEnvVar("SENTRY_DSN");
+
+/**
+ * Function to initialize Sentry for rare cases we want to test sending events to Sentry.
+ *
+ * Note: this should only be called while developing, don't push code to the repo enabling
+ * Sentry in scripts that might send lots of messages to Sentry.
+ *
+ * @see packages/api/src/sentry.ts
+ * @see packages/lambdas/src/shared/capture.ts
+ */
+export function initSentry() {
+  Sentry.init({
+    dsn: sentryDsn,
+    enabled: sentryDsn != null,
+    environment: getEnvType(),
+    sampleRate: 1.0, // error sample rate
+    tracesSampleRate: 0, // transaction sample rate
+  });
+}


### PR DESCRIPTION
### Dependencies

- upstream: none
- downstream: https://github.com/metriport/metriport/pull/3814

### Description

Improve OpenSearch's bulk import error handling.
- group similar errors w/ count when sending to Sentry (cloud env)
- store in NDJSON when running local from utils/scripts to help debugging

### Testing

- Local
  - [x] Errors to ingest are converted correctly
  - [x] Errors in bulk ingestion are sent to Slack when running in cloud
  - [x] Errors in bulk ingestion are stored on file when local
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling for OpenSearch bulk operations with detailed error extraction and callback support.
  - Semantic ingestion errors are now logged to timestamped NDJSON files for easier troubleshooting.
  - Added Sentry initialization for improved error monitoring during development.

- **Improvements**
  - Increased bulk ingestion chunk size and timeout, with retry logic for more reliable processing.
  - Error reporting now includes counts by error type for clearer diagnostics.

- **Refactor**
  - Streamlined internal error processing and ingestion flow for better clarity and maintainability.

- **Chores**
  - Reorganized output folder setup to ensure consistent file management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->