### PR TITLE
PATCH RELEASE: Fixing B64 attachment string validation

### DIFF
--- a/packages/core/src/external/cda/process-attachments.ts
+++ b/packages/core/src/external/cda/process-attachments.ts
@@ -40,7 +40,7 @@ import { B64Attachments } from "./remove-b64";
 import { groupObservations } from "./shared";
 
 const region = Config.getAWSRegion();
-const BASE64_REGEX = /^[A-Za-z0-9+/]+={0,2}$/;
+const BASE64_REGEX = /^["']?[A-Za-z0-9+/]+={0,2}["']?$/;
 
 function getS3UtilsInstance(): S3Utils {
   return new S3Utils(region);
@@ -78,7 +78,7 @@ export async function processAttachments({
   fhirUrl: string;
   medicalDataSource?: string | undefined;
 }) {
-  const { log } = out(`processAttachments - cxId ${cxId}, patientId ${patientId}`);
+  const { log } = out(`processAttachments - filepath ${filePath}`);
   try {
     const s3Utils = getS3UtilsInstance();
 

--- a/packages/core/src/external/cda/process-attachments.ts
+++ b/packages/core/src/external/cda/process-attachments.ts
@@ -40,7 +40,7 @@ import { B64Attachments } from "./remove-b64";
 import { groupObservations } from "./shared";
 
 const region = Config.getAWSRegion();
-const BASE64_REGEX = /^["']?[A-Za-z0-9+/]+={0,2}["']?$/;
+const BASE64_REGEX = /^[A-Za-z0-9+/]+={0,2}$/;
 
 function getS3UtilsInstance(): S3Utils {
   return new S3Utils(region);
@@ -256,8 +256,9 @@ function getFileDetails(
 
   // Clean up the base64 string - remove any whitespace, newlines etc
   const cleanB64 = fileB64Contents.replace(/\s/g, "");
+  const unquotedB64 = cleanB64.replace(/^["']|["']$/g, "");
 
-  if (!isValidBase64(cleanB64)) {
+  if (!isValidBase64(unquotedB64)) {
     const msg = `Invalid base64 string in attachment`;
     log(msg);
     capture.message(msg, {
@@ -268,7 +269,7 @@ function getFileDetails(
     return undefined;
   }
 
-  const fileBuffer = Buffer.from(cleanB64, "base64");
+  const fileBuffer = Buffer.from(unquotedB64, "base64");
   let mimeType = detectFileType(fileBuffer).mimeType;
   log(`Detected mimetype: ${mimeType}`);
 


### PR DESCRIPTION
Part of ENG-221
Issues:

- https://linear.app/metriport/issue/ENG-221

### Description
- Some B64 attachments ended up being wrapped with quotation marks, failing to pass the regex for valid B64 strings

### Testing

- Local
  - [x] Test with attachments that failed in prod 
  - [x] Test with attachments that were successful in prod
- Production
  - [ ] Make sure it fixes the reported issue 

### Release Plan
- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to accept base64 strings with optional surrounding quotes.
  - Updated logging to display the file path instead of other identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->