### PR TITLE
PATCH RELEASE: Minor bug on attachment processing

### DIFF
--- a/packages/core/src/external/cda/process-attachments.ts
+++ b/packages/core/src/external/cda/process-attachments.ts
@@ -23,6 +23,7 @@ import {
   ObservationOrganizer,
 } from "../../fhir-to-cda/cda-types/shared-types";
 import { capture } from "../../util";
+import { isValidBase64 } from "../../util/base64";
 import { executeAsynchronously } from "../../util/concurrency";
 import { Config } from "../../util/config";
 import { detectFileType } from "../../util/file-type";
@@ -40,7 +41,6 @@ import { B64Attachments } from "./remove-b64";
 import { groupObservations } from "./shared";
 
 const region = Config.getAWSRegion();
-const BASE64_REGEX = /^[A-Za-z0-9+/]+={0,2}$/;
 
 function getS3UtilsInstance(): S3Utils {
   return new S3Utils(region);
@@ -279,13 +279,9 @@ function getFileDetails(
   }
 
   return {
-    fileB64Contents: cleanB64,
+    fileB64Contents: unquotedB64,
     mimeType,
   };
-}
-
-function isValidBase64(cleanBase64String: string): boolean {
-  return BASE64_REGEX.test(cleanBase64String);
 }
 
 function buildDocumentReferenceFromAct(


### PR DESCRIPTION
Part of ENG-221
Issues:

- https://linear.app/metriport/issue/ENG-221

### Description
- Returning unquoted B64 string to be saved into a file downstream
- Using existing B64 string validation func

### Testing

- Local
  - [x] Test with attachments that failed in prod 
  - [x] Test with attachments that were successful in prod
- Production
  - [ ] Make sure it fixes the reported issue 

### Release Plan
- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved handling of base64 strings for file attachments, including better removal of surrounding quotes and updated validation.
  - Enhanced logging details for attachment processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->