### PR TITLE
feat(api): allow global offset of organization ID from environment variable

### DIFF
--- a/packages/api/src/command/medical/customer-sequence/create-id.ts
+++ b/packages/api/src/command/medical/customer-sequence/create-id.ts
@@ -1,16 +1,11 @@
-import { getEnvVar } from "@metriport/shared";
+import { Config } from "../../../shared/config";
 import { OrganizationModel } from "../../../models/medical/organization";
 import { makeOrganizationOID } from "../../../shared/oid";
 
+// Adds a configurable offset which defaults to zero
 export async function createOrganizationId(): Promise<{ oid: string; organizationNumber: number }> {
-  let maxOrgNumber = Number(await OrganizationModel.max("organizationNumber"));
-
-  // If the environment variable is set, add it to the max org number
-  const organizationNumberOffset = parseInt(getEnvVar("ORGANIZATION_NUMBER_OFFSET") ?? "0");
-  if (isFinite(organizationNumberOffset)) {
-    maxOrgNumber += organizationNumberOffset;
-  }
-
+  const maxOrgNumber =
+    Number(await OrganizationModel.max("organizationNumber")) + Config.getSystemRootOrgOffset();
   const organizationNumber = maxOrgNumber + 1;
   const oid = makeOrganizationOID(organizationNumber);
   return { oid, organizationNumber };

--- a/packages/api/src/command/medical/customer-sequence/create-id.ts
+++ b/packages/api/src/command/medical/customer-sequence/create-id.ts
@@ -1,8 +1,16 @@
+import { getEnvVar } from "@metriport/shared";
 import { OrganizationModel } from "../../../models/medical/organization";
 import { makeOrganizationOID } from "../../../shared/oid";
 
 export async function createOrganizationId(): Promise<{ oid: string; organizationNumber: number }> {
-  const maxOrgNumber = Number(await OrganizationModel.max("organizationNumber"));
+  let maxOrgNumber = Number(await OrganizationModel.max("organizationNumber"));
+
+  // If the environment variable is set, add it to the max org number
+  const organizationNumberOffset = parseInt(getEnvVar("ORGANIZATION_NUMBER_OFFSET") ?? "0");
+  if (isFinite(organizationNumberOffset)) {
+    maxOrgNumber += organizationNumberOffset;
+  }
+
   const organizationNumber = maxOrgNumber + 1;
   const oid = makeOrganizationOID(organizationNumber);
   return { oid, organizationNumber };

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -204,7 +204,7 @@ export class Config {
     return getEnvVarOrFail("SYSTEM_ROOT_ORG_NAME");
   }
 
-  // Attempt to produce a valid offset from environment as a non-negative integer
+  // Reads SYSTEM_ROOT_ORG_OFFSET to apply a base offset for organization numbers (useful for isolating ID ranges in testing/dev)
   static getSystemRootOrgOffset(): number {
     const offset = getEnvVar("SYSTEM_ROOT_ORG_OFFSET");
     if (offset != null) {

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -204,6 +204,18 @@ export class Config {
     return getEnvVarOrFail("SYSTEM_ROOT_ORG_NAME");
   }
 
+  // Attempt to produce a valid offset from environment as a non-negative integer
+  static getSystemRootOrgOffset(): number {
+    const offset = getEnvVar("SYSTEM_ROOT_ORG_OFFSET");
+    if (offset != null) {
+      const parsed = parseInt(offset);
+      if (Number.isFinite(parsed) && parsed >= 0) {
+        return parsed;
+      }
+    }
+    return 0;
+  }
+
   static getGatewayEndpoint(): string {
     return getEnvVarOrFail("CW_GATEWAY_ENDPOINT");
   }


### PR DESCRIPTION
### Dependencies

- Upstream: None
- Downstream: None

### Description

Safely enables the use of an environment variable for incrementing the original organization index. While I will be the first to tell you that this is not the most clever or clean solution (e.g. it introduces a new environment variable `ORGANIZATION_NUMBER_OFFSET` that will inevitably go undocumented), but I imagine there will be some utility in understanding the code review process. 

### Testing

For safety purpose, `isFinite` ensures that even if one were to set something like `ORGANIZATION_NUMBER_OFFSET = abcd` (which would ultimately result in the expression evaluating to `NaN` as the generated ID), no existing functionality would be at risk of breaking.

- Local
  - [ ] tried setting an environment variable and manually checking ID in database

This is currently a draft as I am still gathering how all the pieces fit together, will update when I can write something more concrete in the testing area.

### Release Plan

- [ ] Add documentation for local development of `ORGANIZATION_NUMBER_OFFSET` environment variable
- [ ] Create a note for individual developers to set the value of this in their environment configuration to their desired first ID **minus 1**. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a configurable numeric offset when generating new organization IDs. This allows organization numbers to start from a custom offset set via an environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->