### PR TITLE
fix(core): blacklist hrv system to quiet alerts

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
@@ -28,6 +28,8 @@ const hl7CodingSystemToUrlMap: Record<string, string> = {
   "ICD-9": ICD_9_URL, // ICD-9
 };
 
+const hl7UnknownCodingSystems: Set<string> = new Set(["HRV"]);
+
 function decompressUuid(shortId: string) {
   return unpackUuid(new Base64Scrambler(Config.getHl7Base64ScramblerSeed()).unscramble(shortId));
 }
@@ -130,8 +132,12 @@ export function getOptionalValueFromField(
 export function mapHl7SystemNameToSystemUrl(systemName: string | undefined): string | undefined {
   if (!systemName) return undefined;
 
-  const systemUrl = hl7CodingSystemToUrlMap[systemName.trim().toUpperCase()];
-  if (!systemUrl) {
+  const cleanedSystemName = systemName.trim().toUpperCase();
+  const systemUrl = hl7CodingSystemToUrlMap[cleanedSystemName];
+  const hasUnknownCodingSystem = hl7UnknownCodingSystems.has(cleanedSystemName);
+
+  // Don't warn on any explicitly unknown coding systems
+  if (!systemUrl && !hasUnknownCodingSystem) {
     const { log } = out(`mapHl7SystemNameToSystemUrl`);
     const msg = "Failed to map HL7 system name to URL";
     log(`${msg}: ${systemName}`);


### PR DESCRIPTION
metriport/metriport-internal#1040

Ref: ENG-272
Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

None

### Description

Getting alerts in sentry for coding systems that we don't know about or understand. Let's keep alerts quiet and track the systems we don't know about at the same time via adding an unknown systems blacklist.

https://metriport.slack.com/archives/C04T256DQPQ/p1746818162830519

### Testing

None

### Release Plan

- [x] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Prevented unnecessary warnings for HL7 coding systems that are deliberately recognized as unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->