### PR TITLE
ENG-191 Always send analytics on getConsolidated

### DIFF
--- a/packages/api/src/command/medical/patient/consolidated-get.ts
+++ b/packages/api/src/command/medical/patient/consolidated-get.ts
@@ -13,11 +13,12 @@ import {
 import { buildConsolidatedSnapshotConnector } from "@metriport/core/command/consolidated/get-snapshot-factory";
 import { getConsolidatedSnapshotFromS3 } from "@metriport/core/command/consolidated/snapshot-on-s3";
 import { createMRSummaryFileName } from "@metriport/core/domain/medical-record-summary";
-import { Patient } from "@metriport/core/domain/patient";
+import { getConsolidatedQueryByRequestId, Patient } from "@metriport/core/domain/patient";
 import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
 import { out } from "@metriport/core/util";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
 import { emptyFunction } from "@metriport/shared";
+import { elapsedTimeFromNow } from "@metriport/shared/common/date";
 import { SearchSetBundle } from "@metriport/shared/medical";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
@@ -252,7 +253,8 @@ export async function getConsolidated({
   conversionType,
   bundle,
 }: GetConsolidatedParams): Promise<ConsolidatedData> {
-  const { log } = out(`API getConsolidated - cxId ${patient.cxId}, patientId ${patient.id}`);
+  const { cxId, id: patientId } = patient;
+  const { log } = out(`API getConsolidated - cxId ${cxId}, patientId ${patientId}`);
   const filters = {
     resources: resources ? resources.join(", ") : undefined,
     dateFrom,
@@ -274,6 +276,24 @@ export async function getConsolidated({
     const hasResources = bundle.entry && bundle.entry.length > 0;
     const shouldCreateMedicalRecord = conversionType && conversionType != "json" && hasResources;
 
+    const currentConsolidatedProgress = getConsolidatedQueryByRequestId(patient, requestId);
+    const sendAnalytics = (
+      conversionTypeForAnalytics: string,
+      resourceCount: number | undefined
+    ) => {
+      analytics({
+        distinctId: cxId,
+        event: EventTypes.consolidatedQuery,
+        properties: {
+          patientId: patientId,
+          duration: elapsedTimeFromNow(currentConsolidatedProgress?.startedAt),
+          conversionType: conversionTypeForAnalytics,
+          resourceCount,
+        },
+      });
+    };
+    sendAnalytics("bundle", bundle.entry?.length);
+
     if (shouldCreateMedicalRecord) {
       // If we need to convert to medical record, we also have to update the resulting
       // FHIR bundle to represent that.
@@ -286,6 +306,7 @@ export async function getConsolidated({
         dateTo,
         conversionType,
       });
+      sendAnalytics(conversionType, bundle.entry?.length);
     }
 
     if (conversionType === "json" && hasResources) {

--- a/packages/api/src/command/medical/patient/consolidated-recreate.ts
+++ b/packages/api/src/command/medical/patient/consolidated-recreate.ts
@@ -48,6 +48,7 @@ export async function recreateConsolidated({
       const payload: ConsolidatedSnapshotRequestSync = {
         patient,
         isAsync: false,
+        sendAnalytics: true,
       };
       const connector = buildConsolidatedSnapshotConnector();
       await connector.execute(payload);

--- a/packages/core/src/command/consolidated/get-snapshot-lambda.ts
+++ b/packages/core/src/command/consolidated/get-snapshot-lambda.ts
@@ -22,6 +22,7 @@ export const TIMEOUT_CALLING_CONVERTER_LAMBDA = dayjs.duration(15, "minutes").ad
 export class ConsolidatedSnapshotConnectorLambda implements ConsolidatedSnapshotConnector {
   readonly lambdaName: string;
   readonly lambdaClient: AWS.Lambda;
+
   constructor() {
     const region = Config.getAWSRegion();
     this.lambdaName = Config.getFHIRtoBundleLambdaName();

--- a/packages/core/src/command/consolidated/get-snapshot.ts
+++ b/packages/core/src/command/consolidated/get-snapshot.ts
@@ -16,6 +16,7 @@ export type ConsolidatedSnapshotRequestAsync = ConsolidatedSnapshotRequest & {
   requestId: string;
   conversionType?: ConsolidationConversionType | undefined;
   fromDashboard?: boolean | undefined;
+  sendAnalytics?: never;
 };
 
 export type ConsolidatedSnapshotRequestSync = ConsolidatedSnapshotRequest & {
@@ -24,6 +25,7 @@ export type ConsolidatedSnapshotRequestSync = ConsolidatedSnapshotRequest & {
   fromDashboard?: boolean | undefined;
   // TODO 2215 Remove this when we have contributed data as part of get consolidated (from S3)
   forceDataFromFhir?: boolean | undefined;
+  sendAnalytics?: boolean | undefined;
 };
 
 export type ConsolidatedSnapshotResponse = {


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3692
- Downstream: none

### Description

Fix a regression, analytics not being sent after upstream was merged - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1746838762218769).

Also update the logic that runs on the lambda so it uses `analyticsAsync` to make sure those are sent before the lambda shuts down - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1746846541702729?thread_ts=1746838762.218769&cid=C04DMKE9DME).

### Testing

- Local - branch-to-staging
  - [x] Consolidated gets generated, with and w/o conversion
  - [x] Analytics are sent to Posthog
- Staging
  - [ ] Run consolidated, check analytics are populated
- Sandbox
  - none
- Production
  - [ ] Analytics are being populated again

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced analytics tracking for consolidated patient queries, including detailed event reporting with timing and resource counts.
- **Refactor**
	- Improved parameter handling and optional analytics triggering for consolidated snapshot requests.
- **Style**
	- Minor formatting updates for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->