### PR TITLE
feat(workflows): update vpn tunnel workflow to build secrets stack

### DIFF
--- a/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
+++ b/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
@@ -15,6 +15,10 @@ on:
         description: "The partner we're deploying the tunnel for, e.g. 'MyTestHIE'"
         required: true
         type: string
+      secrets_cdk_stack:
+        description: "The name of the CDK stack to deploy the secrets to"
+        required: true
+        type: string
       AWS_REGION:
         required: true
         type: string
@@ -98,6 +102,32 @@ jobs:
       - name: Infra test
         run: npm run test
         working-directory: "metriport/packages/infra"
+      # Secrets Stack
+      - name: Diff Secrets CDK Stack
+        uses: metriport/deploy-with-cdk@master
+        with:
+          cdk_action: "diff"
+          cdk_version: "2.122.0"
+          cdk_stack: "${{ inputs.secrets_cdk_stack }}"
+          cdk_env: "${{ inputs.deploy_env }}"
+        env:
+          INPUT_PATH: "metriport/packages/infra"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
+      - name: Deploy Secrets CDK Stack
+        uses: metriport/deploy-with-cdk@master
+        with:
+          cdk_action: "deploy --verbose --require-approval never"
+          cdk_version: "2.122.0"
+          cdk_stack: "${{ inputs.secrets_cdk_stack }}"
+          cdk_env: "${{ inputs.deploy_env }}"
+        env:
+          INPUT_PATH: "metriport/packages/infra"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
+          METRIPORT_VERSION: ${{ github.sha }}
 
       - name: Deploy VPN Tunnel Stack CDK
         uses: metriport/deploy-with-cdk@master

--- a/.github/workflows/branch-to-staging-hl7-vpn-tunnel-cdk.yml
+++ b/.github/workflows/branch-to-staging-hl7-vpn-tunnel-cdk.yml
@@ -14,6 +14,7 @@ jobs:
     with:
       deploy_env: staging
       partner_name: ${{ github.event.inputs.partner_name }}
+      secrets_cdk_stack: ${{ vars.SECRET_STACK_NAME_STAGING }}
       AWS_REGION: ${{ vars.API_REGION_STAGING }}
     secrets:
       SERVICE_PAT: ${{ secrets.SERVICE_PAT }}

--- a/.github/workflows/deploy-hl7-vpn-tunnel-cdk-production.yml
+++ b/.github/workflows/deploy-hl7-vpn-tunnel-cdk-production.yml
@@ -14,6 +14,7 @@ jobs:
     with:
       deploy_env: production
       partner_name: ${{ github.event.inputs.partner_name }}
+      secrets_cdk_stack: ${{ vars.SECRET_STACK_NAME_PRODUCTION }}
       AWS_REGION: ${{ vars.API_REGION_PRODUCTION }}
     secrets:
       SERVICE_PAT: ${{ secrets.SERVICE_PAT }}

--- a/.github/workflows/deploy-hl7-vpn-tunnel-cdk-staging.yml
+++ b/.github/workflows/deploy-hl7-vpn-tunnel-cdk-staging.yml
@@ -14,6 +14,7 @@ jobs:
     with:
       deploy_env: staging
       partner_name: ${{ github.event.inputs.partner_name }}
+      secrets_cdk_stack: ${{ vars.SECRET_STACK_NAME_STAGING }}
       AWS_REGION: ${{ vars.API_REGION_STAGING }}
     secrets:
       SERVICE_PAT: ${{ secrets.SERVICE_PAT }}


### PR DESCRIPTION
metriport/metriport-internal#1040

Ref: ENG-274

### Dependencies

None

### Description

This PR makes sure the secrets stack builds and deploys before the VPN tunnel - required to set up infrastructure the vpn tunnel depends on.

### Testing

Ran a prod deploy with these workflow updates already (lol) - they fix the problem.

Workflow run here: https://github.com/metriport/metriport/actions/runs/14947479483/job/41992700060

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deployment workflows now support specifying a separate stack for secrets, allowing secrets to be deployed alongside infrastructure.
- **Chores**
  - Updated deployment workflows to accept a new input for the secrets stack name in both staging and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->