### PR TITLE
2620 Limit access to GH token to RO

### DIFF
--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -2,6 +2,9 @@ name: Branch to Staging
 
 # Used to manually deploy a branch to staging
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
https://github.com/metriport/metriport-internal/issues/2620

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3614
- Downstream: none

### Description

Addresses suggestion from GH on [this PR](https://github.com/metriport/metriport/pull/3817) to limit the access to GH token to RO.

### Testing

- Local
  - none
- Staging
  - [ ] branch to staging works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to explicitly set repository permissions for improved clarity and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->