### PR TITLE
2620 Fix branch-to-staging

### DIFF
--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -102,7 +102,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   location_services_cdk_stack:
-    if: contains(fromJSON('["location_services_cdk_stack", "all"]'), github.event.inputs.jobs_to_run) && ${{ vars.LOCATION_SERVICES_STACK_NAME_STAGING }} != null
+    if: contains(fromJSON('["location_services_cdk_stack", "all"]'), github.event.inputs.jobs_to_run)
     uses: ./.github/workflows/_deploy-cdk.yml
     with:
       deploy_env: "staging"
@@ -119,7 +119,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   ihe_stack:
-    if: contains(fromJSON('["ihe_stack", "all"]'), github.event.inputs.jobs_to_run) && ${{ vars.IHE_STACK_NAME }} != null
+    if: contains(fromJSON('["ihe_stack", "all"]'), github.event.inputs.jobs_to_run)
     uses: ./.github/workflows/_deploy-cdk.yml
     with:
       deploy_env: "staging"


### PR DESCRIPTION
https://github.com/metriport/metriport-internal/issues/2620

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3818
- Downstream: none

### Description

Fix branch-to-staging, so it Location Services and IHE stack can selectively not be deployed - [context](https://github.com/metriport/metriport/pull/3817#discussion_r2084996641)

### Testing

- Local
  - none
- Staging
  - [ ] branch to staging works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow conditions to simplify job execution logic in the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->