### PR TITLE
2620 Replicate selective CDK deploy to prod/staging CICD

### DIFF
--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -15,6 +15,13 @@ on:
         type: string
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Display parameters
+        shell: bash
+        run: echo "${{ format('<h1>Parameters</h1><p>{0}</p>', tojson(inputs)) }}" > "$GITHUB_STEP_SUMMARY"
+
   api:
     # can't use contains(github.event.inputs.jobs_to_run, 'api') because this would trigger on 'redeploy-api-gw' or 'infra-api-lambdas'
     if: contains(format(',{0},', github.event.inputs.jobs_to_run), ',api,') || contains(github.event.inputs.jobs_to_run, 'all')

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -31,6 +31,8 @@ jobs:
       fhir-converter: ${{ steps.changes.outputs.fhir-converter }}
       terminology: ${{ steps.changes.outputs.terminology }}
       infra-lambdas: ${{ steps.changes.outputs.infra-lambdas }}
+      secrets: ${{ steps.changes.outputs.secrets }}
+      location_services: ${{ steps.changes.outputs.location_services }}
       infra-hl7-notification: ${{ steps.changes.outputs.infra-hl7-notification }}
     steps:
       - name: Login to Docker Hub
@@ -78,10 +80,18 @@ jobs:
               - "packages/terminology/src/**"
               - "packages/infra/**"
             infra-lambdas:
+              - "packages/shared/**"
               - "packages/core/**"
               - "packages/infra/**"
               - "packages/lambdas/**"
-              - "packages/shared/**"
+              - "package*.json"
+            secrets:
+              - "packages/infra/**"
+              - "package*.json"
+            locations-services:
+              - "packages/infra/lib/location-services*"
+              - "packages/infra/shared/**"
+              - "packages/infra/package*.json"
               - "package*.json"
             infra-hl7-notification:
               - "packages/infra/lib/hl7-notification-stack/**"
@@ -165,10 +175,7 @@ jobs:
     needs: files-changed
     with:
       deploy_env: "production"
-      secrets_cdk_stack: ${{ vars.SECRET_STACK_NAME_PRODUCTION }}
-      location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_PRODUCTION }}
       cdk_stack: ${{ vars.API_STACK_NAME_PRODUCTION }}
-      ihe_stack: ${{ vars.IHE_STACK_NAME }}
       AWS_REGION: ${{ vars.API_REGION_PRODUCTION }}
     secrets:
       SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
@@ -184,9 +191,75 @@ jobs:
     if: ${{ !failure() && needs.infra-api-lambdas.result == 'success' }}
     with:
       deploy_env: "sandbox"
-      secrets_cdk_stack: ${{ vars.SECRET_STACK_NAME_SANDBOX }}
       cdk_stack: ${{ vars.API_STACK_NAME_SANDBOX }}
       AWS_REGION: ${{ vars.API_REGION_SANDBOX  }}
+    secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  secrets_cdk_stack_prod:
+    uses: ./.github/workflows/_deploy-cdk.yml
+    needs: files-changed
+    if: needs.files-changed.outputs.secrets == 'true'
+    with:
+      deploy_env: "production"
+      cdk_stack: ${{ vars.SECRET_STACK_NAME_PRODUCTION }}
+      AWS_REGION: ${{ vars.API_REGION_PRODUCTION }}
+    secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  secrets_cdk_stack_sandbox:
+    uses: ./.github/workflows/_deploy-cdk.yml
+    needs: [secrets_cdk_stack_prod]
+    if: ${{ !failure() && needs.secrets_cdk_stack_prod.result == 'success' }}
+    with:
+      deploy_env: "sandbox"
+      cdk_stack: ${{ vars.SECRET_STACK_NAME_SANDBOX }}
+      AWS_REGION: ${{ vars.API_REGION_SANDBOX }}
+    secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  location_services_cdk_stack:
+    uses: ./.github/workflows/_deploy-cdk.yml
+    needs: files-changed
+    if: needs.files-changed.outputs.location_services == 'true'
+    with:
+      deploy_env: "production"
+      cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_PRODUCTION }}
+      AWS_REGION: ${{ vars.API_REGION_PRODUCTION }}
+    secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  ihe_stack:
+    uses: ./.github/workflows/_deploy-cdk.yml
+    needs: files-changed
+    if: ${{ needs.files-changed.outputs.infra-lambdas == 'true' }}
+    with:
+      deploy_env: "production"
+      cdk_stack: ${{ vars.IHE_STACK_NAME }}
+      AWS_REGION: ${{ vars.API_REGION_PRODUCTION }}
     secrets:
       SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,5 +1,8 @@
 name: Deploy - PRODUCTION
 
+permissions:
+  contents: read
+
 on:
   push: # a commit to the specified branches, if any
     branches:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,5 +1,8 @@
 name: Deploy - Staging
 
+permissions:
+  contents: read
+
 on:
   push: # a commit to the specified branches, if any
     branches:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -11,11 +11,11 @@ on:
       - "packages/commonwell-sdk/**"
       - "packages/core/**"
       - "packages/fhir-converter/**"
-      - "packages/terminology/**"
       - "packages/ihe-gateway-sdk/**"
       - "packages/carequality-sdk/**"
       - "packages/infra/**"
       - "packages/lambdas/**"
+      - "packages/terminology/**"
       - "packages/mllp-server/**"
   workflow_dispatch: # manually executed by a user
 
@@ -31,6 +31,8 @@ jobs:
       fhir-converter: ${{ steps.changes.outputs.fhir-converter }}
       terminology: ${{ steps.changes.outputs.terminology }}
       infra-lambdas: ${{ steps.changes.outputs.infra-lambdas }}
+      secrets: ${{ steps.changes.outputs.secrets }}
+      location_services: ${{ steps.changes.outputs.location_services }}
       infra-hl7-notification: ${{ steps.changes.outputs.infra-hl7-notification }}
     steps:
       - name: Login to Docker Hub
@@ -57,11 +59,11 @@ jobs:
               - "packages/shared/**"
               - "packages/core/**"
               - "packages/mllp-server/**"
-              - "package*.json"
               - "packages/infra/lib/hl7-notification-stack/**"
               - "packages/infra/bin/infrastructure.ts"
-            # Doing them individually because there are other stuff there that we don't want to trigger a deploy b/c of that
+              - "package*.json"
             fhir-converter:
+              # Doing them individually because there are other stuff there that we don't want to trigger a deploy b/c of that
               - "packages/fhir-converter/Dockerfile"
               - "packages/fhir-converter/docker-entrypoint.sh"
               - "packages/fhir-converter/package*.json"
@@ -79,6 +81,14 @@ jobs:
               - "packages/core/**"
               - "packages/infra/**"
               - "packages/lambdas/**"
+              - "package*.json"
+            secrets:
+              - "packages/infra/**"
+              - "package*.json"
+            locations-services:
+              - "packages/infra/lib/location-services*"
+              - "packages/infra/shared/**"
+              - "packages/infra/package*.json"
               - "package*.json"
             infra-hl7-notification:
               - "packages/infra/lib/hl7-notification-stack/**"
@@ -145,10 +155,58 @@ jobs:
     needs: files-changed
     with:
       deploy_env: "staging"
-      secrets_cdk_stack: ${{ vars.SECRET_STACK_NAME_STAGING }}
-      location_services_cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_STAGING }}
       cdk_stack: ${{ vars.API_STACK_NAME_STAGING }}
-      ihe_stack: ${{ vars.IHE_STACK_NAME }}
+      AWS_REGION: ${{ vars.API_REGION_STAGING }}
+    secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  secrets_cdk_stack:
+    uses: ./.github/workflows/_deploy-cdk.yml
+    needs: files-changed
+    if: needs.files-changed.outputs.secrets == 'true'
+    with:
+      deploy_env: "staging"
+      cdk_stack: ${{ vars.SECRET_STACK_NAME_STAGING }}
+      AWS_REGION: ${{ vars.API_REGION_STAGING }}
+    secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  location_services_cdk_stack:
+    uses: ./.github/workflows/_deploy-cdk.yml
+    needs: files-changed
+    if: needs.files-changed.outputs.location_services == 'true'
+    with:
+      deploy_env: "staging"
+      cdk_stack: ${{ vars.LOCATION_SERVICES_STACK_NAME_STAGING }}
+      AWS_REGION: ${{ vars.API_REGION_STAGING }}
+    secrets:
+      SERVICE_PAT: ${{ secrets.SERVICE_PAT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  ihe_stack:
+    uses: ./.github/workflows/_deploy-cdk.yml
+    needs: files-changed
+    if: ${{ needs.files-changed.outputs.infra-lambdas == 'true' }}
+    with:
+      deploy_env: "staging"
+      cdk_stack: ${{ vars.IHE_STACK_NAME }}
       AWS_REGION: ${{ vars.API_REGION_STAGING }}
     secrets:
       SERVICE_PAT: ${{ secrets.SERVICE_PAT }}


### PR DESCRIPTION
https://github.com/metriport/metriport-internal/issues/2620

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3822
- Downstream: none

### Description

Replicate selective CDK deploy to prod/staging CICD.

### Testing

- Local
  - none
- Staging
  - [ ] CICD deploys all packages/systems when manually run
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced more granular deployment jobs for secrets and location services, enabling targeted infrastructure updates only when relevant files change.
  - Added new deployment jobs for specific infrastructure stacks, including IHE, secrets, and location services, across staging and production workflows.
  - Enhanced workflow summaries with improved visibility into input parameters.

- **Chores**
  - Updated permissions and improved path filters for better deployment control and clarity in workflow triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->