### PR TITLE
2620 Fix typo on CICD def

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -91,7 +91,7 @@ jobs:
             secrets:
               - "packages/infra/**"
               - "package*.json"
-            locations-services:
+            location_services:
               - "packages/infra/lib/location-services*"
               - "packages/infra/shared/**"
               - "packages/infra/package*.json"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -88,7 +88,7 @@ jobs:
             secrets:
               - "packages/infra/**"
               - "package*.json"
-            locations-services:
+            location_services:
               - "packages/infra/lib/location-services*"
               - "packages/infra/shared/**"
               - "packages/infra/package*.json"


### PR DESCRIPTION
https://github.com/metriport/metriport-internal/issues/2620

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3823
- Downstream: none

### Description

Fix typo on CICD def.

### Testing

- Local
  - none
- Staging
  - [ ] CICD deploys all packages/systems when manually run
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
