### PR TITLE
feat(utils): fixing date of birth error + format validation

### DIFF
--- a/packages/api-sdk/src/shared.ts
+++ b/packages/api-sdk/src/shared.ts
@@ -1,7 +1,7 @@
 import {
   isValidISODate,
+  validateDateIsAfter1900Safe,
   validateIsPastOrPresentSafe,
-  validateDateIsAfter1900,
 } from "@metriport/shared/common/date";
 import dayjs from "dayjs";
 import { z, ZodString } from "zod";
@@ -27,7 +27,7 @@ export const defaultDateString = defaultString.refine(isValidISODate, {
 export const pastOrTodayDateString = defaultDateString.refine(validateIsPastOrPresentSafe, {
   message: `Date can't be in the future`,
 });
-export const validDateOfBirthString = pastOrTodayDateString.refine(validateDateIsAfter1900, {
+export const validDateOfBirthString = pastOrTodayDateString.refine(validateDateIsAfter1900Safe, {
   message: `Date can't be before 1900`,
 });
 

--- a/packages/api/src/command/medical/patient/shared.ts
+++ b/packages/api/src/command/medical/patient/shared.ts
@@ -1,8 +1,8 @@
 import { Period } from "@metriport/core/domain/patient";
 import {
-  validateDateOfBirth,
-  validateDateRange,
-  validateIsPastOrPresent,
+  validateDateOfBirthSafe,
+  validateDateRangeSafe,
+  validateIsPastOrPresentSafe,
 } from "@metriport/shared/common/date";
 import { cloneDeep } from "lodash";
 import { PatientCreateCmd } from "./create-patient";
@@ -22,15 +22,17 @@ export function validate<T extends PatientCreateCmd | PatientUpdateCmd | Patient
 ): boolean {
   if (!patient.address || patient.address.length < 1) return false;
   patient.personalIdentifiers?.forEach(pid => pid.period && validatePeriod(pid.period));
-  return validateIsPastOrPresent(patient.dob) && validateDateOfBirth(patient.dob);
+  return validateDateOfBirthSafe(patient.dob);
 }
 
 function validatePeriod(period: Period): boolean {
   if (period.start && period.end) {
-    return validateIsPastOrPresent(period.start) && validateDateRange(period.start, period.end);
+    return (
+      validateIsPastOrPresentSafe(period.start) && validateDateRangeSafe(period.start, period.end)
+    );
   }
   if (period.start) {
-    return validateIsPastOrPresent(period.start);
+    return validateIsPastOrPresentSafe(period.start);
   }
   return true;
 }

--- a/packages/shared/src/common/__tests__/date.test.ts
+++ b/packages/shared/src/common/__tests__/date.test.ts
@@ -1,7 +1,7 @@
 import {
   buildDayjsFromCompactDate,
   isValidISODate,
-  validateDateIsAfter1900,
+  validateDateIsAfter1900Safe,
   validateIsPastOrPresentSafe,
 } from "../date";
 
@@ -34,61 +34,45 @@ describe("shared date functions", () => {
   });
 });
 
-describe("validateDateIsAfter1900", () => {
+describe("validateDateIsAfter1900Safe", () => {
   it("returns true for dates after 1900", () => {
-    expect(validateDateIsAfter1900("1999-12-31")).toBe(true);
+    expect(validateDateIsAfter1900Safe("1999-12-31")).toBe(true);
   });
 
   it("returns true for dates in 1970", () => {
-    expect(validateDateIsAfter1900("1970-01-31")).toBe(true);
+    expect(validateDateIsAfter1900Safe("1970-01-31")).toBe(true);
   });
 
   it("returns true for 1900-01-01", () => {
-    expect(validateDateIsAfter1900("1900-01-01")).toBe(true);
+    expect(validateDateIsAfter1900Safe("1900-01-01")).toBe(true);
   });
 
   it("returns false for dates before 1900", () => {
-    expect(validateDateIsAfter1900("1899-12-31")).toBe(false);
-  });
-
-  it("returns false for dates with years less than 1000", () => {
-    expect(validateDateIsAfter1900("0007-01-01")).toBe(false);
-  });
-
-  it("returns false for dates with years less than 1000 (2)", () => {
-    expect(validateDateIsAfter1900("0014-01-01")).toBe(false);
+    expect(validateDateIsAfter1900Safe("1899-12-31")).toBe(false);
   });
 
   it("returns false for dates with years less than 1000 (3)", () => {
-    expect(validateDateIsAfter1900("0123-01-01")).toBe(false);
+    expect(validateDateIsAfter1900Safe("0123-01-01")).toBe(false);
   });
 
-  it("returns false for dates with year 970", () => {
-    expect(validateDateIsAfter1900("970-01-31")).toBe(false);
+  it("handles MM/DD/YYYY format correctly", () => {
+    expect(validateDateIsAfter1900Safe("12/31/2020")).toBe(true);
   });
 
-  it("handles MM/DD/YYYY format incorrectly returning false for valid years", () => {
-    expect(validateDateIsAfter1900("12/31/2020")).toBe(false);
+  it("handles YYYY.MM.DD format correctly", () => {
+    expect(validateDateIsAfter1900Safe("2020.12.31")).toBe(true);
   });
 
-  it("handles DD/MM/YYYY format incorrectly returning false for valid years", () => {
-    expect(validateDateIsAfter1900("31/12/2020")).toBe(false);
+  it("handles YYYY/MM/DD format correctly", () => {
+    expect(validateDateIsAfter1900Safe("2020/12/31")).toBe(true);
   });
 
-  it("handles YYYY.MM.DD format returning true for valid years", () => {
-    expect(validateDateIsAfter1900("2020.12.31")).toBe(true);
-  });
-
-  it("handles YYYY/MM/DD format returning true for valid years", () => {
-    expect(validateDateIsAfter1900("2020/12/31")).toBe(true);
-  });
-
-  it("handles textual month format incorrectly", () => {
-    expect(validateDateIsAfter1900("Dec 31, 2020")).toBe(false);
+  it("handles textual month format correctly", () => {
+    expect(validateDateIsAfter1900Safe("Dec 31, 2020")).toBe(true);
   });
 
   it("handles empty string format incorrectly", () => {
-    expect(validateDateIsAfter1900("")).toBe(false);
+    expect(validateDateIsAfter1900Safe("")).toBe(false);
   });
 });
 

--- a/packages/shared/src/domain/dob.ts
+++ b/packages/shared/src/domain/dob.ts
@@ -1,14 +1,17 @@
-import { buildDayjs, ISO_DATE, validateDateOfBirth } from "../common/date";
+import { buildDayjs, ISO_DATE, validateDateOfBirthSafe } from "../common/date";
+import { BadRequestError } from "../error/bad-request";
 
 export function normalizeDobSafe(date: string): string | undefined {
   const trimmedDate = date.trim();
   if (trimmedDate.length < 1) return undefined;
-  if (!validateDateOfBirth(trimmedDate)) throw new Error("Invalid date of birth.");
+  if (!validateDateOfBirthSafe(trimmedDate)) {
+    throw new BadRequestError("Invalid date of birth.", undefined, { date });
+  }
   return buildDayjs(trimmedDate).format(ISO_DATE);
 }
 
 export function normalizeDob(date: string): string {
   const dateOrUndefined = normalizeDobSafe(date);
-  if (!dateOrUndefined) throw new Error("Invalid date of birth.");
+  if (!dateOrUndefined) throw new BadRequestError("Invalid date of birth.", undefined, { date });
   return dateOrUndefined;
 }

--- a/packages/shared/src/domain/gender.ts
+++ b/packages/shared/src/domain/gender.ts
@@ -1,3 +1,5 @@
+import { BadRequestError } from "../error/bad-request";
+
 export type GenderAtBirth = "F" | "M" | "O" | "U";
 
 export function normalizeGenderSafe(gender: string): "F" | "M" | "O" | "U" | undefined {
@@ -16,6 +18,8 @@ export function normalizeGenderSafe(gender: string): "F" | "M" | "O" | "U" | und
 
 export function normalizeGender(gender: string): GenderAtBirth {
   const genderOrUndefined = normalizeGenderSafe(gender);
-  if (!genderOrUndefined) throw new Error("Invalid gender");
+  if (!genderOrUndefined) {
+    throw new BadRequestError("Invalid gender", undefined, { gender });
+  }
   return genderOrUndefined;
 }


### PR DESCRIPTION
Ref: ENG-241

Issues:

- https://linear.app/metriport/issue/ENG-241


### Description

- reverts pre1900 logic to not require ISO date format
- introduces safe versions of pre1900 + validatePeriod
- requires formatting of ISO or American (MM/DD/YYYY) for *dates of birth*
- throws BadRequest error from date of birth normalization

### Testing

- Local
  - [ ] unit testing
- Staging
   - [ ] unit testing
- Sandbox
  - [ ] N/A
- Production
  - [ ] unit testing

### Release Plan

- [ ] Release NPM packages
- [ ] Merge this
