### PR TITLE
feat(core): filter out useless encounters

### DIFF
--- a/packages/core/src/external/fhir/codeable-concept.ts
+++ b/packages/core/src/external/fhir/codeable-concept.ts
@@ -37,6 +37,10 @@ export function isValidCoding(coding: Coding): boolean {
   return false;
 }
 
+export function getValidCodings(codings: Coding[]): Coding[] {
+  return codings.filter(isValidCoding);
+}
+
 export function isUsefulDisplay(text: string) {
   const normalizedText = text.toLowerCase().trim();
   return (

--- a/packages/core/src/external/fhir/normalization/normalize-fhir.ts
+++ b/packages/core/src/external/fhir/normalization/normalize-fhir.ts
@@ -4,6 +4,7 @@ import { buildCompleteBundleEntry, extractFhirTypesFromBundle } from "../shared/
 import { sortCodings } from "./coding";
 import { normalizeConditions } from "./resources/condition";
 import { normalizeCoverages } from "./resources/coverage";
+import { normalizeEncounters } from "./resources/encounter";
 import { normalizeObservations } from "./resources/observation";
 
 export function normalizeFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> {
@@ -17,6 +18,12 @@ export function normalizeFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> {
 
   const normalizedConditions = normalizeConditions(resourceArrays.conditions);
   resourceArrays.conditions = normalizedConditions;
+
+  const normalizedEncounters = normalizeEncounters(
+    resourceArrays.encounters,
+    resourceArrays.locations
+  );
+  resourceArrays.encounters = normalizedEncounters;
 
   normalizedBundle.entry = Object.entries(resourceArrays).flatMap(([, resources]) => {
     const entriesArray = Array.isArray(resources) ? resources : [resources];

--- a/packages/core/src/external/fhir/normalization/normalize-fhir.ts
+++ b/packages/core/src/external/fhir/normalization/normalize-fhir.ts
@@ -7,6 +7,20 @@ import { normalizeCoverages } from "./resources/coverage";
 import { normalizeEncounters } from "./resources/encounter";
 import { normalizeObservations } from "./resources/observation";
 
+/**
+ * Normalizes a FHIR Bundle by standardizing and cleaning up its resources.
+ *
+ * This function performs the following normalizations:
+ * - Normalizes Coverage resources
+ * - Normalizes Vital Signs Observations
+ * - Normalizes Condition resources
+ * - Filters out empty Encounter resources
+ * - Cleans up and sorts all codings within the resources
+ *
+ * @param fhirBundle - The FHIR Bundle to normalize
+ * @returns A new normalized FHIR Bundle with standardized resources
+ */
+
 export function normalizeFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> {
   const normalizedBundle: Bundle = cloneDeep(fhirBundle);
   const resourceArrays = extractFhirTypesFromBundle(normalizedBundle);

--- a/packages/core/src/external/fhir/normalization/resources/encounter.ts
+++ b/packages/core/src/external/fhir/normalization/resources/encounter.ts
@@ -1,0 +1,88 @@
+import { Encounter, Location } from "@medplum/fhirtypes";
+import { toTitleCase } from "@metriport/shared";
+import { getValidCodings } from "../../codeable-concept";
+import { buildReferenceFromStringRelative } from "../../shared/bundle";
+
+export function normalizeEncounters(encounters: Encounter[], locations: Location[]): Encounter[] {
+  return encounters.flatMap(encounter => {
+    const reasons = getEncounterReason(encounter);
+    const location = getEncounterLocation(encounter, locations);
+    const type = renderClassDisplay(encounter);
+    if (!reasons && !location && !type) return [];
+
+    return encounter;
+  });
+}
+
+function getEncounterReason(encounter: Encounter): string | undefined {
+  const reasonSet = new Set<string>();
+
+  for (const reason of encounter.reasonCode ?? []) {
+    const text = reason.text;
+
+    if (text) {
+      reasonSet.add(normalizeDisplay(text));
+    }
+
+    const codings = getValidCodings(reason.coding ?? []);
+
+    codings.forEach(c => {
+      if (c.display) reasonSet.add(normalizeDisplay(c.display));
+    });
+  }
+
+  const reasons = Array.from(reasonSet);
+  return reasons.length > 0 ? reasons.join(", ") : undefined;
+}
+
+function getEncounterLocation(encounter: Encounter, locations: Location[]): string | undefined {
+  const locationNames = encounter.location?.flatMap(locationRef => {
+    const refString = locationRef.location?.reference;
+    if (!refString) return [];
+
+    const refObj = buildReferenceFromStringRelative(refString);
+    const refId = refObj?.id;
+    if (!refId) return [];
+
+    return locations.find(l => l.id === refId)?.name ?? [];
+  });
+
+  return locationNames?.join(", ");
+}
+
+function renderClassDisplay(encounter: Encounter): string | undefined {
+  const isUsefulDisplay = isDisplayUseful(encounter.class?.display);
+
+  if (encounter.class?.display && isUsefulDisplay) {
+    return normalizeDisplay(encounter.class?.display);
+  } else if (encounter.class?.extension) {
+    const extension = encounter.class?.extension?.find(coding => {
+      return coding.valueCoding?.code === encounter.class?.code;
+    });
+    return extension?.valueCoding?.display
+      ? normalizeDisplay(extension.valueCoding.display)
+      : undefined;
+  } else if (encounter.type) {
+    const allTypeStringSet = new Set<string>();
+
+    for (const type of encounter.type) {
+      if (type.text && isDisplayUseful(type.text)) {
+        allTypeStringSet.add(normalizeDisplay(type.text));
+      }
+      type.coding?.forEach(c => {
+        if (c.display) allTypeStringSet.add(c.display);
+      });
+    }
+    return Array.from(allTypeStringSet).join(", ");
+  }
+
+  return undefined;
+}
+
+function isDisplayUseful(display: string | undefined) {
+  return display !== undefined && display !== "unknown";
+}
+
+function normalizeDisplay(str: string): string {
+  return toTitleCase(str.trim());
+}

--- a/packages/core/src/external/fhir/shared/bundle.ts
+++ b/packages/core/src/external/fhir/shared/bundle.ts
@@ -140,7 +140,9 @@ export function getReferences({
   return remainingRefs;
 }
 
-function buildReferenceFromStringRelative(reference: string): ReferenceWithIdAndType | undefined {
+export function buildReferenceFromStringRelative(
+  reference: string
+): ReferenceWithIdAndType | undefined {
   const parts = reference.split("/");
   const type = parts[0] as ResourceType | undefined;
   const id = parts[1];

--- a/packages/utils/src/consolidated/create-consolidate-local.ts
+++ b/packages/utils/src/consolidated/create-consolidate-local.ts
@@ -1,12 +1,13 @@
 import * as dotenv from "dotenv";
 dotenv.config();
 // keep that ^ on top
-import { BundleEntry, Patient } from "@medplum/fhirtypes";
+import { Bundle, BundleEntry, Patient } from "@medplum/fhirtypes";
 import {
   buildConsolidatedBundle,
   merge,
 } from "@metriport/core/command/consolidated/consolidated-create";
 import { deduplicate } from "@metriport/core/external/fhir/consolidated/deduplicate";
+import { normalize } from "@metriport/core/external/fhir/consolidated/normalize";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { getFileContents } from "@metriport/core/util/fs";
 import { sleep } from "@metriport/shared";
@@ -81,6 +82,7 @@ export async function createConsolidatedFromLocal(
   withDups.entry?.push(patient);
   /* eslint-disable @typescript-eslint/no-non-null-assertion */
   const deduped = await deduplicate({ cxId, patientId: patient.id!, bundle: withDups });
+  const normalized = await normalize({ cxId, patientId: patient.id!, bundle: deduped });
 
   const duration = Date.now() - startedAt;
   const durationMin = dayjs.duration(duration).asMinutes();
@@ -91,10 +93,23 @@ export async function createConsolidatedFromLocal(
     `${outputFolderName}/consolidated_with_dups.json`,
     JSON.stringify(withDups, null, 2)
   );
-  fs.writeFileSync(`${outputFolderName}/consolidated.json`, JSON.stringify(deduped, null, 2));
+  fs.writeFileSync(`${outputFolderName}/consolidated.json`, JSON.stringify(normalized, null, 2));
+
+  console.log("countResources before", countResources(withDups));
+  console.log("countResources after", countResources(normalized));
   return;
 }
 
 createConsolidatedFromLocal(bundlesFolder, outputFolder).then(() => {
   process.exit(0);
 });
+
+function countResources(bundle: Bundle): Record<string, number> {
+  const counts: Record<string, number> = {};
+  bundle.entry?.forEach(entry => {
+    if (!entry.resource) return;
+    const resourceType: string = entry.resource.resourceType;
+    counts[resourceType] = (counts[resourceType] || 0) + 1;
+  });
+  return counts;
+}


### PR DESCRIPTION
Part of ENG-101

- https://linear.app/metriport/issue/ENG-101

### Description
- Added useless Encounter filtering to the normalization logic

### Testing

- Local
  - [x] Create a consolidated snapshot locally and count resources to make sure the encounters dissappear
- Staging
  - [ ]  Rerun Consolidated Query and check the snapshot contents
- Production
  - [ ] Rerun Consolidated Query and check the snapshot contents

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a function to filter and extract valid codings from coding arrays.
  - Added functionality to normalize FHIR Encounter resources, providing clearer descriptions and location details.
  - Enhanced bundle consolidation by including normalization after deduplication, resulting in more consistent output.

- **Improvements**
  - Encounter normalization is now integrated into the overall FHIR bundle normalization process.
  - Resource counts are now displayed before and after normalization during bundle consolidation for improved transparency.

- **Documentation**
  - Newly exported functions are now available for reference and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->