### PR TITLE
PATCH RELEASE ai brief missing from consolidated bundles

### DIFF
--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -94,15 +94,6 @@ export async function createConsolidatedFromConversions({
   await dangerouslyDeduplicate({ cxId, patientId, bundle });
   log(`...done, from ${lengthWithDups} to ${bundle.entry?.length} resources`);
 
-  const dedupDestFileName = createConsolidatedDataFilePath(cxId, patientId, true);
-  log(`Storing consolidated bundle on ${destinationBucketName}, key ${dedupDestFileName}`);
-  await s3Utils.uploadFile({
-    bucket: destinationBucketName,
-    key: dedupDestFileName,
-    file: Buffer.from(JSON.stringify(bundle)),
-    contentType: "application/json",
-  });
-
   log(`isAiBriefFeatureFlagEnabled: ${isAiBriefFeatureFlagEnabled}`);
 
   if (isAiBriefFeatureFlagEnabled && bundle.entry && bundle.entry.length > 0) {
@@ -121,6 +112,15 @@ export async function createConsolidatedFromConversions({
       bundle.entry?.push(binaryBundleEntry);
     }
   }
+
+  const dedupDestFileName = createConsolidatedDataFilePath(cxId, patientId, true);
+  log(`Storing consolidated bundle on ${destinationBucketName}, key ${dedupDestFileName}`);
+  await s3Utils.uploadFile({
+    bucket: destinationBucketName,
+    key: dedupDestFileName,
+    file: Buffer.from(JSON.stringify(bundle)),
+    contentType: "application/json",
+  });
 
   log(`Done`);
   return bundle;


### PR DESCRIPTION

Issues: 
- https://linear.app/metriport/issue/ENG-301

### Description
- Fixing the order of operations on consolidated create

### Testing

_[Patch PRs:]_

- :warning: [ ] Run E2E tests locally

- Local
  - [ ] ???
- Production
  - [ ] _testing step 1_
  - [ ] _testing step 2_

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the timing of bundle uploads to ensure that any optional AI brief additions are included before uploading to S3. The final bundle now always contains the latest updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->