### PR TITLE
feat(api): adding internal route to recreate consolidated bundle

### DIFF
--- a/packages/api/src/command/medical/patient/consolidated-get.ts
+++ b/packages/api/src/command/medical/patient/consolidated-get.ts
@@ -151,7 +151,7 @@ export async function startConsolidatedQuery({
   return progress;
 }
 
-function appendProgressToProcessingQueries(
+export function appendProgressToProcessingQueries(
   currentConsolidatedQueries: ConsolidatedQuery[] | undefined,
   progress: ConsolidatedQuery
 ): ConsolidatedQuery[] {

--- a/packages/api/src/routes/internal/medical/patient.ts
+++ b/packages/api/src/routes/internal/medical/patient.ts
@@ -1160,7 +1160,7 @@ router.delete(
 );
 
 /**
- * POST /internal/patient/:id/consolidated/recreate
+ * POST /internal/patient/:id/consolidated/refresh
  *
  * Forcefully recreates the consolidated bundle for a patient.
  *
@@ -1168,13 +1168,13 @@ router.delete(
  * @param req.params.id The patient ID.
  */
 router.post(
-  "/:id/consolidated/recreate",
+  "/:id/consolidated/refresh",
   handleParams,
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const id = getFromParamsOrFail("id", req);
-    const { log } = out(`consolidated/recreate, cx - ${cxId}, pt - ${id} `);
+    const { log } = out(`consolidated/refresh, cx - ${cxId}, pt - ${id} `);
 
     const patient = await getPatientOrFail({ id, cxId });
     const requestId = uuidv7();

--- a/packages/api/src/routes/internal/medical/patient.ts
+++ b/packages/api/src/routes/internal/medical/patient.ts
@@ -1185,7 +1185,7 @@ router.post(
     } catch (err) {
       const msg = `Error recreating consolidated`;
       log(`${msg}, err - ${errorToString(err)}`);
-      throw new MetriportError(msg, { extra: { patientId: id } });
+      throw new MetriportError(msg, { extra: { patientId: id, cxId } });
     }
     return res.status(status.OK).json({ requestId });
   })

--- a/packages/api/src/routes/internal/medical/patient.ts
+++ b/packages/api/src/routes/internal/medical/patient.ts
@@ -1160,7 +1160,7 @@ router.delete(
 );
 
 /**
- * POST /internal/patient/:id/recreate-consolidated
+ * POST /internal/patient/:id/consolidated/recreate
  *
  * Forcefully recreates the consolidated bundle for a patient.
  *
@@ -1168,13 +1168,13 @@ router.delete(
  * @param req.params.id The patient ID.
  */
 router.post(
-  "/:id/recreate-consolidated",
+  "/:id/consolidated/recreate",
   handleParams,
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const id = getFromParamsOrFail("id", req);
-    const { log } = out(`recreate-consolidated, cx - ${cxId}, pt - ${id} `);
+    const { log } = out(`consolidated/recreate, cx - ${cxId}, pt - ${id} `);
 
     const patient = await getPatientOrFail({ id, cxId });
     const requestId = uuidv7();

--- a/packages/utils/src/consolidated/bulk-recreate-consolidated.ts
+++ b/packages/utils/src/consolidated/bulk-recreate-consolidated.ts
@@ -52,13 +52,19 @@ const patientsWithErrors: string[] = [];
 const program = new Command();
 program
   .name("recreate-consolidated")
-  .description("CLI to get coverage/density data multiple patients.")
+  .description("CLI to recreate consolidated data for multiple patients.")
+
   .showHelpAfterError();
 
 async function main() {
   initRunsFolder();
   program.parse();
   const { log } = out("");
+
+  if (patientIds.length === 0) {
+    log(">>> No patient IDs provided. Please add patient IDs to the patientIds array.");
+    process.exit(1);
+  }
 
   const startedAt = Date.now();
   log(`>>> Starting with ${patientIds.length} patient IDs...`);

--- a/packages/utils/src/consolidated/bulk-recreate-consolidated.ts
+++ b/packages/utils/src/consolidated/bulk-recreate-consolidated.ts
@@ -1,0 +1,128 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
+import { out } from "@metriport/core/util/log";
+import { errorToString, getEnvVarOrFail, sleep } from "@metriport/shared";
+import axios from "axios";
+import { Command } from "commander";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import { getDelayTime } from "../shared/duration";
+import { initFile } from "../shared/file";
+import { buildGetDirPathInside, initRunsFolder } from "../shared/folder";
+import { getCxData } from "../shared/get-cx-data";
+import { logErrorToFile } from "../shared/log";
+
+dayjs.extend(duration);
+
+/**
+ * This script triggers the recreation of consolidated data for multiple patients.
+ * It makes parallel requests to the API to recreate consolidated data for each patient.
+ *
+ * Update the `patientIds` array with the list of Patient IDs you want to recreate consolidated data for.
+ *
+ * Any errors encountered during processing are saved in a file in the `runs/recreate-consolidated` folder,
+ * named with the customer's name and timestamp.
+ *
+ * The delay time between requests is managed by the `getDelayTime` function, which
+ * ensures we don't overwhelm the system while maintaining good throughput.
+ *
+ * Execute this with:
+ * $ npm run bulk-recreate-consolidated
+ */
+
+// add patient IDs here to kick off queries for specific patient IDs
+const patientIds: string[] = [];
+
+const cxId = getEnvVarOrFail("CX_ID");
+const apiUrl = getEnvVarOrFail("API_URL");
+const api = axios.create({ baseURL: apiUrl });
+
+// query stuff
+const minimumDelayTime = dayjs.duration(1, "seconds"); // to get to 1s need to be ABSOLUTELY sure the infra will take it (scale it out if needed)
+const defaultDelayTime = dayjs.duration(10, "seconds");
+const confirmationTime = dayjs.duration(10, "seconds");
+const numberOfParallelExecutions = 5;
+
+// output stuff
+const getOutputFileName = buildGetDirPathInside(`recreate-consolidated`);
+const patientsWithErrors: string[] = [];
+
+const program = new Command();
+program
+  .name("recreate-consolidated")
+  .description("CLI to get coverage/density data multiple patients.")
+  .showHelpAfterError();
+
+async function main() {
+  initRunsFolder();
+  program.parse();
+  const { log } = out("");
+
+  const startedAt = Date.now();
+  log(`>>> Starting with ${patientIds.length} patient IDs...`);
+
+  const { orgName } = await getCxData(cxId, undefined, false);
+  await displayWarningAndConfirmation(patientIds.length, orgName, log);
+
+  const errorFileName = getOutputFileName(orgName) + ".error";
+  initFile(errorFileName);
+
+  log(`>>> Running it...`);
+
+  let ptIndex = 0;
+  await executeAsynchronously(
+    patientIds,
+    async patientId => {
+      await recreateConsolidatedForPatient(patientId, cxId, errorFileName, log);
+      log(`>>> Progress: ${++ptIndex}/${patientIds.length} patients complete`);
+      const delayTime = getDelayTime({ log, minimumDelayTime, defaultDelayTime });
+      log(`...sleeping for ${delayTime} ms`);
+      await sleep(delayTime);
+    },
+    { numberOfParallelExecutions }
+  );
+  if (patientsWithErrors.length > 0) {
+    log(
+      `>>> Patients with errors (${patientsWithErrors.length}): ${patientsWithErrors.join(", ")}`
+    );
+    log(`>>> See file ${errorFileName} for more details.`);
+  } else {
+    log(`>>> No patient with errors!`);
+  }
+  const ellapsed = Date.now() - startedAt;
+  log(`>>> Done recreating consolidated for all ${patientIds.length} patients in ${ellapsed} ms`);
+  process.exit(0);
+}
+
+async function displayWarningAndConfirmation(
+  patientCount: number | undefined,
+  orgName: string,
+  log: typeof console.log
+) {
+  const msg = `You are about to get the coverage info of ${patientCount} patients of the org/cx ${orgName}.`;
+  log(msg);
+  log("Cancel this now if you're not sure.");
+  await sleep(confirmationTime.asMilliseconds());
+}
+
+async function recreateConsolidatedForPatient(
+  patientId: string,
+  cxId: string,
+  errorFileName: string,
+  log: typeof console.log
+) {
+  try {
+    await api.post(`/internal/patient/${patientId}/recreate-consolidated?cxId=${cxId}`);
+    log(`>>> Done recreate consolidated for patient ${patientId}...`);
+    //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error) {
+    const msg = `ERROR processing patient ${patientId}: `;
+    log(msg, errorToString(error));
+    patientsWithErrors.push(patientId);
+    logErrorToFile(errorFileName, msg, error as Error);
+  }
+}
+
+main();

--- a/packages/utils/src/consolidated/bulk-recreate-consolidated.ts
+++ b/packages/utils/src/consolidated/bulk-recreate-consolidated.ts
@@ -120,7 +120,7 @@ async function recreateConsolidatedForPatient(
   log: typeof console.log
 ) {
   try {
-    await api.post(`/internal/patient/${patientId}/consolidated/recreate?cxId=${cxId}`);
+    await api.post(`/internal/patient/${patientId}/consolidated/refresh?cxId=${cxId}`);
     log(`>>> Done recreate consolidated for patient ${patientId}...`);
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error) {

--- a/packages/utils/src/consolidated/bulk-recreate-consolidated.ts
+++ b/packages/utils/src/consolidated/bulk-recreate-consolidated.ts
@@ -120,7 +120,7 @@ async function recreateConsolidatedForPatient(
   log: typeof console.log
 ) {
   try {
-    await api.post(`/internal/patient/${patientId}/recreate-consolidated?cxId=${cxId}`);
+    await api.post(`/internal/patient/${patientId}/consolidated/recreate?cxId=${cxId}`);
     log(`>>> Done recreate consolidated for patient ${patientId}...`);
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error) {

--- a/packages/utils/src/consolidated/bulk-recreate-consolidated.ts
+++ b/packages/utils/src/consolidated/bulk-recreate-consolidated.ts
@@ -101,7 +101,7 @@ async function displayWarningAndConfirmation(
   orgName: string,
   log: typeof console.log
 ) {
-  const msg = `You are about to get the coverage info of ${patientCount} patients of the org/cx ${orgName}.`;
+  const msg = `You are about to recreate consolidated data for ${patientCount} patients of the org/cx ${orgName}.`;
   log(msg);
   log("Cancel this now if you're not sure.");
   await sleep(confirmationTime.asMilliseconds());
@@ -119,7 +119,7 @@ async function recreateConsolidatedForPatient(
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error) {
     const msg = `ERROR processing patient ${patientId}: `;
-    log(msg, errorToString(error));
+    log(`${msg}${errorToString(error)}`);
     patientsWithErrors.push(patientId);
     logErrorToFile(errorFileName, msg, error as Error);
   }


### PR DESCRIPTION
Part of ENG-303

Issues:

- https://linear.app/metriport/issue/ENG-303

### Description

- adding internal route to recreate consolidated bundle

### Testing

- Local
  - [x] Recreate consolidated on a local patient and confirm on S3
- Staging
  - [ ] Recreate consolidated and confirm on s3
- Production
  - [ ] Recreate consolidated and confirm on s3

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new POST endpoint to forcefully recreate a patient's consolidated data bundle, providing immediate feedback on the operation's status.
  - Added a bulk processing script to trigger consolidated data recreation for multiple patients with progress tracking and error logging.
- **Chores**
  - Improved internal modularity to support new endpoint functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->