### PR TITLE
feat(docs): fix GitHub capitalization in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <p align="center">
    <a href="https://status.metriport.com/"><img src="https://api.checklyhq.com/v1/badges/checks/6aee48de-8699-4746-8843-80e28366ccb0?style=flat&theme=default" alt="API Status Check"></a>
-   <a href="https://github.com/metriport/metriport/stargazers"><img src="https://img.shields.io/github/stars/metriport/metriport" alt="Github Stars"></a>
+   <a href="https://github.com/metriport/metriport/stargazers"><img src="https://img.shields.io/github/stars/metriport/metriport" alt="GitHub Stars"></a>
    <a href="https://github.com/metriport/metriport/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-AGPLv3-purple" alt="License"></a>
    <a href="https://github.com/metriport/metriport/pulse"><img src="https://img.shields.io/github/commit-activity/m/metriport/metriport" alt="Commits-per-month"></a>
    <a href="https://twitter.com/metriport"><img src="https://img.shields.io/twitter/follow/metriport?style=social"></a>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -31,7 +31,7 @@
       "url": "mailto:contact@metriport.com"
     },
     {
-      "name": "Github",
+      "name": "GitHub",
       "url": "https://github.com/metriport/metriport"
     }
   ],


### PR DESCRIPTION
refs. ENG-305

Fix minor capitalization in docs. Was trying to figure out how to reference https://github.com/metriport/metriport/issues/304 when picking up tickets to fix docs.

Issues:

- https://github.com/metriport/metriport/issues/304 

### Testing

Check the updated docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the capitalization of "GitHub" in the README badge alt text and in documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->