### PR TITLE
ENG-308 create and write to new bucket

### DIFF
--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-factory.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-factory.ts
@@ -7,7 +7,8 @@ export function buildHl7NotificationWebhookSender(): Hl7NotificationWebhookSende
   if (Config.isDev()) {
     return new Hl7NotificationWebhookSenderDirect(
       Config.getApiLoadBalancerAddress(),
-      Config.getHl7OutgoingMessageBucketName()
+      Config.getHl7OutgoingMessageBucketName(),
+      Config.getHl7ConversionBucketName()
     );
   }
   return new Hl7NotificationWebhookSenderCloud(Config.getHl7NotificationQueueUrl());

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
@@ -170,3 +170,14 @@ export function formatDateToHl7(date: Date): string {
 export function buildHl7MessageFhirBundleFileKey(params: Hl7FileKeyParams) {
   return `${buildHl7MessageFileKey(params)}.${JSON_FILE_EXTENSION}`;
 }
+
+export function buildHl7MessageConversionFileKey({
+  cxId,
+  patientId,
+  messageId,
+  timestamp,
+  messageCode,
+  triggerEvent,
+}: Hl7FileKeyParams) {
+  return `cxId=${cxId}/ptId=${patientId}/${messageCode.toUpperCase()}/${timestamp}_${messageId}_${messageCode}_${triggerEvent}.${HL7_FILE_EXTENSION}.${JSON_FILE_EXTENSION}`;
+}

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -98,6 +98,9 @@ export class Config {
   static getHl7OutgoingMessageBucketName(): string {
     return getEnvVarOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME");
   }
+  static getHl7ConversionBucketName(): string {
+    return getEnvVarOrFail("HL7_CONVERSION_BUCKET_NAME");
+  }
   static getHl7NotificationQueueUrl(): string {
     return getEnvVarOrFail("HL7_NOTIFICATION_QUEUE_URL");
   }

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -154,6 +154,7 @@ export const config: EnvConfigNonSandbox = {
     deprecatedIncomingMessageBucketName: "test-hl7-notification-bucket-name",
     incomingMessageBucketName: "test-incoming-message-bucket-name",
     outgoingMessageBucketName: "test-outgoing-message-bucket-name",
+    hl7ConversionBucketName: "test-hl7-conversion-bucket-name",
     notificationWebhookSenderQueue: {
       arn: "arn:aws:sqs:us-west-1:000000000000:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
       url: "https://sqs.us-west-1.amazonaws.com/000000000000/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -7,6 +7,7 @@ export interface Hl7NotificationConfig {
   deprecatedIncomingMessageBucketName: string;
   incomingMessageBucketName: string;
   outgoingMessageBucketName: string;
+  hl7ConversionBucketName: string;
   notificationWebhookSenderQueue: {
     arn: string;
     url: string;

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -124,15 +124,6 @@ export class APIStack extends Stack {
       );
     }
 
-    let hl7ConversionBucket: s3.IBucket | undefined;
-    if (!isSandbox(props.config) && props.config.hl7Notification.hl7ConversionBucketName) {
-      hl7ConversionBucket = s3.Bucket.fromBucketName(
-        this,
-        "Hl7ConversionBucket",
-        props.config.hl7Notification.hl7ConversionBucketName
-      );
-    }
-
     //-------------------------------------------
     // Security Setup
     //-------------------------------------------

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -298,6 +298,17 @@ export class APIStack extends Stack {
       ],
     });
 
+    let hl7ConversionBucket: s3.Bucket | undefined;
+    if (!isSandbox(props.config) && props.config.hl7Notification.hl7ConversionBucketName) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      hl7ConversionBucket = new s3.Bucket(this, "HL7ConversionBucket", {
+        bucketName: props.config.hl7Notification.hl7ConversionBucketName,
+        publicReadAccess: false,
+        encryption: s3.BucketEncryption.S3_MANAGED,
+        versioned: true,
+      });
+    }
+
     let ehrResponsesBucket: s3.Bucket | undefined;
     if (!isSandbox(props.config)) {
       ehrResponsesBucket = new s3.Bucket(this, "EhrResponsedBucket", {

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -116,7 +116,7 @@ export class APIStack extends Stack {
     // Buckets
     //-------------------------------------------
     let outgoingHl7NotificationBucket: s3.IBucket | undefined;
-    if (!isSandbox(props.config) && props.config.hl7Notification.outgoingMessageBucketName) {
+    if (props.config.hl7Notification) {
       outgoingHl7NotificationBucket = s3.Bucket.fromBucketName(
         this,
         "OutgoingHl7MessageBucket",
@@ -383,7 +383,7 @@ export class APIStack extends Stack {
     // HL7 Notification Webhook Sender
     //-------------------------------------------
     let hl7NotificationWebhookSenderLambda: lambda.Function | undefined;
-    if (!isSandbox(props.config) && outgoingHl7NotificationBucket && hl7ConversionBucket) {
+    if (props.config.hl7Notification && outgoingHl7NotificationBucket && hl7ConversionBucket) {
       const { lambda } = new Hl7NotificationWebhookSenderNestedStack(
         this,
         "Hl7NotificationWebhookSenderNestedStack",

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -124,6 +124,15 @@ export class APIStack extends Stack {
       );
     }
 
+    let hl7ConversionBucket: s3.IBucket | undefined;
+    if (!isSandbox(props.config) && props.config.hl7Notification.hl7ConversionBucketName) {
+      hl7ConversionBucket = s3.Bucket.fromBucketName(
+        this,
+        "Hl7ConversionBucket",
+        props.config.hl7Notification.hl7ConversionBucketName
+      );
+    }
+
     //-------------------------------------------
     // Security Setup
     //-------------------------------------------
@@ -383,7 +392,7 @@ export class APIStack extends Stack {
     // HL7 Notification Webhook Sender
     //-------------------------------------------
     let hl7NotificationWebhookSenderLambda: lambda.Function | undefined;
-    if (!isSandbox(props.config) && outgoingHl7NotificationBucket) {
+    if (!isSandbox(props.config) && outgoingHl7NotificationBucket && hl7ConversionBucket) {
       const { lambda } = new Hl7NotificationWebhookSenderNestedStack(
         this,
         "Hl7NotificationWebhookSenderNestedStack",
@@ -393,6 +402,7 @@ export class APIStack extends Stack {
           vpc: this.vpc,
           alarmAction: slackNotification?.alarmAction,
           outgoingHl7NotificationBucket,
+          hl7ConversionBucket,
           secrets,
         }
       );

--- a/packages/infra/lib/buckets-stack.ts
+++ b/packages/infra/lib/buckets-stack.ts
@@ -13,7 +13,6 @@ export class BucketsStack extends Stack {
   public readonly hl7NotificationBucket?: s3.Bucket;
   public readonly incomingHl7NotificationBucket?: s3.Bucket;
   public readonly outgoingHl7NotificationBucket?: s3.Bucket;
-  public readonly hl7ConversionBucket?: s3.Bucket;
 
   constructor(scope: Construct, id: string, props: BucketsStackProps) {
     super(scope, id, props);
@@ -29,10 +28,6 @@ export class BucketsStack extends Stack {
       });
       this.outgoingHl7NotificationBucket = createBucket(this, {
         bucketName: props.config.hl7Notification.outgoingMessageBucketName,
-      });
-      this.hl7ConversionBucket = createBucket(this, {
-        bucketName: props.config.hl7Notification.hl7ConversionBucketName,
-        versioned: true,
       });
     }
   }

--- a/packages/infra/lib/buckets-stack.ts
+++ b/packages/infra/lib/buckets-stack.ts
@@ -13,6 +13,7 @@ export class BucketsStack extends Stack {
   public readonly hl7NotificationBucket?: s3.Bucket;
   public readonly incomingHl7NotificationBucket?: s3.Bucket;
   public readonly outgoingHl7NotificationBucket?: s3.Bucket;
+  public readonly hl7ConversionBucket?: s3.Bucket;
 
   constructor(scope: Construct, id: string, props: BucketsStackProps) {
     super(scope, id, props);
@@ -28,6 +29,11 @@ export class BucketsStack extends Stack {
       });
       this.outgoingHl7NotificationBucket = createBucket(this, {
         bucketName: props.config.hl7Notification.outgoingMessageBucketName,
+      });
+      this.hl7ConversionBucket = createBucket(this, {
+        bucketName: props.config.hl7Notification.hl7ConversionBucketName,
+        versioned: true,
+        objectLockEnabled: true,
       });
     }
   }

--- a/packages/infra/lib/buckets-stack.ts
+++ b/packages/infra/lib/buckets-stack.ts
@@ -33,7 +33,6 @@ export class BucketsStack extends Stack {
       this.hl7ConversionBucket = createBucket(this, {
         bucketName: props.config.hl7Notification.hl7ConversionBucketName,
         versioned: true,
-        objectLockEnabled: true,
       });
     }
   }

--- a/packages/infra/lib/hl7-notification-stack/index.ts
+++ b/packages/infra/lib/hl7-notification-stack/index.ts
@@ -20,13 +20,6 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
   constructor(scope: Construct, id: string, props: Hl7NotificationStackProps) {
     super(scope, id, props);
 
-    // Get references to existing buckets by name
-    const hl7NotificationBucket = s3.Bucket.fromBucketName(
-      this,
-      "Hl7NotificationBucket",
-      props.config.hl7Notification.deprecatedIncomingMessageBucketName
-    );
-
     const incomingHl7NotificationBucket = s3.Bucket.fromBucketName(
       this,
       "IncomingHl7NotificationBucket",
@@ -67,7 +60,6 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
       version: props.version,
       vpc,
       ecrRepo,
-      hl7NotificationBucket,
       incomingHl7NotificationBucket,
       description: "HL7 Notification MLLP Server",
     });

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -18,7 +18,6 @@ interface MllpStackProps extends cdk.StackProps {
   version: string | undefined;
   vpc: ec2.Vpc;
   ecrRepo: Repository;
-  hl7NotificationBucket: s3.IBucket;
   incomingHl7NotificationBucket: s3.IBucket;
 }
 
@@ -26,7 +25,7 @@ export class MllpStack extends cdk.NestedStack {
   constructor(scope: Construct, id: string, props: MllpStackProps) {
     super(scope, id, props);
 
-    const { vpc, ecrRepo, incomingHl7NotificationBucket, hl7NotificationBucket, config } = props;
+    const { vpc, ecrRepo, incomingHl7NotificationBucket, config } = props;
     const { notificationWebhookSenderQueue } = config.hl7Notification;
     const { fargateCpu, fargateMemoryLimitMiB, fargateTaskCountMin, fargateTaskCountMax } =
       props.config.hl7Notification.mllpServer;
@@ -143,7 +142,6 @@ export class MllpStack extends cdk.NestedStack {
     });
 
     targetGroup.addTarget(fargateService);
-    hl7NotificationBucket.grantWrite(fargateService.taskDefinition.taskRole);
     incomingHl7NotificationBucket.grantWrite(fargateService.taskDefinition.taskRole);
 
     const scaling = fargateService.autoScaleTaskCount({

--- a/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
+++ b/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
@@ -48,6 +48,7 @@ interface Hl7NotificationWebhookSenderNestedStackProps extends NestedStackProps 
   alarmAction?: SnsAction;
   lambdaLayers: LambdaLayers;
   outgoingHl7NotificationBucket: s3.IBucket;
+  hl7ConversionBucket: s3.IBucket;
   secrets: Secrets;
 }
 
@@ -71,6 +72,7 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
       sentryDsn: props.config.lambdasSentryDSN,
       alarmAction: props.alarmAction,
       outgoingHl7NotificationBucket: props.outgoingHl7NotificationBucket,
+      hl7ConversionBucket: props.hl7ConversionBucket,
       analyticsSecret,
     });
 
@@ -84,6 +86,7 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
     sentryDsn: string | undefined;
     alarmAction: SnsAction | undefined;
     outgoingHl7NotificationBucket: s3.IBucket;
+    hl7ConversionBucket: s3.IBucket;
     analyticsSecret: ISecret;
   }): { lambda: Lambda } {
     const {
@@ -93,6 +96,7 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
       envType,
       alarmAction,
       outgoingHl7NotificationBucket,
+      hl7ConversionBucket,
       analyticsSecret,
     } = ownProps;
     const {
@@ -126,11 +130,14 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
       envVars: {
         // API_URL set on the api-stack after the OSS API is created
         HL7_OUTGOING_MESSAGE_BUCKET_NAME: outgoingHl7NotificationBucket.bucketName,
+        HL7_CONVERSION_BUCKET_NAME: hl7ConversionBucket.bucketName,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
     });
 
     outgoingHl7NotificationBucket.grantReadWrite(lambda);
+    hl7ConversionBucket.grantReadWrite(lambda);
+
     lambda.addEventSource(new SqsEventSource(queue, eventSourceSettings));
     analyticsSecret.grantRead(lambda);
 

--- a/packages/lambdas/src/hl7-notification-webhook-sender.ts
+++ b/packages/lambdas/src/hl7-notification-webhook-sender.ts
@@ -6,14 +6,15 @@ import { capture } from "./shared/capture";
 import { getEnvOrFail } from "./shared/env";
 import { prefixedLog } from "./shared/log";
 import { getSingleMessageOrFail } from "./shared/sqs";
+import { Config } from "@metriport/core/util/config";
 
 // Keep this as early on the file as possible
 capture.init();
 
 // Automatically set by AWS
 const lambdaName = getEnvOrFail("AWS_LAMBDA_FUNCTION_NAME");
-const oldBucketName = getEnvOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME");
-const bucketName = getEnvOrFail("HL7_CONVERSION_BUCKET_NAME");
+const oldBucketName = Config.getHl7OutgoingMessageBucketName();
+const bucketName = Config.getHl7ConversionBucketName();
 const apiUrl = getEnvOrFail("API_URL");
 
 // TODO move to capture.wrapHandler()

--- a/packages/lambdas/src/hl7-notification-webhook-sender.ts
+++ b/packages/lambdas/src/hl7-notification-webhook-sender.ts
@@ -1,6 +1,5 @@
 import { Hl7Notification } from "@metriport/core/command/hl7-notification/hl7-notification-webhook-sender";
 import { Hl7NotificationWebhookSenderDirect } from "@metriport/core/command/hl7-notification/hl7-notification-webhook-sender-direct";
-import * as Sentry from "@sentry/serverless";
 import { SQSEvent } from "aws-lambda";
 import { z } from "zod";
 import { capture } from "./shared/capture";
@@ -13,11 +12,12 @@ capture.init();
 
 // Automatically set by AWS
 const lambdaName = getEnvOrFail("AWS_LAMBDA_FUNCTION_NAME");
-const bucketName = getEnvOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME");
+const oldBucketName = getEnvOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME");
+const bucketName = getEnvOrFail("HL7_CONVERSION_BUCKET_NAME");
 const apiUrl = getEnvOrFail("API_URL");
 
 // TODO move to capture.wrapHandler()
-export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent): Promise<void> => {
+export const handler = capture.wrapHandler(async (event: SQSEvent): Promise<void> => {
   const params = getSingleMessageOrFail(event.Records, lambdaName);
   if (!params) {
     throw new Error("No message found in SQS event");
@@ -34,7 +34,9 @@ export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent): Pro
     context: "hl7-notification-webhook-sender-cloud.execute",
   });
 
-  await new Hl7NotificationWebhookSenderDirect(apiUrl, bucketName).execute(parsedBody);
+  await new Hl7NotificationWebhookSenderDirect(apiUrl, oldBucketName, bucketName).execute(
+    parsedBody
+  );
 });
 
 const parseBody = (body: string): Hl7Notification => {

--- a/packages/utils/src/hl7v2-notifications/hl7-to-fhir-converter-logic.ts
+++ b/packages/utils/src/hl7v2-notifications/hl7-to-fhir-converter-logic.ts
@@ -7,6 +7,7 @@ import { getOrCreateMessageDatetime } from "@metriport/core/command/hl7v2-subscr
 import { getCxIdAndPatientIdOrFail } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
 import { errorToString, getEnvVarOrFail } from "@metriport/shared";
 import fs from "fs";
+import { Config } from "@metriport/core/util/config";
 
 /**
  * Processes HL7v2 ADT messages from a file and converts them to FHIR format using the HL7 to FHIR Converter.
@@ -34,7 +35,7 @@ import fs from "fs";
  *
  * Required Environment Variables:
  * - API_URL: The API endpoint for the conversion service
- * - HL7_CONVERSIONS_BUCKET_NAME: S3 bucket name for storing converted messages
+ * - HL7_CONVERSION_BUCKET_NAME: S3 bucket name for storing converted messages
  *
  * Usage:
  * 1. Set the filePath and fileName constants to point to your HL7v2 ADT messages file
@@ -42,8 +43,8 @@ import fs from "fs";
  * 3. Run the script using ts-node
  */
 const apiUrl = getEnvVarOrFail("API_URL");
-const oldBucketName = getEnvVarOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME_OLD");
-const bucketName = getEnvVarOrFail("HL7_CONVERSIONS_BUCKET_NAME");
+const oldBucketName = Config.getHl7OutgoingMessageBucketName();
+const bucketName = Config.getHl7ConversionBucketName();
 
 const filePath = "";
 const fileName = "";

--- a/packages/utils/src/hl7v2-notifications/hl7-to-fhir-converter-logic.ts
+++ b/packages/utils/src/hl7v2-notifications/hl7-to-fhir-converter-logic.ts
@@ -42,7 +42,8 @@ import fs from "fs";
  * 3. Run the script using ts-node
  */
 const apiUrl = getEnvVarOrFail("API_URL");
-const bucketName = getEnvVarOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME");
+const oldBucketName = getEnvVarOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME_OLD");
+const bucketName = getEnvVarOrFail("HL7_CONVERSIONS_BUCKET_NAME");
 
 const filePath = "";
 const fileName = "";
@@ -58,7 +59,7 @@ function invokeLambdaLogic() {
 
     try {
       const { cxId, patientId } = getCxIdAndPatientIdOrFail(hl7Message);
-      new Hl7NotificationWebhookSenderDirect(apiUrl, bucketName).execute({
+      new Hl7NotificationWebhookSenderDirect(apiUrl, oldBucketName, bucketName).execute({
         cxId,
         patientId,
         message,


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-308

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/2965

### Description

- remove usage old unused bucket from HL7 stack - the actual bucket definition will be removed in another PR as it needs to be removed incrementally
- Add new bucket for maintaining a latest.hl7.json file
- Write conversions to new bucket w/ new file path 

### Testing
- Local
  - [x] Branch to staging + check that files get written to the new s3 bucket + path
- Staging
  - [ ] Check that files get written to new s3 bucket + path
- Production
  - [ ] Check that files get written to new s3 bucket + path

### Release Plan

See upstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying an HL7 conversion bucket in configuration.
  - Introduced a new optional HL7 conversion S3 bucket in the API stack for certain environments.
  - Enabled uploading HL7 FHIR bundles to both old and new buckets during conversion.
  - Added new file key format for HL7 message conversion files.

- **Refactor**
  - Removed deprecated HL7 notification bucket references and related permissions from infrastructure setup.
  - Updated webhook sender and Lambda handlers to handle dual bucket uploads and environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->