### PR TITLE
ENG-308: write to new bucket

### DIFF
--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-factory.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-factory.ts
@@ -7,7 +7,8 @@ export function buildHl7NotificationWebhookSender(): Hl7NotificationWebhookSende
   if (Config.isDev()) {
     return new Hl7NotificationWebhookSenderDirect(
       Config.getApiLoadBalancerAddress(),
-      Config.getHl7OutgoingMessageBucketName()
+      Config.getHl7OutgoingMessageBucketName(),
+      Config.getHl7ConversionBucketName()
     );
   }
   return new Hl7NotificationWebhookSenderCloud(Config.getHl7NotificationQueueUrl());

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
@@ -170,3 +170,14 @@ export function formatDateToHl7(date: Date): string {
 export function buildHl7MessageFhirBundleFileKey(params: Hl7FileKeyParams) {
   return `${buildHl7MessageFileKey(params)}.${JSON_FILE_EXTENSION}`;
 }
+
+export function buildHl7MessageConversionFileKey({
+  cxId,
+  patientId,
+  messageId,
+  timestamp,
+  messageCode,
+  triggerEvent,
+}: Hl7FileKeyParams) {
+  return `cxId=${cxId}/ptId=${patientId}/${messageCode.toUpperCase()}/${timestamp}_${messageId}_${messageCode}_${triggerEvent}.${HL7_FILE_EXTENSION}.${JSON_FILE_EXTENSION}`;
+}

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -98,6 +98,9 @@ export class Config {
   static getHl7OutgoingMessageBucketName(): string {
     return getEnvVarOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME");
   }
+  static getHl7ConversionBucketName(): string {
+    return getEnvVarOrFail("HL7_CONVERSION_BUCKET_NAME");
+  }
   static getHl7NotificationQueueUrl(): string {
     return getEnvVarOrFail("HL7_NOTIFICATION_QUEUE_URL");
   }

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -124,6 +124,15 @@ export class APIStack extends Stack {
       );
     }
 
+    let hl7ConversionBucket: s3.IBucket | undefined;
+    if (!isSandbox(props.config) && props.config.hl7Notification.hl7ConversionBucketName) {
+      hl7ConversionBucket = s3.Bucket.fromBucketName(
+        this,
+        "Hl7ConversionBucket",
+        props.config.hl7Notification.hl7ConversionBucketName
+      );
+    }
+
     //-------------------------------------------
     // Security Setup
     //-------------------------------------------
@@ -372,7 +381,7 @@ export class APIStack extends Stack {
     // HL7 Notification Webhook Sender
     //-------------------------------------------
     let hl7NotificationWebhookSenderLambda: lambda.Function | undefined;
-    if (!isSandbox(props.config) && outgoingHl7NotificationBucket) {
+    if (!isSandbox(props.config) && outgoingHl7NotificationBucket && hl7ConversionBucket) {
       const { lambda } = new Hl7NotificationWebhookSenderNestedStack(
         this,
         "Hl7NotificationWebhookSenderNestedStack",
@@ -382,6 +391,7 @@ export class APIStack extends Stack {
           vpc: this.vpc,
           alarmAction: slackNotification?.alarmAction,
           outgoingHl7NotificationBucket,
+          hl7ConversionBucket,
           secrets,
         }
       );

--- a/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
+++ b/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
@@ -48,6 +48,7 @@ interface Hl7NotificationWebhookSenderNestedStackProps extends NestedStackProps 
   alarmAction?: SnsAction;
   lambdaLayers: LambdaLayers;
   outgoingHl7NotificationBucket: s3.IBucket;
+  hl7ConversionBucket: s3.IBucket;
   secrets: Secrets;
 }
 
@@ -71,6 +72,7 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
       sentryDsn: props.config.lambdasSentryDSN,
       alarmAction: props.alarmAction,
       outgoingHl7NotificationBucket: props.outgoingHl7NotificationBucket,
+      hl7ConversionBucket: props.hl7ConversionBucket,
       analyticsSecret,
     });
 
@@ -84,6 +86,7 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
     sentryDsn: string | undefined;
     alarmAction: SnsAction | undefined;
     outgoingHl7NotificationBucket: s3.IBucket;
+    hl7ConversionBucket: s3.IBucket;
     analyticsSecret: ISecret;
   }): { lambda: Lambda } {
     const {
@@ -93,6 +96,7 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
       envType,
       alarmAction,
       outgoingHl7NotificationBucket,
+      hl7ConversionBucket,
       analyticsSecret,
     } = ownProps;
     const {
@@ -126,11 +130,14 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
       envVars: {
         // API_URL set on the api-stack after the OSS API is created
         HL7_OUTGOING_MESSAGE_BUCKET_NAME: outgoingHl7NotificationBucket.bucketName,
+        HL7_CONVERSION_BUCKET_NAME: hl7ConversionBucket.bucketName,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
       },
     });
 
     outgoingHl7NotificationBucket.grantReadWrite(lambda);
+    hl7ConversionBucket.grantReadWrite(lambda);
+
     lambda.addEventSource(new SqsEventSource(queue, eventSourceSettings));
     analyticsSecret.grantRead(lambda);
 

--- a/packages/lambdas/src/hl7-notification-webhook-sender.ts
+++ b/packages/lambdas/src/hl7-notification-webhook-sender.ts
@@ -1,6 +1,5 @@
 import { Hl7Notification } from "@metriport/core/command/hl7-notification/hl7-notification-webhook-sender";
 import { Hl7NotificationWebhookSenderDirect } from "@metriport/core/command/hl7-notification/hl7-notification-webhook-sender-direct";
-import * as Sentry from "@sentry/serverless";
 import { SQSEvent } from "aws-lambda";
 import { z } from "zod";
 import { capture } from "./shared/capture";
@@ -13,11 +12,12 @@ capture.init();
 
 // Automatically set by AWS
 const lambdaName = getEnvOrFail("AWS_LAMBDA_FUNCTION_NAME");
-const bucketName = getEnvOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME");
+const oldBucketName = getEnvOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME");
+const bucketName = getEnvOrFail("HL7_CONVERSION_BUCKET_NAME");
 const apiUrl = getEnvOrFail("API_URL");
 
 // TODO move to capture.wrapHandler()
-export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent): Promise<void> => {
+export const handler = capture.wrapHandler(async (event: SQSEvent): Promise<void> => {
   const params = getSingleMessageOrFail(event.Records, lambdaName);
   if (!params) {
     throw new Error("No message found in SQS event");
@@ -34,7 +34,9 @@ export const handler = Sentry.AWSLambda.wrapHandler(async (event: SQSEvent): Pro
     context: "hl7-notification-webhook-sender-cloud.execute",
   });
 
-  await new Hl7NotificationWebhookSenderDirect(apiUrl, bucketName).execute(parsedBody);
+  await new Hl7NotificationWebhookSenderDirect(apiUrl, oldBucketName, bucketName).execute(
+    parsedBody
+  );
 });
 
 const parseBody = (body: string): Hl7Notification => {

--- a/packages/utils/src/hl7v2-notifications/hl7-to-fhir-converter-logic.ts
+++ b/packages/utils/src/hl7v2-notifications/hl7-to-fhir-converter-logic.ts
@@ -42,7 +42,8 @@ import fs from "fs";
  * 3. Run the script using ts-node
  */
 const apiUrl = getEnvVarOrFail("API_URL");
-const bucketName = getEnvVarOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME");
+const oldBucketName = getEnvVarOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME_OLD");
+const bucketName = getEnvVarOrFail("HL7_CONVERSIONS_BUCKET_NAME");
 
 const filePath = "";
 const fileName = "";
@@ -58,7 +59,7 @@ function invokeLambdaLogic() {
 
     try {
       const { cxId, patientId } = getCxIdAndPatientIdOrFail(hl7Message);
-      new Hl7NotificationWebhookSenderDirect(apiUrl, bucketName).execute({
+      new Hl7NotificationWebhookSenderDirect(apiUrl, oldBucketName, bucketName).execute({
         cxId,
         patientId,
         message,


### PR DESCRIPTION
metriport/metriport-internal#1040

Ref: ENG-308

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3843/files

### Description

This PR:
- Has the Hl7 sender lambda write the conversion output to a new bucket, with a new s3 prefix schema

### Testing
- Local
  - [ ] Branch to staging + check that files get written to the new s3 bucket + path
- Staging
  - [ ] Check that files get written to new s3 bucket + path
- Production
  - [ ] Check that files get written to new s3 bucket + path

### Release Plan

See dep chain root: https://github.com/metriport/metriport-internal/pull/2965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for uploading HL7 FHIR bundles to both an existing and a new S3 bucket.
  - Introduced a new file naming scheme for HL7 message conversion files.
  - Integrated a new environment variable for specifying the HL7 conversion bucket.
- **Improvements**
  - Enhanced Lambda environment and permissions to support access to the new S3 bucket.
  - Updated logging to reflect uploads to both buckets.
- **Chores**
  - Updated configuration and infrastructure to handle the additional S3 bucket.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->