### PR TITLE
fix(workflows): fix branch to staging checking out the right feature branch

### DIFF
--- a/.github/workflows/_deploy-hl7-notification-cdk.yml
+++ b/.github/workflows/_deploy-hl7-notification-cdk.yml
@@ -19,6 +19,10 @@ on:
         required: false
         type: string
         description: "the name of the HL7 Notification Routing CDK stack we're deploying"
+      is_branch_to_staging:
+        required: false
+        type: boolean
+        description: "whether we're deploying to staging or not"
       AWS_REGION:
         required: true
         type: string

--- a/.github/workflows/_deploy-hl7-notification-cdk.yml
+++ b/.github/workflows/_deploy-hl7-notification-cdk.yml
@@ -95,6 +95,17 @@ jobs:
           echo "Internal branch for checkout: $INTERNAL_BRANCH"
           echo "INTERNAL_BRANCH=$INTERNAL_BRANCH" >> $GITHUB_ENV
 
+      - name: Checkout internal feature branch
+        uses: actions/checkout@v3
+        if: ${{ inputs.is-branch-to-staging == true }}
+        with:
+          repository: metriport/metriport-internal
+          ref: ${{ env.INTERNAL_BRANCH }}
+          token: ${{ secrets.SERVICE_PAT }} # secret token from user 'metriport-service'
+          path: metriport-internal
+          sparse-checkout: |
+            config-oss/api-infra
+
       - name: Log Git Ref
         run: |
           echo "Git ref: $(git rev-parse HEAD)"

--- a/.github/workflows/_deploy-hl7-notification-cdk.yml
+++ b/.github/workflows/_deploy-hl7-notification-cdk.yml
@@ -21,6 +21,7 @@ on:
         description: "the name of the HL7 Notification Routing CDK stack we're deploying"
       is_branch_to_staging:
         required: false
+        default: false
         type: boolean
         description: "whether this workflow should checkout internal's develop/master or a feature branch"
       AWS_REGION:

--- a/.github/workflows/_deploy-hl7-notification-cdk.yml
+++ b/.github/workflows/_deploy-hl7-notification-cdk.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Checkout internal feature branch
         uses: actions/checkout@v3
-        if: ${{ inputs.is-branch-to-staging == true }}
+        if: ${{ inputs.is_branch_to_staging == true }}
         with:
           repository: metriport/metriport-internal
           ref: ${{ env.INTERNAL_BRANCH }}

--- a/.github/workflows/_deploy-hl7-notification-cdk.yml
+++ b/.github/workflows/_deploy-hl7-notification-cdk.yml
@@ -22,7 +22,7 @@ on:
       is_branch_to_staging:
         required: false
         type: boolean
-        description: "whether we're deploying to staging or not"
+        description: "whether this workflow should checkout internal's develop/master or a feature branch"
       AWS_REGION:
         required: true
         type: string

--- a/.github/workflows/branch-to-staging.yml
+++ b/.github/workflows/branch-to-staging.yml
@@ -62,6 +62,7 @@ jobs:
     uses: ./.github/workflows/_deploy-hl7-notification-cdk.yml
     with:
       deploy_env: "staging"
+      is_branch_to_staging: true
       secrets_cdk_stack: ${{ vars.SECRET_STACK_NAME_STAGING }}
       hl7_notification_stack: ${{ vars.HL7_NOTIFICATION_STACK_NAME_STAGING }}
       AWS_REGION: ${{ vars.API_REGION_STAGING }}


### PR DESCRIPTION
metriport/metriport-internal#1040

Ref: ENG-308
Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>


### Dependencies

None

### Description

Fix github actions workflow so it will check out the right internal branch during a branch to staging.

There's a feature built into branch-to-staging workflows where when you branch OSS to staging, if you have a corresponding branch with the same name on internal, it will use that branch's configs instead of what is on develop. My hl7 cdk workflow was missing the step to make that happen - this fixes that.

### Testing

None

### Release Plan
- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to specify if deployments target a staging environment, enabling conditional actions during workflow execution.

- **Chores**
  - Updated deployment workflows to support feature branch checkouts when deploying to staging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->