### PR TITLE
fix(workflows): deploy buckets cdk stack in hl7 workflow

### DIFF
--- a/.github/workflows/_deploy-hl7-notification-cdk.yml
+++ b/.github/workflows/_deploy-hl7-notification-cdk.yml
@@ -168,6 +168,33 @@ jobs:
           AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
           METRIPORT_VERSION: ${{ github.sha }}
 
+      # Buckets Stack
+      - name: Diff Buckets CDK Stack
+        uses: metriport/deploy-with-cdk@master
+        with:
+          cdk_action: "diff"
+          cdk_version: "2.122.0"
+          cdk_stack: "BucketsStack"
+          cdk_env: "${{ inputs.deploy_env }}"
+        env:
+          INPUT_PATH: "metriport/packages/infra"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
+      - name: Deploy Buckets CDK Stack
+        uses: metriport/deploy-with-cdk@master
+        with:
+          cdk_action: "deploy --verbose --require-approval never"
+          cdk_version: "2.122.0"
+          cdk_stack: "BucketsStack"
+          cdk_env: "${{ inputs.deploy_env }}"
+        env:
+          INPUT_PATH: "metriport/packages/infra"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ inputs.AWS_REGION }}
+          METRIPORT_VERSION: ${{ github.sha }}
+
       - name: Diff HL7 Notification Routing Stack CDK
         uses: metriport/deploy-with-cdk@master
         if: inputs.hl7_notification_stack != null


### PR DESCRIPTION
metriport/metriport-internal#1040

Ref: ENG-308
Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

- Downstream: https://github.com/metriport/metriport/pull/3843

### Description

hl7 cdk deploys need to deploy any differences to the bucket stack, as depends on buckets in the buckets stack, so CI needs to deploy changes to the buckets stack before deploying hl7 infra changes.

### Testing

None

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment workflow to include deployment steps for the new BucketsStack, ensuring it is diffed and deployed alongside existing stacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->