### PR TITLE
feat(utils): continue hung download-url/bulk rquest

### DIFF
--- a/packages/api/src/command/medical/document/start-bulk-get-doc-url.ts
+++ b/packages/api/src/command/medical/document/start-bulk-get-doc-url.ts
@@ -20,19 +20,26 @@ import { getPatientOrFail } from "../patient/get-patient";
  * returns the progress of the bulk signing.
  * @param cxId - cxId
  * @param patientId - patientId
+ * @param retryExisting - if true, continue the bulk signing process from the last request
  * @returns a Promise that resolves to a BulkGetDocumentsUrlProgress object.
  */
-export const startBulkGetDocumentUrls = async (
-  cxId: string,
-  patientId: string,
-  cxDownloadRequestMetadata: unknown
-): Promise<BulkGetDocumentsUrlProgress> => {
+export async function startBulkGetDocumentUrls({
+  cxId,
+  patientId,
+  cxDownloadRequestMetadata,
+  retryExisting = false,
+}: {
+  cxId: string;
+  patientId: string;
+  cxDownloadRequestMetadata: unknown;
+  retryExisting?: boolean;
+}): Promise<BulkGetDocumentsUrlProgress> {
   const { log } = out(`startBulkGetDocumentUrls - M patient ${patientId}`);
   const patient = await getPatientOrFail({ id: patientId, cxId });
 
   const bulkGetDocUrlProgress = patient.data.bulkGetDocumentsUrlProgress;
 
-  if (isBulkGetDocUrlProcessing(bulkGetDocUrlProgress?.status)) {
+  if (!retryExisting && isBulkGetDocUrlProcessing(bulkGetDocUrlProgress?.status)) {
     log(
       `Patient ${patientId}, Request ${bulkGetDocUrlProgress?.requestId}, bulkGetDocUrlProgress is already 'processing', skipping...`
     );
@@ -72,7 +79,7 @@ export const startBulkGetDocumentUrls = async (
   }
 
   return createBulkGetDocumentUrlQueryResponse("processing", updatedPatient);
-};
+}
 
 /**
  * The function `getOrGenerateRequestId` returns the request ID from `bulkGetDocumentsUrlProgress` if it
@@ -102,12 +109,12 @@ const generateRequestId = (): string => uuidv7();
  * @param patient - The patient for whom the `BulkGetDocumentsUrlProgress` is being created.
  * @returns a BulkGetDocumentsUrlProgress object.
  */
-export const createBulkGetDocumentUrlQueryResponse = (
+export function createBulkGetDocumentUrlQueryResponse(
   status: BulkGetDocUrlStatus,
   patient?: Patient
-): BulkGetDocumentsUrlProgress => {
+): BulkGetDocumentsUrlProgress {
   return {
     status,
     requestId: patient?.data.bulkGetDocumentsUrlProgress?.requestId,
   };
-};
+}

--- a/packages/api/src/command/medical/document/start-bulk-get-doc-url.ts
+++ b/packages/api/src/command/medical/document/start-bulk-get-doc-url.ts
@@ -21,7 +21,7 @@ import { getPatientOrFail } from "../patient/get-patient";
  * returns the progress of the bulk signing.
  * @param cxId - cxId
  * @param patientId - patientId
- * @param continueProcessingRequest - if true, continue the bulk signing process from the last request
+ * @param continueProcessingRequest - if true, continue an existing processing request
  * @returns a Promise that resolves to a BulkGetDocumentsUrlProgress object.
  */
 export async function startBulkGetDocumentUrls({

--- a/packages/api/src/routes/internal/medical/docs.ts
+++ b/packages/api/src/routes/internal/medical/docs.ts
@@ -413,14 +413,14 @@ router.post(
     const patientId = getFrom("query").orFail("patientId", req);
     const cxDownloadRequestMetadata = cxRequestMetadataSchema.parse(req.body);
 
-    const BulkGetDocumentsUrlProgress = await startBulkGetDocumentUrls({
+    const bulkGetDocumentsUrlProgress = await startBulkGetDocumentUrls({
       cxId,
       patientId,
       cxDownloadRequestMetadata: cxDownloadRequestMetadata?.metadata,
       continueProcessingRequest: true,
     });
 
-    return res.status(httpStatus.OK).json(BulkGetDocumentsUrlProgress);
+    return res.status(httpStatus.OK).json(bulkGetDocumentsUrlProgress);
   })
 );
 

--- a/packages/api/src/routes/internal/medical/docs.ts
+++ b/packages/api/src/routes/internal/medical/docs.ts
@@ -396,16 +396,17 @@ router.post(
 );
 
 /**
- * POST /internal/docs/download-url/bulk/retry
+ * POST /internal/docs/download-url/bulk/continue
  *
- * Retries the existing bulk download request.
+ * Continues the existing bulk download request.
  * @param req.query.cxId - The customer/account's ID.
  * @param req.query.patientId - The patient's ID.
  * @param req.body The metadata for the bulk download request.
  * @returns The status of the bulk signing process.
+ * @throws 400 if no processing request is found for the patient.
  */
 router.post(
-  "/download-url/bulk/retry",
+  "/download-url/bulk/continue",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getFrom("query").orFail("cxId", req);
@@ -416,7 +417,7 @@ router.post(
       cxId,
       patientId,
       cxDownloadRequestMetadata: cxDownloadRequestMetadata?.metadata,
-      retryExisting: true,
+      continueProcessingRequest: true,
     });
 
     return res.status(httpStatus.OK).json(BulkGetDocumentsUrlProgress);

--- a/packages/api/src/routes/medical/document.ts
+++ b/packages/api/src/routes/medical/document.ts
@@ -240,13 +240,13 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const { cxId, id: patientId } = getPatientInfoOrFail(req);
     const cxDownloadRequestMetadata = cxRequestMetadataSchema.parse(req.body);
-    const BulkGetDocumentsUrlProgress = await startBulkGetDocumentUrls({
+    const bulkGetDocumentsUrlProgress = await startBulkGetDocumentUrls({
       cxId,
       patientId,
       cxDownloadRequestMetadata: cxDownloadRequestMetadata?.metadata,
     });
 
-    return res.status(OK).json(BulkGetDocumentsUrlProgress);
+    return res.status(OK).json(bulkGetDocumentsUrlProgress);
   })
 );
 

--- a/packages/api/src/routes/medical/document.ts
+++ b/packages/api/src/routes/medical/document.ts
@@ -240,11 +240,11 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const { cxId, id: patientId } = getPatientInfoOrFail(req);
     const cxDownloadRequestMetadata = cxRequestMetadataSchema.parse(req.body);
-    const BulkGetDocumentsUrlProgress = await startBulkGetDocumentUrls(
+    const BulkGetDocumentsUrlProgress = await startBulkGetDocumentUrls({
       cxId,
       patientId,
-      cxDownloadRequestMetadata?.metadata
-    );
+      cxDownloadRequestMetadata: cxDownloadRequestMetadata?.metadata,
+    });
 
     return res.status(OK).json(BulkGetDocumentsUrlProgress);
   })

--- a/packages/utils/src/bulk-trigger-bulk-download-continue.ts
+++ b/packages/utils/src/bulk-trigger-bulk-download-continue.ts
@@ -16,7 +16,7 @@ import { chunk } from "lodash";
  * 1. Set the env vars:
  *  - CX_ID
  *  - API_URL
- * 2. Set the patientIds and rerunPdOnNewDemographics
+ * 2. Set the patientIds and cxDownloadRequestMetadata
  * 3. Run the script with `ts-node src/bulk-trigger-bulk-download-continue.ts`
  */
 

--- a/packages/utils/src/bulk-trigger-bulk-download-continue.ts
+++ b/packages/utils/src/bulk-trigger-bulk-download-continue.ts
@@ -24,7 +24,7 @@ dayjs.extend(duration);
 
 const patientAndRequestId: {
   patientId: string;
-  cxDownloadRequestMetadataAsString: string | undefined;
+  cxDownloadRequestMetadata: object | undefined;
 }[] = [];
 
 const confirmationTime = dayjs.duration(10, "seconds");
@@ -49,7 +49,7 @@ async function main() {
       console.log(`Chunk ${i + 1} of ${patientChunks.length}`);
       console.log(`# of patients ${patients.length}`);
 
-      for (const { patientId, cxDownloadRequestMetadataAsString } of patients) {
+      for (const { patientId, cxDownloadRequestMetadata } of patients) {
         const log = out(
           `Triggering bulk download continue: cxId - ${cxId}, patientId - ${patientId}`
         ).log;
@@ -59,8 +59,8 @@ async function main() {
           patientId,
         });
         const body = {
-          ...(cxDownloadRequestMetadataAsString && {
-            metadata: JSON.parse(cxDownloadRequestMetadataAsString),
+          ...(cxDownloadRequestMetadata && {
+            metadata: cxDownloadRequestMetadata,
           }),
         };
         const resp = (await axios.post(

--- a/packages/utils/src/bulk-trigger-bulk-download-continue.ts
+++ b/packages/utils/src/bulk-trigger-bulk-download-continue.ts
@@ -10,14 +10,14 @@ import duration from "dayjs/plugin/duration";
 import { chunk } from "lodash";
 
 /**
- * This script triggers the bulk download retry for the indicated patients.
+ * This script triggers the bulk download continue for the indicated patients.
  *
  * To run:
  * 1. Set the env vars:
  *  - CX_ID
  *  - API_URL
  * 2. Set the patientIds and rerunPdOnNewDemographics
- * 3. Run the script with `ts-node src/bulk-trigger-bulk-download-wh.ts`
+ * 3. Run the script with `ts-node src/bulk-trigger-bulk-download-continue.ts`
  */
 
 dayjs.extend(duration);
@@ -51,9 +51,9 @@ async function main() {
 
       for (const { patientId, cxDownloadRequestMetadataAsString } of patients) {
         const log = out(
-          `Triggering bulk download retry: cxId - ${cxId}, patientId - ${patientId}`
+          `Triggering bulk download continue: cxId - ${cxId}, patientId - ${patientId}`
         ).log;
-        const endpointUrl = `${apiUrl}/internal/docs/download-url/bulk/retry`;
+        const endpointUrl = `${apiUrl}/internal/docs/download-url/bulk/continue`;
         const params = new URLSearchParams({
           cxId,
           patientId,
@@ -84,7 +84,7 @@ async function main() {
 async function displayInitialWarningAndConfirmation(numberPatients: number) {
   console.log("\n\x1b[31m%s\x1b[0m\n", "---- ATTENTION - THIS IS NOT A SIMULATED RUN ----"); // https://stackoverflow.com/a/41407246/2099911
   console.log(
-    `Triggering bulk download retry for ${numberPatients} patients. CX: ${cxId}. Sleeping ${confirmationTime.asMilliseconds()} ms before starting.`
+    `Triggering bulk download continue for ${numberPatients} patients. CX: ${cxId}. Sleeping ${confirmationTime.asMilliseconds()} ms before starting.`
   );
   await sleep(confirmationTime.asMilliseconds());
 }

--- a/packages/utils/src/bulk-trigger-bulk-download-retry.ts
+++ b/packages/utils/src/bulk-trigger-bulk-download-retry.ts
@@ -1,0 +1,92 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import { getEnvVarOrFail } from "@metriport/core/util/env-var";
+import { out } from "@metriport/core/util/log";
+import { sleep } from "@metriport/shared";
+import axios from "axios";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import { chunk } from "lodash";
+
+/**
+ * This script triggers the bulk download retry for the indicated patients.
+ *
+ * To run:
+ * 1. Set the env vars:
+ *  - CX_ID
+ *  - API_URL
+ * 2. Set the patientIds and rerunPdOnNewDemographics
+ * 3. Run the script with `ts-node src/bulk-trigger-bulk-download-wh.ts`
+ */
+
+dayjs.extend(duration);
+
+const patientAndRequestId: {
+  patientId: string;
+  cxDownloadRequestMetadataAsString: string | undefined;
+}[] = [];
+
+const confirmationTime = dayjs.duration(10, "seconds");
+const delayTime = dayjs.duration(10, "seconds");
+const cxId = getEnvVarOrFail("CX_ID");
+const apiUrl = getEnvVarOrFail("API_URL");
+const PATIENT_CHUNK_SIZE = 2;
+
+type TriggerBulkDownloadWebhookResponse = {
+  data: {
+    requestId: string;
+  };
+};
+
+async function main() {
+  try {
+    await displayInitialWarningAndConfirmation(patientAndRequestId.length);
+
+    const patientChunks = chunk(patientAndRequestId, PATIENT_CHUNK_SIZE);
+
+    for (const [i, patients] of patientChunks.entries()) {
+      console.log(`Chunk ${i + 1} of ${patientChunks.length}`);
+      console.log(`# of patients ${patients.length}`);
+
+      for (const { patientId, cxDownloadRequestMetadataAsString } of patients) {
+        const log = out(
+          `Triggering bulk download retry: cxId - ${cxId}, patientId - ${patientId}`
+        ).log;
+        const endpointUrl = `${apiUrl}/internal/docs/download-url/bulk/retry`;
+        const params = new URLSearchParams({
+          cxId,
+          patientId,
+        });
+        const body = {
+          ...(cxDownloadRequestMetadataAsString && {
+            metadata: JSON.parse(cxDownloadRequestMetadataAsString),
+          }),
+        };
+        const resp = (await axios.post(
+          `${endpointUrl}?${params}`,
+          body
+        )) as TriggerBulkDownloadWebhookResponse;
+        log(`Request ID - ${JSON.stringify(resp.data.requestId)}`);
+      }
+      if (i < patientChunks.length - 1) {
+        const sleepTime = delayTime.asMilliseconds();
+        console.log(`Chunk ${i + 1} finished. Sleeping for ${sleepTime} ms...`);
+        await sleep(sleepTime);
+      }
+    }
+  } catch (err) {
+    const msg = "Triggering bulk download failed.";
+    console.log(`${msg}. Error - ${err}`);
+  }
+}
+
+async function displayInitialWarningAndConfirmation(numberPatients: number) {
+  console.log("\n\x1b[31m%s\x1b[0m\n", "---- ATTENTION - THIS IS NOT A SIMULATED RUN ----"); // https://stackoverflow.com/a/41407246/2099911
+  console.log(
+    `Triggering bulk download retry for ${numberPatients} patients. CX: ${cxId}. Sleeping ${confirmationTime.asMilliseconds()} ms before starting.`
+  );
+  await sleep(confirmationTime.asMilliseconds());
+}
+
+main();


### PR DESCRIPTION
Ref: ENG-00

Ref: #1040

### Description

- new internal endpoint that will bypass the processing check for bulk-download and pickup the existing processing task

### Testing

- Local
  - [x] setup patient in processing state and validate script works as expected
  - [x] valid 400 if no processing request
- Staging
  - [ ] find patient in processing state and validate script works as expected
  - [ ] valid 400 if no processing request
- Sandbox
  - [ ] n/a
- Production
  - [ ] run hung patients

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new API endpoint to allow continuation of bulk document download requests for patients.
	- Introduced a script to automate triggering of bulk download continuation for multiple patients, with progress logging and error handling.

- **Bug Fixes**
	- Improved error handling for bulk document download continuation requests.

- **Refactor**
	- Updated internal logic to use named parameters for bulk document download requests, improving clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->