### PR TITLE
ENG-302 Increase page size on CQ dir rebuild

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory.ts
@@ -23,7 +23,7 @@ import {
 
 dayjs.extend(duration);
 
-const BATCH_SIZE = 5_000;
+const BATCH_SIZE = 10_000;
 const parallelQueriesToGetManagingOrg = 20;
 const SLEEP_TIME = dayjs.duration({ milliseconds: 750 });
 const heartbeatUrl = Config.getCqDirRebuildHeartbeatUrl();

--- a/packages/carequality-sdk/src/client/carequality-fhir.ts
+++ b/packages/carequality-sdk/src/client/carequality-fhir.ts
@@ -15,7 +15,7 @@ dayjs.extend(duration);
 const DEFAULT_AXIOS_TIMEOUT = dayjs.duration(120, "seconds");
 const DEFAULT_MAXIMUM_BACKOFF = dayjs.duration(30, "seconds");
 const BASE_DELAY = dayjs.duration(1, "seconds");
-const MAX_COUNT = 5_000;
+const MAX_COUNT = 10_000;
 const DEFAULT_MAX_RETRIES = 3;
 const JSON_FORMAT = "json";
 

--- a/packages/carequality-sdk/src/client/carequality.ts
+++ b/packages/carequality-sdk/src/client/carequality.ts
@@ -28,7 +28,7 @@ export interface CarequalityManagementApi {
   /**
    * Lists the indicated number of organizations.
    *
-   * @param count Optional, number of organizations to fetch. Defaults to 5000.
+   * @param count Optional, number of organizations to fetch. See implementation for defaults.
    * @param start Optional, the index of the directory to start querying from. Defaults to 0.
    * @param oid Optional, the OID of the organization to fetch.
    * @param active Optional, indicates whether to list active or inactive organizations. If not

--- a/packages/utils/src/carequality/download-directory.ts
+++ b/packages/utils/src/carequality/download-directory.ts
@@ -7,6 +7,7 @@ import { getEnvVarOrFail, sleep } from "@metriport/shared";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import fs from "fs";
+import { chunk } from "lodash";
 import { elapsedTimeAsStr } from "../shared/duration";
 import { buildGetDirPathInside, initRunsFolder } from "../shared/folder";
 
@@ -24,7 +25,7 @@ dayjs.extend(duration);
 const apiKey = getEnvVarOrFail("CQ_MANAGEMENT_API_KEY");
 const apiMode = APIMode.production;
 
-const BATCH_SIZE = 5_000;
+const BATCH_SIZE = 10_000;
 const SLEEP_TIME = dayjs.duration({ milliseconds: 750 });
 
 const dirName = "cq-directory";
@@ -42,6 +43,7 @@ export async function downloadCQDirectory(
   let currentPosition = 0;
   let isDone = false;
 
+  console.log(`Downloading organizations in batches of ${BATCH_SIZE}...`);
   while (!isDone) {
     const maxPosition = currentPosition + BATCH_SIZE;
     const orgs = await cq.listOrganizations({
@@ -50,9 +52,9 @@ export async function downloadCQDirectory(
       active: true,
       sortKey: "_id",
     });
-    console.log(`Downloaded ${orgs.length} organizations (total: ${allOrgs.length})`);
 
     allOrgs.push(...orgs);
+    console.log(`Downloaded ${orgs.length} organizations (total: ${allOrgs.length})`);
 
     if (orgs.length < BATCH_SIZE) {
       isDone = true;
@@ -70,13 +72,24 @@ async function main() {
   const startedAt = Date.now();
   console.log(`############## Started at ${new Date(startedAt).toISOString()} ##############`);
   initRunsFolder(dirName);
+  const outputFilename = getFolderName() + ".json";
 
   const orgs = await downloadCQDirectory(apiKey, apiMode);
+  console.log(`Downloaded ${orgs.length} organizations, storing them on file ${outputFilename}`);
 
-  const outputFilename = getFolderName() + ".json";
-  fs.writeFileSync(outputFilename, JSON.stringify(orgs, null, 2));
+  const chunks = chunk(orgs, 1_000);
+  let idx = 0;
+  fs.appendFileSync(outputFilename, "{");
+  for (const chunk of chunks) {
+    const chunkProp = { [`chunk-${++idx}`]: chunk };
+    const chunkString = JSON.stringify(chunkProp, null, 2);
+    const chunkContents = chunkString.slice(1, -1);
+    if (idx > 1) fs.appendFileSync(outputFilename, ",");
+    fs.appendFileSync(outputFilename, chunkContents);
+  }
+  fs.appendFileSync(outputFilename, "}");
 
-  console.log(`Downloaded ${orgs.length} organizations`);
+  console.log(`Stored ${orgs.length} organizations on file ${outputFilename}`);
 
   console.log(`>>>>>>> Done after ${elapsedTimeAsStr(startedAt)}`);
 }


### PR DESCRIPTION
### Dependencies

none

### Description

Increase page size on CQ dir rebuild and improve the script to download it local in a JSON file.

Usually it takes 10 minutes w/ pages of 5,000, moving to 10,000 should improve the performance in the cloud env.

Running w/ 5,000:

![image](https://github.com/user-attachments/assets/854d7278-c751-4b6e-9d8d-0f78a9625d28)

Running w/ 10,000:

### Testing

- Local
  - [x] Download the CQ directory
- Staging
  - [ ] Rebuild the CQ directory
- Sandbox
  - none
- Production
  - none

### Release Plan

- :warning: Points to `master`
- [ ] Release NPM packages: `carequality-sdk`
- [ ] Merge this
