### PR TITLE
feat(terminology): adding ndc code lookups

### DIFF
--- a/packages/core/src/external/term-server/index.ts
+++ b/packages/core/src/external/term-server/index.ts
@@ -8,6 +8,7 @@ import {
   CVX_URL,
   ICD_10_URL,
   LOINC_URL,
+  NDC_URL,
   RXNORM_URL,
   SNOMED_URL,
 } from "../../util/constants";
@@ -23,7 +24,15 @@ export type CodeSystemLookupOutput = {
 export const termServerUrl = Config.getTermServerUrl();
 const bulkLookupUrl = "code-system/lookup/bulk";
 
-export const supportedSystems = [ICD_10_URL, SNOMED_URL, LOINC_URL, RXNORM_URL, CPT_URL, CVX_URL];
+export const supportedSystems = [
+  ICD_10_URL,
+  SNOMED_URL,
+  LOINC_URL,
+  RXNORM_URL,
+  CPT_URL,
+  CVX_URL,
+  NDC_URL,
+];
 
 export function isSystemValid(system: string) {
   const trimmedSystem = system.trim();

--- a/packages/terminology/package-lock.json
+++ b/packages/terminology/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terminology",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terminology",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@medplum/core": "^3.2.5",

--- a/packages/terminology/package.json
+++ b/packages/terminology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminology",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "embedded term server",
   "main": "app.js",
   "private": true,

--- a/packages/terminology/src/init-term-server.ts
+++ b/packages/terminology/src/init-term-server.ts
@@ -17,7 +17,7 @@ async function initTables(dbClient: DbClient): Promise<void> {
 }
 
 export async function initTermServer(): Promise<void> {
-  const key = "terminology.db";
+  const key = "terminology_v2.db";
 
   const dbPath = join(process.cwd(), key);
 

--- a/packages/terminology/src/operations/codeLookup.ts
+++ b/packages/terminology/src/operations/codeLookup.ts
@@ -28,9 +28,12 @@ export type CodeSystemLookupOutput = {
 };
 
 /**
- * Normalizes an NDC code by removing dashes
+ * Normalize codes prior to lookup
+ *
+ * For NDC, remove dashes
+ * For other systems, return the code as is
  */
-function normalizeNdcCode(code: string, system?: string): string {
+function normalizeCode(code: string, system: string): string {
   if (system === ndcCodeSystem.url) {
     return code.replace(/-/g, "");
   }
@@ -143,15 +146,15 @@ export async function lookupPartialCoding(
   codeSystem: CodeSystem,
   coding: Coding
 ): Promise<CodeSystemLookupOutput[] | FhirResponse> {
-  const code = coding.code;
-  if (!code) return [notFound];
+  const { code, system } = coding;
+  if (!code || !system) return [notFound];
 
-  if (coding.system && coding.system !== codeSystem.url) {
+  if (system !== codeSystem.url) {
     return [notFound];
   }
 
   const dbClient = getTermServerClient();
-  const normalizedCode = normalizeNdcCode(code, coding.system);
+  const normalizedCode = normalizeCode(code, system);
 
   const query = `
     SELECT 
@@ -214,13 +217,13 @@ export async function lookupCoding(
   codeSystem: CodeSystem,
   coding: Coding
 ): Promise<CodeSystemLookupOutput[] | FhirResponse> {
-  const code = coding.code;
-  if (!code) return [notFound];
+  const { code, system } = coding;
+  if (!code || !system) return [notFound];
 
-  if (coding.system && coding.system !== codeSystem.url) {
+  if (system !== codeSystem.url) {
     return [notFound];
   }
-  const normalizedCode = normalizeNdcCode(code, coding.system);
+  const normalizedCode = normalizeCode(code, system);
 
   const dbClient = getTermServerClient();
 

--- a/packages/terminology/src/operations/codeLookup.ts
+++ b/packages/terminology/src/operations/codeLookup.ts
@@ -168,7 +168,7 @@ export async function lookupPartialCoding(
     WHERE cs.id = ? AND c.code LIKE ?
   `;
 
-  const params = [codeSystem.id, `${normalizedCode}%`];
+  const params = [codeSystem.id, normalizedCode];
   const result = await dbClient.select(query, params);
 
   if (result.length === 0) {

--- a/packages/terminology/src/operations/definitions/codeSystem.ts
+++ b/packages/terminology/src/operations/definitions/codeSystem.ts
@@ -1363,3 +1363,22 @@ export const icd10cm: CodeSystem = {
     },
   ],
 };
+
+export const ndcCodeSystem: CodeSystem = {
+  resourceType: "CodeSystem",
+  url: "http://hl7.org/fhir/sid/ndc",
+  identifier: [
+    {
+      system: "urn:ietf:rfc:3986",
+      value: "urn:oid:2.16.840.1.113883.6.69",
+    },
+  ],
+  version: "11/14/2024",
+  name: "NDC",
+  title: "National drug codes",
+  status: "active",
+  experimental: false,
+  date: "2019-03-20T00:00:00-04:00",
+  publisher: "U.S. Food and Drug Administration (FDA)",
+  content: "not-present",
+};

--- a/packages/terminology/src/router.ts
+++ b/packages/terminology/src/router.ts
@@ -43,7 +43,6 @@ fhirRouter.post(
   "/code-system/lookup/bulk",
   asyncHandler(async (req: Request, res: Response) => {
     const fhirRequest = parseIntoFhirRequest(req);
-    console.log("Received bulk request body:", JSON.stringify(fhirRequest.body));
     const response = await bulkCodeSystemLookupHandler(fhirRequest);
     return res.status(response.status).json(response.data);
   })

--- a/packages/terminology/src/seed/seedUmlsLookup.ts
+++ b/packages/terminology/src/seed/seedUmlsLookup.ts
@@ -1,19 +1,20 @@
 // Licensed under Apache. See LICENSE-APACHE in the repo root for license information.
 import { CodeSystem, Coding, Parameters } from "@medplum/fhirtypes";
 import { WriteStream, createReadStream } from "node:fs";
+import { argv, env } from "node:process";
 import { createInterface } from "node:readline";
+import { Readable, Transform, TransformCallback } from "node:stream";
+import * as unzip from "unzip-stream";
 import {
   cpt,
   cvx,
   icd10cm,
   icd10pcs,
   loinc,
+  ndcCodeSystem,
   rxnorm,
   snomed,
 } from "../operations/definitions/codeSystem";
-import { argv, env } from "node:process";
-import { Readable, Transform, TransformCallback } from "node:stream";
-import * as unzip from "unzip-stream";
 
 import { TerminologyClient } from "../client";
 
@@ -67,6 +68,11 @@ export const umlsSources: Record<string, UmlsSource> = {
   CVX: { system: "http://hl7.org/fhir/sid/cvx", tty: ["PT"], resource: cvx },
   ICD10PCS: { system: "http://hl7.org/fhir/sid/icd-10-pcs", tty: ["PT", "HT"], resource: icd10pcs },
   ICD10CM: { system: "http://hl7.org/fhir/sid/icd-10-cm", tty: ["PT", "HT"], resource: icd10cm },
+  NDC: {
+    system: "http://hl7.org/fhir/sid/ndc",
+    tty: [], // Add these when RxNorm > NDC crosswalks are in place
+    resource: ndcCodeSystem,
+  },
 };
 
 class EOF extends Error {

--- a/packages/utils/src/fhir-hydration/hydrate-files-local.ts
+++ b/packages/utils/src/fhir-hydration/hydrate-files-local.ts
@@ -8,6 +8,9 @@ import { elapsedTimeFromNow } from "@metriport/shared/common/date";
 import fs from "fs";
 import { v4 as uuidv4 } from "uuid";
 import { getFileContents, getFileNames } from "../shared/fs";
+import { getEnvVarOrFail } from "@metriport/shared";
+
+const termServerUrl = getEnvVarOrFail("TERM_SERVER_URL");
 
 /**
  * Takes all the JSON files from the specified folder, and hydrates them, storing the result in the same folder, with the `_hydrated` suffix.
@@ -19,11 +22,14 @@ const samplesFolderPath = "";
 const suffix = "_hydrated";
 
 async function main() {
+  if (!termServerUrl) throw new Error("TERM_SERVER_URL has not been set.");
+
   const bundleFileNames = getFileNames({
     folder: samplesFolderPath,
     recursive: true,
     extension: "json",
   });
+
   const filteredBundleFileNames = bundleFileNames.filter(f => !f.includes(suffix));
 
   await executeAsynchronously(filteredBundleFileNames, async (filePath, index) => {


### PR DESCRIPTION
Part of ENG-315

Issues:

- https://linear.app/metriport/issue/ENG-315

### Description
- Adding NDC as one of the recognized systems in the term server
- Adding some string sanitization prior to lookup to allow lookup with and without the dashes (`-`) 

### Testing

- Local
  - [x] Lookup some NDC codes on Postman
  - [x] Hydrate a Bundle and confirm display property being added to NDC codes
- Staging
  - [ ] Lookup some NDC codes on Postman
  - [ ] Hydrate a Bundle and confirm display property being added to NDC codes
- Production
  - [ ] Lookup some NDC codes on Postman
  - [ ] Hydrate a Bundle and confirm display property being added to NDC codes

### Release Plan
- [x] Upload the new SQLite file to S3
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for National Drug Codes (NDC) as a recognized code system, including a formal definition and integration into supported code systems.
- **Improvements**
  - NDC codes are now automatically normalized by removing dashes before lookup, improving search accuracy.
  - Updated database file to a new version for terminology operations.
  - Enhanced error handling to ensure required environment variables are set before running local file hydration.
- **Chores**
  - Removed unnecessary console logging for cleaner output.
  - Improved internal documentation and import organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->