### PR TITLE
ENG-319 Trim identifier so its always string

### DIFF
--- a/packages/core/src/external/fhir/normalization/resources/encounter.ts
+++ b/packages/core/src/external/fhir/normalization/resources/encounter.ts
@@ -81,7 +81,7 @@ function hasEncounterType(encounter: Encounter): boolean {
 }
 
 function isDisplayUseful(display: string | undefined) {
-  return display !== undefined && display !== "unknown";
+  return display != undefined && display.trim() !== "unknown";
 }
 
 function normalizeDisplay(str: string): string {

--- a/packages/fhir-converter/src/templates/cda/DataType/Identifier.hbs
+++ b/packages/fhir-converter/src/templates/cda/DataType/Identifier.hbs
@@ -29,17 +29,17 @@
         {{#with (evaluate 'ValueSet/SystemReference.hbs' code=id.root) as |system|}}
             {
                 "system": "{{system.oid}}",
-                "value":"{{../id.extension}}",
+                "value":"{{trim ../id.extension}}",
                 "assigner":{
                     "display":"{{../id.assigningAuthorityName}}"
                 },
-            {{#unless (startsWith system.oid "http:")}}
-                {{#with (evaluate 'ValueSet/IdentifierType.hbs' code=../id.root) as |system|}}
-                    "type": {
-                        "text": "{{system.oid}}",
-                    },
-                {{/with}}
-            {{/unless}}
+                {{#unless (startsWith system.oid "http:")}}
+                    {{#with (evaluate 'ValueSet/IdentifierType.hbs' code=../id.root) as |system|}}
+                        "type": {
+                            "text": "{{system.oid}}",
+                        },
+                    {{/with}}
+                {{/unless}}
             },
          {{/with}}
         

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -138,6 +138,7 @@ export const handler = capture.wrapHandler(async (event: SQSEvent) => {
     try {
       log(`Body: ${message.body}`);
       const { s3BucketName, s3FileName, documentExtension } = parseBody(message.body);
+      capture.setExtra({ s3FileName });
       const metrics: Metrics = {};
 
       log(`Getting contents from bucket ${s3BucketName}, key ${s3FileName}`);


### PR DESCRIPTION
### Dependencies

none

### Description

Trim identifier so its always string.

### Testing

- Local
  - [x] converts the CDA id into proper FHIR string identifier
- Staging
  - [ ] converts the CDA id into proper FHIR string identifier
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of display strings by trimming whitespace and better detecting "unknown" values.
  - Ensured identifier values are rendered without leading or trailing spaces.

- **Chores**
  - Enhanced logging and observability by including the S3 file name in event context for debugging purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->