### PR TITLE
Eng 325 strict patient name matches

### DIFF
--- a/packages/core/src/mpi/__tests__/inbound-epic-match.test.ts
+++ b/packages/core/src/mpi/__tests__/inbound-epic-match.test.ts
@@ -347,46 +347,4 @@ describe("epicMatchingAlgorithm", () => {
     };
     expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(false);
   });
-
-  it("pass w/ requirePartialNameMatch and first name matches (5), dob (8), exact address (2), exact phone (2), exact email (2), exact ssn (5)", () => {
-    const patient1 = { ...basePatient };
-    const patient2 = {
-      ...differentPatient,
-      dob: basePatient.dob,
-      firstName: basePatient.firstName,
-      lastName: "Smith",
-      address: basePatient.address,
-      contact: basePatient.contact ?? [],
-      personalIdentifiers: basePatient.personalIdentifiers,
-    };
-    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(true);
-  });
-
-  it("pass w/ requirePartialNameMatch and last name matches (5), dob (8), exact address (2), exact phone (2), exact email (2), exact ssn (5)", () => {
-    const patient1 = { ...basePatient };
-    const patient2 = {
-      ...differentPatient,
-      dob: basePatient.dob,
-      firstName: "Jane",
-      lastName: basePatient.lastName,
-      address: basePatient.address,
-      contact: basePatient.contact ?? [],
-      personalIdentifiers: basePatient.personalIdentifiers,
-    };
-    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(true);
-  });
-
-  it("pass w/ requirePartialNameMatch and both names match (10), dob (8), exact address (2), exact phone (2), exact email (2), exact ssn (5)", () => {
-    const patient1 = { ...basePatient };
-    const patient2 = {
-      ...differentPatient,
-      dob: basePatient.dob,
-      firstName: basePatient.firstName,
-      lastName: basePatient.lastName,
-      address: basePatient.address,
-      contact: basePatient.contact ?? [],
-      personalIdentifiers: basePatient.personalIdentifiers,
-    };
-    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(true);
-  });
 });

--- a/packages/core/src/mpi/__tests__/inbound-epic-match.test.ts
+++ b/packages/core/src/mpi/__tests__/inbound-epic-match.test.ts
@@ -333,4 +333,60 @@ describe("epicMatchingAlgorithm", () => {
     };
     expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(false);
   });
+
+  it("fail w/ requirePartialNameMatch and no name matches, dob (8), exact address (2), exact phone (2), exact email (2), exact ssn (5)", () => {
+    const patient1 = { ...basePatient };
+    const patient2 = {
+      ...differentPatient,
+      dob: basePatient.dob,
+      firstName: "Jane",
+      lastName: "Smith",
+      address: basePatient.address,
+      contact: basePatient.contact ?? [],
+      personalIdentifiers: basePatient.personalIdentifiers,
+    };
+    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(false);
+  });
+
+  it("pass w/ requirePartialNameMatch and first name matches (5), dob (8), exact address (2), exact phone (2), exact email (2), exact ssn (5)", () => {
+    const patient1 = { ...basePatient };
+    const patient2 = {
+      ...differentPatient,
+      dob: basePatient.dob,
+      firstName: basePatient.firstName,
+      lastName: "Smith",
+      address: basePatient.address,
+      contact: basePatient.contact ?? [],
+      personalIdentifiers: basePatient.personalIdentifiers,
+    };
+    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(true);
+  });
+
+  it("pass w/ requirePartialNameMatch and last name matches (5), dob (8), exact address (2), exact phone (2), exact email (2), exact ssn (5)", () => {
+    const patient1 = { ...basePatient };
+    const patient2 = {
+      ...differentPatient,
+      dob: basePatient.dob,
+      firstName: "Jane",
+      lastName: basePatient.lastName,
+      address: basePatient.address,
+      contact: basePatient.contact ?? [],
+      personalIdentifiers: basePatient.personalIdentifiers,
+    };
+    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(true);
+  });
+
+  it("pass w/ requirePartialNameMatch and both names match (10), dob (8), exact address (2), exact phone (2), exact email (2), exact ssn (5)", () => {
+    const patient1 = { ...basePatient };
+    const patient2 = {
+      ...differentPatient,
+      dob: basePatient.dob,
+      firstName: basePatient.firstName,
+      lastName: basePatient.lastName,
+      address: basePatient.address,
+      contact: basePatient.contact ?? [],
+      personalIdentifiers: basePatient.personalIdentifiers,
+    };
+    expect(epicMatchingAlgorithm(patient1, patient2, 20)).toBe(true);
+  });
 });

--- a/packages/core/src/mpi/match-patients.ts
+++ b/packages/core/src/mpi/match-patients.ts
@@ -233,6 +233,8 @@ export function epicMatchingAlgorithm(
     scores.names = 10;
   } else if (hasMatchingFirstName || hasMatchingLastName) {
     scores.names = 5;
+  } else {
+    return false;
   }
 
   const addressMatch = normalizedPatient1.address?.some(addr1 =>


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-325

### Dependencies

- Upstream: none
- Downstream: none

### Description

- When we receive a link that has no valid first name or last name we should not treat this as a match. 

### Testing

- Local
  - [ ] Unit test
- Staging
  - [ ] Unit test
- Production
  - [ ] Monitor invalid links

### Release Plan

- [ ] Merge this
