### PR TITLE
ENG-132 - add a second hl7 vpc nlb

### DIFF
--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -1,5 +1,6 @@
 export const MLLP_DEFAULT_PORT = 2575;
 export const HL7_NOTIFICATION_VPC_CIDR = "10.1.0.0/16";
 export const PROBLEMATIC_IPSEC_CHARACTERS = "!@#$%^&*()_+-=[]{}|;:,.<>?~`'\"\\/";
-export const MLLP_SERVER_NLB_INTERNAL_IP = "10.1.1.20";
+export const MLLP_SERVER_NLB_INTERNAL_IP_A = "10.1.1.20";
+export const MLLP_SERVER_NLB_INTERNAL_IP_B = "10.1.1.21";
 export const MLLP_SERVER_CONTAINER_NAME = "MllpServer";

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -195,6 +195,11 @@ export class MllpStack extends cdk.NestedStack {
       description: "DNS name of the Network Load Balancer for MLLP",
     });
 
+    new cdk.CfnOutput(this, "MllpNlbDnsNameB", {
+      value: nlbB.loadBalancerDnsName,
+      description: "DNS name of the Network Load Balancer for MLLP B",
+    });
+
     new cdk.CfnOutput(this, "MllpNlbInternalIpA", {
       value: MLLP_SERVER_NLB_INTERNAL_IP_A,
       description: "Internal IP address of the MLLP Network Load Balancer A",

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -1,17 +1,21 @@
 import * as cdk from "aws-cdk-lib";
 import { Duration } from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
-import * as s3 from "aws-cdk-lib/aws-s3";
 import { Repository } from "aws-cdk-lib/aws-ecr";
 import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as logs from "aws-cdk-lib/aws-logs";
+import { LogGroup } from "aws-cdk-lib/aws-logs";
+import * as s3 from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import { EnvConfigNonSandbox } from "../../config/env-config";
 import { buildSecrets, secretsToECS } from "../shared/secrets";
-import { MLLP_DEFAULT_PORT, MLLP_SERVER_NLB_INTERNAL_IP } from "./constants";
-import { LogGroup } from "aws-cdk-lib/aws-logs";
+import {
+  MLLP_DEFAULT_PORT,
+  MLLP_SERVER_NLB_INTERNAL_IP_A,
+  MLLP_SERVER_NLB_INTERNAL_IP_B,
+} from "./constants";
 
 interface MllpStackProps extends cdk.StackProps {
   config: EnvConfigNonSandbox;
@@ -20,6 +24,42 @@ interface MllpStackProps extends cdk.StackProps {
   ecrRepo: Repository;
   incomingHl7NotificationBucket: s3.IBucket;
 }
+
+const setupNlb = (identifier: string, vpc: ec2.Vpc, nlb: elbv2.NetworkLoadBalancer, ip: string) => {
+  const privateSubnet = vpc.privateSubnets[0];
+  if (!privateSubnet || vpc.privateSubnets.length !== 1) {
+    throw new Error("Should have exactly one private subnet");
+  }
+
+  const cfnNlb = nlb.node.defaultChild as elbv2.CfnLoadBalancer;
+  cfnNlb.addDeletionOverride("Properties.Subnets");
+
+  cfnNlb.subnetMappings = [
+    {
+      subnetId: privateSubnet.subnetId,
+      privateIPv4Address: ip,
+    },
+  ];
+
+  const listener = nlb.addListener(`MllpListener${identifier}`, {
+    port: MLLP_DEFAULT_PORT,
+  });
+
+  const targetGroup = listener.addTargets(`MllpTargets${identifier}`, {
+    port: MLLP_DEFAULT_PORT,
+    protocol: elbv2.Protocol.TCP,
+    healthCheck: {
+      port: MLLP_DEFAULT_PORT.toString(),
+      protocol: elbv2.Protocol.TCP,
+      healthyThresholdCount: 3,
+      unhealthyThresholdCount: 2,
+      timeout: Duration.seconds(10),
+      interval: Duration.seconds(20),
+    },
+  });
+
+  return targetGroup;
+};
 
 export class MllpStack extends cdk.NestedStack {
   constructor(scope: Construct, id: string, props: MllpStackProps) {
@@ -53,41 +93,18 @@ export class MllpStack extends cdk.NestedStack {
       "Allow outbound traffic from MLLP server"
     );
 
-    const nlb = new elbv2.NetworkLoadBalancer(this, "MllpServerNLB2", {
+    const nlbA = new elbv2.NetworkLoadBalancer(this, "MllpServerNLB2", {
       vpc,
       internetFacing: false,
     });
 
-    // Set static IP address for NLB in private subnet
-    const privateSubnet = vpc.privateSubnets[0];
-    if (!privateSubnet || vpc.privateSubnets.length !== 1) {
-      throw new Error("Should have exactly one private subnet");
-    }
-    const cfnNlb = nlb.node.defaultChild as elbv2.CfnLoadBalancer;
-    cfnNlb.addDeletionOverride("Properties.Subnets");
-    cfnNlb.subnetMappings = [
-      {
-        subnetId: privateSubnet.subnetId,
-        privateIPv4Address: MLLP_SERVER_NLB_INTERNAL_IP,
-      },
-    ];
-
-    const listener = nlb.addListener("MllpListener", {
-      port: MLLP_DEFAULT_PORT,
+    const nlbB = new elbv2.NetworkLoadBalancer(this, "MllpServerNLB2b", {
+      vpc,
+      internetFacing: false,
     });
 
-    const targetGroup = listener.addTargets("MllpTargets", {
-      port: MLLP_DEFAULT_PORT,
-      protocol: elbv2.Protocol.TCP,
-      healthCheck: {
-        port: MLLP_DEFAULT_PORT.toString(),
-        protocol: elbv2.Protocol.TCP,
-        healthyThresholdCount: 3,
-        unhealthyThresholdCount: 2,
-        timeout: Duration.seconds(10),
-        interval: Duration.seconds(20),
-      },
-    });
+    const targetGroupA = setupNlb("NlbA", vpc, nlbA, MLLP_SERVER_NLB_INTERNAL_IP_A);
+    const targetGroupB = setupNlb("NlbB", vpc, nlbB, MLLP_SERVER_NLB_INTERNAL_IP_B);
 
     const taskRole = new iam.Role(this, "MllpServerTaskRole", {
       assumedBy: new iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
@@ -141,7 +158,8 @@ export class MllpStack extends cdk.NestedStack {
       }),
     });
 
-    targetGroup.addTarget(fargateService);
+    targetGroupA.addTarget(fargateService);
+    targetGroupB.addTarget(fargateService);
     incomingHl7NotificationBucket.grantWrite(fargateService.taskDefinition.taskRole);
 
     const scaling = fargateService.autoScaleTaskCount({
@@ -173,13 +191,18 @@ export class MllpStack extends cdk.NestedStack {
     });
 
     new cdk.CfnOutput(this, "MllpNlbDnsName", {
-      value: nlb.loadBalancerDnsName,
+      value: nlbA.loadBalancerDnsName,
       description: "DNS name of the Network Load Balancer for MLLP",
     });
 
-    new cdk.CfnOutput(this, "MllpNlbInternalIp", {
-      value: MLLP_SERVER_NLB_INTERNAL_IP,
-      description: "Internal IP address of the MLLP Network Load Balancer",
+    new cdk.CfnOutput(this, "MllpNlbInternalIpA", {
+      value: MLLP_SERVER_NLB_INTERNAL_IP_A,
+      description: "Internal IP address of the MLLP Network Load Balancer A",
+    });
+
+    new cdk.CfnOutput(this, "MllpNlbInternalIpB", {
+      value: MLLP_SERVER_NLB_INTERNAL_IP_B,
+      description: "Internal IP address of the MLLP Network Load Balancer B",
     });
   }
 }


### PR DESCRIPTION
### Dependencies

None

### Description

This change adds a second NLB to support multiple traffic destinations. This makes it easy for third parties to set their routing rules to send traffic simultaneously through both AWS tunnels.

The other two options assessed were:
1. Switch to a proper multi-AZ setup, but CDK does not support adding or changing subnet configuration once VPC has been created, and destroying and rebooting the entire vpc is a non-starter - [link](https://github.com/aws/aws-cdk/issues/6683)
2. Attaching a second ENI to our current single NLB - also not supported.

### Testing

#### Staging
- [ ] Ping new nlb over VPN tunnel

#### Production
- [ ] Ping new nlb over VPN tunnel

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for two separate Network Load Balancers (NLBs) for the MLLP server, each with its own static internal IP address.

- **Refactor**
	- Updated infrastructure configuration to use dual NLBs instead of a single NLB, enhancing network load balancing setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->