### PR TITLE
ENG-132 fix nlb identifiers so cdk can deploy

### DIFF
--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -103,8 +103,12 @@ export class MllpStack extends cdk.NestedStack {
       internetFacing: false,
     });
 
-    const targetGroupA = setupNlb("NlbA", vpc, nlbA, MLLP_SERVER_NLB_INTERNAL_IP_A);
-    const targetGroupB = setupNlb("NlbB", vpc, nlbB, MLLP_SERVER_NLB_INTERNAL_IP_B);
+    /**
+     * We're using an empty string for the first setupNlb call to maintain identifiers and
+     * avoid having to recreate a new listener and target group for the existing NLB.
+     */
+    const targetGroupA = setupNlb("", vpc, nlbA, MLLP_SERVER_NLB_INTERNAL_IP_A);
+    const targetGroupB = setupNlb("B", vpc, nlbB, MLLP_SERVER_NLB_INTERNAL_IP_B);
 
     const taskRole = new iam.Role(this, "MllpServerTaskRole", {
       assumedBy: new iam.ServicePrincipal("ecs-tasks.amazonaws.com"),


### PR DESCRIPTION
### Dependencies

- Downstream: https://github.com/metriport/metriport/pull/3878

### Description

Nlb identifiers were changed, leading to CDK trying to create second a listener where there already was one. This keeps identifiers the same, ensuring that CDK will deploy correctly.

### Testing

None

### Release Plan

- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal configuration to maintain existing resource identifiers for network load balancers, preventing unnecessary recreation of resources. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->