### PR TITLE
ENG-334: add shortcode support to organization table

### DIFF
--- a/packages/api/src/routes/internal/medical/organization.ts
+++ b/packages/api/src/routes/internal/medical/organization.ts
@@ -41,6 +41,7 @@ router.put(
       cxId,
       type: orgDetails.businessType,
       data: {
+        shortcode: orgDetails.shortcode,
         name: orgDetails.nameInMetriport,
         type: orgDetails.type,
         location: {

--- a/packages/api/src/routes/internal/medical/organization.ts
+++ b/packages/api/src/routes/internal/medical/organization.ts
@@ -13,11 +13,10 @@ import { getUUIDFrom } from "../../schemas/uuid";
 import { asyncHandler, getFromQueryAsBoolean } from "../../util";
 import { internalDtoFromModel } from "../../medical/dtos/organizationDTO";
 import { organiationInternalDetailsSchema } from "../../medical/schemas/organization";
-
+import { getOrganizationOrFail } from "../../../command/medical/organization/get-organization";
 const router = Router();
 
 /** ---------------------------------------------------------------------------
- *
  * PUT /internal/organization
  *
  * Creates or updates a organization and registers it within HIEs if new.
@@ -80,6 +79,22 @@ router.put(
         isObo: false,
       }).catch(processAsyncError("cw.internal.organization"));
     }
+    return res.status(httpStatus.OK).json(internalDtoFromModel(org));
+  })
+);
+
+/** ---------------------------------------------------------------------------
+ * GET /internal/organization/
+ *
+ * Returns an organization from the db.
+ */
+router.get(
+  "/",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").orFail();
+    const org = await getOrganizationOrFail({ cxId });
+
     return res.status(httpStatus.OK).json(internalDtoFromModel(org));
   })
 );

--- a/packages/api/src/routes/medical/dtos/organizationDTO.ts
+++ b/packages/api/src/routes/medical/dtos/organizationDTO.ts
@@ -5,6 +5,7 @@ import { AddressStrictDTO } from "./location-address-dto";
 export type OrganizationDTO = BaseDTO & {
   oid: string;
   name: string;
+  shortcode: string | undefined;
   type: OrgType;
   location: AddressStrictDTO;
 };
@@ -19,23 +20,26 @@ export type InternalOrganizationDTO = BaseDTO &
   };
 
 export function dtoFromModel(org: Organization): OrganizationDTO {
-  const { name, type, location } = org.data;
+  const { shortcode, name, type, location } = org.data;
   return {
     ...toBaseDTO(org),
     oid: org.oid,
     name,
+    shortcode,
     type,
     location,
   };
 }
 
 export function internalDtoFromModel(org: Organization): InternalOrganizationDTO {
-  const { name, type, location } = org.data;
+  const { shortcode, name, type, location } = org.data;
+
   return {
     ...toBaseDTO(org),
     oid: org.oid,
     businessType: org.type,
     name,
+    shortcode,
     type,
     location,
     cqApproved: org.cqApproved,

--- a/packages/api/src/routes/medical/schemas/organization.ts
+++ b/packages/api/src/routes/medical/schemas/organization.ts
@@ -20,6 +20,7 @@ export const organiationInternalDetailsSchema = z
     nameInMetriport: z.string().min(1),
     businessType: organizationBizTypeSchema,
     type: orgTypeSchema,
+    shortcode: z.string().optional(),
     // CQ
     cqApproved: z.boolean().optional(),
     cqActive: z.boolean().optional(),

--- a/packages/api/src/sequelize/migrations/2025-05-21_00_create-shortcode-unique-index.ts
+++ b/packages/api/src/sequelize/migrations/2025-05-21_00_create-shortcode-unique-index.ts
@@ -1,0 +1,24 @@
+import { QueryTypes } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "organization";
+const indexName = "idx_organizations_shortcode_unique";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  const sql = `
+    CREATE UNIQUE INDEX ${indexName} 
+    ON ${tableName} ((data->>'shortcode'))
+    WHERE data->>'shortcode' IS NOT NULL;
+  `;
+
+  await queryInterface.sequelize.query(sql, {
+    type: QueryTypes.RAW,
+  });
+};
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  const sql = `DROP INDEX IF EXISTS ${indexName};`;
+  await queryInterface.sequelize.query(sql, {
+    type: QueryTypes.RAW,
+  });
+};

--- a/packages/core/src/domain/organization.ts
+++ b/packages/core/src/domain/organization.ts
@@ -30,6 +30,7 @@ export enum TreatmentType {
 
 export type OrganizationData = {
   name: string;
+  shortcode?: string;
   type: OrgType;
   location: AddressStrict;
 };


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-334

### Dependencies

None

### Description

This PR adds support for updating and getting a new shortcode field in the organization table.
- uniqueness constraint in DB (needed to be defined as index)
- new GET endpoint
- updated PUT endpoint
- updated /internal/cx-data endpoint for comprehensiveness

Postman collection updated here: [link](https://metriport.postman.co/workspace/Team-Workspace~d17be5cc-10ed-49ad-8ad9-09d04d0c0d88/folder/24641704-e2bb9d47-d789-479d-9363-dfe30076c7db?action=share&creator=40762277&ctx=documentation&active-environment=24641704-95328571-96c9-485b-bdae-428e844f4b4f)

### Testing

- Local
  - [x] Verify that `PUT /internal/organization/?cxId=some-uuid` with a payload including a shortcode properly adds the shortcode to an organization
  - [x] Verify that `PUT /internal/organization/?cxId=some-uuid` with an in-use shortcode throws error "error: duplicate key value violates unique constraint..."
  - [x] Verify that `GET /internal/organization/?cxId=some-uuid` returns the organization including the shortcode
  - [x] Verify that `GET /internal/cx-data/?cxId=some-uuid` returns the shortcode in the appropriate location
- Staging
  - [ ] Verify that `PUT /internal/organization/?cxId=some-uuid` with a payload including a shortcode properly adds the shortcode to an organization
  - [ ] Verify that `GET /internal/organization/?cxId=some-uuid` returns the organization including the shortcode
- Production
  - [ ] Verify that `PUT /internal/organization/?cxId=some-uuid` with a payload including a shortcode properly adds the shortcode to an organization
  - [ ] Verify that `GET /internal/organization/?cxId=some-uuid` returns the organization including the shortcode

### Release Plan

- :warning: This contains a DB migration
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional organization shortcode field, including in API responses and organization creation.
  - Introduced a new endpoint to retrieve organization details by ID.
- **Bug Fixes**
  - Ensured the organization shortcode is validated and included in relevant data structures.
- **Chores**
  - Enforced uniqueness for organization shortcodes at the database level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->