### PR TITLE
build(infra): remove FIFO queue setting from SQS queues

### DIFF
--- a/packages/infra/lib/surescripts-stack.ts
+++ b/packages/infra/lib/surescripts-stack.ts
@@ -296,7 +296,6 @@ export class SurescriptsNestedStack extends NestedStack {
       ...queueSettings,
       stack: this,
       name,
-      fifo: true,
       createDLQ: true,
       lambdaLayers: [lambdaLayers.shared],
       envType,


### PR DESCRIPTION
This fixes a CDK build error caused by the `fifo` queue setting, which is unnecessary in the case of Surescripts since we do not need incoming/outgoing message processing to be strictly ordered.

Issues:

- https://linear.app/metriport/issue/ENG-313

### Dependencies

- Upstream: None
- Downstream: None

### Description

Fixes the CDK deployment issue caused by the `fifo` setting.

```
Error: Batching window is not supported for FIFO queues
    at new SqsEventSource (/home/runner/work/***/***/***/node_modules/aws-cdk-lib/aws-lambda-event-sources/lib/sqs.js:1:850)
    at SurescriptsNestedStack.setupLambdaAndQueue (/home/runner/work/***/***/***/packages/infra/lib/surescripts-stack.ts:326:7)
    at new SurescriptsNestedStack (/home/runner/work/***/***/***/packages/infra/lib/surescripts-stack.ts:225:34)
    at new APIStack (/home/runner/work/***/***/***/packages/infra/lib/api-stack.ts:458:9)
    at deploy (/home/runner/work/***/***/***/packages/infra/bin/infrastructure.ts:54:3)
    at /home/runner/work/***/***/***/packages/infra/bin/infrastructure.ts:105:37
```

### Testing

Will coordinate with Lucas on how to test CDK changes and/or verify that the settings are correct for future CDK updates.

### Release Plan

Once merged into develop, this should fix the CDK build which I will monitor for any other potential issues.
