### PR TITLE
Eng 346 remove mpi warning alert

### DIFF
--- a/packages/core/src/mpi/get-patient-by-demo.ts
+++ b/packages/core/src/mpi/get-patient-by-demo.ts
@@ -60,7 +60,7 @@ export const getPatientByDemo = async ({
 
   if (matchingPatients.length > 1) {
     const msg = `matchPatients returned more than one patient`;
-    log(`WARN: ${msg} - demo: ${JSON.stringify(demo)}, cxId: ${cxId}`);
+    log(`WARN: ${msg} - cxId: ${cxId}, ids: [${matchingPatients.map(p => p.id).join(", ")}]`);
   }
   // Merge the matching patients
   const mpiPatient = useFirstMatchingPatient(matchingPatients);

--- a/packages/core/src/mpi/get-patient-by-demo.ts
+++ b/packages/core/src/mpi/get-patient-by-demo.ts
@@ -1,5 +1,6 @@
-import { Patient, PatientData } from "../domain/patient";
 import { PatientLoader } from "../command/patient-loader";
+import { Patient, PatientData } from "../domain/patient";
+import { log } from "../util/log";
 import {
   jaroWinklerSimilarity,
   matchingContactDetailsRule,
@@ -9,8 +10,6 @@ import {
 import { useFirstMatchingPatient } from "./merge-patients";
 import { normalizePatient } from "./normalize-patient";
 import { patientToPatientMPI } from "./shared";
-import { log } from "../util/log";
-import { capture } from "../util/notifications";
 
 const SIMILARITY_THRESHOLD = 0.96;
 
@@ -62,14 +61,6 @@ export const getPatientByDemo = async ({
   if (matchingPatients.length > 1) {
     const msg = `matchPatients returned more than one patient`;
     log(`WARN: ${msg} - demo: ${JSON.stringify(demo)}, cxId: ${cxId}`);
-    capture.message(msg, {
-      extra: {
-        context: `mpi.getPatientByDemo`,
-        cxId,
-        demo,
-      },
-      level: "warning",
-    });
   }
   // Merge the matching patients
   const mpiPatient = useFirstMatchingPatient(matchingPatients);


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-346

### Description
- Remove alert
- Only provide matching patient IDs in the logs

### Testing
- N/A

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified warning logs when multiple matching patients are found, now displaying only relevant IDs and context.
- **Chores**
  - Improved code organization by updating import statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->