### PR TITLE
ENG-313: implementation of CDK build with optional Surescripts resources

### DIFF
--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -180,12 +180,12 @@ export function createAPIService({
   semanticSearchEndpoint: string | undefined;
   semanticSearchIndexName: string | undefined;
   semanticSearchModelId: string | undefined;
-  surescriptsReplicaBucket: s3.IBucket;
-  medicationBundleBucket: s3.IBucket;
-  surescriptsSynchronizeSftpQueue: IQueue;
-  surescriptsSendPatientRequestQueue: IQueue;
-  surescriptsReceiveVerificationResponseQueue: IQueue;
-  surescriptsReceiveFlatFileResponseQueue: IQueue;
+  surescriptsReplicaBucket?: s3.IBucket;
+  medicationBundleBucket?: s3.IBucket;
+  surescriptsSynchronizeSftpQueue?: IQueue;
+  surescriptsSendPatientRequestQueue?: IQueue;
+  surescriptsReceiveVerificationResponseQueue?: IQueue;
+  surescriptsReceiveFlatFileResponseQueue?: IQueue;
   // TODO eng-41 Make this an actual Secret before going to prod
   semanticSearchAuth: { userName: string; secret: string } | undefined;
   featureFlagsTable: dynamodb.Table;
@@ -377,14 +377,20 @@ export function createAPIService({
           ...(props.config.cqDirectoryRebuilder?.heartbeatUrl && {
             CQ_DIR_REBUILD_HEARTBEAT_URL: props.config.cqDirectoryRebuilder.heartbeatUrl,
           }),
-          MEDICATION_BUNDLE_BUCKET_NAME: medicationBundleBucket.bucketName,
-          SURESCRIPTS_REPLICA_BUCKET_NAME: surescriptsReplicaBucket.bucketName,
-          SURESCRIPTS_SYNCHRONIZE_SFTP_QUEUE_URL: surescriptsSynchronizeSftpQueue.queueUrl,
-          SURESCRIPTS_SEND_PATIENT_REQUEST_QUEUE_URL: surescriptsSendPatientRequestQueue.queueUrl,
-          SURESCRIPTS_RECEIVE_VERIFICATION_RESPONSE_QUEUE_URL:
-            surescriptsReceiveVerificationResponseQueue.queueUrl,
-          SURESCRIPTS_RECEIVE_FLAT_FILE_RESPONSE_QUEUE_URL:
-            surescriptsReceiveFlatFileResponseQueue.queueUrl,
+          ...(medicationBundleBucket != null && {
+            MEDICATION_BUNDLE_BUCKET_NAME: medicationBundleBucket.bucketName,
+          }),
+          ...(!isSandbox(props.config) &&
+            props.config.surescripts && {
+              SURESCRIPTS_REPLICA_BUCKET_NAME: surescriptsReplicaBucket?.bucketName,
+              SURESCRIPTS_SYNCHRONIZE_SFTP_QUEUE_URL: surescriptsSynchronizeSftpQueue?.queueUrl,
+              SURESCRIPTS_SEND_PATIENT_REQUEST_QUEUE_URL:
+                surescriptsSendPatientRequestQueue?.queueUrl,
+              SURESCRIPTS_RECEIVE_VERIFICATION_RESPONSE_QUEUE_URL:
+                surescriptsReceiveVerificationResponseQueue?.queueUrl,
+              SURESCRIPTS_RECEIVE_FLAT_FILE_RESPONSE_QUEUE_URL:
+                surescriptsReceiveFlatFileResponseQueue?.queueUrl,
+            }),
         },
       },
       healthCheckGracePeriod: Duration.seconds(60),
@@ -469,8 +475,15 @@ export function createAPIService({
   conversionBucket.grantReadWrite(fargateService.taskDefinition.taskRole);
   medicalDocumentsUploadBucket.grantReadWrite(fargateService.taskDefinition.taskRole);
   ehrBundleBucket.grantReadWrite(fargateService.taskDefinition.taskRole);
-  medicationBundleBucket.grantReadWrite(fargateService.taskDefinition.taskRole);
-  surescriptsReplicaBucket.grantReadWrite(fargateService.taskDefinition.taskRole);
+
+  if (medicationBundleBucket) {
+    medicationBundleBucket.grantReadWrite(fargateService.taskDefinition.taskRole);
+  }
+
+  if (surescriptsReplicaBucket) {
+    surescriptsReplicaBucket.grantReadWrite(fargateService.taskDefinition.taskRole);
+  }
+
   if (ehrResponsesBucket) {
     ehrResponsesBucket.grantReadWrite(fargateService.taskDefinition.taskRole);
   }
@@ -504,26 +517,39 @@ export function createAPIService({
     queue: ehrRefreshEhrBundlesQueue,
     resource: fargateService.taskDefinition.taskRole,
   });
-  provideAccessToQueue({
-    accessType: "send",
-    queue: surescriptsSynchronizeSftpQueue,
-    resource: fargateService.taskDefinition.taskRole,
-  });
-  provideAccessToQueue({
-    accessType: "send",
-    queue: surescriptsSendPatientRequestQueue,
-    resource: fargateService.taskDefinition.taskRole,
-  });
-  provideAccessToQueue({
-    accessType: "send",
-    queue: surescriptsReceiveVerificationResponseQueue,
-    resource: fargateService.taskDefinition.taskRole,
-  });
-  provideAccessToQueue({
-    accessType: "send",
-    queue: surescriptsReceiveFlatFileResponseQueue,
-    resource: fargateService.taskDefinition.taskRole,
-  });
+
+  if (surescriptsSynchronizeSftpQueue) {
+    provideAccessToQueue({
+      accessType: "send",
+      queue: surescriptsSynchronizeSftpQueue,
+      resource: fargateService.taskDefinition.taskRole,
+    });
+  }
+
+  if (surescriptsSendPatientRequestQueue) {
+    provideAccessToQueue({
+      accessType: "send",
+      queue: surescriptsSendPatientRequestQueue,
+      resource: fargateService.taskDefinition.taskRole,
+    });
+  }
+
+  if (surescriptsReceiveVerificationResponseQueue) {
+    provideAccessToQueue({
+      accessType: "send",
+      queue: surescriptsReceiveVerificationResponseQueue,
+      resource: fargateService.taskDefinition.taskRole,
+    });
+  }
+
+  if (surescriptsReceiveFlatFileResponseQueue) {
+    provideAccessToQueue({
+      accessType: "send",
+      queue: surescriptsReceiveFlatFileResponseQueue,
+      resource: fargateService.taskDefinition.taskRole,
+    });
+  }
+
   // Allow access to search services/infra
   provideAccessToQueue({
     accessType: "send",

--- a/packages/infra/lib/surescripts-stack.ts
+++ b/packages/infra/lib/surescripts-stack.ts
@@ -172,6 +172,7 @@ interface SurescriptsNestedStackProps extends NestedStackProps {
   vpc: ec2.IVpc;
   alarmAction?: SnsAction;
   lambdaLayers: LambdaLayers;
+  medicationBundleBucket: s3.Bucket;
 }
 
 export class SurescriptsNestedStack extends NestedStack {
@@ -198,12 +199,7 @@ export class SurescriptsNestedStack extends NestedStack {
       versioned: true,
     });
 
-    this.medicationBundleBucket = new s3.Bucket(this, "MedicationBundleBucket", {
-      bucketName: props.config.medicationBundleBucketName,
-      publicReadAccess: false,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      versioned: true,
-    });
+    this.medicationBundleBucket = props.medicationBundleBucket;
 
     const { envVars, secrets } = surescriptsEnvironmentVariablesAndSecrets({
       nestedStack: this,

--- a/packages/infra/lib/surescripts/surescripts-stack.ts
+++ b/packages/infra/lib/surescripts/surescripts-stack.ts
@@ -1,7 +1,7 @@
 import { Duration, NestedStack, NestedStackProps } from "aws-cdk-lib";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
-import { Function as Lambda } from "aws-cdk-lib/aws-lambda";
+import { Function as Lambda, Runtime } from "aws-cdk-lib/aws-lambda";
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
@@ -336,6 +336,7 @@ export class SurescriptsNestedStack extends NestedStack {
       name,
       entry,
       envType,
+      runtime: Runtime.NODEJS_20_X,
       envVars: {
         ...envVars,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),

--- a/packages/infra/lib/surescripts/types.ts
+++ b/packages/infra/lib/surescripts/types.ts
@@ -1,0 +1,16 @@
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Function as Lambda } from "aws-cdk-lib/aws-lambda";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+
+export type SurescriptsAssets = {
+  synchronizeSftpLambda: Lambda;
+  synchronizeSftpQueue: Queue;
+  sendPatientRequestLambda: Lambda;
+  sendPatientRequestQueue: Queue;
+  receiveVerificationResponseLambda: Lambda;
+  receiveVerificationResponseQueue: Queue;
+  receiveFlatFileResponseLambda: Lambda;
+  receiveFlatFileResponseQueue: Queue;
+  surescriptsReplicaBucket: Bucket;
+  medicationBundleBucket: Bucket;
+};


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-313

### Dependencies

- Upstream: None
- Downstream: None

### Description

This update would simply release any resources associated with Surescripts in the sandbox environment, adding some further guarantee that the Surescripts pharmacy integration cannot be triggered from a sandbox workflow.

### Testing

Run `cdk diff` to verify that the resources associated with Surescripts (the replica bucket, 4 Lambda functions and queues) are released in the changeset.

- Local
  - [x] `cdk diff`
- Staging
  - [ ] no change to staging environment
  - [ ] all environment variables still set
- Sandbox
  - [ ] no bucket named "surescripts-replica-sandbox"
- Production
  - [ ] no effect

### Release Plan

This is an eventual change simply to release any resources that were created by the CDK in the sandbox - there is already no configuration for Surescripts in the sandbox environment, so it anyways doesn't work. This simply removes any AWS resources associated with SS in the sandbox.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Consolidated Surescripts-related resources into a single structured object, improving organization and maintainability.
  - Surescripts integration is now conditionally included based on configuration, reducing unnecessary resource usage.
  - Internal resources are now encapsulated and accessed through dedicated methods, providing clearer and more secure resource management.

- **New Features**
  - Added structured grouping for Surescripts assets, enabling more streamlined configuration and access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->