### PR TITLE
feat(api): move query params to body + clean up commands

### DIFF
--- a/packages/api-sdk/src/index.ts
+++ b/packages/api-sdk/src/index.ts
@@ -79,4 +79,7 @@ export {
 } from "./medical/models/patient";
 export { PatientDTO } from "./medical/models/patientDTO";
 export { NetworkEntry } from "./medical/models/network-entry";
-export { patientSettingsSchema } from "./medical/models/patient-settings";
+export {
+  upsertPatientSettingsSchema,
+  patientSettingsSchema,
+} from "./medical/models/patient-settings";

--- a/packages/api-sdk/src/medical/models/patient-settings.ts
+++ b/packages/api-sdk/src/medical/models/patient-settings.ts
@@ -6,6 +6,25 @@ const subscriptionsSchema = z.object({
 
 export type PatientSubscriptions = z.infer<typeof subscriptionsSchema>;
 
-export const patientSettingsSchema = z.object({
-  subscriptions: subscriptionsSchema.optional(),
+export const upsertPatientSettingsBaseSchema = z.object({
+  cxId: z.string(),
+  settings: z.object({
+    subscriptions: subscriptionsSchema.optional(),
+  }),
 });
+
+export const upsertPatientSettingsSchema = upsertPatientSettingsBaseSchema.and(
+  z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("patientList"),
+      patientIds: z.array(z.string()),
+    }),
+    z.object({
+      type: z.literal("facility"),
+      facilityId: z.string(),
+    }),
+  ])
+);
+
+export type UpsertPatientSettingsBase = z.infer<typeof upsertPatientSettingsBaseSchema>;
+export type UpsertPatientSettings = z.infer<typeof upsertPatientSettingsSchema>;

--- a/packages/api-sdk/src/medical/models/patient-settings.ts
+++ b/packages/api-sdk/src/medical/models/patient-settings.ts
@@ -4,13 +4,15 @@ const subscriptionsSchema = z.object({
   adt: z.boolean().optional(),
 });
 
-export type PatientSubscriptions = z.infer<typeof subscriptionsSchema>;
+export const patientSettingsSchema = z.object({
+  subscriptions: subscriptionsSchema.optional(),
+});
+
+export type PatientSettings = z.infer<typeof patientSettingsSchema>;
 
 export const upsertPatientSettingsBaseSchema = z.object({
   cxId: z.string(),
-  settings: z.object({
-    subscriptions: subscriptionsSchema.optional(),
-  }),
+  settings: patientSettingsSchema,
 });
 
 export const upsertPatientSettingsSchema = upsertPatientSettingsBaseSchema.and(

--- a/packages/api/src/command/medical/patient/settings/create-patient-settings.ts
+++ b/packages/api/src/command/medical/patient/settings/create-patient-settings.ts
@@ -91,8 +91,8 @@ async function upsertPatientSettingsByPatientSelector({
 
   const { validPatientIds, invalidPatientIds: patientsNotFound } = await verifyPatients({
     cxId,
-    facilityId,
-    patientIds,
+    ...(facilityId && { facilityId }),
+    ...(patientIds && patientIds.length > 0 && { patientIds }),
   });
 
   if (validPatientIds.length === 0) {

--- a/packages/api/src/routes/internal/medical/patient-settings.ts
+++ b/packages/api/src/routes/internal/medical/patient-settings.ts
@@ -25,6 +25,7 @@ const defaultSettings = {};
  * Creates or updates patient settings for a select set of patients.
  *
  * @param req.query.cxId The customer ID.
+ * @param req.query.type The type of operation to perform. Either "patientList" or "facility".
  * @param req.query.facilityId The facility ID. Either this or patientIds must be provided.
  * @param req.query.patientIds List of patient IDs to update. Either this or facilityId must be provided.
  * @param req.body The patient settings to apply. Optional, defaults to empty object.


### PR DESCRIPTION
metriport/metriport-internal#1040

Ref: ENG-350

Issues:

- https://linear.app/metriport/issue/ENG-257

### Dependencies

None

### Description

- Update the patient settings endpoints so I can pass a data in the body of the payloads
- Do a bit of cleanup so query params / organization of handlers makes more sense

### Testing

- Local
  - [x] Verify can toggle multiple patients using patient ids
  - [x] Verify can toggle multiple patients using facility id
  - [x] Verify can toggle multiple patients using cxId
- Staging
  - [ ] Verify can toggle multiple patients using patient ids
  - [ ] Verify can toggle multiple patients using facility id
  - [ ] Verify can toggle multiple patients using cxId
- Production
  - [ ] Verify can toggle multiple patients using patient ids
  - [ ] Verify can toggle multiple patients using facility id
  - [ ] Verify can toggle multiple patients using cxId

### Release Plan

- [ ] Release NPM packages
- [ ] Merge this
- [ ] Run prod toggles for circle

