### PR TITLE
fix(infra): add Surescripts secrets to secret manager stack

### DIFF
--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -79,6 +79,13 @@ export class SecretsStack extends Stack {
     }
 
     if (!isSandbox(props.config)) {
+      if (props.config.surescripts) {
+        for (const secretName of Object.values(props.config.surescripts.secrets)) {
+          const secret = makeSecret(secretName);
+          logSecretInfo(this, secret, secretName);
+        }
+      }
+
       for (const secretName of Object.values(props.config.hl7Notification.secrets)) {
         const secret = makeSecret(secretName);
         logSecretInfo(this, secret, secretName);

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -78,14 +78,14 @@ export class SecretsStack extends Stack {
       logSecretInfo(this, secret, secretName);
     }
 
-    if (!isSandbox(props.config)) {
-      if (props.config.surescripts) {
-        for (const secretName of Object.values(props.config.surescripts.secrets)) {
-          const secret = makeSecret(secretName);
-          logSecretInfo(this, secret, secretName);
-        }
+    if (props.config.surescripts) {
+      for (const secretName of Object.values(props.config.surescripts.secrets)) {
+        const secret = makeSecret(secretName);
+        logSecretInfo(this, secret, secretName);
       }
+    }
 
+    if (!isSandbox(props.config)) {
       for (const secretName of Object.values(props.config.hl7Notification.secrets)) {
         const secret = makeSecret(secretName);
         logSecretInfo(this, secret, secretName);

--- a/packages/infra/lib/surescripts/surescripts-stack.ts
+++ b/packages/infra/lib/surescripts/surescripts-stack.ts
@@ -166,7 +166,9 @@ function surescriptsEnvironmentVariablesAndSecrets({
 }
 
 function buildSecret(nestedStack: SurescriptsNestedStack, name: string): secret.ISecret {
-  return secret.Secret.fromSecretNameV2(nestedStack, name, name);
+  return new secret.Secret(nestedStack, name, {
+    secretName: name,
+  });
 }
 
 interface SurescriptsNestedStackProps extends NestedStackProps {

--- a/packages/infra/lib/surescripts/surescripts-stack.ts
+++ b/packages/infra/lib/surescripts/surescripts-stack.ts
@@ -166,9 +166,7 @@ function surescriptsEnvironmentVariablesAndSecrets({
 }
 
 function buildSecret(nestedStack: SurescriptsNestedStack, name: string): secret.ISecret {
-  return new secret.Secret(nestedStack, name, {
-    secretName: name,
-  });
+  return secret.Secret.fromSecretNameV2(nestedStack, name, name);
 }
 
 interface SurescriptsNestedStackProps extends NestedStackProps {


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-313

### Dependencies

- Upstream: None
- Downstream: None

### Description

Uses a consistent pattern to `secrets-stack.ts` in `surescripts-stack.ts` to create a CDK construct for an AWS secret.

### Testing

- Staging
  - [ ] run the CDK deployment
  - [ ] verify that the AWS secrets now show up in the Secrets Manager
- Production
  - [ ] deploy to production
  - [ ] verify that AWS secrets are now in production region

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Secrets for the surescripts configuration are now created and logged automatically, improving management and visibility of these secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->