### PR TITLE
fix(ENG-334): move conversion bucket getter out of module scope

### DIFF
--- a/packages/core/src/external/fhir/adt-encounters.ts
+++ b/packages/core/src/external/fhir/adt-encounters.ts
@@ -7,7 +7,6 @@ import { S3Utils } from "../aws/s3";
 import { mergeBundles } from "./shared/utils";
 
 const s3Utils = new S3Utils(Config.getAWSRegion());
-const s3BucketName = Config.getHl7ConversionBucketName();
 
 export function createPrefixAdtEncounter({
   cxId,
@@ -119,6 +118,7 @@ export async function saveAdtConversionBundle({
   const { log } = out(
     `saveAdtConversionBundle - cx: ${cxId}, pt: ${patientId}, enc: ${encounterId}`
   );
+  const s3BucketName = Config.getHl7ConversionBucketName();
 
   const newMessageBundleFileKey = createFileKeyAdtConversion({
     cxId,
@@ -162,6 +162,7 @@ export async function getAdtSourcedEncounter({
   const { log } = out(
     `getAdtSourcedEncounter - cx: ${cxId}, pt: ${patientId}, enc: ${encounterId}`
   );
+  const s3BucketName = Config.getHl7ConversionBucketName();
 
   const fileKey = createFileKeyAdtSourcedEncounter({
     cxId,
@@ -247,6 +248,7 @@ export async function putAdtSourcedEncounter({
   const { log } = out(
     `putAdtSourcedEncounter - cx: ${cxId}, pt: ${patientId}, enc: ${encounterId}`
   );
+  const s3BucketName = Config.getHl7ConversionBucketName();
 
   const fileKey = createFileKeyAdtSourcedEncounter({
     cxId,


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-334

### Dependencies

Fixes staging.

### Description

This PR moves the config getter out of module scope. The config getter in module scope was breaking other services that imported the module but did not have the environment variable (mllp-server). Error in ECS tasks that are failing to start:

```
Error: Missing HL7_CONVERSION_BUCKET_NAME env var
```

But the mllp server uses none of the functions that actually require the bucketName.

### Testing

None - need to test on staging.

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->