### PR TITLE
ENG-268 Enable ingestion on data pipeline

### DIFF
--- a/packages/api/src/command/medical/patient/consolidated-recreate.ts
+++ b/packages/api/src/command/medical/patient/consolidated-recreate.ts
@@ -2,7 +2,7 @@ import { ConsolidationConversionType } from "@metriport/api-sdk";
 import { deleteConsolidated } from "@metriport/core/command/consolidated/consolidated-delete";
 import { ConsolidatedSnapshotRequestSync } from "@metriport/core/command/consolidated/get-snapshot";
 import { buildConsolidatedSnapshotConnector } from "@metriport/core/command/consolidated/get-snapshot-factory";
-// import { makeIngestConsolidated } from "@metriport/core/command/consolidated/search/fhir-resource/ingest-consolidated-factory";
+import { makeIngestConsolidated } from "@metriport/core/command/consolidated/search/fhir-resource/ingest-consolidated-factory";
 import { Patient } from "@metriport/core/domain/patient";
 import { processAsyncError } from "@metriport/core/util/error/shared";
 import { out } from "@metriport/core/util/log";
@@ -56,14 +56,13 @@ export async function recreateConsolidated({
 
     log(`Consolidated recreated`);
 
-    // TODO ENG-268 Uncomment this
-    // const ingestor = makeIngestConsolidated();
-    // ingestor
-    //   .ingestConsolidatedIntoSearchEngine({
-    //     cxId: patient.cxId,
-    //     patientId: patient.id,
-    //   })
-    //   .catch(processAsyncError("Post-DQ ingestConsolidatedIntoSearchEngine"));
+    const ingestor = makeIngestConsolidated();
+    ingestor
+      .ingestConsolidatedIntoSearchEngine({
+        cxId: patient.cxId,
+        patientId: patient.id,
+      })
+      .catch(processAsyncError("Post-DQ ingestConsolidatedIntoSearchEngine"));
 
     if (isDq) {
       startCreateResourceDiffBundlesJobsAcrossEhrs({


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3857
- Downstream: none

### Description

Enable ingestion on data pipeline.

### Testing

- Local
  - none
- Staging
  - [ ] Successful ingestion when consolidated is recreated
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] RELEASE upstream
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored the ability to process and ingest consolidated patient data into the search engine, ensuring improved data availability and search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->