### PR TITLE
PATCH: added pharmacies query parameter to start document query

### DIFF
--- a/docs/medical-api/api-reference/document/start-document-query.mdx
+++ b/docs/medical-api/api-reference/document/start-document-query.mdx
@@ -41,8 +41,8 @@ for more details:
 </ParamField>
 
 <ParamField query="pharmacies" type="boolean">
-  When set to `true`, the document query will also request medication history from PBMs.
-  Defaults to `false`.
+  When set to `true`, the document query will also request detailed medication history nationally across pharmacies and PBMs, 
+  including advanced insights like fill data - allowing you to know whether the patient picked up their medications, for example.
 
   <Info>
     This will retrieve up to one year of medication history.


### PR DESCRIPTION
Issues:
- None

### Dependencies

- Upstream: None
- Downstream: None

### Description

Adds a "pharmacies" query parameter to the docs for "start document query".

### Testing

Check that the regenerated documentation has the query parameter.

https://docs.metriport.com/medical-api/api-reference/document/start-document-query

### Release Plan

- :warning: Points to `master`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to include a new optional parameter that enables retrieval of detailed medication history from pharmacies and Pharmacy Benefit Managers, including medication fill data for up to one year.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->