### PR TITLE
ENG-268 Enable consolidated/search to EHR routes

### DIFF
--- a/packages/api/src/routes/ehr/shared.ts
+++ b/packages/api/src/routes/ehr/shared.ts
@@ -61,6 +61,10 @@ export const validPatientPaths: PathDetails[] = [
     pathParamKey: "id",
   },
   {
+    pathRegex: new RegExp(`^/consolidated/search$`),
+    pathParamKey: "id",
+  },
+  {
     pathRegex: new RegExp(`^/consolidated/webhook$`),
     pathParamKey: "id",
   },


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3857
- Downstream: none

### Description

Enable consolidated/search to EHR routes - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1748547963798069?thread_ts=1748400876.077349&cid=C04DMKE9DME)

### Testing

- Local
  - none
- Staging
  - [x] Consolidated search works on Athena
  - [x] Consolidated search works on Canvas
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `/consolidated/search` patient path, enabling recognition and handling of this route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->