### PR TITLE
ENG-268 Move ingestion queue to FIFO

### DIFF
--- a/packages/core/src/external/opensearch/file/file-searcher-direct.ts
+++ b/packages/core/src/external/opensearch/file/file-searcher-direct.ts
@@ -30,7 +30,7 @@ export class OpenSearchFileSearcherDirect implements OpenSearchFileSearcher {
                   {
                     // https://docs.opensearch.org/docs/latest/query-dsl/full-text/simple-query-string/
                     simple_query_string: {
-                      query: cleanupQuery(actualQuery),
+                      query: actualQuery,
                       fields: ["content"],
                       analyze_wildcard: true,
                     },

--- a/packages/core/src/external/opensearch/lexical/lexical-search.ts
+++ b/packages/core/src/external/opensearch/lexical/lexical-search.ts
@@ -36,7 +36,7 @@ export function createLexicalSearchQuery({
                   {
                     // https://docs.opensearch.org/docs/latest/query-dsl/full-text/match/
                     match: {
-                      content: {
+                      [contentFieldName]: {
                         query: actualQuery,
                         fuzziness: "AUTO",
                       },

--- a/packages/infra/lib/lambdas-nested-stack-settings.ts
+++ b/packages/infra/lib/lambdas-nested-stack-settings.ts
@@ -6,7 +6,7 @@ export function getConsolidatedIngestionConnectorSettings() {
   return {
     name: "ConsolidatedIngestion",
     queue: {
-      fifo: false,
+      fifo: true,
       createRetryLambda: false,
       maxReceiveCount: 2,
       alarmMaxAgeOfOldestMessage: Duration.seconds(lambdaTimeout.toSeconds() * 3),


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3913
- Downstream: none

### Description

Move ingestion queue to FIFO - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1748556751588939?thread_ts=1748554236.530489&cid=C04T256DQPQ)

Also address 🐰 messages from the previous release PR ([1](https://github.com/metriport/metriport/pull/3914#discussion_r2114716240), [2](https://github.com/metriport/metriport/pull/3914#discussion_r2114716220))

### Testing

- Local
   - none
- Staging
  - [ ] Ingestion works
  - [ ] Subsequent ingestion works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
- [ ] Unthrottle `ConsolidatedIngestionLambda`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved search reliability by ensuring queries target the correct fields and avoid redundant query cleanup.
- **Chores**
	- Enhanced message processing order and deduplication by enabling FIFO behavior for message queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->