### PR TITLE
ENG-268 Remove max batching window from ingestion queue

### DIFF
--- a/packages/infra/lib/lambdas-nested-stack-settings.ts
+++ b/packages/infra/lib/lambdas-nested-stack-settings.ts
@@ -21,7 +21,6 @@ export function getConsolidatedIngestionConnectorSettings() {
     },
     eventSource: {
       batchSize: 1,
-      maxBatchingWindow: Duration.seconds(0),
       maxConcurrency: 5, // how many lambdas can hit the OpenSearch service at once
       // Partial batch response: https://docs.aws.amazon.com/prescriptive-guidance/latest/lambda-event-filtering-partial-batch-responses-for-sqs/welcome.html
       reportBatchItemFailures: false,


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3918
- Downstream: none

### Description

Remove max batching window from ingestion queue - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1748560097913349?thread_ts=1748400876.077349&cid=C04DMKE9DME)

### Testing

- Local
  - none
- Staging
  - [ ] Ingestion works
  - [ ] Subsequent ingestion works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated event processing settings to remove unnecessary batching configuration. No impact on existing features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->