### PR TITLE
PATCH RELEASE ENG-268 Fix ingestion sqs setup

### DIFF
--- a/packages/core/src/command/consolidated/search/fhir-resource/ingest-consolidated-sqs.ts
+++ b/packages/core/src/command/consolidated/search/fhir-resource/ingest-consolidated-sqs.ts
@@ -1,5 +1,4 @@
 import { executeWithNetworkRetries } from "@metriport/shared";
-import { nanoid } from "nanoid";
 import { SQSClient } from "../../../../external/aws/sqs";
 import { executeAsynchronously } from "../../../../util/concurrency";
 import { Config } from "../../../../util/config";
@@ -7,6 +6,7 @@ import {
   SQS_MESSAGE_BATCH_MILLIS_TO_SLEEP,
   SQS_MESSAGE_BATCH_SIZE_STANDARD,
 } from "../../../../util/sqs";
+import { uuidv7 } from "../../../../util/uuid-v7";
 import {
   IngestConsolidated,
   IngestConsolidatedParams,
@@ -67,7 +67,7 @@ export class IngestConsolidatedSqs implements IngestConsolidated {
       // if we use patientId, only a single message per pt will be processed in a 5 minute window
       // which means loading the dash for a pt not ingested and triggering DQ wouldn't update
       // the search engine after DQ is complete
-      messageDeduplicationId: nanoid(),
+      messageDeduplicationId: uuidv7(),
     });
   }
 }


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-268/be-global-search-by-keyword-endpoint

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3917
- Downstream: none

### Description

- Fix messageDedupId to use UUID - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1748568650260949?thread_ts=1748566819.572709&cid=C04T256DQPQ)

### Testing

none

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the generation of message deduplication IDs for SQS FIFO queues to enhance message handling reliability. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->