### PR TITLE
ENG-268 Increase ingestion timeout

### DIFF
--- a/packages/infra/lib/lambdas-nested-stack-settings.ts
+++ b/packages/infra/lib/lambdas-nested-stack-settings.ts
@@ -2,7 +2,7 @@ import { Duration } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 
 export function getConsolidatedIngestionConnectorSettings() {
-  const lambdaTimeout = Duration.minutes(3);
+  const lambdaTimeout = Duration.minutes(5);
   return {
     name: "ConsolidatedIngestion",
     queue: {

--- a/packages/utils/src/open-search/ingest-patients.ts
+++ b/packages/utils/src/open-search/ingest-patients.ts
@@ -10,6 +10,7 @@ import { chunk, groupBy } from "lodash";
 import { normalizeExternalIdUtils } from "../bulk-insert-patients";
 import { elapsedTimeAsStr } from "../shared/duration";
 import { buildGetDirPathInside } from "../shared/folder";
+import { initFile } from "../shared/file";
 
 /**
  * Trigger ingestion of patients' consolidated into OpenSearch.
@@ -29,7 +30,7 @@ interface PatientRecord {
   patientId: string;
 }
 
-const getFolderName = buildGetDirPathInside(`ingest-patients`);
+const getFolderName = buildGetDirPathInside(`consolidated-ingestion`);
 const outputFolderName = getFolderName("");
 
 async function main() {
@@ -118,6 +119,7 @@ async function main() {
 
   if (failedIngestions.length > 0) {
     const errorFilePath = `${outputFolderName}/failed-ingestions.json`;
+    initFile(errorFilePath);
     fs.writeFileSync(errorFilePath, JSON.stringify(failedIngestions, null, 2));
     console.log(``);
     console.log(`Failed ingestions: ${failedIngestions.length} (written to ${errorFilePath})`);


### PR DESCRIPTION
### Dependencies

none

### Description

Increase ingestion timeout from 3 to 5 min - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1748618488891029).

Fix the issue w/ storing failures on the ingestion script.

### Testing

- Local
  - [ ] Failures when running ingestion script are stored on the /runs folder
- Staging
  - [ ] ingestion lambda timeout updated to 5 min
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
- prod
   - [ ] update max concurrency to 10 so we can migrate the pts timely


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the timeout for a key background process from 3 to 5 minutes, improving reliability for longer-running tasks.
  - Adjusted related system settings to align with the new timeout duration.
  - Updated file handling for error logs, including initializing error files and changing the output folder name for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->