### PR TITLE
refactor(infra): consistently change name from "medication" to "pharmacy" for bundles

### DIFF
--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -122,7 +122,7 @@ type EnvConfigBase = {
   generalBucketName: string;
   medicalDocumentsBucketName: string;
   medicalDocumentsUploadBucketName: string;
-  medicationBundleBucketName: string;
+  pharmacyBundleBucketName: string;
   surescriptsReplicaBucketName: string;
   ehrResponsesBucketName?: string;
   ehrBundleBucketName: string;

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -211,7 +211,7 @@ export const config: EnvConfigNonSandbox = {
   },
   medicalDocumentsBucketName: "test-bucket",
   medicalDocumentsUploadBucketName: "test-upload-bucket",
-  medicationBundleBucketName: "test-medication-bundle-bucket",
+  pharmacyBundleBucketName: "test-pharmacy-bundle-bucket",
   surescriptsReplicaBucketName: "test-surescripts-replica-bucket",
   ehrBundleBucketName: "test-ehr-bundle-bucket",
   ehrResponsesBucketName: "test-ehr-responses-bucket",

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -356,7 +356,7 @@ export function createAPIService({
             CQ_DIR_REBUILD_HEARTBEAT_URL: props.config.cqDirectoryRebuilder.heartbeatUrl,
           }),
           ...(surescriptsAssets && {
-            MEDICATION_BUNDLE_BUCKET_NAME: surescriptsAssets.medicationBundleBucket.bucketName,
+            PHARMACY_BUNDLE_BUCKET_NAME: surescriptsAssets.pharmacyBundleBucket.bucketName,
             SURESCRIPTS_REPLICA_BUCKET_NAME: surescriptsAssets.surescriptsReplicaBucket.bucketName,
             SURESCRIPTS_SYNCHRONIZE_SFTP_QUEUE_URL: surescriptsAssets.synchronizeSftpQueue.queueUrl,
             SURESCRIPTS_SEND_PATIENT_REQUEST_QUEUE_URL:
@@ -453,7 +453,7 @@ export function createAPIService({
   ehrBundleBucket.grantReadWrite(fargateService.taskDefinition.taskRole);
 
   if (surescriptsAssets) {
-    surescriptsAssets.medicationBundleBucket.grantReadWrite(fargateService.taskDefinition.taskRole);
+    surescriptsAssets.pharmacyBundleBucket.grantReadWrite(fargateService.taskDefinition.taskRole);
     surescriptsAssets.surescriptsReplicaBucket.grantReadWrite(
       fargateService.taskDefinition.taskRole
     );

--- a/packages/infra/lib/surescripts/surescripts-stack.ts
+++ b/packages/infra/lib/surescripts/surescripts-stack.ts
@@ -124,12 +124,12 @@ function surescriptsEnvironmentVariablesAndSecrets({
   nestedStack,
   surescripts,
   surescriptsReplicaBucket,
-  medicationBundleBucket,
+  pharmacyBundleBucket,
 }: {
   nestedStack: SurescriptsNestedStack;
   surescripts: EnvConfig["surescripts"];
   surescriptsReplicaBucket: s3.Bucket;
-  medicationBundleBucket: s3.Bucket;
+  pharmacyBundleBucket: s3.Bucket;
 }): { envVars: Record<string, string>; secrets: secret.ISecret[] } {
   if (!surescripts) {
     return { envVars: {}, secrets: [] };
@@ -140,7 +140,7 @@ function surescriptsEnvironmentVariablesAndSecrets({
     SURESCRIPTS_SFTP_SENDER_ID: surescripts.surescriptsSenderId,
     SURESCRIPTS_SFTP_RECEIVER_ID: surescripts.surescriptsReceiverId,
     SURESCRIPTS_REPLICA_BUCKET_NAME: surescriptsReplicaBucket.bucketName,
-    MEDICATION_BUNDLE_BUCKET_NAME: medicationBundleBucket.bucketName,
+    PHARMACY_BUNDLE_BUCKET_NAME: pharmacyBundleBucket.bucketName,
   };
 
   const secrets: secret.ISecret[] = [];
@@ -186,7 +186,7 @@ export class SurescriptsNestedStack extends NestedStack {
   private readonly receiveFlatFileResponseLambda: Lambda;
   private readonly receiveFlatFileResponseQueue: Queue;
   private readonly surescriptsReplicaBucket: s3.Bucket;
-  private readonly medicationBundleBucket: s3.Bucket;
+  private readonly pharmacyBundleBucket: s3.Bucket;
 
   constructor(scope: Construct, id: string, props: SurescriptsNestedStackProps) {
     super(scope, id, props);
@@ -200,8 +200,8 @@ export class SurescriptsNestedStack extends NestedStack {
       versioned: true,
     });
 
-    this.medicationBundleBucket = new s3.Bucket(this, "MedicationBundleBucket", {
-      bucketName: props.config.medicationBundleBucketName,
+    this.pharmacyBundleBucket = new s3.Bucket(this, "PharmacyBundleBucket", {
+      bucketName: props.config.pharmacyBundleBucketName,
       publicReadAccess: false,
       encryption: s3.BucketEncryption.S3_MANAGED,
       versioned: true,
@@ -211,7 +211,7 @@ export class SurescriptsNestedStack extends NestedStack {
       nestedStack: this,
       surescripts: props.config.surescripts,
       surescriptsReplicaBucket: this.surescriptsReplicaBucket,
-      medicationBundleBucket: this.medicationBundleBucket,
+      pharmacyBundleBucket: this.pharmacyBundleBucket,
     });
 
     const commonConfig = {
@@ -248,7 +248,7 @@ export class SurescriptsNestedStack extends NestedStack {
     const receiveFlatFileResponse = this.setupLambdaAndQueue("receiveFlatFileResponse", {
       ...commonConfig,
       surescriptsReplicaBucket: this.surescriptsReplicaBucket,
-      medicationBundleBucket: this.medicationBundleBucket,
+      pharmacyBundleBucket: this.pharmacyBundleBucket,
     });
     this.receiveFlatFileResponseLambda = receiveFlatFileResponse.lambda;
     this.receiveFlatFileResponseQueue = receiveFlatFileResponse.queue;
@@ -272,7 +272,7 @@ export class SurescriptsNestedStack extends NestedStack {
       receiveFlatFileResponseLambda: this.receiveFlatFileResponseLambda,
       receiveFlatFileResponseQueue: this.receiveFlatFileResponseQueue,
       surescriptsReplicaBucket: this.surescriptsReplicaBucket,
-      medicationBundleBucket: this.medicationBundleBucket,
+      pharmacyBundleBucket: this.pharmacyBundleBucket,
     };
   }
 
@@ -296,7 +296,7 @@ export class SurescriptsNestedStack extends NestedStack {
       sentryDsn: string | undefined;
       alarmAction: SnsAction | undefined;
       surescriptsReplicaBucket: s3.Bucket;
-      medicationBundleBucket?: s3.Bucket;
+      pharmacyBundleBucket?: s3.Bucket;
     }
   ): { lambda: Lambda; queue: Queue } {
     const {
@@ -307,7 +307,7 @@ export class SurescriptsNestedStack extends NestedStack {
       sentryDsn,
       alarmAction,
       surescriptsReplicaBucket,
-      medicationBundleBucket,
+      pharmacyBundleBucket,
     } = props;
 
     const {
@@ -347,7 +347,7 @@ export class SurescriptsNestedStack extends NestedStack {
     });
 
     surescriptsReplicaBucket.grantReadWrite(lambda);
-    medicationBundleBucket?.grantReadWrite(lambda);
+    pharmacyBundleBucket?.grantReadWrite(lambda);
 
     lambda.addEventSource(
       new SqsEventSource(queue, {

--- a/packages/infra/lib/surescripts/types.ts
+++ b/packages/infra/lib/surescripts/types.ts
@@ -12,5 +12,5 @@ export type SurescriptsAssets = {
   receiveFlatFileResponseLambda: Lambda;
   receiveFlatFileResponseQueue: Queue;
   surescriptsReplicaBucket: Bucket;
-  medicationBundleBucket: Bucket;
+  pharmacyBundleBucket: Bucket;
 };


### PR DESCRIPTION
metriport/metriport-internal#2995

Issues:

- https://linear.app/metriport/issue/ENG-313

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/2996
- Downstream: None

### Description

Consistently changes the name from "medication" to "pharmacy" for the final generated bundle bucket. See the upstream PR for more context with a link to the Slack conversation.

### Testing

- Local
  - [ ] run `cdk diff -c env=staging`

Verify that environment variables are being consistently updated to `PHARMACY_BUNDLE_BUCKET_NAME`.

<img width="807" alt="Screenshot 2025-05-30 at 10 07 48 AM" src="https://github.com/user-attachments/assets/24eda7d1-8a01-4529-b094-a884164d94fb" />

Verify that the old bucket is now an orphan, and the new bucket is created with the new name.

<img width="583" alt="Screenshot 2025-05-30 at 10 08 18 AM" src="https://github.com/user-attachments/assets/a63adcaf-ad1c-47ca-b5ac-ecb205c7e634" />

This bucket is only accessible to one Lambda execution handler in the workflow - ensure that this Lambda is receiving access to the new bucket.

<img width="1351" alt="Screenshot 2025-05-30 at 10 06 14 AM" src="https://github.com/user-attachments/assets/3168ce08-85c1-4260-b033-ee49eb24d8ed" />

- Staging
  - [ ] check that the new bucket name `metriport-pharmacy-bundle-staging` take effect on staging
- Production
  - [ ] check that the new bucket name `metriport-pharmacy-bundle-production` take effect on production

_[Release PRs:]_

Check each PR.

### Release Plan

_[How does the changes on this PR impact/interact with the existing environment (database, configs, secrets, FFs, api contracts, etc.)?
Consider creating 2+ PRs if we need to ship those changes in a staged way]_

_[This is the release plan for production]_

_[You should execute the exact same steps when releasing to staging to validate it works]_

_[Add and remove items below accordingly]_

- :warning: Points to `master`
- :warning: This contains a DB migration
- [ ] Maintenance window scheduled/created at Checkly (if needed)
- [ ] Execute this on <env1>, <env2>
  - [ ] _step1_
  - [ ] _step2_
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (deprecates a feature that needs to be communicated with customers)
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (introduce a feature that would be useful customers)
- [ ] Upstream dependencies are met/released
- [ ] Release NPM packages
- [ ] Fern Definition Updated
- [ ] Release Fern SDKs
- [ ] FFs have been set in Staging, Production, and Sandbox
- [ ] Happy-path E2E test created checking new FF flow
- [ ] No dependencies between API and Infra that will cause errors during deployment
- [ ] _[action n-1]_
- [ ] _[action n]_
- [ ] Merge this
