### PR TITLE
PATCH RELEASE ENG-383 Update ingestion timeout

### DIFF
--- a/packages/infra/lib/lambdas-nested-stack-settings.ts
+++ b/packages/infra/lib/lambdas-nested-stack-settings.ts
@@ -2,7 +2,7 @@ import { Duration } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 
 export function getConsolidatedIngestionConnectorSettings() {
-  const lambdaTimeout = Duration.minutes(5);
+  const lambdaTimeout = Duration.minutes(10);
   return {
     name: "ConsolidatedIngestion",
     queue: {


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-383/be-ingest-existing-patients

### Dependencies

none

### Description

Update ingestion timeout from 5 to 10s - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1748627203606069?thread_ts=1748400876.077349&cid=C04DMKE9DME).

### Testing

none

### Release Plan

:warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the timeout for the ingestion connector process from 5 to 10 minutes, resulting in updated queue and alarm settings to match the new duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->