### PR TITLE
PATCH RELEASE Ingestion lambda timeout from 10 to 15s

### DIFF
--- a/packages/infra/lib/lambdas-nested-stack-settings.ts
+++ b/packages/infra/lib/lambdas-nested-stack-settings.ts
@@ -2,7 +2,7 @@ import { Duration } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 
 export function getConsolidatedIngestionConnectorSettings() {
-  const lambdaTimeout = Duration.minutes(10);
+  const lambdaTimeout = Duration.minutes(15).minus(Duration.seconds(5));
   return {
     name: "ConsolidatedIngestion",
     queue: {


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-383/be-ingest-existing-patients

### Dependencies

none

### Description

Ingestion lambda timeout from 10 to 15s - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1748637353395619)

### Testing

none

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Increased the timeout duration for a Lambda function to 14 minutes and 55 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->