### PR TITLE
ENG-393 add data for fixed partner config

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -199,7 +199,7 @@ export function createRosterRowInput(
   const scrambledId = createScrambledId(p.cxId, p.id);
   const rosterGenerationDate = buildDayjs(new Date()).format("YYYY-MM-DD");
   const dob = data.dob;
-  const dobNoDelimiter = data.dob.replace(/[-]/g, "");
+  const dobNoDelimiter = dob.replace(/[-]/g, "");
   const authorizingParticipantFacilityCode = org.shortcode;
   const authorizingParticipantMrn = p.externalId || createUuidFromText(scrambledId);
   const assigningAuthorityIdentifier = METRIPORT_ASSIGNING_AUTHORITY_IDENTIFIER;

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -198,6 +198,8 @@ export function createRosterRowInput(
   const email = data.contact?.find(c => c.email)?.email;
   const scrambledId = createScrambledId(p.cxId, p.id);
   const rosterGenerationDate = buildDayjs(new Date()).format("YYYY-MM-DD");
+  const dob = data.dob;
+  const dobNoDelimiter = data.dob.replace(/[-]/g, "");
   const authorizingParticipantFacilityCode = org.shortcode;
   const authorizingParticipantMrn = p.externalId || createUuidFromText(scrambledId);
   const assigningAuthorityIdentifier = METRIPORT_ASSIGNING_AUTHORITY_IDENTIFIER;
@@ -210,7 +212,8 @@ export function createRosterRowInput(
     lastName: data.lastName,
     firstName: data.firstName,
     middleName: "",
-    dob: data.dob,
+    dob,
+    dobNoDelimiter,
     genderAtBirth: data.genderAtBirth,
     address1AddressLine1: addresses[0]?.addressLine1,
     address1AddressLine2: addresses[0]?.addressLine2,

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -17,6 +17,7 @@ export type RosterRowData = {
   firstName: string;
   lastName: string;
   dob: string;
+  dobNoDelimiter: string;
   middleName: string | undefined;
   genderAtBirth: string | undefined;
   scrambledId: string;


### PR DESCRIPTION
metriport/metriport-internal#1040

Ref: ENG-393
Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

Issues:

- https://linear.app/metriport/issue/ENG-393

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/3002

### Description

This pr adds an additional piece of data that is required to generate the partner roster

### Testing

None

### Release Plan

- See upstream release plan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new field to display date of birth without delimiters alongside the existing date of birth format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->