### PR TITLE
ENG-392 Add env var to medical bucket

### DIFF
--- a/packages/core/src/command/consolidated/search/fhir-resource/ingest-lexical.ts
+++ b/packages/core/src/command/consolidated/search/fhir-resource/ingest-lexical.ts
@@ -28,11 +28,7 @@ export async function ingestPatientConsolidated({
 
   log("Getting consolidated and cleaning up the index...");
   const [bundle] = await Promise.all([
-    timed(
-      () => getConsolidatedBundle({ cxId, patientId }),
-      "getConsolidatedBundleAndNotifyWhenMissing",
-      log
-    ),
+    timed(() => getConsolidatedBundle({ cxId, patientId }), "getConsolidatedBundle", log),
     ingestor.delete({ cxId, patientId }),
   ]);
 

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -826,6 +826,7 @@ export class LambdasNestedStack extends NestedStack {
       envVars: {
         // API_URL set on the api-stack after the OSS API is created
         FEATURE_FLAGS_TABLE_NAME: featureFlagsTable.tableName,
+        MEDICAL_DOCUMENTS_BUCKET_NAME: bundleBucket.bucketName,
         SEARCH_ENDPOINT: openSearchEndpoint,
         SEARCH_USERNAME: openSearchAuth.userName,
         SEARCH_PASSWORD_SECRET_ARN: openSearchAuth.secret.secretArn,


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3938
- Downstream: 

### Description

Add env var to medical bucket - [context](https://metriport.slack.com/archives/C04T5Q9JHFX/p1748733257286879)

### Testing

- Local
  - none
- Staging
  - [x] ingestion lambda works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
