### PR TITLE
ENG-387 Wait after ingest if needed

### DIFF
--- a/packages/core/src/command/consolidated/search/fhir-resource/ingest-if-needed.ts
+++ b/packages/core/src/command/consolidated/search/fhir-resource/ingest-if-needed.ts
@@ -1,10 +1,12 @@
 import { buildDayjs } from "@metriport/shared/common/date";
+import { sleep } from "@metriport/shared/common/sleep";
 import { Patient } from "../../../../domain/patient";
 import { OpenSearchFhirSearcher } from "../../../../external/opensearch/lexical/fhir-searcher";
 import { Config } from "../../../../util/config";
 import { getConfigs } from "./fhir-config";
 import { IngestConsolidatedDirect } from "./ingest-consolidated-direct";
 
+const WAIT_AFTER_INGESTION_IN_MILLIS = 1_000;
 const consolidatedDataIngestionInitialDate = Config.getConsolidatedDataIngestionInitialDate();
 
 /**
@@ -35,5 +37,7 @@ export async function ingestIfNeeded(patient: Patient): Promise<void> {
   if (!isIngested) {
     const ingestor = new IngestConsolidatedDirect();
     await ingestor.ingestConsolidatedIntoSearchEngine({ cxId, patientId });
+
+    await sleep(WAIT_AFTER_INGESTION_IN_MILLIS);
   }
 }

--- a/packages/core/src/external/opensearch/fhir-ingestor.ts
+++ b/packages/core/src/external/opensearch/fhir-ingestor.ts
@@ -184,7 +184,7 @@ export class OpenSearchFhirIngestor {
   }
 
   async delete({ cxId, patientId }: DeleteRequest): Promise<void> {
-    const { log, debug } = out(`${this.constructor.name}.delete - cx ${cxId}, pt ${patientId}`);
+    const { log } = out(`${this.constructor.name}.delete - cx ${cxId}, pt ${patientId}`);
 
     const indexName = this.indexName;
     const auth = { username: this.username, password: this.password };
@@ -193,13 +193,12 @@ export class OpenSearchFhirIngestor {
     log(`Deleting resources from index ${indexName}...`);
     const startedAt = Date.now();
 
-    const response = await client.deleteByQuery({
+    await client.deleteByQuery({
       index: indexName,
       body: createDeleteQuery({ cxId, patientId }),
     });
     const time = Date.now() - startedAt;
     log(`Successfully deleted in ${time} milliseconds`);
-    debug(`Response: `, () => JSON.stringify(response.body));
   }
 }
 


### PR DESCRIPTION
### Dependencies

none

### Description

Wait after ingest if needed - see [this](https://metriport.slack.com/archives/C04DMKE9DME/p1748734845354799).

Throw on ingestion error - see ticket.

### Testing

- Local
  - none
- Staging
  - [ ] ingest on search works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during resource ingestion by throwing detailed errors when issues are detected, providing clearer feedback.

- **Chores**
  - Introduced a short delay after certain ingestion processes to enhance reliability.
  - Removed unnecessary debug logging from delete operations to streamline logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->