### PR TITLE
ENG-394 spin up new ips for staging hl7 nlbs

### DIFF
--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -176,8 +176,8 @@ export const config: EnvConfigNonSandbox = {
       fargateMemoryLimitMiB: 2048,
       fargateTaskCountMin: 2,
       fargateTaskCountMax: 4,
-      nlbInternalIpAddress1: "10.1.1.0",
-      nlbInternalIpAddress2: "10.1.1.1",
+      nlbInternalIpAddressA: "10.1.1.0",
+      nlbInternalIpAddressB: "10.1.1.1",
     },
     hl7v2RosterUploadLambda: {
       bucketName: "your-roster-bucket",

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -176,8 +176,8 @@ export const config: EnvConfigNonSandbox = {
       fargateMemoryLimitMiB: 2048,
       fargateTaskCountMin: 2,
       fargateTaskCountMax: 4,
-      nlbInternalIpAddressA: "10.1.1.0",
-      nlbInternalIpAddressB: "10.1.1.1",
+      nlbInternalIpAddress1: "10.1.1.0",
+      nlbInternalIpAddress2: "10.1.1.1",
     },
     hl7v2RosterUploadLambda: {
       bucketName: "your-roster-bucket",

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -176,6 +176,8 @@ export const config: EnvConfigNonSandbox = {
       fargateMemoryLimitMiB: 2048,
       fargateTaskCountMin: 2,
       fargateTaskCountMax: 4,
+      nlbInternalIpAddressA: "10.1.1.0",
+      nlbInternalIpAddressB: "10.1.1.1",
     },
     hl7v2RosterUploadLambda: {
       bucketName: "your-roster-bucket",

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -18,6 +18,8 @@ export interface Hl7NotificationConfig {
     fargateMemoryLimitMiB: number;
     fargateTaskCountMin: number;
     fargateTaskCountMax: number;
+    nlbInternalIpAddressA: string;
+    nlbInternalIpAddressB: string;
   };
   hl7v2RosterUploadLambda: {
     bucketName: string;

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -18,8 +18,8 @@ export interface Hl7NotificationConfig {
     fargateMemoryLimitMiB: number;
     fargateTaskCountMin: number;
     fargateTaskCountMax: number;
-    nlbInternalIpAddressA: string;
-    nlbInternalIpAddressB: string;
+    nlbInternalIpAddress1: string;
+    nlbInternalIpAddress2: string;
   };
   hl7v2RosterUploadLambda: {
     bucketName: string;

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -18,8 +18,8 @@ export interface Hl7NotificationConfig {
     fargateMemoryLimitMiB: number;
     fargateTaskCountMin: number;
     fargateTaskCountMax: number;
-    nlbInternalIpAddress1: string;
-    nlbInternalIpAddress2: string;
+    nlbInternalIpAddressA: string;
+    nlbInternalIpAddressB: string;
   };
   hl7v2RosterUploadLambda: {
     bucketName: string;

--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -1,6 +1,8 @@
 export const MLLP_DEFAULT_PORT = 2575;
 export const HL7_NOTIFICATION_VPC_CIDR = "10.1.0.0/16";
 export const PROBLEMATIC_IPSEC_CHARACTERS = "!@#$%^&*()_+-=[]{}|;:,.<>?~`'\"\\/";
-export const MLLP_SERVER_NLB_INTERNAL_IP_A = "10.1.1.20";
-export const MLLP_SERVER_NLB_INTERNAL_IP_B = "10.1.1.21";
+export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_A = "10.1.1.20";
+export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_B = "10.1.1.21";
+export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_A = "10.1.1.22";
+export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_B = "10.1.1.23";
 export const MLLP_SERVER_CONTAINER_NAME = "MllpServer";

--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -2,13 +2,3 @@ export const MLLP_DEFAULT_PORT = 2575;
 export const HL7_NOTIFICATION_VPC_CIDR = "10.1.0.0/16";
 export const PROBLEMATIC_IPSEC_CHARACTERS = "!@#$%^&*()_+-=[]{}|;:,.<>?~`'\"\\/";
 export const MLLP_SERVER_CONTAINER_NAME = "MllpServer";
-
-/**
- * These IPs are used to configure the NLB internal IPs for the MLLP server.
- * They need to each be unique to simplify the VPN routing configuration
- * for our third party partners.
- */
-export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_A = "10.1.1.20";
-export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_B = "10.1.1.21";
-export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_A = "10.1.1.22";
-export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_B = "10.1.1.23";

--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -8,7 +8,7 @@ export const MLLP_SERVER_CONTAINER_NAME = "MllpServer";
  * They need to each be unique to simplify the VPN routing configuration
  * for our third party partners.
  */
-export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_1 = "10.1.1.20";
-export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_2 = "10.1.1.21";
-export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_1 = "10.1.1.22";
-export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_2 = "10.1.1.23";
+export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_A = "10.1.1.20";
+export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_B = "10.1.1.21";
+export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_A = "10.1.1.22";
+export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_B = "10.1.1.23";

--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -8,7 +8,7 @@ export const MLLP_SERVER_CONTAINER_NAME = "MllpServer";
  * They need to each be unique to simplify the VPN routing configuration
  * for our third party partners.
  */
-export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_A = "10.1.1.20";
-export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_B = "10.1.1.21";
-export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_A = "10.1.1.22";
-export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_B = "10.1.1.23";
+export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_1 = "10.1.1.20";
+export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_2 = "10.1.1.21";
+export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_1 = "10.1.1.22";
+export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_2 = "10.1.1.23";

--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -1,8 +1,14 @@
 export const MLLP_DEFAULT_PORT = 2575;
 export const HL7_NOTIFICATION_VPC_CIDR = "10.1.0.0/16";
 export const PROBLEMATIC_IPSEC_CHARACTERS = "!@#$%^&*()_+-=[]{}|;:,.<>?~`'\"\\/";
+export const MLLP_SERVER_CONTAINER_NAME = "MllpServer";
+
+/**
+ * These IPs are used to configure the NLB internal IPs for the MLLP server.
+ * They need to each be unique to simplify the VPN routing configuration
+ * for our third party partners.
+ */
 export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_A = "10.1.1.20";
 export const MLLP_SERVER_NLB_PROD_INTERNAL_IP_B = "10.1.1.21";
 export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_A = "10.1.1.22";
 export const MLLP_SERVER_NLB_STAGING_INTERNAL_IP_B = "10.1.1.23";
-export const MLLP_SERVER_CONTAINER_NAME = "MllpServer";

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -69,8 +69,8 @@ export class MllpStack extends cdk.NestedStack {
       fargateMemoryLimitMiB,
       fargateTaskCountMin,
       fargateTaskCountMax,
-      nlbInternalIpAddress1,
-      nlbInternalIpAddress2,
+      nlbInternalIpAddressA,
+      nlbInternalIpAddressB,
     } = props.config.hl7Notification.mllpServer;
 
     const cluster = new ecs.Cluster(this, "MllpServerCluster", {
@@ -162,8 +162,8 @@ export class MllpStack extends cdk.NestedStack {
      * We're using an empty string for the first setupNlb call to maintain identifiers and
      * avoid having to recreate a new listener and target group for the existing NLB.
      */
-    setupNlb("1", vpc, nlbA, nlbInternalIpAddress1).addTarget(fargateService);
-    setupNlb("2", vpc, nlbB, nlbInternalIpAddress2).addTarget(fargateService);
+    setupNlb("", vpc, nlbA, nlbInternalIpAddressA).addTarget(fargateService);
+    setupNlb("B", vpc, nlbB, nlbInternalIpAddressB).addTarget(fargateService);
 
     incomingHl7NotificationBucket.grantWrite(fargateService.taskDefinition.taskRole);
 
@@ -196,12 +196,12 @@ export class MllpStack extends cdk.NestedStack {
     });
 
     new cdk.CfnOutput(this, "MllpNlbInternalIp1", {
-      value: nlbInternalIpAddress1,
+      value: nlbInternalIpAddressA,
       description: "Internal IP address of the MLLP Network Load Balancer 1",
     });
 
     new cdk.CfnOutput(this, "MllpNlbInternalIp2", {
-      value: nlbInternalIpAddress2,
+      value: nlbInternalIpAddressB,
       description: "Internal IP address of the MLLP Network Load Balancer 2",
     });
   }

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as cdk from "aws-cdk-lib";
 import { Duration } from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
@@ -68,8 +69,8 @@ export class MllpStack extends cdk.NestedStack {
       fargateMemoryLimitMiB,
       fargateTaskCountMin,
       fargateTaskCountMax,
-      nlbInternalIpAddressA,
-      nlbInternalIpAddressB,
+      nlbInternalIpAddress1,
+      nlbInternalIpAddress2,
     } = props.config.hl7Notification.mllpServer;
 
     const cluster = new ecs.Cluster(this, "MllpServerCluster", {
@@ -161,8 +162,9 @@ export class MllpStack extends cdk.NestedStack {
      * We're using an empty string for the first setupNlb call to maintain identifiers and
      * avoid having to recreate a new listener and target group for the existing NLB.
      */
-    setupNlb("", vpc, nlbA, nlbInternalIpAddressA).addTarget(fargateService);
-    setupNlb("B", vpc, nlbB, nlbInternalIpAddressB).addTarget(fargateService);
+    setupNlb("1", vpc, nlbA, nlbInternalIpAddress1).addTarget(fargateService);
+    setupNlb("2", vpc, nlbB, nlbInternalIpAddress2).addTarget(fargateService);
+
     incomingHl7NotificationBucket.grantWrite(fargateService.taskDefinition.taskRole);
 
     const scaling = fargateService.autoScaleTaskCount({
@@ -193,24 +195,14 @@ export class MllpStack extends cdk.NestedStack {
       description: "ARN of the MLLP Fargate Service",
     });
 
-    new cdk.CfnOutput(this, "MllpNlbDnsName", {
-      value: nlbA.loadBalancerDnsName,
-      description: "DNS name of the Network Load Balancer for MLLP",
+    new cdk.CfnOutput(this, "MllpNlbInternalIp1", {
+      value: nlbInternalIpAddress1,
+      description: "Internal IP address of the MLLP Network Load Balancer 1",
     });
 
-    new cdk.CfnOutput(this, "MllpNlbDnsNameB", {
-      value: nlbB.loadBalancerDnsName,
-      description: "DNS name of the Network Load Balancer for MLLP B",
-    });
-
-    new cdk.CfnOutput(this, "MllpNlbInternalIpA", {
-      value: nlbInternalIpAddressA,
-      description: "Internal IP address of the MLLP Network Load Balancer A",
-    });
-
-    new cdk.CfnOutput(this, "MllpNlbInternalIpB", {
-      value: nlbInternalIpAddressB,
-      description: "Internal IP address of the MLLP Network Load Balancer B",
+    new cdk.CfnOutput(this, "MllpNlbInternalIp2", {
+      value: nlbInternalIpAddress2,
+      description: "Internal IP address of the MLLP Network Load Balancer 2",
     });
   }
 }


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/3011

### Description

This PR environmentizes the nlb internal ips so we can have unique ips across our VPC. This is important to make test integration. 

### Testing

Branch to staging

### Release Plan

See upstream release plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring two internal IP addresses for the MLLP server, allowing for environment-specific setup.
- **Refactor**
  - Updated configuration and infrastructure to use environment-specific internal IP addresses for improved flexibility and clarity.
  - Streamlined network load balancer setup to use configurable IP addresses instead of hardcoded values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->