### PR TITLE
ENG-415 Cancel ai summary if lambda times out before it starts

### DIFF
--- a/packages/core/src/command/ai-brief/shared.ts
+++ b/packages/core/src/command/ai-brief/shared.ts
@@ -5,7 +5,12 @@ import { isBinary } from "../../external/fhir/shared";
 import { capture, out } from "../../util";
 import { base64ToString, stringToBase64 } from "../../util/base64";
 import { uuidv7 } from "../../util/uuid-v7";
+
 const AI_BRIEF_SOURCE = "metriport:ai-generated-brief";
+
+export type AiBriefControls = {
+  cancelled: boolean;
+};
 
 export function generateAiBriefFhirResource(content: string): Binary {
   const encodedContent = stringToBase64(content);

--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -17,6 +17,7 @@ import { capture, executeAsynchronously, out } from "../../util";
 import { Config } from "../../util/config";
 import { processAsyncError } from "../../util/error/shared";
 import { controlDuration } from "../../util/race-control";
+import { AiBriefControls } from "../ai-brief/shared";
 import { isAiBriefFeatureFlagEnabledForCx } from "../feature-flags/domain-ffs";
 import { getConsolidatedLocation, getConsolidatedSourceLocation } from "./consolidated-shared";
 import { makeIngestConsolidated } from "./search/fhir-resource/ingest-consolidated-factory";
@@ -98,14 +99,19 @@ export async function createConsolidatedFromConversions({
   await dangerouslyDeduplicate({ cxId, patientId, bundle });
   log(`...done, from ${lengthWithDups} to ${bundle.entry?.length} resources`);
 
+  // TODO This whole section with AI-related logic should be moved to the `generateAiBriefBundleEntry`.
   log(`isAiBriefFeatureFlagEnabled: ${isAiBriefFeatureFlagEnabled}`);
   if (isAiBriefFeatureFlagEnabled && bundle.entry && bundle.entry.length > 0) {
+    const aiBriefControls: AiBriefControls = {
+      cancelled: false,
+    };
     const binaryBundleEntry = await Promise.race([
-      generateAiBriefBundleEntry(bundle, cxId, patientId, log),
+      generateAiBriefBundleEntry(bundle, cxId, patientId, log, aiBriefControls),
       controlDuration(AI_BRIEF_TIMEOUT.asMilliseconds(), TIMED_OUT),
     ]);
 
     if (binaryBundleEntry === TIMED_OUT) {
+      aiBriefControls.cancelled = true;
       log(`AI Brief generation timed out after ${AI_BRIEF_TIMEOUT.asMinutes()} minutes`);
       capture.message("AI Brief generation timed out", {
         extra: { cxId, patientId, timeoutMinutes: AI_BRIEF_TIMEOUT.asMinutes() },

--- a/packages/core/src/domain/ai-brief/generate.ts
+++ b/packages/core/src/domain/ai-brief/generate.ts
@@ -4,7 +4,7 @@ import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import { summarizeFilteredBundleWithAI } from "../../command/ai-brief/create";
 import { prepareBundleForAiSummarization } from "../../command/ai-brief/filter";
-import { generateAiBriefFhirResource } from "../../command/ai-brief/shared";
+import { AiBriefControls, generateAiBriefFhirResource } from "../../command/ai-brief/shared";
 import { buildBundleEntry } from "../../external/fhir/shared/bundle";
 import { capture } from "../../util";
 
@@ -17,7 +17,8 @@ export async function generateAiBriefBundleEntry(
   bundle: Bundle<Resource>,
   cxId: string,
   patientId: string,
-  log: typeof console.log
+  log: typeof console.log,
+  aiBriefControls?: AiBriefControls
 ): Promise<BundleEntry<Binary> | undefined> {
   let aiBriefContent;
   let attemptNumber = 1;
@@ -26,8 +27,13 @@ export async function generateAiBriefBundleEntry(
     const filteredBundle = prepareBundleForAiSummarization(bundle, log);
     await executeWithNetworkRetries(
       async () => {
-        log(`Attempt #: ${attemptNumber}`);
-        aiBriefContent = await summarizeFilteredBundleWithAI(cxId, patientId, filteredBundle);
+        log(`generateAiBriefBundleEntry - Attempt #: ${attemptNumber}`);
+        aiBriefContent = await summarizeFilteredBundleWithAI(
+          cxId,
+          patientId,
+          filteredBundle,
+          aiBriefControls
+        );
         attemptNumber++;
       },
       {


### PR DESCRIPTION
### Dependencies

none

### Description

Cancel ai summary if lambda times out before it starts.

### Testing

- Local
  - [x] AI Summary gets generated and stored properly
  - [x] AI Summary doesn't get generated if the process times out before it gets sent to Bedrock
- Staging
  - [ ] AI Summary gets generated and stored properly
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to cancel AI brief generation, improving control over long-running operations.

- **Improvements**
  - Enhanced performance of AI brief generation by processing certain steps concurrently, resulting in faster summary creation.
  - Added internal timing for key steps to support future diagnostics (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->