### PR TITLE
PATCH RELEASE ENG-422 Minimize hits to FHIR DB upon CQ DQ

### DIFF
--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -2,6 +2,7 @@ import { isCQDirectEnabledForCx } from "@metriport/core/command/feature-flags/do
 import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
 import { cqExtension } from "@metriport/core/external/carequality/extension";
 import { OutboundDocQueryRespParam } from "@metriport/core/external/carequality/ihe-gateway/outbound-result-poller-direct";
+import { getDocuments } from "@metriport/core/external/fhir/document/get-documents";
 import { MedicalDataSource } from "@metriport/core/external/index";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { errorToString } from "@metriport/core/util/error/shared";
@@ -243,6 +244,8 @@ async function getRespWithDocsToDownload({
   const respWithDocsToDownload: DqRespWithDocRefsWithMetriportId[] = [];
   const seenMetriportIds = new Set<string>();
 
+  const fhirDocRefs = await getDocuments({ cxId, patientId });
+
   await executeAsynchronously(
     response,
     async gwResp => {
@@ -264,7 +267,8 @@ async function getRespWithDocsToDownload({
       const docsToDownload = await getNonExistentDocRefs(
         deduplicatedDocRefsWithMetriportId,
         patientId,
-        cxId
+        cxId,
+        fhirDocRefs
       );
 
       if (docsToDownload.length === 0) {


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-422

### Dependencies

none

### Description

Minimize hits to FHIR DB upon CQ DQ.

### Testing

none

### Release Plan

- ⚠️  This is pointing to `master`/`production`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy in identifying which document references need to be downloaded by considering existing FHIR documents during the process. This helps prevent unnecessary downloads and ensures up-to-date document management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->