### PR TITLE
Eng 403 update ingestion lambda size

### DIFF
--- a/packages/infra/lib/lambdas-nested-stack-settings.ts
+++ b/packages/infra/lib/lambdas-nested-stack-settings.ts
@@ -1,8 +1,10 @@
 import { Duration } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 
+// Single timeout for both lambdas b/c ingestion needs more time, and currently search might also ingest
+const lambdaTimeout = Duration.minutes(15).minus(Duration.seconds(5));
+
 export function getConsolidatedIngestionConnectorSettings() {
-  const lambdaTimeout = Duration.minutes(15).minus(Duration.seconds(5));
   return {
     name: "ConsolidatedIngestion",
     queue: {
@@ -16,7 +18,7 @@ export function getConsolidatedIngestionConnectorSettings() {
     },
     lambda: {
       runtime: lambda.Runtime.NODEJS_20_X,
-      memory: 2048,
+      memory: 4096,
       timeout: lambdaTimeout,
     },
     eventSource: {
@@ -24,6 +26,17 @@ export function getConsolidatedIngestionConnectorSettings() {
       maxConcurrency: 5, // how many lambdas can hit the OpenSearch service at once
       // Partial batch response: https://docs.aws.amazon.com/prescriptive-guidance/latest/lambda-event-filtering-partial-batch-responses-for-sqs/welcome.html
       reportBatchItemFailures: false,
+    },
+  };
+}
+
+export function getConsolidatedSearchConnectorSettings() {
+  return {
+    name: "ConsolidatedSearch",
+    lambda: {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      memory: 4096,
+      timeout: lambdaTimeout,
     },
   };
 }


### PR DESCRIPTION
### Dependencies

none

### Description

- Don't hydrate reverse-hydrated resources
   - search > for Meds, reverse hydrate to get the Medication* resources that point to it (e.g., MedicationAdministration, MedicationStatement)
   - until now, we'd hydrate that last level of resources, this removes that step
   - this means, before, hit OS:
      1. to search
      1. then to hydrate that search - resources referenced by (1)
      2. then to reverse hydrate any medication we have from (1) + (2)
      3. then to hydrate resources referenced by (4) that haven't been queried yet
   - now, hit OS:
      1. to search
      1. then to hydrate that search - resources referenced by (1)
      2. then to reverse hydrate any medication we have from (1) + (2)
      3. ~~then to hydrate resources referenced by (4) that haven't been queried yet~~
- Update ingestion lambda size - [context1](https://metriport.slack.com/archives/C04T256DQPQ/p1749350546335869), [context2](https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252FConsolidatedIngestionLambda/log-events$3FfilterPattern$3D$252268be8e98-5617-5e38-a932-ee26aa9d0647$2522$26start$3D1749350400000$26end$3D1749351120000)

### Testing

- Local
  - [ ] regular resources are returned, like Condition
  - [ ] medication is returned when medication* related is found
  - [ ] medication* related is returned when medicationis found
- Staging
  - [ ] regular resources are returned, like Condition
  - [ ] medication is returned when medication* related is found
  - [ ] medication* related is returned when medicationis found
  - [ ] ingestion lambda's memory is increased to 4GB
- Sandbox
  - [ ] ingestion lambda's memory is increased to 4GB
- Production
  - [ ] ingestion lambda's memory is increased to 4GB

### Release Plan

- [ ] Merge this
