### PR TITLE
ENG-430 Fix org internal endpoints

### DIFF
--- a/packages/api/src/routes/medical/schemas/organization.ts
+++ b/packages/api/src/routes/medical/schemas/organization.ts
@@ -14,12 +14,12 @@ export const organizationCreateSchema = z.object({
 
 export const organizationUpdateSchema = organizationCreateSchema;
 
-export const organiationInternalDetailsSchema = z
+export const organizationInternalDetailsSchema = z
   .object({
     id: z.string().optional(),
-    nameInMetriport: z.string().min(1),
     businessType: organizationBizTypeSchema,
     type: orgTypeSchema,
+    location: addressStrictSchema,
     shortcode: z.string().optional(),
     // CQ
     cqApproved: z.boolean().optional(),
@@ -28,4 +28,13 @@ export const organiationInternalDetailsSchema = z
     cwApproved: z.boolean().optional(),
     cwActive: z.boolean().optional(),
   })
-  .merge(addressStrictSchema);
+  .and(
+    z.union([
+      z.object({
+        nameInMetriport: z.string().min(1),
+      }),
+      z.object({
+        name: z.string().min(1),
+      }),
+    ])
+  );

--- a/packages/core/src/external/aws/s3.ts
+++ b/packages/core/src/external/aws/s3.ts
@@ -619,6 +619,7 @@ export function isNotFoundError(error: any): boolean {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isRetriableError(error: any): boolean {
+  if (error.message && ["EPIPE", "ECONNRESET"].includes(error.message)) return true;
   return error.retryable === false || error.Retryable === false;
 }
 

--- a/packages/core/src/external/aws/s3.ts
+++ b/packages/core/src/external/aws/s3.ts
@@ -619,7 +619,13 @@ export function isNotFoundError(error: any): boolean {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isRetriableError(error: any): boolean {
-  if (error.message && ["EPIPE", "ECONNRESET"].includes(error.message)) return true;
+  const errorsToRetry = ["EPIPE", "ECONNRESET"];
+  if (
+    (typeof error.code === "string" && errorsToRetry.includes(error.code)) ||
+    (typeof error.message === "string" && errorsToRetry.some(code => error.message.includes(code)))
+  ) {
+    return true;
+  }
   return error.retryable === true || error.Retryable === true;
 }
 

--- a/packages/core/src/external/aws/s3.ts
+++ b/packages/core/src/external/aws/s3.ts
@@ -620,7 +620,7 @@ export function isNotFoundError(error: any): boolean {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isRetriableError(error: any): boolean {
   if (error.message && ["EPIPE", "ECONNRESET"].includes(error.message)) return true;
-  return error.retryable === false || error.Retryable === false;
+  return error.retryable === true || error.Retryable === true;
 }
 
 export async function storeInS3WithRetries({

--- a/packages/shared/src/error/shared.ts
+++ b/packages/shared/src/error/shared.ts
@@ -12,6 +12,7 @@ export function errorToString(
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function genericErrorToString(err: any): string {
+  if (typeof err !== "object" || err == null) return String(err);
   const msg = "message" in err ? err.message : String(err);
   const code = "code" in err ? err.code : undefined;
   const status = "response" in err ? err.response.status : undefined;

--- a/packages/shared/src/net/error.ts
+++ b/packages/shared/src/net/error.ts
@@ -24,7 +24,11 @@ export type AxiosTimeoutError = (typeof axiosTimeoutErrorCodes)[number];
 export const axiosResponseErrorCodes = [AxiosError.ERR_BAD_RESPONSE] as const;
 export type AxiosResponseError = (typeof axiosResponseErrorCodes)[number];
 
-export const axiosNetworkErrors = [...axiosResponseErrorCodes, ...axiosTimeoutErrorCodes] as const;
+export const axiosNetworkErrors = [
+  AxiosError.ERR_NETWORK,
+  ...axiosResponseErrorCodes,
+  ...axiosTimeoutErrorCodes,
+] as const;
 export type AxiosNetworkError = (typeof axiosNetworkErrors)[number];
 
 // General Network errors


### PR DESCRIPTION
### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/3026

### Description

From ticket:
- Input payload on internal `PUT /internal/organization` matches response's 

From local tests:
- `executeWithRetriesS3` retries on network errors 
- `executeWithNetworkRetries` includes Axios' `ERR_NETWORK `
- `errorToString` don't error when cause is number 

### Testing

- Local
  - [x] Load Org on internal endpoint shows shortcode
  - [x] Send output of GET internal endpoint to PUT and it works (subsequent GET returns data sent to PUT)
  - [x] OpsDash loads org's data
  - [x] OpsDash updates org's data
- Staging
  - [ ] Load Org on internal endpoint shows shortcode
  - [ ] Send output of GET internal endpoint to PUT and it works (subsequent GET returns data sent to PUT)
  - [ ] OpsDash loads org's data
  - [ ] OpsDash updates org's data
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
- [ ] Merge downstream


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for AWS S3 operations and generic error conversion, ensuring more robust and accurate error reporting.
	- Enhanced network error recognition for Axios, increasing reliability in network failure scenarios.

- **New Features**
	- Updated organization validation to require either a name or an alternate name, providing greater flexibility when submitting organization details.

- **Refactor**
	- Simplified and clarified internal organization data handling for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->