### PR TITLE
feat(api): add patient_id index to patient_settings table

### DIFF
--- a/packages/api/src/sequelize/migrations/2025-06-09_00_add-patient-settings-patient-id-index.ts
+++ b/packages/api/src/sequelize/migrations/2025-06-09_00_add-patient-settings-patient-id-index.ts
@@ -1,0 +1,16 @@
+import type { Migration } from "..";
+
+const tableName = "patient_settings";
+const indexName = "idx_patient_settings_patient_id";
+const fieldName = "patient_id";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addIndex(tableName, {
+    name: indexName,
+    fields: [fieldName],
+  });
+};
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeIndex(tableName, indexName);
+};


### PR DESCRIPTION
Issues:
- https://linear.app/metriport/issue/ENG-395

### Dependencies

None

### Description

There was no index on the patient_id column, and we're not querying by cx_id so the (cx_id, patient_id) compound index was not getting hit so the full scans that were happening were absurdly slow (5m+) when querying /internal/patient/hl7v2-subscribers/.

### Testing

`npx ts-node src/sequelize/cli.ts up` runs my migration successfully and i see the index in my db.

### Release Plan

- [ ] Merge this