### PR TITLE
ENG-418 chore(release): publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28547,7 +28547,7 @@
       }
     },
     "packages/api": {
-      "version": "1.27.8-alpha.0",
+      "version": "1.27.8",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.800.0",
@@ -28631,12 +28631,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "15.0.5-alpha.0",
+      "version": "15.0.5",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.9.8-alpha.0",
-        "@metriport/shared": "^0.23.8-alpha.0",
+        "@metriport/commonwell-sdk": "^5.9.8",
+        "@metriport/shared": "^0.23.8",
         "axios": "^1.8.2",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28693,11 +28693,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.18.8-alpha.0",
+      "version": "1.18.8",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.19.8-alpha.0",
-        "@metriport/shared": "^0.23.8-alpha.0"
+        "@metriport/ihe-gateway-sdk": "^0.19.8",
+        "@metriport/shared": "^0.23.8"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -28705,7 +28705,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.6.8-alpha.0",
+      "version": "1.6.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -28729,10 +28729,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.26.10-alpha.0",
+      "version": "1.26.10",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.9.8-alpha.0",
+        "@metriport/commonwell-sdk": "^5.9.8",
         "axios": "^1.8.2",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -28771,10 +28771,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.24.10-alpha.0",
+      "version": "1.24.10",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.9.8-alpha.0",
+        "@metriport/commonwell-sdk": "^5.9.8",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -28806,10 +28806,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.9.8-alpha.0",
+      "version": "5.9.8",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.23.8-alpha.0",
+        "@metriport/shared": "^0.23.8",
         "axios": "^1.8.2",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -28857,7 +28857,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.24.8-alpha.0",
+      "version": "1.24.8",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -29200,17 +29200,17 @@
     "packages/core/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.19.8-alpha.0",
+      "version": "0.19.8",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.23.8-alpha.0",
+        "@metriport/shared": "^0.23.8",
         "axios": "^1.8.2",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.22.8-alpha.0",
+      "version": "1.22.8",
       "dependencies": {
         "@metriport/core": "file:packages/core",
         "@metriport/shared": "file:packages/shared",
@@ -29269,7 +29269,7 @@
     "packages/infra/packages/core": {},
     "packages/infra/packages/shared": {},
     "packages/mllp-server": {
-      "version": "0.3.8-alpha.0",
+      "version": "0.3.8",
       "license": "ISC",
       "dependencies": {
         "@medplum/core": "^3.2.33",
@@ -29425,7 +29425,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.23.8-alpha.0",
+      "version": "0.23.8",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -29474,7 +29474,7 @@
       }
     },
     "packages/utils": {
-      "version": "1.25.8-alpha.0",
+      "version": "1.25.8",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.800.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "15.0.5-alpha.0",
+  "version": "15.0.5",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.9.8-alpha.0",
-    "@metriport/shared": "^0.23.8-alpha.0",
+    "@metriport/commonwell-sdk": "^5.9.8",
+    "@metriport/shared": "^0.23.8",
     "axios": "^1.8.2",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.27.8-alpha.0",
+  "version": "1.27.8",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.18.8-alpha.0",
+  "version": "1.18.8",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.19.8-alpha.0",
-    "@metriport/shared": "^0.23.8-alpha.0"
+    "@metriport/ihe-gateway-sdk": "^0.19.8",
+    "@metriport/shared": "^0.23.8"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.6.8-alpha.0",
+  "version": "1.6.8",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.26.10-alpha.0",
+  "version": "1.26.10",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.9.8-alpha.0",
+    "@metriport/commonwell-sdk": "^5.9.8",
     "axios": "^1.8.2",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.24.10-alpha.0",
+  "version": "1.24.10",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.9.8-alpha.0",
+    "@metriport/commonwell-sdk": "^5.9.8",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.9.8-alpha.0",
+  "version": "5.9.8",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.23.8-alpha.0",
+    "@metriport/shared": "^0.23.8",
     "axios": "^1.8.2",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.24.8-alpha.0",
+  "version": "1.24.8",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.19.8-alpha.0",
+  "version": "0.19.8",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.23.8-alpha.0",
+    "@metriport/shared": "^0.23.8",
     "axios": "^1.8.2",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.22.8-alpha.0",
+  "version": "1.22.8",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mllp-server",
-  "version": "0.3.8-alpha.0",
+  "version": "0.3.8",
   "description": "MLLP server that reads HL7 messages off of a raw tcp connection",
   "main": "app.js",
   "private": true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.23.8-alpha.0",
+  "version": "0.23.8",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.25.8-alpha.0",
+  "version": "1.25.8",
   "description": "",
   "private": true,
   "scripts": {


### PR DESCRIPTION
### Dependencies

- upstream: https://github.com/metriport/metriport/pull/3969


### Description

Ref: #000

 - api@1.27.8
 - @metriport/api-sdk@15.0.5
 - @metriport/carequality-cert-runner@1.18.8
 - @metriport/carequality-sdk@1.6.8
 - @metriport/commonwell-cert-runner@1.26.10
 - @metriport/commonwell-jwt-maker@1.24.10
 - @metriport/commonwell-sdk@5.9.8
 - @metriport/core@1.24.8
 - @metriport/ihe-gateway-sdk@0.19.8
 - infrastructure@1.22.8
 - mllp-server@0.3.8
 - @metriport/shared@0.23.8
 - utils@1.25.8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated multiple packages from pre-release (alpha) versions to stable release versions.
  - Updated internal dependencies to use stable versions across all affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->