### PR TITLE
ENG-403 HydrateMissingReferences actually ignore ids to exclude

### DIFF
--- a/packages/core/src/command/consolidated/search/fhir-resource/search-consolidated.ts
+++ b/packages/core/src/command/consolidated/search/fhir-resource/search-consolidated.ts
@@ -309,21 +309,17 @@ export async function hydrateMissingReferences({
     }
   });
 
-  const missingRefIds = resourcesToHydrate.flatMap(r => {
-    const referenceId = r.id;
-    if (!referenceId || referenceId === patientId) return [];
-    return getEntryId(cxId, patientId, referenceId);
-  });
-  if (missingRefIds.length < 1) return resources;
-
+  const missingRefIds = resourcesToHydrate.flatMap(r => r.id);
   const uniqueIds = uniq(missingRefIds);
   const filteredUniqueIds = uniqueIds.filter(uniqueId => !idsToExclude.includes(uniqueId));
+  const filteredUniqueEntryIds = filteredUniqueIds.map(id => getEntryId(cxId, patientId, id));
+  if (filteredUniqueEntryIds.length < 1) return resources;
 
   const searchService = new OpenSearchFhirSearcher(getConfigs());
   const openSearchResults = await searchService.getByIds({
     cxId,
     patientId,
-    ids: filteredUniqueIds,
+    ids: filteredUniqueEntryIds,
   });
   if (!openSearchResults || openSearchResults.length < 1) {
     log(`No results found for (count=${missingRefIds.length}) ${missingRefIds.join(", ")}`);


### PR DESCRIPTION
### Dependencies

none

### Description

HydrateMissingReferences actually ignore ids to exclude

### Testing

- Local
  - [x] unit tests
- Staging
  - [ ] search: hydration works (med related to med)
  - [ ] search: reverse hydration works (med to med related)
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new tests to ensure resources specified in an exclusion list are not hydrated, even if missing, and that excluded IDs are properly respected during hydration scenarios.

- **Bug Fixes**
  - Improved the handling of resource IDs during hydration to ensure excluded IDs are filtered out before processing, preventing unnecessary lookups and streamlining the hydration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->