### PR TITLE
feat(cq): moving the lambdas to ro creds

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -415,7 +415,7 @@ export class APIStack extends Stack {
       vpc: this.vpc,
       lambdaLayers,
       dbCluster,
-      dbCredsSecret,
+      roDbSecrets,
       secrets,
       medicalDocumentsBucket,
       sandboxSeedDataBucket,

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -148,9 +148,9 @@ export function createAPIService({
   fhirConverterServiceUrl: string | undefined;
   cdaToVisualizationLambda: ILambda;
   documentDownloaderLambda: ILambda;
-  outboundPatientDiscoveryLambda: ILambda;
-  outboundDocumentQueryLambda: ILambda;
-  outboundDocumentRetrievalLambda: ILambda;
+  outboundPatientDiscoveryLambda: ILambda | undefined;
+  outboundDocumentQueryLambda: ILambda | undefined;
+  outboundDocumentRetrievalLambda: ILambda | undefined;
   patientImportParseLambda: ILambda;
   patientImportResultLambda: ILambda;
   patientImportBucket: s3.IBucket;
@@ -286,9 +286,15 @@ export function createAPIService({
           PROPELAUTH_PUBLIC_KEY: props.config.propelAuth.publicKey,
           CONVERT_DOC_LAMBDA_NAME: cdaToVisualizationLambda.functionName,
           DOCUMENT_DOWNLOADER_LAMBDA_NAME: documentDownloaderLambda.functionName,
-          OUTBOUND_PATIENT_DISCOVERY_LAMBDA_NAME: outboundPatientDiscoveryLambda.functionName,
-          OUTBOUND_DOC_QUERY_LAMBDA_NAME: outboundDocumentQueryLambda.functionName,
-          OUTBOUND_DOC_RETRIEVAL_LAMBDA_NAME: outboundDocumentRetrievalLambda.functionName,
+          ...(outboundPatientDiscoveryLambda && {
+            OUTBOUND_PATIENT_DISCOVERY_LAMBDA_NAME: outboundPatientDiscoveryLambda.functionName,
+          }),
+          ...(outboundDocumentQueryLambda && {
+            OUTBOUND_DOC_QUERY_LAMBDA_NAME: outboundDocumentQueryLambda.functionName,
+          }),
+          ...(outboundDocumentRetrievalLambda && {
+            OUTBOUND_DOC_RETRIEVAL_LAMBDA_NAME: outboundDocumentRetrievalLambda.functionName,
+          }),
           PATIENT_IMPORT_BUCKET_NAME: patientImportBucket.bucketName,
           PATIENT_IMPORT_PARSE_LAMBDA_NAME: patientImportParseLambda.functionName,
           PATIENT_IMPORT_RESULT_LAMBDA_NAME: patientImportResultLambda.functionName,
@@ -440,9 +446,9 @@ export function createAPIService({
 
   cdaToVisualizationLambda.grantInvoke(fargateService.taskDefinition.taskRole);
   documentDownloaderLambda.grantInvoke(fargateService.taskDefinition.taskRole);
-  outboundPatientDiscoveryLambda.grantInvoke(fargateService.taskDefinition.taskRole);
-  outboundDocumentQueryLambda.grantInvoke(fargateService.taskDefinition.taskRole);
-  outboundDocumentRetrievalLambda.grantInvoke(fargateService.taskDefinition.taskRole);
+  outboundPatientDiscoveryLambda?.grantInvoke(fargateService.taskDefinition.taskRole);
+  outboundDocumentQueryLambda?.grantInvoke(fargateService.taskDefinition.taskRole);
+  outboundDocumentRetrievalLambda?.grantInvoke(fargateService.taskDefinition.taskRole);
   patientImportParseLambda.grantInvoke(fargateService.taskDefinition.taskRole);
   patientImportResultLambda.grantInvoke(fargateService.taskDefinition.taskRole);
   fhirToCdaConverterLambda?.grantInvoke(fargateService.taskDefinition.taskRole);


### PR DESCRIPTION
Ref: ENG-235

Issues:

- https://linear.app/metriport/issue/ENG-235

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/3954

### Description

- moving the ihe polling lambdas to the new creds

### Testing

- Local
  - [ ] N/A
- Staging
  - [ ] PD / DQ / DR lambdas use ro DB
- Sandbox
  - [ ] No errors after removing the lambdas
- Production
  - [ ] PD / DQ / DR lambdas use ro DB

### Release Plan

- [ ] Upstream dependencies are met/released
- [ ] Merge this
