### PR TITLE
feat(cq): patch calling handlers

### DIFF
--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -36,7 +36,6 @@ import {
 } from "./shared";
 
 const parallelUpsertsToFhir = 10;
-const resultPoller = makeOutboundResultPoller();
 
 export async function processOutboundDocumentQueryResps({
   requestId,
@@ -45,6 +44,8 @@ export async function processOutboundDocumentQueryResps({
   response,
 }: OutboundDocQueryRespParam): Promise<void> {
   const { log } = out(`CQ DR - requestId ${requestId}, patient ${patientId}`);
+
+  const resultPoller = makeOutboundResultPoller();
 
   const interrupt = buildInterrupt({ requestId, patientId, cxId, log });
   if (!resultPoller.isDREnabled()) return interrupt(`IHE DR result poller not available`);

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -27,8 +27,6 @@ import { filterCqLinksByManagingOrg } from "./filter-oids-by-managing-org";
 
 const staleLookbackHours = 24;
 
-const resultPoller = makeOutboundResultPoller();
-
 export async function getDocumentsFromCQ({
   requestId,
   facilityId,
@@ -56,6 +54,8 @@ export async function getDocumentsFromCQ({
   });
 
   const isCqQueryEnabled = await isFacilityEnabledToQueryCQ(facilityId, { id: patientId, cxId });
+
+  const resultPoller = makeOutboundResultPoller();
 
   if (!resultPoller.isDQEnabled()) return interrupt(`IHE DQ result poller not available`);
   if (!(await isCQDirectEnabledForCx(cxId))) return interrupt(`CQ disabled for cx ${cxId}`);

--- a/packages/api/src/external/carequality/patient.ts
+++ b/packages/api/src/external/carequality/patient.ts
@@ -24,7 +24,6 @@ import { getCqInitiator, isCqEnabled } from "./shared";
 dayjs.extend(duration);
 
 const context = "cq.patient.discover";
-const resultPoller = makeOutboundResultPoller();
 
 export async function discover({
   patient,
@@ -96,6 +95,8 @@ async function prepareAndTriggerPD({
         cxId: patient.cxId,
       });
     }
+
+    const resultPoller = makeOutboundResultPoller();
 
     await resultPoller.pollOutboundPatientDiscoveryResults({
       requestId: pdRequestGatewayV2.id,

--- a/packages/api/src/external/carequality/process-subsequent-outbound-patient-discovery-resps.ts
+++ b/packages/api/src/external/carequality/process-subsequent-outbound-patient-discovery-resps.ts
@@ -11,7 +11,6 @@ import { getPatientOrFail } from "../../command/medical/patient/get-patient";
 dayjs.extend(duration);
 
 const context = "cq.patient.post-response.discover";
-const resultPoller = makeOutboundResultPoller();
 const MAX_SAFE_GWS = 100000;
 
 export async function processPostRespOutboundPatientDiscoveryResps({
@@ -34,6 +33,8 @@ export async function processPostRespOutboundPatientDiscoveryResps({
       log(`Kicking off post resp patient discovery`);
       // TODO Internal #1832 (rework)
       await updatePatientDiscoveryStatus({ patient, status: "processing" });
+
+      const resultPoller = makeOutboundResultPoller();
 
       await resultPoller.pollOutboundPatientDiscoveryResults({
         requestId: requestId,


### PR DESCRIPTION
Ref: ENG-235

Issues:

- https://linear.app/metriport/issue/ENG-235

### Description

- initialize pollers when they're used

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved reliability by ensuring that certain background processes are now initialized separately for each request, rather than being shared across requests. This enhances the isolation and consistency of operations for document and patient discovery queries. No changes to user-facing features or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->