### PR TITLE
ENG-454 Custodian on XCPD doesn't have assignedCustodian

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/create/xcpd-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/inbound/xcpd/create/xcpd-response.ts
@@ -153,9 +153,6 @@ function createSubjectAndRegistrationEvent(response: InboundPatientDiscoveryResp
       },
       custodian: {
         "@_typeCode": "CST",
-        assignedCustodian: {
-          "@_typeCode": "CST",
-        },
         assignedEntity: {
           "@_classCode": "ASSIGNED",
           id: {


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4012
- Downstream: none

### Description

Custodian on XCPD doesn't have assignedCustodian

### Testing

none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the structure of custodian information in responses for improved clarity. No changes to visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->