### PR TITLE
ENG-441 Set a special error msg on inbound parsing error 

### DIFF
--- a/packages/core/src/shareback/metadata/parse-metadata-xml.ts
+++ b/packages/core/src/shareback/metadata/parse-metadata-xml.ts
@@ -26,11 +26,14 @@ interface ExtrinsicObjectXMLData {
   };
 }
 
-export async function parseExtrinsicObjectXmlToDocumentReference(
-  xml: string,
-  patientId: string
-): Promise<DocumentReference> {
-  const parsedXml: ExtrinsicObjectXMLData = await parseStringPromise(xml);
+export async function parseExtrinsicObjectXmlToDocumentReference({
+  patientId,
+  xmlContents,
+}: {
+  patientId: string;
+  xmlContents: string;
+}): Promise<DocumentReference> {
+  const parsedXml: ExtrinsicObjectXMLData = await parseStringPromise(xmlContents);
   const extrinsicObject = parsedXml.ExtrinsicObject;
 
   const docRefContent: DocumentReferenceContent = {


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-441

### Dependencies

none

### Description

Set a special error msg on inbound parsing error - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1749779937454419?thread_ts=1744022437.986899&cid=C04T256DQPQ).

### Testing

- [ ] Monitor inbound for a while (`Begins GET /oauth/fhir/DocumentReference`)

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
