### PR TITLE
feat(core): use adt sourced data in consolidated generation

### DIFF
--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -21,6 +21,7 @@ import { AiBriefControls } from "../ai-brief/shared";
 import { isAiBriefFeatureFlagEnabledForCx } from "../feature-flags/domain-ffs";
 import { getConsolidatedLocation, getConsolidatedSourceLocation } from "./consolidated-shared";
 import { makeIngestConsolidated } from "./search/fhir-resource/ingest-consolidated-factory";
+import { getAllAdtSourcedEncounters } from "../../external/fhir/adt-encounters";
 
 dayjs.extend(duration);
 
@@ -59,16 +60,23 @@ export async function createConsolidatedFromConversions({
   const fhirPatient = patientToFhir(patient);
   const patientEntry = buildBundleEntry(fhirPatient);
 
-  const [conversions, docRefs, isAiBriefFeatureFlagEnabled] = await Promise.all([
-    getConversions({ cxId, patient, sourceBucketName }),
-    getDocumentReferences({ cxId, patientId }),
-    isAiBriefFeatureFlagEnabledForCx(cxId),
-  ]);
-  log(`Got ${conversions.length} resources from conversions`);
+  const [cdaConversions, adtSourcedEncounters, docRefs, isAiBriefFeatureFlagEnabled] =
+    await Promise.all([
+      getConversions({ cxId, patient, sourceBucketName }),
+      getAllAdtSourcedEncounters({ cxId, patientId }),
+      getDocumentReferences({ cxId, patientId }),
+      isAiBriefFeatureFlagEnabledForCx(cxId),
+    ]);
+  log(`Got ${cdaConversions.length} resources from cdaConversions`);
 
   const bundle = buildCollectionBundle();
   const docRefsWithUpdatedMeta = insertSourceDocumentToAllDocRefMeta(docRefs);
-  bundle.entry = [...conversions, ...docRefsWithUpdatedMeta.map(buildBundleEntry), patientEntry];
+  bundle.entry = [
+    ...cdaConversions,
+    ...adtSourcedEncounters,
+    ...docRefsWithUpdatedMeta.map(buildBundleEntry),
+    patientEntry,
+  ];
   bundle.total = bundle.entry.length;
   log(
     `Added ${docRefsWithUpdatedMeta.length} docRefs and the Patient, to a total of ${bundle.entry.length} entries`

--- a/packages/core/src/external/fhir/adt-encounters.ts
+++ b/packages/core/src/external/fhir/adt-encounters.ts
@@ -1,5 +1,6 @@
 import { Bundle, Resource } from "@medplum/fhirtypes";
 import { MetriportError } from "@metriport/shared";
+import { compact } from "lodash";
 import { out } from "../../util";
 import { Config } from "../../util/config";
 import { HL7_FILE_EXTENSION, JSON_FILE_EXTENSION } from "../../util/mime";
@@ -7,6 +8,18 @@ import { S3Utils } from "../aws/s3";
 import { mergeBundles } from "./bundle/utils";
 
 const s3Utils = new S3Utils(Config.getAWSRegion());
+
+export function createCxIdPtIdPrefix({ cxId, patientId }: { cxId: string; patientId: string }) {
+  return `cxId=${cxId}/ptId=${patientId}`;
+}
+
+export function getEncounterIdFromFileKey(key: string) {
+  const encounterId = key.split("/")[3];
+  if (!encounterId) {
+    throw new MetriportError("Encounter ID not found in file key", undefined, { key });
+  }
+  return encounterId;
+}
 
 export function createPrefixAdtEncounter({
   cxId,
@@ -17,7 +30,7 @@ export function createPrefixAdtEncounter({
   patientId: string;
   encounterId: string;
 }) {
-  return `cxId=${cxId}/ptId=${patientId}/ADT/${encounterId}`;
+  return `${createCxIdPtIdPrefix({ cxId, patientId })}/ADT/${encounterId}`;
 }
 
 /**
@@ -183,6 +196,40 @@ export async function getAdtSourcedEncounter({
   log(`Found ADT encounter in S3 bucket: ${s3BucketName} at key: ${fileKey}`);
 
   return JSON.parse(fileData.toString());
+}
+
+/**
+ * Retrieves all ADT-sourced encounters for a patient
+ *
+ * @param cxId Customer ID
+ * @param patientId Patient ID
+ * @returns The encounter data as a parsed JSON object
+ */
+export async function getAllAdtSourcedEncounters({
+  cxId,
+  patientId,
+}: {
+  cxId: string;
+  patientId: string;
+}): Promise<Bundle<Resource>[]> {
+  const { log } = out(`getAllAdtSourcedEncounters - cx: ${cxId}, pt: ${patientId}`);
+  const s3BucketName = Config.getHl7ConversionBucketName();
+  const getEncounter = (encounterId: string) =>
+    getAdtSourcedEncounter({ cxId, patientId, encounterId });
+
+  const encounters = await s3Utils.listObjects(
+    s3BucketName,
+    createCxIdPtIdPrefix({ cxId, patientId })
+  );
+
+  const encounterKeys = encounters.flatMap(encounter => encounter.Key ?? []);
+
+  const encounterBundles = await Promise.all(
+    encounterKeys.map(getEncounterIdFromFileKey).map(getEncounter)
+  );
+  log(`Found ${compact(encounterBundles).length} encounters`);
+
+  return compact(encounterBundles);
 }
 
 /**


### PR DESCRIPTION
- https://linear.app/metriport/issue/ENG-258

### Dependencies

None

### Description

Add ADT data source bundle in consolidated

### Testing

TODO

- Local
  - [ ] _[Indicate how you tested this, on local or staging]_
  - [ ] ...
- Staging
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Sandbox
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Production
  - [ ] _testing step 1_
  - [ ] _testing step 2_

_[Release PRs:]_

Check each PR.

### Release Plan

_[How does the changes on this PR impact/interact with the existing environment (database, configs, secrets, FFs, api contracts, etc.)?
Consider creating 2+ PRs if we need to ship those changes in a staged way]_

_[This is the release plan for production]_

_[You should execute the exact same steps when releasing to staging to validate it works]_

_[Add and remove items below accordingly]_

- :warning: Points to `master`
- :warning: This contains a DB migration
- [ ] Maintenance window scheduled/created at Checkly (if needed)
- [ ] Execute this on <env1>, <env2>
  - [ ] _step1_
  - [ ] _step2_
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (deprecates a feature that needs to be communicated with customers)
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (introduce a feature that would be useful customers)
- [ ] Upstream dependencies are met/released
- [ ] Release NPM packages
- [ ] Fern Definition Updated
- [ ] Release Fern SDKs
- [ ] FFs have been set in Staging, Production, and Sandbox
- [ ] Happy-path E2E test created checking new FF flow
- [ ] No dependencies between API and Infra that will cause errors during deployment
- [ ] _[action n-1]_
- [ ] _[action n]_
- [ ] Merge this
