### PR TITLE
PATCH ENG-466 revert DR logs + update epic page size

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
@@ -48,7 +48,7 @@ export function doesGatewayUseSha1(oid: string): boolean {
 const gatewaysThatAcceptOneDocRefPerRequest = [pointClickCareOid, surescriptsOid];
 
 const prefixDocRefsPerRequest: Record<string, number> = {
-  [epicOidPrefix]: 10,
+  [epicOidPrefix]: 9,
   [redoxOidPrefix]: 1,
   [ntstPrefix]: 1,
 };

--- a/packages/core/src/external/carequality/ihe-gateway-v2/monitor/store.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/monitor/store.ts
@@ -121,14 +121,12 @@ export async function storeDrResponse({
       timestamp,
       requestChunkId,
     });
-    log(`Storing DR response to ${key}`);
-    const resp = await s3Utils.uploadFile({
+    await s3Utils.uploadFile({
       bucket: bucketOutbound,
       key,
       file: response,
       contentType: "application/xml",
     });
-    log(`DR response metadata: ${JSON.stringify(resp)}`);
   } catch (error) {
     log(`Error storing DR response: ${error}`);
   }

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/error.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/error.ts
@@ -201,8 +201,7 @@ export function isRetryable(
   outboundResponse: OutboundDocumentRetrievalResp | OutboundDocumentQueryResp | undefined
 ): boolean {
   if (!outboundResponse) return false;
-
-  const isRetryableResponse =
+  return (
     outboundResponse.operationOutcome?.issue.some(
       issue =>
         issue.severity === "error" &&
@@ -211,11 +210,6 @@ export function isRetryable(
         !knownNonRetryableErrors.some(nonRetryableError =>
           issue.details.text?.includes(nonRetryableError)
         )
-    ) ?? false;
-
-  if (isRetryableResponse && "document" in outboundResponse) {
-    log(`Document retrieval response that will be retried: ${JSON.stringify(outboundResponse)}`);
-  }
-
-  return isRetryableResponse;
+    ) ?? false
+  );
 }

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/send/dr-requests.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/send/dr-requests.ts
@@ -48,7 +48,6 @@ export async function sendSignedDrRequest({
       gateway: request.gateway,
       requestChunkId: request.outboundRequest.requestChunkId,
     });
-    console.log({ mtomParts: JSON.stringify(mtomParts) });
     return {
       gateway: request.gateway,
       mtomResponse: mtomParts,


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-466

### Dependencies

None

### Description

Albany med health requests were failing because they require 9 docs per request max, instead of 10. Reducing the number to minimize the chance of this happening in prod in the future.

### Testing

None :)

### Release Plan

- :warning: Points to `master`
- [x] Merge this
- [ ] Refresh patient consolidated and see if docs appear


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the clarity and separation of retry logic for outbound responses, with no change to user-facing behavior.
  - Removed several internal logging statements to streamline operations without impacting functionality.
  - Adjusted the default limit for document references per request in specific gateway connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->