### PR TITLE
ENG-36 Expose pt bulk import on ops-dash

### DIFF
--- a/packages/api/src/command/medical/patient/patient-import/get.ts
+++ b/packages/api/src/command/medical/patient/patient-import/get.ts
@@ -75,10 +75,12 @@ export async function getPatientImportJobModelOrFail({
 
 export async function getPatientImportJobList({
   cxId,
+  facilityId,
   jobIds,
   status: statusParam,
 }: {
   cxId: string;
+  facilityId?: string;
   jobIds?: string[];
   status?: PatientImportJobStatus | PatientImportJobStatus[];
 }): Promise<PatientImportJob[]> {
@@ -90,6 +92,7 @@ export async function getPatientImportJobList({
   const jobs = await PatientImportJobModel.findAll({
     where: {
       cxId,
+      ...(facilityId ? { facilityId } : {}),
       ...(jobIds ? { id: { [Op.in]: jobIds } } : {}),
       ...(status ? { status: { [Op.in]: status } } : {}),
     },

--- a/packages/api/src/external/commonwell/shared.ts
+++ b/packages/api/src/external/commonwell/shared.ts
@@ -10,6 +10,7 @@ import z from "zod";
 import { Config } from "../../shared/config";
 import { CwLink } from "../commonwell/cw-patient-data";
 import { getHieInitiator, HieInitiator, isHieEnabledToQuery } from "../hie/get-hie-initiator";
+
 export async function getCwInitiator(
   patient: Pick<Patient, "id" | "cxId">,
   facilityId?: string

--- a/packages/api/src/routes/internal/medical/patient-import.ts
+++ b/packages/api/src/routes/internal/medical/patient-import.ts
@@ -17,7 +17,10 @@ import status from "http-status";
 import { z } from "zod";
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 import { createPatientImportJob } from "../../../command/medical/patient/patient-import/create";
-import { getPatientImportJobOrFail } from "../../../command/medical/patient/patient-import/get";
+import {
+  getPatientImportJobList,
+  getPatientImportJobOrFail,
+} from "../../../command/medical/patient/patient-import/get";
 import {
   createPatientImportMapping,
   CreatePatientImportMappingCmd,
@@ -213,6 +216,26 @@ router.post(
 );
 
 const detailSchema = z.enum(["info", "debug"]).optional().default("info");
+
+/** ---------------------------------------------------------------------------
+ * GET /internal/patient/bulk
+ *
+ * Returns all bulk patient import jobs for a given customer.
+ *
+ * @param req.query.cxId The customer ID.
+ * @return The patient import job.
+ */
+router.get(
+  "/",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").orFail();
+
+    const patientImports = await getPatientImportJobList({ cxId });
+
+    return res.status(status.OK).json(patientImports);
+  })
+);
 
 /** ---------------------------------------------------------------------------
  * GET /internal/patient/bulk/:id

--- a/packages/infra/lib/surescripts/surescripts-stack.ts
+++ b/packages/infra/lib/surescripts/surescripts-stack.ts
@@ -438,7 +438,6 @@ export class SurescriptsNestedStack extends NestedStack {
       lambda: lambdaSettings,
       queue: queueSettings,
       eventSource: eventSourceSettings,
-      waitTime,
     } = settings[job];
 
     const queue = createQueue({
@@ -471,12 +470,7 @@ export class SurescriptsNestedStack extends NestedStack {
     surescriptsReplicaBucket.grantReadWrite(lambda);
     pharmacyConversionBucket?.grantReadWrite(lambda);
 
-    lambda.addEventSource(
-      new SqsEventSource(queue, {
-        ...eventSourceSettings,
-        maxBatchingWindow: waitTime,
-      })
-    );
+    lambda.addEventSource(new SqsEventSource(queue, eventSourceSettings));
 
     return { lambda, queue };
   }


### PR DESCRIPTION
### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/3034

### Description

Expose endpoint to list bulk imports.

### Testing

- Local
  - [x] List of bulk imports returns list correctly
  - [x] List of bulk imports filters by facility
  - [x] List of bulk imports includes download URLs
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
- [ ] Merge downstream


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint to retrieve a list of all bulk patient import jobs for a specified customer, with optional filtering by facility.
  - Enhanced patient import job retrieval to support facility-specific queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->