### PR TITLE
Eng 473 small fixes

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory-raw-sql.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/rebuild-cq-directory-raw-sql.ts
@@ -118,14 +118,17 @@ export async function updateCqDirectoryViewDefinition(sequelize: Sequelize): Pro
     async function runSql(sql: string): Promise<void> {
       await sequelize.query(sql, { type: QueryTypes.RAW, transaction });
     }
+    const timestamp = new Date().getTime();
     await runSql(
       `ALTER TABLE ${cqDirectoryEntryTemp} ADD CONSTRAINT ${addTimestampSuffix(
-        pkNamePrefix
+        pkNamePrefix,
+        timestamp
       )} PRIMARY KEY (id);`
     );
     await runSql(
       `CREATE INDEX ${addTimestampSuffix(
-        indexNamePrefix
+        indexNamePrefix,
+        timestamp
       )} ON ${cqDirectoryEntryTemp} (managing_organization_id);`
     );
     await runSql(
@@ -143,7 +146,6 @@ export async function updateCqDirectoryViewDefinition(sequelize: Sequelize): Pro
   });
 }
 
-function addTimestampSuffix(name: string): string {
-  const timestamp = new Date().getTime();
+function addTimestampSuffix(name: string, timestamp: number): string {
   return `${name}_${timestamp}`;
 }

--- a/packages/api/src/sequelize/migrations/2025-06-16-00_alter-cq_directory_entry_new-add-index.ts
+++ b/packages/api/src/sequelize/migrations/2025-06-16-00_alter-cq_directory_entry_new-add-index.ts
@@ -15,8 +15,12 @@ export const up: Migration = async ({ context: queryInterface }) => {
 
 export const down: Migration = async ({ context: queryInterface }) => {
   return queryInterface.sequelize.transaction(async transaction => {
-    await queryInterface.removeIndex(tableName, [indexColumnName], {
-      transaction,
-    });
+    await queryInterface.removeIndex(
+      tableName,
+      "cq_directory_entry_new_managing_organization_id_idx",
+      {
+        transaction,
+      }
+    );
   });
 };

--- a/packages/api/src/sequelize/migrations/2025-06-16-00_alter-cq_directory_entry_new-add-index.ts
+++ b/packages/api/src/sequelize/migrations/2025-06-16-00_alter-cq_directory_entry_new-add-index.ts
@@ -15,12 +15,8 @@ export const up: Migration = async ({ context: queryInterface }) => {
 
 export const down: Migration = async ({ context: queryInterface }) => {
   return queryInterface.sequelize.transaction(async transaction => {
-    await queryInterface.removeIndex(
-      tableName,
-      "cq_directory_entry_new_managing_organization_id_idx",
-      {
-        transaction,
-      }
-    );
+    await queryInterface.removeIndex(tableName, indexName, {
+      transaction,
+    });
   });
 };


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-473

### Dependencies

- Upstream: _[this PR points to another PR or depends on its release]_
- Downstream: _[PRs that depend on this one, either point to this or can only be released after this one is released]_

### Description
- Down migration to use the index name instead of the columns

### Testing

- Local
  - [x] Test that the up- and down-migrations happen as expected

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency in naming constraints and indexes by ensuring the same timestamp is used throughout a transaction.
  - Resolved an issue with database migration rollback to correctly reference index names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->