### PR TITLE
fix(core): accidentally committed local decompression change

### DIFF
--- a/packages/core/src/external/surescripts/replica.ts
+++ b/packages/core/src/external/surescripts/replica.ts
@@ -2,7 +2,7 @@ import { Config } from "../../util/config";
 import { S3Replica } from "../sftp/replica/s3";
 import { SurescriptsFileIdentifier, SurescriptsSftpConfig } from "./types";
 import { buildRequestFileName, buildResponseFileNamePrefix } from "./file/file-names";
-// import { decompressGzip } from "../sftp/compression";
+import { decompressGzip } from "../sftp/compression";
 
 export class SurescriptsReplica extends S3Replica {
   constructor(config: Pick<SurescriptsSftpConfig, "replicaBucket" | "replicaBucketRegion"> = {}) {
@@ -40,8 +40,7 @@ export class SurescriptsReplica extends S3Replica {
     if (!responseFile) {
       return undefined;
     }
-    return await this.readFile(responseFile);
-    // const fileContent = await this.readFile(responseFile);
-    // return decompressGzip(fileContent);
+    const fileContent = await this.readFile(responseFile);
+    return decompressGzip(fileContent);
   }
 }


### PR DESCRIPTION
metriport/metriport-internal#2995

Issues:

- https://linear.app/metriport/issue/ENG-377

### Dependencies

- Upstream: None
- Downstream: None

### Description

An older version of the Surescripts client stored the response files as uncompressed binary data, while the current version stores the response as the original .gz files to prevent accidental double-decompression (automatically decompressing means the replica is not a true replica anymore). 

I commented these lines out to work with a previous patient panel and forgot to reset them to the original for the current workload, this didn't affect any production workflow runs but we must get this patch in before merging to production.

### Testing

Tested that this works and rectifies any issues related to decompressed files (as all future files would be).

- Local
  - [ ] Tested locally to ensure this is the correct fix
- Staging
  - [ ] Will run through the SS flow on staging tonight to ensure that the full flow up to decompression works, then test the decompressed results via this branch
- Production
  - [ ] Should align with the existing ENG-377 testing plan

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of response files by ensuring they are automatically decompressed before being returned to the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->