### PR TITLE
PATCH: feat(core): add FHIR source extension to Surescripts resources

### DIFF
--- a/packages/core/src/external/surescripts/fhir/condition.ts
+++ b/packages/core/src/external/surescripts/fhir/condition.ts
@@ -3,6 +3,7 @@ import { Condition } from "@medplum/fhirtypes";
 import { ResponseDetail } from "../schema/response";
 import { SurescriptsContext } from "./types";
 import { getPatientReference } from "./patient";
+import { getSurescriptsDataSourceExtension } from "./shared";
 import { ICD_10_URL } from "../../../util/constants";
 
 export function getCondition(
@@ -24,5 +25,6 @@ export function getCondition(
         },
       ],
     },
+    extension: [getSurescriptsDataSourceExtension()],
   };
 }

--- a/packages/core/src/external/surescripts/fhir/coverage.ts
+++ b/packages/core/src/external/surescripts/fhir/coverage.ts
@@ -2,6 +2,7 @@ import { uuidv7 } from "@metriport/shared/util/uuid-v7";
 import { Coverage, Identifier } from "@medplum/fhirtypes";
 import { ResponseDetail } from "../schema/response";
 import { getPlanCodeName } from "@metriport/shared/interface/external/surescripts/plan-code";
+import { getSurescriptsDataSourceExtension } from "./shared";
 import {
   NCPDP_PROVIDER_ID_SYSTEM,
   PLAN_NETWORK_BIN_SYSTEM,
@@ -12,6 +13,7 @@ import {
 export function getCoverage(detail: ResponseDetail): Coverage | undefined {
   if (!detail.planCode) return undefined;
   const identifier = getCoverageIdentifiers(detail);
+  const extension = [getSurescriptsDataSourceExtension()];
 
   return {
     resourceType: "Coverage",
@@ -27,6 +29,7 @@ export function getCoverage(detail: ResponseDetail): Coverage | undefined {
       ],
     },
     ...(identifier.length > 0 ? { identifier } : undefined),
+    extension,
   };
 }
 

--- a/packages/core/src/external/surescripts/fhir/medication-dispense.ts
+++ b/packages/core/src/external/surescripts/fhir/medication-dispense.ts
@@ -10,7 +10,7 @@ import { MEDICATION_DISPENSE_FILL_NUMBER_EXTENSION, UNIT_OF_MEASURE_URL } from "
 import { getMedicationReference } from "./medication";
 import { getPatientReference } from "./patient";
 import { getPrescriberReference } from "./prescriber";
-import { getResourceByNpiNumber } from "./shared";
+import { getResourceByNpiNumber, getSurescriptsDataSourceExtension } from "./shared";
 import { SurescriptsContext } from "./types";
 
 export function getMedicationDispense(
@@ -25,7 +25,9 @@ export function getMedicationDispense(
   const medicationReference = getMedicationReference(medication);
   const whenHandedOver = getWhenHandedOver(detail);
   const fillNumber = getFillNumberAsExtension(detail);
-  const extensions = [fillNumber].filter(Boolean) as Extension[];
+  const extensions = [fillNumber, getSurescriptsDataSourceExtension()].filter(
+    Boolean
+  ) as Extension[];
 
   const medicationDispense: MedicationDispense = {
     resourceType: "MedicationDispense",
@@ -36,8 +38,8 @@ export function getMedicationDispense(
     ...(whenHandedOver ? { whenHandedOver } : undefined),
     ...(dosageInstruction ? { dosageInstruction } : undefined),
     ...(daysSupply ? { daysSupply } : undefined),
-    ...(extensions.length > 0 ? { extension: extensions } : undefined),
     ...(performer.length > 0 ? { performer } : undefined),
+    extension: extensions,
   };
 
   return medicationDispense;

--- a/packages/core/src/external/surescripts/fhir/medication-request.ts
+++ b/packages/core/src/external/surescripts/fhir/medication-request.ts
@@ -3,6 +3,7 @@ import { Medication, MedicationRequest } from "@medplum/fhirtypes";
 import type { SurescriptsContext } from "./types";
 import { ResponseDetail } from "../schema/response";
 import { getMedicationReference } from "./medication";
+import { getSurescriptsDataSourceExtension } from "./shared";
 
 export function getMedicationRequest(
   context: SurescriptsContext,
@@ -14,6 +15,7 @@ export function getMedicationRequest(
   const medicationReference = getMedicationReference(medication);
   const dosageInstruction = getDosageInstruction(detail);
   const authoredOn = getAuthoredOn(detail);
+  const extension = [getSurescriptsDataSourceExtension()];
 
   return {
     resourceType: "MedicationRequest",
@@ -23,6 +25,7 @@ export function getMedicationRequest(
     ...(dispenseRequest ? { dispenseRequest } : undefined),
     ...(dosageInstruction ? { dosageInstruction } : undefined),
     ...(substitution ? { substitution } : undefined),
+    extension,
   };
 }
 

--- a/packages/core/src/external/surescripts/fhir/medication.ts
+++ b/packages/core/src/external/surescripts/fhir/medication.ts
@@ -13,6 +13,7 @@ import { getDeaScheduleName } from "@metriport/shared/interface/external/surescr
 import { getNcpdpName } from "@metriport/shared/interface/external/surescripts/ncpdp";
 import { DEA_SCHEDULE_URL, UNIT_OF_MEASURE_URL } from "./constants";
 import { NDC_URL, SNOMED_URL } from "../../../util/constants";
+import { getSurescriptsDataSourceExtension } from "./shared";
 
 export function getMedication(detail: ResponseDetail): Medication {
   const code = getMedicationCodeableConcept(detail);
@@ -20,6 +21,7 @@ export function getMedication(detail: ResponseDetail): Medication {
   const form = getMedicationForm(detail);
   const amount = getMedicationAmount(detail);
   const batch = getMedicationBatch(detail);
+  const extension = [getSurescriptsDataSourceExtension()];
 
   return {
     resourceType: "Medication",
@@ -30,6 +32,7 @@ export function getMedication(detail: ResponseDetail): Medication {
     ...(form ? { form } : undefined),
     ...(amount ? { amount } : undefined),
     ...(batch ? { batch } : undefined),
+    extension,
   };
 }
 

--- a/packages/core/src/external/surescripts/fhir/patient.ts
+++ b/packages/core/src/external/surescripts/fhir/patient.ts
@@ -2,11 +2,13 @@ import { BadRequestError } from "@metriport/shared";
 import { Patient, Reference } from "@medplum/fhirtypes";
 import { ResponseDetail } from "../schema/response";
 import { convertDateToString } from "@metriport/shared/common/date";
+import { getSurescriptsDataSourceExtension } from "./shared";
 
 export function getPatient(detail: ResponseDetail): Patient {
   const name = getPatientName(detail);
   const gender = getPatientGender(detail);
   const birthDate = getPatientBirthDate(detail);
+  const extension = [getSurescriptsDataSourceExtension()];
 
   return {
     resourceType: "Patient",
@@ -14,6 +16,7 @@ export function getPatient(detail: ResponseDetail): Patient {
     ...(name ? { name } : undefined),
     ...(gender ? { gender } : undefined),
     ...(birthDate ? { birthDate } : undefined),
+    extension,
   };
 }
 

--- a/packages/core/src/external/surescripts/fhir/pharmacy.ts
+++ b/packages/core/src/external/surescripts/fhir/pharmacy.ts
@@ -3,6 +3,7 @@ import { uuidv7 } from "@metriport/shared/util/uuid-v7";
 import { ResponseDetail } from "../schema/response";
 import { NCPDP_PROVIDER_ID_SYSTEM } from "./constants";
 import { NPI_URL } from "./constants";
+import { getSurescriptsDataSourceExtension } from "./shared";
 
 export function getPharmacy(detail: ResponseDetail): Organization | undefined {
   if (!detail.pharmacyNpiNumber && !detail.ncpdpId) return undefined;
@@ -11,6 +12,7 @@ export function getPharmacy(detail: ResponseDetail): Organization | undefined {
   const address = getPharmacyAddress(detail);
   const telecom = getPharmacyTelecom(detail);
   const identifiers = getPharmacyIdentifiers(detail);
+  const extension = [getSurescriptsDataSourceExtension()];
 
   return {
     resourceType: "Organization",
@@ -19,6 +21,7 @@ export function getPharmacy(detail: ResponseDetail): Organization | undefined {
     ...(identifiers.length > 0 ? { identifier: identifiers } : undefined),
     ...(address && address.length > 0 ? { address } : undefined),
     ...(telecom && telecom.length > 0 ? { telecom } : undefined),
+    extension,
   };
 }
 

--- a/packages/core/src/external/surescripts/fhir/prescriber.ts
+++ b/packages/core/src/external/surescripts/fhir/prescriber.ts
@@ -2,14 +2,14 @@ import { Identifier, Practitioner, Reference } from "@medplum/fhirtypes";
 import { uuidv7 } from "@metriport/shared/util/uuid-v7";
 import { ResponseDetail } from "../schema/response";
 import { DEA_SCHEDULE_URL, NPI_URL } from "./constants";
+import { getSurescriptsDataSourceExtension } from "./shared";
 
 export function getPrescriber(detail: ResponseDetail): Practitioner {
   const prescriberName = getPrescriberName(detail);
   const prescriberAddress = getPrescriberAddress(detail);
   const identifiers = getPrescriberIdentifiers(detail);
   const telecom = getPrescriberTelecom(detail);
-
-  // detail.prescriberSuffix
+  const extension = [getSurescriptsDataSourceExtension()];
 
   return {
     resourceType: "Practitioner",
@@ -20,6 +20,7 @@ export function getPrescriber(detail: ResponseDetail): Practitioner {
       ? { address: prescriberAddress }
       : undefined),
     ...(telecom && telecom.length > 0 ? { telecom } : undefined),
+    extension,
   };
 }
 

--- a/packages/core/src/external/surescripts/fhir/provenance.ts
+++ b/packages/core/src/external/surescripts/fhir/provenance.ts
@@ -2,12 +2,17 @@ import { Provenance, ProvenanceAgent } from "@medplum/fhirtypes";
 import { ResponseDetail } from "../schema/response";
 import { SURESCRIPTS_AGENT_ID } from "../constants";
 import { NPI_URL } from "./constants";
+import { getSurescriptsDataSourceExtension } from "./shared";
 
 export function getProvenance(detail: ResponseDetail): Provenance {
+  const agent = [getProvenanceAgent(detail)];
+  const extension = [getSurescriptsDataSourceExtension()];
+
   return {
     resourceType: "Provenance",
     recorded: detail.sentTime.toISOString(),
-    agent: [getProvenanceAgent(detail)],
+    agent,
+    extension,
   };
 }
 

--- a/packages/core/src/external/surescripts/fhir/shared.ts
+++ b/packages/core/src/external/surescripts/fhir/shared.ts
@@ -1,11 +1,13 @@
 import {
   Condition,
   Coverage,
+  Extension,
   Medication,
   Organization,
   Practitioner,
   Resource,
 } from "@medplum/fhirtypes";
+import { dataSourceExtensionDefaults } from "../../fhir/shared/extensions/extension";
 import { NPI_URL } from "./constants";
 import { ResourceMap, SurescriptsContext, SystemIdentifierMap } from "./types";
 
@@ -90,4 +92,14 @@ export function getResourceFromResourceMap<R extends Resource>(
     resourceMap[key] = resource;
   }
   return resource;
+}
+
+export function getSurescriptsDataSourceExtension(): Extension {
+  return {
+    ...dataSourceExtensionDefaults,
+    valueCoding: {
+      ...dataSourceExtensionDefaults.valueCoding,
+      code: "SURESCRIPTS",
+    },
+  };
 }

--- a/packages/core/src/external/surescripts/file/file-names.ts
+++ b/packages/core/src/external/surescripts/file/file-names.ts
@@ -28,7 +28,7 @@ export function buildConversionBundleFileNameForJob({
   patientId: string;
   jobId: string;
 }): string {
-  return `cxId=${cxId}/ptId=${patientId}/surescripts/jobId=${jobId}/conversion.json`;
+  return `surescripts/cxId=${cxId}/ptId=${patientId}/jobId=${jobId}/conversion.json`;
 }
 
 export function parseHistoryFileName(remoteFileName: string):

--- a/packages/utils/src/surescripts/convert-customer-response.ts
+++ b/packages/utils/src/surescripts/convert-customer-response.ts
@@ -5,6 +5,7 @@ dotenv.config();
 import { Command } from "commander";
 import { SurescriptsConvertPatientResponseHandlerDirect } from "@metriport/core/external/surescripts/command/convert-patient-response/convert-patient-response-direct";
 import { getTransmissionsFromCsv } from "./shared";
+import { buildLatestConversionBundleFileName } from "@metriport/core/external/surescripts/file/file-names";
 
 const program = new Command();
 
@@ -22,7 +23,7 @@ program
   .option("--facility-id <facilityId>", "The facility ID")
   .option("--csv-data <csvData>", "The CSV data")
   .option("--start <start>", "Start at index")
-  .option("--end <end> end before index")
+  .option("--end <end>", "end before index")
   .description("Converts a customer response to FHIR bundles")
   .showHelpAfterError()
   .version("1.0.0")
@@ -54,6 +55,7 @@ program
         transmissionId,
         populationId: patientId,
       });
+      console.log(`Key: ${buildLatestConversionBundleFileName(cxId, patientId)}`);
       convertedCount++;
       if (convertedCount % 100 === 0) {
         console.log(`Converted ${convertedCount} patients`);

--- a/packages/utils/src/surescripts/convert-customer-response.ts
+++ b/packages/utils/src/surescripts/convert-customer-response.ts
@@ -3,7 +3,6 @@ import dotenv from "dotenv";
 dotenv.config();
 
 import { Command } from "commander";
-import { SurescriptsReplica } from "@metriport/core/external/surescripts/replica";
 import { SurescriptsConvertPatientResponseHandlerDirect } from "@metriport/core/external/surescripts/command/convert-patient-response/convert-patient-response-direct";
 import { getTransmissionsFromCsv } from "./shared";
 
@@ -13,6 +12,8 @@ interface ConvertCustomerResponseOptions {
   cxId?: string;
   facilityId?: string;
   csvData?: string;
+  start?: string;
+  end?: string;
 }
 
 program
@@ -20,18 +21,33 @@ program
   .option("--cx-id <cxId>", "The customer ID")
   .option("--facility-id <facilityId>", "The facility ID")
   .option("--csv-data <csvData>", "The CSV data")
+  .option("--start <start>", "Start at index")
+  .option("--end <end> end before index")
   .description("Converts a customer response to FHIR bundles")
   .showHelpAfterError()
   .version("1.0.0")
-  .action(async function ({ cxId, facilityId, csvData }: ConvertCustomerResponseOptions) {
+  .action(async function ({
+    cxId,
+    facilityId,
+    csvData,
+    start,
+    end,
+  }: ConvertCustomerResponseOptions) {
     if (!cxId) throw new Error("Customer ID is required");
     if (!facilityId) throw new Error("Facility ID is required");
     if (!csvData) throw new Error("CSV data is required");
 
-    const transmissions = await getTransmissionsFromCsv(cxId, csvData);
+    let transmissions = await getTransmissionsFromCsv(cxId, csvData);
+    if (start != null || end != null) {
+      const startIndex = parseInt(start ?? "0");
+      const endIndex = end != null ? parseInt(end) : undefined;
+      transmissions = transmissions.slice(startIndex, endIndex);
+      console.log(`Got ${transmissions.length} transmissions from ${startIndex} to ${endIndex}`);
+    }
+
     let convertedCount = 0;
     for (const { patientId, transmissionId } of transmissions) {
-      const handler = new SurescriptsConvertPatientResponseHandlerDirect(new SurescriptsReplica());
+      const handler = new SurescriptsConvertPatientResponseHandlerDirect();
       await handler.convertPatientResponse({
         cxId,
         facilityId,


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-377

### Dependencies

- Upstream: None
- Downstream: https://github.com/metriport/metriport/pull/4045

### Description

This adds a standard Metriport source extension to all generated FHIR resources in the Surescripts conversion bundle. 

### Testing

Run `npm run surescripts -- convert-customer-response --cx-id [CX-ID] --facility-id [FACILITY-ID] --csv-data [PATH-TO-ID-TRANSMISSION-FILE-CSV] (can share the ID-transmission file for the current giant patient panel privately)

- Local
  - [x] Works when converting local bundles for pilot customer
- Staging
  - [x] Regenerate large customer batch with extension, spot check to ensure all resources have extension
- Production
  - [ ] Run a conversion job through Lambda and observe the results (should match the results of the utils script since it is calling the same handler)

### Release Plan

See downstream PRs.

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a standardized extension field to FHIR resources for Surescripts data source identification, enhancing consistency across patient, medication, coverage, condition, pharmacy, prescriber, and provenance data.
  - Enhanced the customer response conversion tool with new options to process a specific range of transmissions.
  - Updated file path formatting for conversion bundle storage to include a consistent prefix.

- **Improvements**
  - Improved batch analysis tool with clearer descriptions and ensured deduplication of FHIR bundles for more accurate data comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->