### PR TITLE
ENG-476 Add SS data into consolidated

### DIFF
--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -17,7 +17,7 @@ import { dangerouslyDeduplicate } from "../../external/fhir/consolidated/dedupli
 import { getDocuments as getDocumentReferences } from "../../external/fhir/document/get-documents";
 import { toFHIR as patientToFhir } from "../../external/fhir/patient/conversion";
 import { insertSourceDocumentToAllDocRefMeta } from "../../external/fhir/shared/meta";
-import { getPharmacyResources } from "../../external/surescripts/command/bundle/get-bundle";
+import { getBundleResources as getPharmacyResources } from "../../external/surescripts/command/bundle/get-bundle";
 import { capture, executeAsynchronously, out } from "../../util";
 import { Config } from "../../util/config";
 import { processAsyncError } from "../../util/error/shared";

--- a/packages/core/src/external/surescripts/command/bundle/get-bundle.ts
+++ b/packages/core/src/external/surescripts/command/bundle/get-bundle.ts
@@ -19,8 +19,12 @@ export async function getBundle({
   patientId: string;
 }): Promise<Bundle | undefined> {
   const { log } = out(`ss.getBundle - cx ${cxId}, pat ${patientId}`);
-  const s3Utils = new S3Utils(Config.getAWSRegion());
   const bucketName = Config.getPharmacyConversionBucketName();
+  if (!bucketName) {
+    log(`No pharmacy conversion bucket name found, skipping`);
+    return undefined;
+  }
+  const s3Utils = new S3Utils(Config.getAWSRegion());
   const fileName = buildLatestConversionBundleFileName(cxId, patientId);
   const fileExists = await s3Utils.fileExists(bucketName, fileName);
   if (!fileExists) {

--- a/packages/core/src/external/surescripts/command/bundle/save-bundle.ts
+++ b/packages/core/src/external/surescripts/command/bundle/save-bundle.ts
@@ -1,0 +1,51 @@
+import { Bundle } from "@medplum/fhirtypes";
+import { executeWithNetworkRetries } from "@metriport/shared";
+import { Config } from "../../../../util/config";
+import { S3Utils } from "../../../aws/s3";
+import {
+  buildConversionBundleFileNameForJob,
+  buildLatestConversionBundleFileName,
+} from "../../file/file-names";
+
+/**
+ * Saves the bundle with Surescripts data to the repository.
+ *
+ * @param bundle - The bundle to save.
+ * @param cxId - The ID of the care experience.
+ * @param patientId - The ID of the patient.
+ * @param jobId - The ID of the job.
+ */
+export async function saveBundle({
+  bundle,
+  cxId,
+  patientId,
+  jobId,
+}: {
+  bundle: Bundle;
+  cxId: string;
+  patientId: string;
+  jobId: string;
+}): Promise<void> {
+  const latestBundleName = buildLatestConversionBundleFileName(cxId, patientId);
+  const conversionBundleName = buildConversionBundleFileNameForJob({
+    cxId,
+    patientId,
+    jobId,
+  });
+  const s3Utils = new S3Utils(Config.getAWSRegion());
+  const fileContent = Buffer.from(JSON.stringify(bundle));
+  await executeWithNetworkRetries(async () => {
+    await Promise.all([
+      s3Utils.uploadFile({
+        bucket: Config.getPharmacyConversionBucketName(),
+        key: latestBundleName,
+        file: fileContent,
+      }),
+      s3Utils.uploadFile({
+        bucket: Config.getPharmacyConversionBucketName(),
+        key: conversionBundleName,
+        file: fileContent,
+      }),
+    ]);
+  });
+}

--- a/packages/core/src/external/surescripts/command/convert-batch-response/convert-batch-response-direct.ts
+++ b/packages/core/src/external/surescripts/command/convert-batch-response/convert-batch-response-direct.ts
@@ -2,7 +2,8 @@ import { NotFoundError } from "@metriport/shared";
 import { SurescriptsConvertBatchResponseHandler } from "./convert-batch-response";
 import { SurescriptsReplica } from "../../replica";
 import { SurescriptsConversionBundle, SurescriptsJob } from "../../types";
-import { convertBatchResponseToFhirBundles, uploadConversionBundle } from "../../fhir-converter";
+import { convertBatchResponseToFhirBundles } from "../../fhir-converter";
+import { saveBundle } from "../bundle/save-bundle";
 
 export class SurescriptsConvertBatchResponseHandlerDirect
   implements SurescriptsConvertBatchResponseHandler
@@ -29,7 +30,7 @@ export class SurescriptsConvertBatchResponseHandlerDirect
 
     const conversionBundles = await convertBatchResponseToFhirBundles(cxId, responseFileContent);
     for (const { patientId, bundle } of conversionBundles) {
-      await uploadConversionBundle({ bundle, cxId, patientId, jobId: transmissionId });
+      await saveBundle({ bundle, cxId, patientId, jobId: transmissionId });
     }
     return conversionBundles;
   }

--- a/packages/core/src/external/surescripts/command/convert-patient-response/convert-patient-response-direct.ts
+++ b/packages/core/src/external/surescripts/command/convert-patient-response/convert-patient-response-direct.ts
@@ -1,7 +1,8 @@
-import { SurescriptsConvertPatientResponseHandler } from "./convert-patient-response";
+import { convertPatientResponseToFhirBundle } from "../../fhir-converter";
 import { SurescriptsReplica } from "../../replica";
 import { SurescriptsConversionBundle, SurescriptsJob } from "../../types";
-import { convertPatientResponseToFhirBundle, uploadConversionBundle } from "../../fhir-converter";
+import { saveBundle } from "../bundle/save-bundle";
+import { SurescriptsConvertPatientResponseHandler } from "./convert-patient-response";
 
 export class SurescriptsConvertPatientResponseHandlerDirect
   implements SurescriptsConvertPatientResponseHandler
@@ -23,7 +24,7 @@ export class SurescriptsConvertPatientResponseHandlerDirect
     if (!conversionBundle) return undefined;
 
     const { patientId, bundle } = conversionBundle;
-    await uploadConversionBundle({ bundle, cxId, patientId, jobId: transmissionId });
+    await saveBundle({ bundle, cxId, patientId, jobId: transmissionId });
     return conversionBundle;
   }
 }

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -245,8 +245,8 @@ export class Config {
   static getSurescriptsReplicaBucketName(): string {
     return getEnvVarOrFail("SURESCRIPTS_REPLICA_BUCKET_NAME");
   }
-  static getPharmacyConversionBucketName(): string {
-    return getEnvVarOrFail("PHARMACY_CONVERSION_BUCKET_NAME");
+  static getPharmacyConversionBucketName(): string | undefined {
+    return getEnvVar("PHARMACY_CONVERSION_BUCKET_NAME");
   }
   static getSurescriptsSftpActionLambdaName(): string {
     return getEnvVarOrFail("SURESCRIPTS_SFTP_ACTION_LAMBDA_NAME");

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -374,6 +374,19 @@ export class APIStack extends Stack {
     });
 
     //-------------------------------------------
+    // Surescripts
+    //-------------------------------------------
+    let surescriptsStack: SurescriptsNestedStack | undefined = undefined;
+    if (props.config.surescripts) {
+      surescriptsStack = new SurescriptsNestedStack(this, "SurescriptsNestedStack", {
+        config: props.config,
+        vpc: this.vpc,
+        alarmAction: slackNotification?.alarmAction,
+        lambdaLayers,
+      });
+    }
+
+    //-------------------------------------------
     // General lambdas
     //-------------------------------------------
     const {
@@ -402,6 +415,7 @@ export class APIStack extends Stack {
       dbCluster,
       secrets,
       medicalDocumentsBucket,
+      pharmacyBundleBucket: surescriptsStack?.getAssets()?.pharmacyConversionBucket,
       sandboxSeedDataBucket,
       alarmAction: slackNotification?.alarmAction,
       bedrock: props.config.bedrock,
@@ -478,19 +492,6 @@ export class APIStack extends Stack {
       ehrResponsesBucket,
       medicalDocumentsBucket,
     });
-
-    //-------------------------------------------
-    // Surescripts
-    //-------------------------------------------
-    let surescriptsStack: SurescriptsNestedStack | undefined = undefined;
-    if (props.config.surescripts) {
-      surescriptsStack = new SurescriptsNestedStack(this, "SurescriptsNestedStack", {
-        config: props.config,
-        vpc: this.vpc,
-        alarmAction: slackNotification?.alarmAction,
-        lambdaLayers,
-      });
-    }
 
     //-------------------------------------------
     // Rate Limiting


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-476

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4043
- Downstream: 

### Description

Add SS data into consolidated

### Testing

- Local
  - [x] Re-generate consolidated includes SS data
- Staging
  - [ ] Re-generate consolidated includes SS data
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to save Surescripts data bundles to secure cloud storage for each patient and care experience.
  - Introduced support for optional pharmacy bundle storage in deployment infrastructure and lambda functions.

- **Bug Fixes**
  - Improved retrieval of Surescripts data bundles, now returning the latest available bundle from cloud storage or indicating if none exists.

- **Refactor**
  - Updated internal methods to use new bundle saving and retrieval functions, streamlining storage operations and removing outdated upload logic.
  - Refined configuration handling to gracefully handle missing pharmacy conversion bucket settings.
  - Consolidated infrastructure stack creation and improved bucket access permissions for lambdas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->