### PR TITLE
ENG-476 `consolidated.test.ts` to use `expect.objectContaining`

### DIFF
--- a/packages/core/src/external/fhir/consolidated/__tests__/consolidated.test.ts
+++ b/packages/core/src/external/fhir/consolidated/__tests__/consolidated.test.ts
@@ -26,9 +26,6 @@ afterAll(() => {
 describe("getConsolidatedFhirBundle", () => {
   const cxId = uuidv4();
   const patientId = uuidv4();
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
 
   it("paginates appropriately", async () => {
     const returnedResource: Observation = {
@@ -59,7 +56,9 @@ describe("getConsolidatedFhirBundle", () => {
     expect(resp).toBeTruthy();
     expect(resp.resourceType).toEqual(`Bundle`);
     expect(resp.total).toEqual(2);
-    expect(resp.entry).toEqual(expect.arrayContaining([{ resource: returnedResource }]));
+    expect(resp.entry).toEqual(
+      expect.arrayContaining([expect.objectContaining({ resource: returnedResource })])
+    );
     expect(fhir_searchResourcePages).toHaveBeenCalledTimes(1);
   });
 
@@ -130,10 +129,10 @@ describe("getConsolidatedFhirBundle", () => {
     expect(resp.total).toEqual(4);
     expect(resp.entry).toEqual(
       expect.arrayContaining([
-        { resource: initialResource },
-        { resource: missingResourceBaseL1 },
-        { resource: missingL2 },
-        { resource: missingL3 },
+        expect.objectContaining({ resource: initialResource }),
+        expect.objectContaining({ resource: missingResourceBaseL1 }),
+        expect.objectContaining({ resource: missingL2 }),
+        expect.objectContaining({ resource: missingL3 }),
       ])
     );
     expect(fhir_searchResourcePages).toHaveBeenCalledTimes(1);
@@ -201,9 +200,9 @@ describe("getConsolidatedFhirBundle", () => {
     expect(resp.total).toEqual(3);
     expect(resp.entry).toEqual(
       expect.arrayContaining([
-        { resource: initialResource },
-        { resource: missingResourceBaseL1 },
-        { resource: missingL2 },
+        expect.objectContaining({ resource: initialResource }),
+        expect.objectContaining({ resource: missingResourceBaseL1 }),
+        expect.objectContaining({ resource: missingL2 }),
       ])
     );
     expect(fhir_searchResourcePages).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4054
- Downstream: none

### Description

`consolidated.test.ts` to use `expect.objectContaining`

### Testing

- Local
  - [x] Unit tests succeed
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test assertions for bundle entries to use more flexible matching.
  - Removed redundant cleanup of Jest mocks after each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->