### PR TITLE
feat(jobs): move job scheduler starter to after api

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -46,6 +46,7 @@ import { EnvType } from "./env-type";
 import { FeatureFlagsNestedStack } from "./feature-flags-nested-stack";
 import { Hl7NotificationWebhookSenderNestedStack } from "./hl7-notification-webhook-sender-nested-stack";
 import { IHEGatewayV2LambdasNestedStack } from "./ihe-gateway-v2-stack";
+import { createJobsScheduler } from "./jobs/jobs-scheduler";
 import { JobsNestedStack } from "./jobs/jobs-stack";
 import { LambdasLayersNestedStack } from "./lambda-layers-nested-stack";
 import { CDA_TO_VIS_TIMEOUT, LambdasNestedStack } from "./lambdas-nested-stack";
@@ -729,6 +730,14 @@ export class APIStack extends Stack {
     });
 
     createCqDirectoryRebuilder({
+      lambdaLayers,
+      stack: this,
+      vpc: this.vpc,
+      apiAddress: apiDirectUrl,
+      alarmSnsAction: slackNotification?.alarmAction,
+    });
+
+    createJobsScheduler({
       lambdaLayers,
       stack: this,
       vpc: this.vpc,

--- a/packages/infra/lib/jobs/jobs-scheduler.ts
+++ b/packages/infra/lib/jobs/jobs-scheduler.ts
@@ -1,0 +1,45 @@
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { IVpc } from "aws-cdk-lib/aws-ec2";
+import { Construct } from "constructs";
+import { EnvConfig } from "../../config/env-config";
+import { getConfig } from "../shared/config";
+import { LambdaLayers } from "../shared/lambda-layers";
+import { createScheduledLambda } from "../shared/lambda-scheduled";
+
+export type JobsSchedulerProps = {
+  stack: Construct;
+  lambdaLayers: LambdaLayers;
+  vpc: IVpc;
+  apiAddress: string;
+  alarmSnsAction?: SnsAction;
+};
+
+function getSettings(props: JobsSchedulerProps, config: NonNullable<EnvConfig["jobs"]>) {
+  return {
+    ...props,
+    name: "StartPatientJobsScheduler",
+    scheduleExpression: config.startPatientJobsSchedulerScheduleExpression, // See: https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html
+    url: `http://${props.apiAddress}${config.startPatientJobsSchedulerUrl}`,
+  };
+}
+
+export function createJobsScheduler(props: JobsSchedulerProps) {
+  const config = getConfig();
+  if (!config.jobs) return;
+
+  const { stack, lambdaLayers, vpc, alarmSnsAction, name, scheduleExpression, url } = getSettings(
+    props,
+    config.jobs
+  );
+
+  createScheduledLambda({
+    stack,
+    layers: [lambdaLayers.shared],
+    name,
+    vpc,
+    scheduleExpression,
+    url,
+    alarmSnsAction,
+    envType: config.environmentType,
+  });
+}

--- a/packages/infra/lib/jobs/jobs-stack.ts
+++ b/packages/infra/lib/jobs/jobs-stack.ts
@@ -9,7 +9,6 @@ import { EnvConfig } from "../../config/env-config";
 import { EnvType } from "../env-type";
 import { createLambda } from "../shared/lambda";
 import { LambdaLayers } from "../shared/lambda-layers";
-import { createScheduledLambda } from "../shared/lambda-scheduled";
 import { QueueAndLambdaSettings } from "../shared/settings";
 import { createQueue } from "../shared/sqs";
 import { JobsAssets } from "./types";
@@ -70,16 +69,6 @@ export class JobsNestedStack extends NestedStack {
       sentryDsn: props.config.lambdasSentryDSN,
       alarmAction: props.alarmAction,
     };
-
-    createScheduledLambda({
-      stack: this,
-      envType: props.config.environmentType,
-      layers: [props.lambdaLayers.shared],
-      alarmSnsAction: props.alarmAction,
-      name: "StartPatientJobsScheduler",
-      scheduleExpression: props.config.jobs.startPatientJobsSchedulerScheduleExpression,
-      url: props.config.jobs.startPatientJobsSchedulerUrl,
-    });
 
     const runPatientJob = this.setupRunPatientJob({
       ...commonConfig,


### PR DESCRIPTION
Ref: ENG-433

Issues:

- https://linear.app/metriport/issue/ENG-433

### Description

- moving scheduler starter to after api

### Testing

- Local
  - [ ] cdk diff
- Staging
  - [ ] lambda has full URL
- Sandbox
  - [ ] lambda has full URL
- Production
  - [ ] lambda has full URL

### Release Plan

- [ ] Merge this
