### PR TITLE
fix(api): normalized state for cq org creation on tests

### DIFF
--- a/packages/api/src/external/carequality/command/cq-organization/__tests__/carequality-fhir.test.e2e.ts
+++ b/packages/api/src/external/carequality/command/cq-organization/__tests__/carequality-fhir.test.e2e.ts
@@ -6,7 +6,7 @@ dotenv.config();
 import { faker } from "@faker-js/faker";
 import { APIMode, CarequalityManagementApi } from "@metriport/carequality-sdk";
 import { OrganizationWithId } from "@metriport/carequality-sdk/client/carequality";
-import { getEnvVar, getEnvVarOrFail } from "@metriport/shared";
+import { getEnvVar, getEnvVarOrFail, normalizeState } from "@metriport/shared";
 import { cloneDeep } from "lodash";
 import { metriportOid } from "../constants";
 import { getOrganizationFhirTemplate } from "../organization-template";
@@ -27,7 +27,7 @@ function makeCarequalityManagementAPI(): CarequalityManagementApi | undefined {
   });
 }
 
-describe.skip("CarequalityManagementApiFhir", () => {
+describe("CarequalityManagementApiFhir", () => {
   const api = makeCarequalityManagementAPI();
   if (!api) {
     console.log("WARNING: Skipping tests because the CQ API is not configured");
@@ -69,7 +69,7 @@ describe.skip("CarequalityManagementApiFhir", () => {
       name: faker.company.name(),
       addressLine1: faker.location.streetAddress(),
       city: faker.location.city(),
-      state: faker.location.state(),
+      state: normalizeState(faker.location.state()),
       postalCode: faker.location.zipCode(),
       lat: faker.location.latitude().toString(),
       lon: faker.location.longitude().toString(),

--- a/packages/api/src/external/carequality/command/cq-organization/organization-template.ts
+++ b/packages/api/src/external/carequality/command/cq-organization/organization-template.ts
@@ -6,6 +6,7 @@ import {
   XCA_DR_STRING,
   XCPD_STRING,
 } from "@metriport/carequality-sdk/common/util";
+import { normalizeState } from "@metriport/shared/domain/address/state";
 import { CQOrgDetailsWithUrls } from "../../shared";
 import { metriportOid } from "./constants";
 
@@ -43,7 +44,7 @@ function getFhirOrganization(
     email,
     addressLine1,
     city,
-    state,
+    state: stateRaw,
     postalCode,
     lat,
     lon,
@@ -51,6 +52,8 @@ function getFhirOrganization(
     oboOid,
     oboName,
   } = orgDetails;
+
+  const state = normalizeState(stateRaw);
   const addressText = `${addressLine1} ${city} ${state} ${postalCode} US`;
   const org: OrganizationWithId = {
     resourceType: "Organization",
@@ -108,6 +111,7 @@ function getFhirOrganization(
           type: "both",
           line: [addressLine1],
           city,
+          state,
           postalCode,
           country: "US",
         },


### PR DESCRIPTION
Part of ENG-481

Issues:

- https://linear.app/metriport/issue/ENG-481

### Description
- Fixed CQ Org creation error on e2e tests by normalizing the state to the state codes
- Added state to the org data on CQ Org creation logic

### Testing

- Local
  - [x] Run local e2e tests
- Staging
  - N/A, just make sure e2e tests are passing
- Production
  - N/A, just make sure e2e tests are passing

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Reactivated a previously skipped test suite for Carequality FHIR organization management.
  - Updated test data to use normalized state values for organization addresses.

- **Refactor**
  - Improved consistency by normalizing state values in organization address fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->