### PR TITLE
fix(api): validate cohort id

### DIFF
--- a/packages/api/src/command/medical/cohort/patient-cohort/bulk-assign.ts
+++ b/packages/api/src/command/medical/cohort/patient-cohort/bulk-assign.ts
@@ -1,5 +1,7 @@
 import { out } from "@metriport/core/util";
+import { BadRequestError } from "@metriport/shared";
 import { uuidv7 } from "@metriport/shared/util/uuid-v7";
+import { validate as validateUuid } from "uuid";
 import { PatientCohortModel } from "../../../../models/medical/patient-cohort";
 import { strictlyValidateAllAndPatientIds } from "../../../../routes/medical/schemas/shared";
 import { getPatientIds } from "../../patient/get-patient-read-only";
@@ -21,6 +23,10 @@ export async function bulkAssignPatientsToCohort({
 }: BulkAssignPatientsToCohortParams): Promise<CohortWithPatientIdsAndCount> {
   // This validation ensures this command does not require special handling of patientIds vs isAssignAll
   strictlyValidateAllAndPatientIds({ patientIds, all: isAssignAll });
+  const isValidCohortId = validateUuid(cohortId);
+  if (!isValidCohortId) {
+    throw new BadRequestError(`Cohort ID is not a valid UUID`, undefined, { cohortId });
+  }
 
   const { log } = out(`bulkAssignPatientsToCohort - cx ${cxId}, cohort ${cohortId}`);
   const uniquePatientIds = [...new Set(patientIds)];

--- a/packages/api/src/command/medical/cohort/patient-cohort/bulk-assign.ts
+++ b/packages/api/src/command/medical/cohort/patient-cohort/bulk-assign.ts
@@ -1,7 +1,5 @@
 import { out } from "@metriport/core/util";
-import { BadRequestError } from "@metriport/shared";
 import { uuidv7 } from "@metriport/shared/util/uuid-v7";
-import { validate as validateUuid } from "uuid";
 import { PatientCohortModel } from "../../../../models/medical/patient-cohort";
 import { strictlyValidateAllAndPatientIds } from "../../../../routes/medical/schemas/shared";
 import { getPatientIds } from "../../patient/get-patient-read-only";
@@ -23,10 +21,6 @@ export async function bulkAssignPatientsToCohort({
 }: BulkAssignPatientsToCohortParams): Promise<CohortWithPatientIdsAndCount> {
   // This validation ensures this command does not require special handling of patientIds vs isAssignAll
   strictlyValidateAllAndPatientIds({ patientIds, all: isAssignAll });
-  const isValidCohortId = validateUuid(cohortId);
-  if (!isValidCohortId) {
-    throw new BadRequestError(`Cohort ID is not a valid UUID`, undefined, { cohortId });
-  }
 
   const { log } = out(`bulkAssignPatientsToCohort - cx ${cxId}, cohort ${cohortId}`);
   const uniquePatientIds = [...new Set(patientIds)];

--- a/packages/api/src/routes/medical/cohort.ts
+++ b/packages/api/src/routes/medical/cohort.ts
@@ -14,6 +14,7 @@ import { updateCohort } from "../../command/medical/cohort/update-cohort";
 import { getETag } from "../../shared/http";
 import { handleParams } from "../helpers/handle-params";
 import { requestLogger } from "../helpers/request-logger";
+import { getUUIDFrom } from "../schemas/uuid";
 import { asyncHandler, getCxIdOrFail, getFromParamsOrFail } from "../util";
 import {
   CohortWithCountDTO,
@@ -175,7 +176,7 @@ router.post(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
-    const cohortId = getFromParamsOrFail("id", req);
+    const cohortId = getUUIDFrom("query", req, "cohortId").orFail();
     const { patientIds, all: isAssignAll } = allOrSelectPatientIdsSchema.parse(req.body);
 
     const cohortDetails = await bulkAssignPatientsToCohort({
@@ -211,7 +212,7 @@ router.delete(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
-    const cohortId = getFromParamsOrFail("id", req);
+    const cohortId = getUUIDFrom("query", req, "cohortId").orFail();
     const { patientIds, all: isRemoveAll } = allOrSelectPatientIdsSchema.parse(req.body);
 
     const unassignedCount = await bulkRemovePatientsFromCohort({


### PR DESCRIPTION
Part of ENG-420

Issues:

- https://linear.app/metriport/issue/ENG-420

### Description
- Small fix to validate the cohort ID is a UUID

### Testing

- Local
  - [x] Try to run the route with some random id and get expected error

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the method for extracting the cohort ID in patient assignment and removal routes to use query parameters instead of route parameters. No changes to visible functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->