### PR TITLE
fix(api): minor fixes from rabbit

### DIFF
--- a/packages/api/src/command/medical/cohort/update-cohort.ts
+++ b/packages/api/src/command/medical/cohort/update-cohort.ts
@@ -23,7 +23,7 @@ export async function updateCohort({
     const trimmedName = name.trim();
 
     const existingCohort = await getCohortByName({ cxId, name: trimmedName });
-    if (existingCohort) {
+    if (existingCohort && existingCohort.id !== id) {
       throw new BadRequestError("A cohort with this name already exists", undefined, {
         cxId,
         name: trimmedName,

--- a/packages/api/src/routes/medical/cohort.ts
+++ b/packages/api/src/routes/medical/cohort.ts
@@ -223,7 +223,7 @@ router.delete(
     });
 
     return res
-      .status(status.NO_CONTENT)
+      .status(status.OK)
       .json({ message: "Patient(s) unassigned from cohort", unassignedCount });
   })
 );


### PR DESCRIPTION
Part of ENG-420

Issues:

- https://linear.app/metriport/issue/ENG-420

### Description
- Catching an edge case on cohort update
- Returning json on delete 

### Testing

- Local
  - [x] Test the affected routes

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where updating a cohort with the same name triggered a false "name already exists" error.

- **Refactor**
	- Changed the response status for removing a patient from a cohort to 200 OK, ensuring a JSON message and unassigned patient count are always returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->