### PR TITLE
ENG-484: Surescripts bug fixes, improvements, and deduplication logic fix

### DIFF
--- a/packages/core/src/external/surescripts/fhir/bundle-entry.ts
+++ b/packages/core/src/external/surescripts/fhir/bundle-entry.ts
@@ -20,6 +20,7 @@ export function getAllBundleEntries(
   const pharmacy = deduplicateBySystemIdentifier(context.pharmacy, getPharmacy(data));
   const medication = deduplicateByCoding(context.medication, getMedication(data));
   const condition = deduplicateByCoding(context.condition, getCondition(context, data));
+
   const medicationDispense = medication
     ? getMedicationDispense(context, medication, data)
     : undefined;

--- a/packages/core/src/external/surescripts/fhir/bundle.ts
+++ b/packages/core/src/external/surescripts/fhir/bundle.ts
@@ -5,7 +5,8 @@ import { IncomingData } from "../schema/shared";
 import { initializeContext } from "./shared";
 import { getAllBundleEntries } from "./bundle-entry";
 
-import { dangerouslyDeduplicateFhir } from "../../../fhir-deduplication/deduplicate-fhir";
+// TODO: uncomment this, rebuild core, and run utils script again
+// import { dangerouslyDeduplicateFhir } from "../../../fhir-deduplication/deduplicate-fhir";
 import { hydrateFhir } from "../../fhir/hydration/hydrate-fhir";
 import { crosswalkNdcToRxNorm } from "../../term-server";
 import { NDC_URL } from "../../../util/constants";
@@ -21,7 +22,7 @@ export async function convertIncomingDataToFhirBundle(
     const entries = getAllBundleEntries(context, detail);
     bundle.entry?.push(...entries);
   }
-  dangerouslyDeduplicateFhir(bundle, cxId, patientId);
+  // dangerouslyDeduplicateFhir(bundle, cxId, patientId);
   await dangerouslyHydrateMedications(bundle);
   await hydrateFhir(bundle, console.log);
 

--- a/packages/core/src/external/surescripts/fhir/bundle.ts
+++ b/packages/core/src/external/surescripts/fhir/bundle.ts
@@ -5,8 +5,7 @@ import { IncomingData } from "../schema/shared";
 import { initializeContext } from "./shared";
 import { getAllBundleEntries } from "./bundle-entry";
 
-// TODO: uncomment this, rebuild core, and run utils script again
-// import { dangerouslyDeduplicateFhir } from "../../../fhir-deduplication/deduplicate-fhir";
+import { dangerouslyDeduplicateFhir } from "../../../fhir-deduplication/deduplicate-fhir";
 import { hydrateFhir } from "../../fhir/hydration/hydrate-fhir";
 import { crosswalkNdcToRxNorm } from "../../term-server";
 import { NDC_URL } from "../../../util/constants";
@@ -22,7 +21,7 @@ export async function convertIncomingDataToFhirBundle(
     const entries = getAllBundleEntries(context, detail);
     bundle.entry?.push(...entries);
   }
-  // dangerouslyDeduplicateFhir(bundle, cxId, patientId);
+  dangerouslyDeduplicateFhir(bundle, cxId, patientId);
   await dangerouslyHydrateMedications(bundle);
   await hydrateFhir(bundle, console.log);
 

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -57,6 +57,7 @@ export function dangerouslyDeduplicateFhir(
   use medication references. This is different than all other resources.
   */
   resourceArrays = replaceResourceReferences(resourceArrays, medicationsResult.refReplacementMap, [
+    "medicationDispenses",
     "medicationAdministrations",
     "medicationStatements",
     "medicationRequests",
@@ -71,6 +72,9 @@ export function dangerouslyDeduplicateFhir(
 
   const medStatementResult = deduplicateMedStatements(resourceArrays.medicationStatements);
   resourceArrays.medicationStatements = medStatementResult.combinedResources;
+
+  // const medDispenseResult = deduplicateMedDispenses(resourceArrays.medicationDispenses);
+  // resourceArrays.medicationDispenses = medDispenseResult.combinedResources;
 
   resourceArrays.documentReferences = processDocumentReferences(resourceArrays.documentReferences);
 

--- a/packages/infra/lib/surescripts/surescripts-stack.ts
+++ b/packages/infra/lib/surescripts/surescripts-stack.ts
@@ -288,12 +288,14 @@ export class SurescriptsNestedStack extends NestedStack {
     const convertPatientResponse = this.setupLambda("convertPatientResponse", {
       ...commonConfig,
       surescriptsReplicaBucket: this.surescriptsReplicaBucket,
+      pharmacyConversionBucket: this.pharmacyConversionBucket,
     });
     this.convertPatientResponseLambda = convertPatientResponse.lambda;
 
     const convertBatchResponse = this.setupLambda("convertBatchResponse", {
       ...commonConfig,
       surescriptsReplicaBucket: this.surescriptsReplicaBucket,
+      pharmacyConversionBucket: this.pharmacyConversionBucket,
     });
     this.convertBatchResponseLambda = convertBatchResponse.lambda;
 
@@ -435,6 +437,7 @@ export class SurescriptsNestedStack extends NestedStack {
       alarmAction,
       systemRootOID,
       surescriptsReplicaBucket,
+      pharmacyConversionBucket,
     } = props;
 
     const lambda = createLambda({
@@ -454,6 +457,7 @@ export class SurescriptsNestedStack extends NestedStack {
     });
 
     surescriptsReplicaBucket.grantReadWrite(lambda);
+    pharmacyConversionBucket?.grantReadWrite(lambda);
 
     return { lambda };
   }

--- a/packages/terminology/.gitignore
+++ b/packages/terminology/.gitignore
@@ -1,4 +1,6 @@
 **/terminology.db
+**/terminology_v2.db
+**/terminology_v2.1.db
 dist
 node_modules
 # dotenv environment variable files

--- a/packages/utils/src/surescripts/bundle-verification.ts
+++ b/packages/utils/src/surescripts/bundle-verification.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import dotenv from "dotenv";
+dotenv.config();
+
+import { Command } from "commander";
+import { SurescriptsConvertPatientResponseHandlerDirect } from "@metriport/core/external/surescripts/command/convert-patient-response/convert-patient-response-direct";
+import { buildCsvPath, getConversionBundle, getTransmissionsFromCsv } from "./shared";
+import { Bundle, BundleEntry, Medication, MedicationDispense } from "@medplum/fhirtypes";
+
+const program = new Command();
+
+program
+  .name("bundle-verification")
+  .description("verify customer bundles")
+  .option("--cx-id <cxId>", "The customer ID")
+  .option("--facility-id <facilityId>", "The facility ID")
+  .option("--csv-data <csvData>", "The CSV data with patient IDs and transmission IDs")
+  .action(
+    async ({
+      cxId,
+      facilityId,
+      csvData,
+    }: {
+      cxId: string;
+      facilityId: string;
+      csvData: string;
+    }) => {
+      if (!cxId) throw new Error("Customer ID is required");
+      if (!facilityId) throw new Error("Facility ID is required");
+      if (!csvData) throw new Error("Either patient ID or CSV data is required");
+      csvData = buildCsvPath(csvData);
+
+      const transmissions = await getTransmissionsFromCsv(cxId, csvData);
+
+      let convertedCount = 0;
+      const handler = new SurescriptsConvertPatientResponseHandlerDirect();
+      for (const { patientId, transmissionId } of transmissions) {
+        await handler.convertPatientResponse({
+          cxId,
+          facilityId,
+          transmissionId,
+          populationId: patientId,
+        });
+
+        const conversionBundle = await getConversionBundle(cxId, patientId);
+        if (!conversionBundle) {
+          console.log(`No conversion bundle generated for patient ${patientId}`);
+          continue;
+        }
+        console.log(`✅ Conversion bundle successfully generated for patient ${patientId}`);
+        verifyMedicationDispenseRefersToMedication(conversionBundle);
+
+        convertedCount++;
+        if (convertedCount % 100 === 0) {
+          console.log(`Converted ${convertedCount} patients`);
+        }
+      }
+      console.log(`Converted ${convertedCount} patients`);
+    }
+  );
+
+function verifyMedicationDispenseRefersToMedication(bundle: Bundle): void {
+  const medicationEntries =
+    bundle.entry?.filter(entry => entry.resource?.resourceType === "Medication") ??
+    ([] as BundleEntry<Medication>[]);
+  const medicationDispenseEntries = bundle.entry?.filter(
+    entry => entry.resource?.resourceType === "MedicationDispense"
+  ) as BundleEntry<MedicationDispense>[];
+  const medicationIdMap = new Map<string, Medication>(
+    medicationEntries.map(medicationEntry => [
+      "Medication/" + medicationEntry.resource?.id,
+      medicationEntry.resource as Medication,
+    ])
+  );
+
+  for (const medicationDispenseEntry of medicationDispenseEntries) {
+    const medication = medicationDispenseEntry.resource?.medicationReference?.reference;
+
+    if (!medication) {
+      console.log(
+        `❌ Medication dispense ${medicationDispenseEntry.fullUrl} does not refer to a medication.`
+      );
+    } else if (!medicationIdMap.has(medication)) {
+      console.log(
+        `❌ Medication dispense ${medicationDispenseEntry.resource?.id} refers to a medication that does not exist.`
+      );
+      console.log(`Medication: ${medication}`);
+      console.log(`Medication ID map: ${Array.from(medicationIdMap.keys())}`);
+    }
+  }
+}
+
+export default program;

--- a/packages/utils/src/surescripts/convert-customer-response.ts
+++ b/packages/utils/src/surescripts/convert-customer-response.ts
@@ -4,7 +4,7 @@ dotenv.config();
 
 import { Command } from "commander";
 import { SurescriptsConvertPatientResponseHandlerDirect } from "@metriport/core/external/surescripts/command/convert-patient-response/convert-patient-response-direct";
-import { getTransmissionsFromCsv } from "./shared";
+import { buildCsvPath, getTransmissionsFromCsv } from "./shared";
 import { buildLatestConversionBundleFileName } from "@metriport/core/external/surescripts/file/file-names";
 
 const program = new Command();
@@ -37,6 +37,7 @@ program
     if (!cxId) throw new Error("Customer ID is required");
     if (!facilityId) throw new Error("Facility ID is required");
     if (!csvData) throw new Error("CSV data is required");
+    csvData = buildCsvPath(csvData);
 
     let transmissions = await getTransmissionsFromCsv(cxId, csvData);
     if (start != null || end != null) {

--- a/packages/utils/src/surescripts/find-largest.ts
+++ b/packages/utils/src/surescripts/find-largest.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import dotenv from "dotenv";
+import csv from "csv-parser";
+dotenv.config();
+
+import fs from "fs";
+import path from "path";
+
+import { Command } from "commander";
+import { SurescriptsReplica } from "@metriport/core/external/surescripts/replica";
+import { parseResponseFile } from "@metriport/core/external/surescripts/file/file-parser";
+import { buildCsvPath } from "./shared";
+
+const program = new Command();
+const dataPoints: Array<{ patientId: string; transmissionId: string; size: number }> = [];
+const reportingThreshold = 200;
+
+program
+  .name("find-largest")
+  .description("find largest surescripts responses for a customer")
+  .option("--cx-id <cxId>", "The customer ID")
+  .option("--facility-id <facilityId>", "The facility ID")
+  .option("--csv-data <csvData>", "The CSV data with patient IDs and transmission IDs")
+  .action(
+    async ({
+      cxId,
+      facilityId,
+      csvData,
+    }: {
+      cxId: string;
+      facilityId: string;
+      csvData: string;
+    }) => {
+      if (!cxId) throw new Error("Customer ID is required");
+      if (!facilityId) throw new Error("Facility ID is required");
+      if (!csvData) throw new Error("Either patient ID or CSV data is required");
+      csvData = buildCsvPath(csvData);
+
+      const replica = new SurescriptsReplica();
+      const transmissions = await getTransmissionsFromCsv(cxId, csvData);
+      let totalProcessed = 0;
+
+      for (const { patientId, transmissionId } of transmissions) {
+        const file = await replica.getRawResponseFile({ transmissionId, populationId: patientId });
+        if (!file) {
+          console.log(`No file found for patient ${patientId} and transmission ${transmissionId}`);
+          continue;
+        }
+        const parsedFile = parseResponseFile(file);
+        const size = parsedFile.details.length;
+        dataPoints.push({
+          patientId,
+          transmissionId,
+          size,
+        });
+        if (size >= reportingThreshold) {
+          console.log(`Found large patient: ${patientId} (${size} entries)`);
+          console.log(
+            `  npm run surescripts -- preview --cx-id ${cxId} --facility-id ${facilityId} --patient-id ${patientId} --transmission-id ${transmissionId}`
+          );
+        }
+        totalProcessed++;
+        if (totalProcessed % 100 === 0) {
+          console.log(`Processed ${totalProcessed} patients`);
+        }
+      }
+
+      dataPoints.sort((a, b) => b.size - a.size);
+
+      // Write the response data frequency to a CSV file
+      const csvContent =
+        '"' +
+        ["patient_id", "transmission_id", "size"].join('","') +
+        '"\n' +
+        dataPoints
+          .map(({ patientId, transmissionId, size }) => {
+            return [`"${patientId}"`, `"${transmissionId}"`, `"${size}"`].join(",");
+          })
+          .join("\n");
+      fs.writeFileSync(
+        path.join(process.cwd(), "runs/surescripts/largest_patients.csv"),
+        csvContent,
+        "utf-8"
+      );
+    }
+  );
+
+interface PatientTransmission {
+  cxId: string;
+  patientId: string;
+  transmissionId: string;
+}
+
+async function getTransmissionsFromCsv(
+  cxId: string,
+  csvData: string
+): Promise<PatientTransmission[]> {
+  return new Promise((resolve, reject) => {
+    const transmissions: PatientTransmission[] = [];
+    fs.createReadStream(csvData)
+      .pipe(csv())
+      .on("data", function (row) {
+        transmissions.push({
+          cxId,
+          patientId: row.patient_id,
+          transmissionId: row.transmission_id,
+        });
+      })
+      .on("end", function () {
+        resolve(transmissions);
+      })
+      .on("error", function (error) {
+        reject(error);
+      });
+  });
+}
+
+export default program;

--- a/packages/utils/src/surescripts/index.ts
+++ b/packages/utils/src/surescripts/index.ts
@@ -10,6 +10,8 @@ import convertCustomerResponse from "./convert-customer-response";
 import analysis from "./analysis";
 import analyzeResponses from "./analyze-responses";
 import batchAnalysis from "./batch-analysis";
+import preview from "./preview";
+import findLargest from "./find-largest";
 
 const program = new Command();
 program.addCommand(sftpAction);
@@ -23,4 +25,6 @@ program.addCommand(convertCustomerResponse);
 program.addCommand(analysis);
 program.addCommand(batchAnalysis);
 program.addCommand(analyzeResponses);
+program.addCommand(preview);
+program.addCommand(findLargest);
 program.parse();

--- a/packages/utils/src/surescripts/index.ts
+++ b/packages/utils/src/surescripts/index.ts
@@ -12,6 +12,7 @@ import analyzeResponses from "./analyze-responses";
 import batchAnalysis from "./batch-analysis";
 import preview from "./preview";
 import findLargest from "./find-largest";
+import bundleVerification from "./bundle-verification";
 
 const program = new Command();
 program.addCommand(sftpAction);
@@ -27,4 +28,5 @@ program.addCommand(batchAnalysis);
 program.addCommand(analyzeResponses);
 program.addCommand(preview);
 program.addCommand(findLargest);
+program.addCommand(bundleVerification);
 program.parse();

--- a/packages/utils/src/surescripts/preview.ts
+++ b/packages/utils/src/surescripts/preview.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import dotenv from "dotenv";
+dotenv.config();
+
+import { Command } from "commander";
+import { SurescriptsConvertPatientResponseHandlerDirect } from "@metriport/core/external/surescripts/command/convert-patient-response/convert-patient-response-direct";
+import {
+  dangerouslyMergeBundles,
+  getConsolidatedBundle,
+  openPreviewUrl,
+  writeConsolidatedBundlePreview,
+} from "./shared";
+
+const program = new Command();
+
+interface ConvertResponseOptions {
+  cxId?: string;
+  facilityId?: string;
+  transmissionId?: string;
+  patientId?: string;
+}
+
+program
+  .name("preview")
+  .option("--cx-id <cxId>", "The customer ID")
+  .option("--facility-id <facilityId>", "The facility ID")
+  .option("--transmission-id <transmissionId>", "The transmission ID")
+  .option("--patient-id <patientId>", "The patient ID")
+  .description("Launch a preview window for a consolidated bundle")
+  .showHelpAfterError()
+  .version("1.0.0")
+  .action(async function ({ cxId, facilityId, transmissionId, patientId }: ConvertResponseOptions) {
+    if (!cxId) throw new Error("Customer ID is required");
+    if (!facilityId) throw new Error("Facility ID is required");
+    if (!transmissionId) throw new Error("Transmission ID is required");
+    if (!patientId) throw new Error("Patient ID is required");
+
+    const handler = new SurescriptsConvertPatientResponseHandlerDirect();
+    const start = Date.now();
+    const conversion = await handler.convertPatientResponse({
+      cxId,
+      facilityId,
+      transmissionId,
+      populationId: patientId,
+    });
+    const end = Date.now();
+    console.log(`Conversion took ${end - start} ms`);
+
+    if (!conversion || !conversion.bundle) {
+      console.error("No conversion bundle found");
+      return;
+    }
+
+    const bundle = conversion.bundle;
+    const consolidatedBundle = await getConsolidatedBundle(cxId, patientId);
+    if (!consolidatedBundle) {
+      console.error("No consolidated bundle found");
+      return;
+    }
+
+    const mergedBundle = dangerouslyMergeBundles(cxId, patientId, consolidatedBundle, bundle);
+    const previewUrl = await writeConsolidatedBundlePreview(cxId, patientId, mergedBundle);
+    openPreviewUrl(previewUrl);
+  });
+
+export default program;

--- a/packages/utils/src/surescripts/shared.ts
+++ b/packages/utils/src/surescripts/shared.ts
@@ -1,10 +1,24 @@
 import fs from "fs";
+import path from "path";
 import csv from "csv-parser";
+import { execSync } from "child_process";
+import { Bundle } from "@medplum/fhirtypes";
+import { S3Utils } from "@metriport/core/external/aws/s3";
+import { getEnvVarOrFail } from "@metriport/shared";
+import { createConsolidatedDataFileNameWithSuffix } from "@metriport/core/domain/consolidated/filename";
+import { dangerouslyDeduplicateFhir } from "@metriport/core/fhir-deduplication/deduplicate-fhir";
 
 interface PatientTransmission {
   cxId: string;
   patientId: string;
   transmissionId: string;
+}
+
+export function buildCsvPath(csvPath: string): string {
+  if (csvPath.startsWith("/")) {
+    return csvPath;
+  }
+  return path.join(process.cwd(), "runs/surescripts", csvPath);
 }
 
 export async function getTransmissionsFromCsv(
@@ -29,4 +43,57 @@ export async function getTransmissionsFromCsv(
         reject(error);
       });
   });
+}
+
+export async function getConsolidatedBundle(
+  cxId: string,
+  patientId: string
+): Promise<Bundle | undefined> {
+  const s3Utils = new S3Utils("us-west-1");
+  const medicalDocsBucketName = getEnvVarOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
+
+  const fileKey = createConsolidatedDataFileNameWithSuffix(cxId, patientId) + ".json";
+  if (!(await s3Utils.fileExists(medicalDocsBucketName, fileKey))) {
+    return undefined;
+  }
+  const fileContent = await s3Utils.downloadFile({ bucket: medicalDocsBucketName, key: fileKey });
+  return JSON.parse(fileContent.toString());
+}
+
+export async function writeConsolidatedBundlePreview(
+  cxId: string,
+  patientId: string,
+  bundle: Bundle
+): Promise<string> {
+  const s3Utils = new S3Utils("us-west-1");
+  const bucketName = getEnvVarOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
+
+  const fileName = createConsolidatedDataFileNameWithSuffix(cxId, patientId) + "-preview.json";
+  const fileContent = JSON.stringify(bundle);
+  await s3Utils.uploadFile({
+    bucket: bucketName,
+    key: fileName,
+    file: Buffer.from(fileContent),
+    contentType: "application/json",
+  });
+  return await s3Utils.getSignedUrl({
+    bucketName,
+    fileName,
+    durationSeconds: 60 * 30,
+  });
+}
+
+export function openPreviewUrl(url: string): void {
+  execSync(`open https://preview.metriport.com/?url=${encodeURIComponent(url)}`);
+}
+
+export function dangerouslyMergeBundles(
+  cxId: string,
+  patientId: string,
+  baseBundle: Bundle,
+  conversionBundle: Bundle
+): Bundle {
+  baseBundle.entry = [...(baseBundle.entry ?? []), ...(conversionBundle.entry ?? [])];
+  dangerouslyDeduplicateFhir(baseBundle, cxId, patientId);
+  return baseBundle;
 }


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-484

### Dependencies

- Upstream: None
- Downstream: None

### Description

This introduces the following FHIR resource generation improvements for Surescripts:
- MedicationDispense provides quantity (how dashboard viewer displays it)
- critical bug fix to deduplication code to include medicationDispense (was included in mapping but not in reference remapping)

This also introduces the following infrastructure fixes/improvements:
- Increases timeout for SFTP actions to allow for long cloning operations
- Fix permissions for conversion Lambdas to access conversion bucket

Also adds several utils scripts for performing analysis and verification on the generated bundles (which is how the dedupe bug fix was found and verified to be fixed by this simple change).

### Testing

- Local
  - [x] Run conversion locally with utils scripts (`npm run surescripts -- convert-customer-response ...`)
  - [x] See Surescripts runbook for full list of verification commands
- Staging
  - [ ] Run conversion bundle on patient #2 from Surescripts runbook of staging examples
- Production
  - [ ] Regenerate conversion bundles for large customer panel and run consolidated regeneration

### Release Plan

Merge this, run the conversion on all patients, then run the consolidated regeneration.

- [ ] Merge this
