### PR TITLE
fix(core): Fix deduplication to properly handle references for MedicationDispense

### DIFF
--- a/packages/core/src/external/fhir/bundle/bundle.ts
+++ b/packages/core/src/external/fhir/bundle/bundle.ts
@@ -381,6 +381,7 @@ export function extractFhirTypesFromBundle(bundle: Bundle): ExtractedFhirTypes {
   const medicationAdministrations: MedicationAdministration[] = [];
   const medicationRequests: MedicationRequest[] = [];
   const medicationStatements: MedicationStatement[] = [];
+  const medicationDispenses: MedicationDispense[] = [];
   const medications: Medication[] = [];
   const conditions: Condition[] = [];
   const allergies: AllergyIntolerance[] = [];
@@ -396,7 +397,6 @@ export function extractFhirTypesFromBundle(bundle: Bundle): ExtractedFhirTypes {
   const relatedPersons: RelatedPerson[] = [];
   const coverages: Coverage[] = [];
   const organizations: Organization[] = [];
-  const medicationDispenses: MedicationDispense[] = [];
   const communications: Communication[] = [];
   const consents: Consent[] = [];
   const devices: Device[] = [];
@@ -499,6 +499,7 @@ export function extractFhirTypesFromBundle(bundle: Bundle): ExtractedFhirTypes {
     medicationAdministrations,
     medicationStatements,
     medicationRequests,
+    medicationDispenses,
     conditions,
     allergies,
     locations,
@@ -513,7 +514,6 @@ export function extractFhirTypesFromBundle(bundle: Bundle): ExtractedFhirTypes {
     relatedPersons,
     coverages,
     organizations,
-    medicationDispenses,
     communications,
     consents,
     devices,

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -32,6 +32,7 @@ const medicationRelatedTypes = [
   "MedicationStatement",
   "MedicationAdministration",
   "MedicationRequest",
+  "MedicationDispense",
 ];
 
 /**
@@ -60,6 +61,7 @@ export function dangerouslyDeduplicateFhir(
     "medicationAdministrations",
     "medicationStatements",
     "medicationRequests",
+    "medicationDispenses",
   ]);
   resourceArrays.medications = medicationsResult.combinedResources;
 


### PR DESCRIPTION
metriport/metriport-internal#1040

Issues:

- https://linear.app/metriport/issue/ENG-498

### Dependencies

- Upstream: None
- Downstream: None

### Description

I received a report that Surescripts conversion bundles had broken references for MedicationDispense, but I couldn't figure out anywhere that the logic would allow that to happen. I wrote an analysis script to test this, which showed that bundles with MedicationDispense were having their references broken by `dangerouslyDeduplicateFhir`. This is an issue that likely affects any FHIR bundle with MedicationDispense resources.

<img width="797" alt="Screenshot 2025-06-20 at 7 41 19 PM" src="https://github.com/user-attachments/assets/367d7470-e2f5-459d-b842-078cd98859c0" />

After implementing the fix, all patient bundles were deduplicating correctly with correct references.

<img width="526" alt="Screenshot 2025-06-20 at 7 41 40 PM" src="https://github.com/user-attachments/assets/8441abb0-93db-472b-9e5e-6aa29d9d46d9" />

### Testing

Will test by deduplicating some large bundles.

- Local
  - [x] Use utils script to download large bundles and deduplicate
- Staging
  - [ ] Run deduplication on staging bundles through Surescripts
- Production
  - [ ] Run deduplication on production and monitor

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that MedicationDispense resources are correctly extracted and included alongside other medication-related data.
  - Extended deduplication and reference replacement processes to cover MedicationDispense resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->