### PR TITLE
PATCH RELEASE ENG-507 Close OS client + insights to lambda

### DIFF
--- a/packages/core/src/external/opensearch/file/file-remover-direct.ts
+++ b/packages/core/src/external/opensearch/file/file-remover-direct.ts
@@ -1,3 +1,4 @@
+import { errorToString } from "@metriport/shared";
 import { Client } from "@opensearch-project/opensearch";
 import { out } from "../../../util";
 import { OpenSearchFileRemover, OpenSearchFileRemoverConfig } from "./file-remover";
@@ -17,8 +18,15 @@ export class OpenSearchFileRemoverDirect implements OpenSearchFileRemover {
 
     const auth = { username, password };
     const client = new Client({ node: endpoint, auth });
-
-    await client.delete({ index: indexName, id: entryId });
-    log(`Successfully deleted ${entryId}`);
+    try {
+      await client.delete({ index: indexName, id: entryId });
+      log(`Successfully deleted ${entryId}`);
+    } finally {
+      try {
+        await client.close();
+      } catch (error) {
+        log(`Error closing OS client: ${errorToString(error)}`);
+      }
+    }
   }
 }

--- a/packages/infra/lib/api-stack/ccda-search-connector.ts
+++ b/packages/infra/lib/api-stack/ccda-search-connector.ts
@@ -115,6 +115,7 @@ export function setup({
     },
     retryAttempts,
     timeout,
+    isEnableInsights: true,
     alarmSnsAction,
   });
 


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-507

### Dependencies

none

### Description

- Close OS client
- Add insights to CCDA OS lambda

### Testing

- Local
  - none
- Staging
  - none
- Sandbox
  - none
- Production
  - [ ] CCDA OS lambda working well
  - [ ] Consolidated OS lambda working well
  - [ ] CCDA OS lambda got insights enabled

### Release Plan

- :warning: Points to `master`
- :warning: Contains infra changes
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved resource management by ensuring OpenSearch client connections are properly closed after operations, with enhanced error handling and logging for client closure across search, ingestion, update, and deletion processes.
- **New Features**
	- Added a new configuration option to enable insights for the CCDA ingestion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->