### PR TITLE
ENG-503: switch eslint-rules to use warn level so CI checks still pass

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -43,7 +43,7 @@ app.use((_req, res, next) => {
 mountRoutes(app);
 module.exports = app;
 
-// route used for health checks
+// health check route
 app.get("/", (req: Request, res: Response) => {
   if (req.accepts("application/json")) return res.json({ status: "OK" });
   return res.status(200).send("OK");

--- a/packages/eslint-rules/index.js
+++ b/packages/eslint-rules/index.js
@@ -6,7 +6,7 @@ module.exports = {
     recommended: {
       plugins: ['@metriport/eslint-rules'],
       rules: {
-        '@metriport/eslint-rules/no-named-arrow-functions': 'error',
+        '@metriport/eslint-rules/no-named-arrow-functions': 'warn',
       },
     },
     all: {


### PR DESCRIPTION
### Dependencies

None

### Description

Switch to warn level instead of error. Warnings trigger will fail the precommit hook for linting only staged files but not the CI run that lints _all_ files.

### Testing

Ci

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated a comment for clarity on the health check route.

- **Chores**
  - Changed the severity of a specific ESLint rule from error to warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->