### PR TITLE
feat(api-sdk): added cohort methods to sdk

### DIFF
--- a/packages/api-sdk/src/medical/models/cohort.ts
+++ b/packages/api-sdk/src/medical/models/cohort.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+import { baseUpdateSchema } from "./common/base-update";
+
+export const cohortMonitoringSchema = z.object({
+  adt: z.boolean(),
+});
+
+export const cohortCreateSchema = z.object({
+  name: z.string(),
+  monitoring: cohortMonitoringSchema,
+});
+
+export const cohortUpdateSchema = z
+  .object({
+    name: z.string(),
+    monitoring: cohortMonitoringSchema.optional(),
+  })
+  .merge(baseUpdateSchema);
+
+export const cohortDTOSchema = cohortCreateSchema.merge(
+  z.object({
+    id: z.string().uuid(),
+    dateCreated: z.string().datetime().optional(),
+  })
+);
+
+export const cohortWithCountDTOSchema = z.object({
+  cohort: cohortDTOSchema,
+  patientCount: z.number(),
+});
+
+export const cohortWithPatientIdsAndCountDTOSchema = cohortWithCountDTOSchema.merge(
+  z.object({
+    patientIds: z.array(z.string()),
+  })
+);
+
+export const cohortListResponseSchema = z.object({
+  cohorts: z.array(cohortWithCountDTOSchema),
+});
+
+export const patientUnassignmentResponseSchema = z.object({
+  message: z.string(),
+  unassignedCount: z.number(),
+});
+
+export type CohortMonitoring = z.infer<typeof cohortMonitoringSchema>;
+export type CohortCreate = z.infer<typeof cohortCreateSchema>;
+export type CohortUpdate = z.infer<typeof cohortUpdateSchema>;
+export type CohortDTO = z.infer<typeof cohortDTOSchema>;
+export type CohortWithCountDTO = z.infer<typeof cohortWithCountDTOSchema>;
+export type CohortWithPatientIdsAndCountDTO = z.infer<typeof cohortWithPatientIdsAndCountDTOSchema>;
+export type CohortListResponse = z.infer<typeof cohortListResponseSchema>;
+
+export type PatientAssignmentRequest = {
+  patientIds?: string[];
+  all?: boolean;
+};
+
+export type PatientUnassignmentResponse = z.infer<typeof patientUnassignmentResponseSchema>;


### PR DESCRIPTION
Part of ENG-526

Issues:

- https://linear.app/metriport/issue/ENG-526

### Description
- Added cohort methods to the `metriport.ts` SDK client

### Testing

- Local
  - [x] Use local script to test each method
    - [x] createCohort
    - [x] updateCohort
    - [x] listCohorts
    - [x] getCohort
    - [x] deleteCohort
    - [x] assignPatientsToCohort
    - [x] removePatientsFromCohort
- Staging
  - [ ] Use local script pointing to staging test each method
    - [ ] createCohort
    - [ ] updateCohort
    - [ ] listCohorts
    - [ ] getCohort
    - [ ] deleteCohort
    - [ ] assignPatientsToCohort
    - [ ] removePatientsFromCohort

### Release Plan
- [ ] Release NPM packages
- [ ] Merge this
