### PR TITLE
RELEASE elation contribution

### DIFF
--- a/packages/api/src/external/cda/generate-ccd.ts
+++ b/packages/api/src/external/cda/generate-ccd.ts
@@ -8,6 +8,7 @@ import {
 import { Organization } from "@metriport/core/domain/organization";
 import { Patient } from "@metriport/core/domain/patient";
 import { S3Utils } from "@metriport/core/external/aws/s3";
+import { dangerouslyDeduplicate } from "@metriport/core/external/fhir/consolidated/deduplicate";
 import { toFHIR as toFhirOrganization } from "@metriport/core/external/fhir/organization/conversion";
 import { metriportDataSourceExtension } from "@metriport/core/external/fhir/shared/extensions/metriport";
 import { out } from "@metriport/core/util/log";
@@ -48,6 +49,11 @@ export async function generateCcd(
     type: "collection",
     entry: [...metriportGenerated, { resource: fhirOrganization }],
   };
+  dangerouslyDeduplicate({
+    cxId: patient.cxId,
+    patientId: patient.id,
+    bundle,
+  });
   const normalizedBundle = normalizeBundle(bundle);
   const parsedBundle = bundleSchema.parse(normalizedBundle);
   await uploadCcdFhirDataToS3(patient, parsedBundle, requestId);

--- a/packages/api/src/external/ehr/shared/job/bundle/create-resource-diff-bundles/start-jobs-across-ehrs.ts
+++ b/packages/api/src/external/ehr/shared/job/bundle/create-resource-diff-bundles/start-jobs-across-ehrs.ts
@@ -45,6 +45,13 @@ export async function startCreateResourceDiffBundlesJobsAcrossEhrs({
         ehrPatientId: patientMapping.externalId,
         requestId,
       }).catch(processAsyncError(`${EhrSources.athena} startCreateResourceDiffBundlesJobAtEhr`));
+    } else if (patientMapping.source === EhrSources.elation) {
+      startCreateResourceDiffBundlesJobAtEhr({
+        ehr: EhrSources.elation,
+        cxId,
+        ehrPatientId: patientMapping.externalId,
+        requestId,
+      }).catch(processAsyncError(`${EhrSources.elation} startCreateResourceDiffBundlesJobAtEhr`));
     }
   }
 }

--- a/packages/api/src/routes/internal/ehr/patient.ts
+++ b/packages/api/src/routes/internal/ehr/patient.ts
@@ -1,10 +1,9 @@
 import { isResourceDiffBundleType } from "@metriport/core/external/ehr/bundle/bundle-shared";
-import { BadRequestError, isValidJobEntryStatus } from "@metriport/shared";
+import { BadRequestError } from "@metriport/shared";
 import { isEhrSource } from "@metriport/shared/interface/external/ehr/source";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import httpStatus from "http-status";
-import { setPatientJobEntryStatus } from "../../../command/job/patient/update/set-entry-status";
 import { contributeResourceDiffBundle } from "../../../external/ehr/shared/command/bundle/contribute-resource-diff-bundle";
 import {
   getLatestResourceDiffBundlesJobPayload,
@@ -148,44 +147,6 @@ router.post(
       ehrPatientId: patientId,
       resourceType,
       jobId,
-    });
-    return res.sendStatus(httpStatus.OK);
-  })
-);
-
-/**
- * @deprecated TODO Remove as follow up from ENG-499
- *
- * POST /internal/ehr/:ehrId/patient/:id/resource/diff/set-entry-status
- *
- * Sets the status of a resource diff job entry.
- *
- * @param req.query.ehrId - The EHR source.
- * @param req.query.cxId - The CX ID of the patient.
- * @param req.params.id - The patient id of the EHR patient.
- * @param req.query.jobId - The job ID.
- * @param req.query.entryStatus - The status of the entry.
- * @returns 200 OK
- */
-router.post(
-  "/:id/resource/diff/set-entry-status",
-  requestLogger,
-  asyncHandler(async (req: Request, res: Response) => {
-    const ehr = getFromQueryOrFail("ehrId", req);
-    if (!isEhrSource(ehr)) throw new BadRequestError("Invalid EHR", undefined, { ehr });
-    const cxId = getUUIDFrom("query", req, "cxId").orFail();
-    const jobId = getFromQueryOrFail("jobId", req);
-    const entryStatus = getFromQueryOrFail("entryStatus", req);
-    if (!isValidJobEntryStatus(entryStatus)) {
-      throw new BadRequestError("Status must a valid job entry status");
-    }
-    await setPatientJobEntryStatus({
-      jobId,
-      cxId,
-      entryStatus,
-      onCompleted: async () => {
-        //TODO: Contribute EHR-only bundles
-      },
     });
     return res.sendStatus(httpStatus.OK);
   })

--- a/packages/core/src/command/conversion-fhir/conversion-fhir-cloud.ts
+++ b/packages/core/src/command/conversion-fhir/conversion-fhir-cloud.ts
@@ -1,0 +1,32 @@
+import { Bundle, Resource } from "@medplum/fhirtypes";
+import { getLambdaResultPayload, LambdaClient, makeLambdaClient } from "../../external/aws/lambda";
+import { Config } from "../../util/config";
+import { ConversionFhirHandler, ConverterRequest } from "./conversion-fhir";
+
+export class ConversionFhirCloud extends ConversionFhirHandler {
+  constructor(
+    private readonly nodejsFhirConvertLambdaName: string = Config.getFhirConverterLambdaName(),
+    private readonly lambdaClient: LambdaClient = makeLambdaClient(Config.getAWSRegion())
+  ) {
+    super();
+  }
+
+  async callConverter(request: ConverterRequest): Promise<Bundle<Resource>> {
+    const payload = JSON.stringify({
+      body: request.payload,
+      queryStringParameters: request.params,
+    });
+    const result = await this.lambdaClient
+      .invoke({
+        FunctionName: this.nodejsFhirConvertLambdaName,
+        InvocationType: "RequestResponse",
+        Payload: payload,
+      })
+      .promise();
+    const resultPayload = getLambdaResultPayload({
+      result,
+      lambdaName: this.nodejsFhirConvertLambdaName,
+    });
+    return JSON.parse(resultPayload) as Bundle<Resource>;
+  }
+}

--- a/packages/core/src/command/conversion-fhir/conversion-fhir-direct.ts
+++ b/packages/core/src/command/conversion-fhir/conversion-fhir-direct.ts
@@ -1,0 +1,26 @@
+import { Bundle, Resource } from "@medplum/fhirtypes";
+import axios from "axios";
+import { TXT_MIME_TYPE } from "../../util/mime";
+import { ConversionFhirHandler, ConverterRequest } from "./conversion-fhir";
+import { Config } from "../../util/config";
+
+const FHIR_CONVERSION_API_PATH = "/api/convert/cda/ccd.hbs";
+
+function buildConversionFhirUrl(fhirConverterUrl: string): string {
+  return `${fhirConverterUrl}${FHIR_CONVERSION_API_PATH}`;
+}
+
+export class ConversionFhirDirect extends ConversionFhirHandler {
+  constructor(private readonly fhirConverterUrl: string = Config.getFhirConvertServerURL()) {
+    super();
+  }
+
+  async callConverter(request: ConverterRequest): Promise<Bundle<Resource>> {
+    const url = buildConversionFhirUrl(this.fhirConverterUrl);
+    const resp = await axios.post(url, request.payload, {
+      params: request.params,
+      headers: { "Content-Type": TXT_MIME_TYPE },
+    });
+    return resp.data.fhirResource as Bundle<Resource>;
+  }
+}

--- a/packages/core/src/command/conversion-fhir/conversion-fhir-factory.ts
+++ b/packages/core/src/command/conversion-fhir/conversion-fhir-factory.ts
@@ -1,0 +1,11 @@
+import { Config } from "../../util/config";
+import { ConversionFhirHandler } from "./conversion-fhir";
+import { ConversionFhirCloud } from "./conversion-fhir-cloud";
+import { ConversionFhirDirect } from "./conversion-fhir-direct";
+
+export function buildConversionFhirHandler(): ConversionFhirHandler {
+  if (Config.isDev()) {
+    return new ConversionFhirDirect();
+  }
+  return new ConversionFhirCloud();
+}

--- a/packages/core/src/command/conversion-fhir/conversion-fhir.ts
+++ b/packages/core/src/command/conversion-fhir/conversion-fhir.ts
@@ -1,0 +1,85 @@
+import { Bundle, Resource } from "@medplum/fhirtypes";
+import { uuidv7 } from "@metriport/shared/util/uuid-v7";
+import { FhirConverterParams } from "../../domain/conversion/bundle-modifications/modifications";
+import {
+  buildDocumentNameForConversionResult,
+  buildKeyForConversionFhir,
+} from "../../domain/conversion/filename";
+import { buildBatchBundleFromResources } from "../../external/fhir/bundle/bundle";
+import { out } from "../../util/log";
+import { JSON_TXT_MIME_TYPE } from "../../util/mime";
+import { capture } from "../../util/notifications";
+import { getPayloadPartitions, saveConverterStep } from "./utils";
+
+const LARGE_CHUNK_SIZE_IN_BYTES = 50_000_000;
+
+export type ConversionFhirRequest = {
+  cxId: string;
+  patientId: string;
+  requestId?: string;
+  inputS3Key: string;
+  inputS3BucketName: string;
+};
+
+export type ConverterRequest = {
+  payload: string;
+  params: FhirConverterParams;
+};
+
+export abstract class ConversionFhirHandler {
+  async convertToFhir(params: ConversionFhirRequest): Promise<{
+    bundle: Bundle;
+    resultKey: string;
+    resultBucket: string;
+  }> {
+    const { log } = out(`convertPayloadToFHIR - cxId ${params.cxId} patientId ${params.patientId}`);
+    const requestId = params.requestId ?? uuidv7();
+    const paramsWithRequestId = { ...params, requestId };
+    const partitionedPayloads = await getPayloadPartitions(paramsWithRequestId);
+    const converterParams: FhirConverterParams = {
+      patientId: paramsWithRequestId.patientId,
+      fileName: buildKeyForConversionFhir({
+        cxId: paramsWithRequestId.cxId,
+        patientId: paramsWithRequestId.patientId,
+        requestId: paramsWithRequestId.requestId,
+        fileName: buildDocumentNameForConversionResult(paramsWithRequestId.requestId),
+      }),
+      // TODO Eng-531: Make these optional
+      unusedSegments: "false",
+      invalidAccess: "false",
+    };
+    const resources = new Set<Resource>();
+    for (const [index, payload] of partitionedPayloads.entries()) {
+      const chunkSize = new Blob([payload]).size;
+      if (chunkSize > LARGE_CHUNK_SIZE_IN_BYTES) {
+        const msg = "Chunk size is too large";
+        log(`${msg} - chunkSize ${chunkSize} on ${index}`);
+        capture.message(msg, {
+          extra: {
+            chunkSize,
+            patientId: converterParams.patientId,
+            fileName: converterParams.fileName,
+          },
+          level: "warning",
+        });
+      }
+      const conversionResult = await this.callConverter({ payload, params: converterParams });
+      if (!conversionResult || !conversionResult.entry || conversionResult.entry.length < 1)
+        continue;
+      for (const entry of conversionResult.entry) {
+        if (entry.resource) resources.add(entry.resource);
+      }
+    }
+    const bundle = buildBatchBundleFromResources([...resources.values()]);
+    const { key: resultKey, bucket: resultBucket } = await saveConverterStep({
+      paramsWithRequestId,
+      result: bundle,
+      contentType: JSON_TXT_MIME_TYPE,
+      fileName: buildDocumentNameForConversionResult(requestId),
+      stepName: "result",
+    });
+    return { bundle, resultKey, resultBucket };
+  }
+
+  abstract callConverter(params: ConverterRequest): Promise<Bundle<Resource>>;
+}

--- a/packages/core/src/command/conversion-fhir/utils.ts
+++ b/packages/core/src/command/conversion-fhir/utils.ts
@@ -1,0 +1,123 @@
+import { Bundle, Resource } from "@medplum/fhirtypes";
+import { BadRequestError, errorToString, MetriportError } from "@metriport/shared";
+import { cleanUpPayload } from "../../domain/conversion/cleanup";
+import {
+  buildDocumentNameForCleanConversion,
+  buildDocumentNameForPreConversion,
+  buildKeyForConversionFhir,
+} from "../../domain/conversion/filename";
+import { S3Utils } from "../../external/aws/s3";
+import { partitionPayload } from "../../external/cda/partition-payload";
+import { removeBase64PdfEntries } from "../../external/cda/remove-b64";
+import { Config } from "../../util/config";
+import { out } from "../../util/log";
+import { JSON_TXT_MIME_TYPE, XML_TXT_MIME_TYPE } from "../../util/mime";
+import { ConversionFhirRequest } from "./conversion-fhir";
+
+function getS3Utils(): S3Utils {
+  return new S3Utils(Config.getAWSRegion());
+}
+
+type ConversionFhirRequestWithRequestId = Omit<ConversionFhirRequest, "requestId"> & {
+  requestId: string;
+};
+
+export async function getPayloadPartitions(
+  paramsWithRequestId: ConversionFhirRequestWithRequestId
+): Promise<string[]> {
+  const { log } = out(
+    `getConverterParamsAndPayloadPartitions - cxId ${paramsWithRequestId.cxId} patientId ${paramsWithRequestId.patientId} requestId ${paramsWithRequestId.requestId}`
+  );
+  const s3Utils = getS3Utils();
+  const payloadRaw = await s3Utils.getFileContentsAsString(
+    paramsWithRequestId.inputS3BucketName,
+    paramsWithRequestId.inputS3Key
+  );
+  const additionalInfo = {
+    cxId: paramsWithRequestId.cxId,
+    patientId: paramsWithRequestId.patientId,
+    inputS3Key: paramsWithRequestId.inputS3Key,
+    inputS3BucketName: paramsWithRequestId.inputS3BucketName,
+  };
+  if (payloadRaw.includes("nonXMLBody")) {
+    throw new BadRequestError("XML document is unstructured CDA with nonXMLBody", undefined, {
+      ...additionalInfo,
+    });
+  }
+  await saveConverterStep({
+    paramsWithRequestId,
+    result: payloadRaw,
+    contentType: XML_TXT_MIME_TYPE,
+    fileName: buildDocumentNameForPreConversion(paramsWithRequestId.requestId),
+    stepName: "pre-conversion",
+    throwError: false,
+  });
+  const { documentContents, b64Attachments } = removeBase64PdfEntries(payloadRaw);
+  if (b64Attachments && b64Attachments.total > 0) {
+    // TODO Eng-517: Process B64 attachments
+    log(`Extracted ${b64Attachments.total} B64 attachments - not processing....`);
+  }
+  const payloadClean = cleanUpPayload(documentContents).trim();
+  if (payloadClean.length < 1) {
+    throw new BadRequestError("XML document is empty", undefined, {
+      ...additionalInfo,
+    });
+  }
+  await saveConverterStep({
+    paramsWithRequestId,
+    result: payloadClean,
+    contentType: XML_TXT_MIME_TYPE,
+    fileName: buildDocumentNameForCleanConversion(paramsWithRequestId.requestId),
+    stepName: "clean",
+    throwError: false,
+  });
+  const partitionedPayloads = partitionPayload(payloadClean);
+  return partitionedPayloads;
+}
+
+export async function saveConverterStep({
+  paramsWithRequestId,
+  result,
+  contentType,
+  fileName,
+  stepName,
+  throwError = true,
+}: {
+  paramsWithRequestId: ConversionFhirRequestWithRequestId;
+  result: string | Bundle<Resource>;
+  contentType: typeof JSON_TXT_MIME_TYPE | typeof XML_TXT_MIME_TYPE;
+  fileName: string;
+  stepName: string;
+  throwError?: boolean;
+}): Promise<{ key: string; bucket: string }> {
+  const { log } = out(
+    `saveConverterStep - cxId ${paramsWithRequestId.cxId} patientId ${paramsWithRequestId.patientId} requestId ${paramsWithRequestId.requestId}`
+  );
+  const s3Utils = getS3Utils();
+  const bucket = Config.getFhirConversionBucketName();
+  const key = buildKeyForConversionFhir({
+    cxId: paramsWithRequestId.cxId,
+    patientId: paramsWithRequestId.patientId,
+    requestId: paramsWithRequestId.requestId,
+    fileName,
+  });
+  try {
+    await s3Utils.uploadFile({
+      bucket,
+      key,
+      file: Buffer.from(typeof result === "string" ? result : JSON.stringify(result), "utf8"),
+      contentType,
+    });
+  } catch (error) {
+    const msg = `Error saving converter file ${fileName} for step ${stepName}`;
+    log(`${msg}. Cause: ${errorToString(error)}`);
+    if (throwError) {
+      throw new MetriportError(msg, error, {
+        cxId: paramsWithRequestId.cxId,
+        patientId: paramsWithRequestId.patientId,
+        fileName,
+      });
+    }
+  }
+  return { key, bucket };
+}

--- a/packages/core/src/domain/conversion/filename.ts
+++ b/packages/core/src/domain/conversion/filename.ts
@@ -3,6 +3,27 @@ export function buildDocumentNameForPartialConversions(fileName: string, index: 
   return `${fileName}_part_${paddedIndex}.xml`;
 }
 
+type ConversionFhirPath = {
+  cxId: string;
+  patientId: string;
+  requestId: string;
+};
+
+export function buildPathForConversionFhir({
+  cxId,
+  patientId,
+  requestId,
+}: ConversionFhirPath): string {
+  return `conversion-fhir/cxid=${cxId}/patientid=${patientId}/requestid=${requestId}`;
+}
+
+export function buildKeyForConversionFhir({
+  fileName,
+  ...conversionFhirPathParams
+}: ConversionFhirPath & { fileName: string }): string {
+  return `${buildPathForConversionFhir(conversionFhirPathParams)}/${fileName}`;
+}
+
 export function buildDocumentNameForFromConverter(fileName: string): string {
   return `${fileName}.from_converter.json`;
 }

--- a/packages/core/src/external/ehr/bundle/command/create-or-replace-ccda.ts
+++ b/packages/core/src/external/ehr/bundle/command/create-or-replace-ccda.ts
@@ -1,0 +1,74 @@
+import { errorToString, executeWithNetworkRetries, MetriportError } from "@metriport/shared";
+import { Config } from "../../../../util/config";
+import { out } from "../../../../util/log";
+import { BundleKeyBaseParams, createFileKeyCcda, getS3UtilsInstance } from "../bundle-shared";
+
+export type CreateOrReplaceCcdaParams = Omit<
+  BundleKeyBaseParams,
+  "bundleType" | "resourceId" | "getLastModified"
+> & {
+  payload: string;
+};
+
+/**
+ * Creates or replaces a CCDA file.
+ *
+ * @param ehr - The EHR source.
+ * @param cxId - The CX ID.
+ * @param metriportPatientId - The Metriport ID.
+ * @param ehrPatientId - The EHR patient ID.
+ * @param resourceType - The resource type of the CCDA file.
+ * @param jobId - The job ID of the CCDA file. If not provided, the tag 'latest' will be used.
+ * @param s3BucketName - The S3 bucket name (optional, defaults to the EHR bundle bucket)
+ * @param payload - The payload of the CCDA file.
+ * @param s3FileName - The S3 file name of the CCDA file.
+ */
+export async function createOrReplaceCcda({
+  ehr,
+  cxId,
+  metriportPatientId,
+  ehrPatientId,
+  payload,
+  resourceType,
+  jobId,
+  s3BucketName = Config.getEhrBundleBucketName(),
+}: CreateOrReplaceCcdaParams): Promise<{
+  s3key: string;
+  s3BucketName: string;
+}> {
+  const { log } = out(
+    `Ehr createOrReplaceCcda - ehr ${ehr} cxId ${cxId} ehrPatientId ${ehrPatientId}`
+  );
+  const s3Utils = getS3UtilsInstance();
+  const key = createFileKeyCcda({
+    ehr,
+    cxId,
+    metriportPatientId,
+    ehrPatientId,
+    resourceType,
+    jobId,
+  });
+  try {
+    await executeWithNetworkRetries(async () => {
+      await s3Utils.uploadFile({
+        bucket: s3BucketName,
+        key,
+        file: Buffer.from(payload, "utf8"),
+        contentType: "application/xml",
+      });
+    });
+    return { s3key: key, s3BucketName };
+  } catch (error) {
+    const msg = "Failure while creating or replacing CCDA file @ S3";
+    log(`${msg}. Cause: ${errorToString(error)}`);
+    throw new MetriportError(msg, error, {
+      ehr,
+      cxId,
+      metriportPatientId,
+      ehrPatientId,
+      resourceType,
+      key,
+      context: "ehr.createOrReplaceCcda",
+    });
+  }
+}

--- a/packages/core/src/external/ehr/canvas/index.ts
+++ b/packages/core/src/external/ehr/canvas/index.ts
@@ -12,8 +12,6 @@ import {
 } from "@medplum/fhirtypes";
 import {
   BadRequestError,
-  EhrFhirResourceBundle,
-  ehrFhirResourceBundleSchema,
   errorToString,
   JwtTokenInfo,
   MetriportError,
@@ -35,6 +33,10 @@ import {
   SlimBookedAppointment,
   slimBookedAppointmentSchema,
 } from "@metriport/shared/interface/external/ehr/canvas/index";
+import {
+  EhrFhirResourceBundle,
+  ehrFhirResourceBundleSchema,
+} from "@metriport/shared/interface/external/ehr/fhir-resource";
 import { Patient, patientSchema } from "@metriport/shared/interface/external/ehr/patient";
 import {
   Practitioner,

--- a/packages/core/src/external/ehr/command/get-bundle-by-resource-type.ts
+++ b/packages/core/src/external/ehr/command/get-bundle-by-resource-type.ts
@@ -3,6 +3,7 @@ import { BadRequestError } from "@metriport/shared";
 import { EhrSource, EhrSources } from "@metriport/shared/interface/external/ehr/source";
 import { getBundleByResourceType as getBundleByResourceTypeAthena } from "../athenahealth/command/get-bundle-by-resource-type";
 import { getBundleByResourceType as getBundleByResourceTypeCanvas } from "../canvas/command/get-bundle-by-resource-type";
+import { getBundleByResourceType as getBundleByResourceTypeElation } from "../elation/command/get-bundle-by-resource-type";
 
 export type GetBundleByResourceTypeRequest = {
   ehr: EhrSource;
@@ -32,7 +33,7 @@ type GetBundleByResourceTypeFnMap = Record<EhrSource, GetBundleByResourceTypeFn 
 const ehrGetBundleByResourceTypeMap: GetBundleByResourceTypeFnMap = {
   [EhrSources.canvas]: getBundleByResourceTypeCanvas,
   [EhrSources.athena]: getBundleByResourceTypeAthena,
-  [EhrSources.elation]: undefined,
+  [EhrSources.elation]: getBundleByResourceTypeElation,
   [EhrSources.healthie]: undefined,
   [EhrSources.eclinicalworks]: undefined,
 };

--- a/packages/core/src/external/ehr/command/get-resource-bundle-by-resource-id.ts
+++ b/packages/core/src/external/ehr/command/get-resource-bundle-by-resource-id.ts
@@ -3,6 +3,7 @@ import { BadRequestError } from "@metriport/shared";
 import { EhrSource, EhrSources } from "@metriport/shared/interface/external/ehr/source";
 import { getResourceBundleByResourceId as getAthenaResourceBundleByResourceId } from "../athenahealth/command/get-resource-bundle-by-resource-id";
 import { getResourceBundleByResourceId as getCanvasResourceBundleByResourceId } from "../canvas/command/get-resource-bundle-by-resource-id";
+import { getResourceBundleByResourceId as getElationResourceBundleByResourceId } from "../elation/command/get-resource-bundle-by-resource-id";
 
 export type GetResourceBundleByResourceIdRequest = {
   ehr: EhrSource;
@@ -41,7 +42,7 @@ type GetResourceBundleByResourceIdMethodsMap = Record<
 const ehrGetResourceBundleByResourceIdMap: GetResourceBundleByResourceIdMethodsMap = {
   [EhrSources.canvas]: getCanvasResourceBundleByResourceId,
   [EhrSources.athena]: getAthenaResourceBundleByResourceId,
-  [EhrSources.elation]: undefined,
+  [EhrSources.elation]: getElationResourceBundleByResourceId,
   [EhrSources.healthie]: undefined,
   [EhrSources.eclinicalworks]: undefined,
 };

--- a/packages/core/src/external/ehr/elation/command/get-bundle-by-resource-type.ts
+++ b/packages/core/src/external/ehr/elation/command/get-bundle-by-resource-type.ts
@@ -1,0 +1,41 @@
+import { Bundle } from "@medplum/fhirtypes";
+import { ehrFhirResourceBundleSchema } from "@metriport/shared/interface/external/ehr/fhir-resource";
+import { buildConversionFhirHandler } from "../../../../command/conversion-fhir/conversion-fhir-factory";
+import { GetBundleByResourceTypeClientRequest } from "../../command/get-bundle-by-resource-type";
+import { createElationHealthClient } from "../shared";
+
+export async function getBundleByResourceType(
+  params: GetBundleByResourceTypeClientRequest
+): Promise<Bundle> {
+  const {
+    tokenId,
+    cxId,
+    practiceId,
+    metriportPatientId,
+    ehrPatientId,
+    resourceType,
+    useCachedBundle,
+  } = params;
+  const client = await createElationHealthClient({
+    cxId,
+    practiceId,
+    ...(tokenId && { tokenId }),
+  });
+  const handler = buildConversionFhirHandler();
+  const bundle = await client.getBundleByResourceType({
+    cxId,
+    metriportPatientId,
+    elationPatientId: ehrPatientId,
+    resourceType,
+    fhirConverterToEhrBundle: async params => {
+      const conversionResult = await handler.convertToFhir({
+        ...params,
+        cxId,
+        patientId: metriportPatientId,
+      });
+      return ehrFhirResourceBundleSchema.parse(conversionResult.bundle);
+    },
+    useCachedBundle,
+  });
+  return bundle;
+}

--- a/packages/core/src/external/ehr/elation/command/get-resource-bundle-by-resource-id.ts
+++ b/packages/core/src/external/ehr/elation/command/get-resource-bundle-by-resource-id.ts
@@ -1,0 +1,35 @@
+import { Bundle } from "@medplum/fhirtypes";
+import { BadRequestError } from "@metriport/shared";
+import { GetResourceBundleByResourceIdClientRequest } from "../../command/get-resource-bundle-by-resource-id";
+import { createElationHealthClient } from "../shared";
+
+export async function getResourceBundleByResourceId(
+  params: GetResourceBundleByResourceIdClientRequest
+): Promise<Bundle> {
+  const {
+    tokenId,
+    cxId,
+    practiceId,
+    metriportPatientId,
+    ehrPatientId,
+    resourceType,
+    resourceId,
+    useCachedBundle,
+  } = params;
+  if (!useCachedBundle) {
+    throw new BadRequestError("useCachedBundle false is not supported");
+  }
+  const client = await createElationHealthClient({
+    cxId,
+    practiceId,
+    ...(tokenId && { tokenId }),
+  });
+  const bundle = await client.getResourceBundleByResourceId({
+    cxId,
+    metriportPatientId,
+    elationPatientId: ehrPatientId,
+    resourceId,
+    resourceType,
+  });
+  return bundle;
+}

--- a/packages/core/src/external/ehr/job/create-resource-diff-bundles/shared.ts
+++ b/packages/core/src/external/ehr/job/create-resource-diff-bundles/shared.ts
@@ -12,7 +12,11 @@ export type CreateResourceDiffBundlesBaseRequest = {
   reportError?: boolean;
 };
 
-const ehrSourcesWithCreateResourceDiffBundles = [EhrSources.canvas, EhrSources.athena] as const;
+const ehrSourcesWithCreateResourceDiffBundles = [
+  EhrSources.canvas,
+  EhrSources.athena,
+  EhrSources.elation,
+] as const;
 export type EhrSourceWithCreateResourceDiffBundles =
   (typeof ehrSourcesWithCreateResourceDiffBundles)[number];
 export function isEhrSourceWithCreateResourceDiffBundles(

--- a/packages/core/src/external/ehr/shared.ts
+++ b/packages/core/src/external/ehr/shared.ts
@@ -758,13 +758,13 @@ export async function saveEhrReferenceBundle({
     }
   });
   if (saveReferenceBundleErrors.length > 0) {
-    const msg = `Failure while saving some reference bundle entries @ Elation`;
+    const msg = `Failure while saving some reference bundle entries @ ${ehr}`;
     capture.message(msg, {
       extra: {
         saveReferenceBundleArgsCount: saveReferenceBundleArgs.length,
         saveReferenceBundleErrorsCount: saveReferenceBundleErrors.length,
         errors: saveReferenceBundleErrors,
-        context: "elation.get-bundle-by-resource-type",
+        context: `${ehr}.save-reference-bundle`,
       },
       level: "warning",
     });

--- a/packages/core/src/external/fhir/bundle/bundle.ts
+++ b/packages/core/src/external/fhir/bundle/bundle.ts
@@ -174,6 +174,14 @@ export function buildBundleFromResources({
   };
 }
 
+export function buildBatchBundleFromResources(resources: Resource[]): BundleWithEntry {
+  return {
+    resourceType: "Bundle",
+    type: "batch",
+    entry: resources.map(buildBundleEntry),
+  };
+}
+
 export type RequiredBundleType = NonNullable<Bundle["type"]>;
 
 export type BundleType<B extends RequiredBundleType, R extends Resource> = Bundle<R> & {
@@ -312,11 +320,11 @@ export function createFullBundleEntries(bundle: Bundle<Resource>): Bundle<Resour
   return updBundle;
 }
 
-export const buildFullUrl = <T extends Resource>(resource: T | undefined): string | undefined => {
+export function buildFullUrl<T extends Resource>(resource: T | undefined): string | undefined {
   if (!resource || !resource.id) return undefined;
   if (isValidUuid(resource.id)) return wrapIdInUrnUuid(resource.id);
   return wrapIdInUrnId(resource.id);
-};
+}
 
 export function buildFhirRequest(resource: Resource | undefined): BundleEntryRequest | undefined {
   if (!resource?.id) return undefined;

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -315,4 +315,14 @@ export class Config {
   static getRunPatientJobQueueUrl(): string {
     return getEnvVarOrFail("RUN_PATIENT_JOB_QUEUE_URL");
   }
+
+  static getFhirConverterLambdaName(): string {
+    return getEnvVarOrFail("FHIR_CONVERTER_LAMBDA_NAME");
+  }
+  static getFhirConvertServerURL(): string {
+    return getEnvVarOrFail("FHIR_CONVERTER_SERVER_URL");
+  }
+  static getFhirConversionBucketName(): string {
+    return getEnvVarOrFail("FHIR_CONVERTER_BUCKET_NAME");
+  }
 }

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -471,31 +471,6 @@ export class APIStack extends Stack {
     });
 
     //-------------------------------------------
-    // EHR
-    //-------------------------------------------
-    const {
-      getAppointmentsLambda: ehrGetAppointmentsLambda,
-      syncPatientQueue: ehrSyncPatientQueue,
-      syncPatientLambda: ehrSyncPatientLambda,
-      elationLinkPatientQueue,
-      elationLinkPatientLambda,
-      healthieLinkPatientQueue,
-      healthieLinkPatientLambda,
-      contributeResourceDiffBundlesLambda: ehrContributeResourceDiffBundlesLambda,
-      computeResourceDiffBundlesLambda: ehrComputeResourceDiffBundlesLambda,
-      refreshEhrBundlesQueue: ehrRefreshEhrBundlesQueue,
-      refreshEhrBundlesLambda: ehrRefreshEhrBundlesLambda,
-      ehrBundleBucket,
-    } = new EhrNestedStack(this, "EhrNestedStack", {
-      config: props.config,
-      lambdaLayers,
-      vpc: this.vpc,
-      alarmAction: slackNotification?.alarmAction,
-      ehrResponsesBucket,
-      medicalDocumentsBucket,
-    });
-
-    //-------------------------------------------
     // Jobs
     //-------------------------------------------
     const jobsStack = new JobsNestedStack(this, "JobsNestedStack", {
@@ -570,6 +545,33 @@ export class APIStack extends Stack {
       alarmSnsAction: slackNotification?.alarmAction,
     });
     const cookieStore = cwEnhancedQueryQueues?.cookieStore;
+
+    //-------------------------------------------
+    // EHR
+    //-------------------------------------------
+    const {
+      getAppointmentsLambda: ehrGetAppointmentsLambda,
+      syncPatientQueue: ehrSyncPatientQueue,
+      syncPatientLambda: ehrSyncPatientLambda,
+      elationLinkPatientQueue,
+      elationLinkPatientLambda,
+      healthieLinkPatientQueue,
+      healthieLinkPatientLambda,
+      contributeResourceDiffBundlesLambda: ehrContributeResourceDiffBundlesLambda,
+      computeResourceDiffBundlesLambda: ehrComputeResourceDiffBundlesLambda,
+      refreshEhrBundlesQueue: ehrRefreshEhrBundlesQueue,
+      refreshEhrBundlesLambda: ehrRefreshEhrBundlesLambda,
+      ehrBundleBucket,
+    } = new EhrNestedStack(this, "EhrNestedStack", {
+      config: props.config,
+      lambdaLayers,
+      vpc: this.vpc,
+      alarmAction: slackNotification?.alarmAction,
+      ehrResponsesBucket,
+      fhirConverterLambda: fhirConverter?.lambda,
+      fhirConverterBucket: fhirConverter?.bucket,
+      medicalDocumentsBucket,
+    });
 
     //-------------------------------------------
     // ECR + ECS + Fargate for Backend Servers

--- a/packages/shared/src/interface/external/ehr/elation/ccda.ts
+++ b/packages/shared/src/interface/external/ehr/elation/ccda.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const ccdaDocumentSchema = z.object({
+  id: z.coerce.string(),
+  base64_ccda: z.string(),
+});
+export type CcdaDocument = z.infer<typeof ccdaDocumentSchema>;

--- a/packages/shared/src/interface/external/ehr/elation/index.ts
+++ b/packages/shared/src/interface/external/ehr/elation/index.ts
@@ -5,3 +5,4 @@ export * from "./problem";
 export * from "./subscription";
 export * from "./cx-mapping";
 export * from "./event";
+export * from "./ccda";


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-139

### Description

- https://github.com/metriport/metriport/pull/4082

### Testing

Check each PR.

### Release Plan


- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for the Elation EHR source, enabling retrieval and conversion of CCDA documents and FHIR resource bundles.
  - Added new FHIR conversion workflows, including direct HTTP and AWS Lambda-based conversion handlers, with automatic environment-based selection.
  - Implemented utilities for partitioning and saving FHIR conversion payloads and results.
  - Enhanced infrastructure to integrate and grant permissions for FHIR converter Lambda and storage resources.

- **Improvements**
  - Expanded resource diff bundle creation to support Elation EHR.
  - Improved error messages and context for bundle processing across EHR sources.
  - Added new utilities for generating file paths and S3 keys for conversion artifacts.

- **Bug Fixes**
  - Removed a deprecated internal API endpoint for setting resource diff job entry status.

- **Documentation**
  - Added schema validation and type definitions for Elation CCDA documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->