### PR TITLE
feat(api): send notif to slack for discharge adt for select cx

### DIFF
--- a/packages/api/src/command/medical/patient/hl7-fhir-webhook.ts
+++ b/packages/api/src/command/medical/patient/hl7-fhir-webhook.ts
@@ -67,7 +67,7 @@ export async function processHl7FhirBundleWebhook({
 
         const message: SlackMessage = {
           subject: `Patient Discharge Detected`,
-          message: JSON.stringify(messagePayload),
+          message: JSON.stringify(messagePayload, null, 2),
           emoji: ":hospital:",
         };
 

--- a/packages/api/src/command/medical/patient/hl7-fhir-webhook.ts
+++ b/packages/api/src/command/medical/patient/hl7-fhir-webhook.ts
@@ -57,21 +57,26 @@ export async function processHl7FhirBundleWebhook({
       triggerEvent === "A03" &&
       (await isDischargeSlackNotificationFeatureFlagEnabledForCx(cxId))
     ) {
-      const messagePayload = {
-        cxId,
-        patientId,
-        admitTimestamp,
-        dischargeTimestamp,
-      };
+      try {
+        const messagePayload = {
+          cxId,
+          patientId,
+          admitTimestamp,
+          dischargeTimestamp,
+        };
 
-      const message: SlackMessage = {
-        subject: `Patient Discharge Detected`,
-        message: JSON.stringify(messagePayload),
-        emoji: ":hospital:",
-      };
+        const message: SlackMessage = {
+          subject: `Patient Discharge Detected`,
+          message: JSON.stringify(messagePayload),
+          emoji: ":hospital:",
+        };
 
-      const channelUrl = Config.getDischargeNotificationSlackUrl();
-      await sendToSlack(message, channelUrl);
+        const channelUrl = Config.getDischargeNotificationSlackUrl();
+        await sendToSlack(message, channelUrl);
+        log(`Slack discharge notification sent successfully`);
+      } catch (slackError) {
+        log(`Failed to send Slack discharge notification: ${errorToString(slackError)}`);
+      }
     }
 
     if (!(await isHl7NotificationWebhookFeatureFlagEnabledForCx(cxId))) {

--- a/packages/core/src/command/feature-flags/domain-ffs.ts
+++ b/packages/core/src/command/feature-flags/domain-ffs.ts
@@ -251,3 +251,16 @@ export async function isHl7NotificationWebhookFeatureFlagEnabledForCx(
     await getCxsWithHl7NotificationWebhookFeatureFlag();
   return cxIdsWithHl7NotificationWebhookEnabled.some(i => i === cxId);
 }
+
+export async function getCxsWithDischargeSlackNotificationFeatureFlag(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithDischargeSlackNotificationFeatureFlag");
+}
+
+// ENG-536 remove this once we automatically find the discharge summary
+export async function isDischargeSlackNotificationFeatureFlagEnabledForCx(
+  cxId: string
+): Promise<boolean> {
+  const cxsWithDischargeSlackNotificationFeatureFlag =
+    await getCxsWithDischargeSlackNotificationFeatureFlag();
+  return cxsWithDischargeSlackNotificationFeatureFlag.some(i => i === cxId);
+}

--- a/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
+++ b/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
@@ -60,6 +60,7 @@ export const initialFeatureFlags: FeatureFlagDatastore = {
   cxsWithPcpVisitAiSummaryFeatureFlag: { enabled: false, values: [] },
   cxsWithHl7NotificationWebhookFeatureFlag: { enabled: false, values: [] },
   cxsWithDischargeRequeryFeatureFlag: { enabled: false, values: [] },
+  cxsWithDischargeSlackNotificationFeatureFlag: { enabled: false, values: [] },
 };
 
 /**

--- a/packages/core/src/command/feature-flags/types.ts
+++ b/packages/core/src/command/feature-flags/types.ts
@@ -36,6 +36,7 @@ export const cxBasedFFsSchema = z.object({
   cxsWithAthenaCustomFieldsEnabled: ffStringValuesSchema,
   cxsWithPcpVisitAiSummaryFeatureFlag: ffStringValuesSchema,
   cxsWithHl7NotificationWebhookFeatureFlag: ffStringValuesSchema,
+  cxsWithDischargeSlackNotificationFeatureFlag: ffStringValuesSchema,
 });
 export type CxBasedFFsSchema = z.infer<typeof cxBasedFFsSchema>;
 

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -329,4 +329,9 @@ export class Config {
   static getFhirConversionBucketName(): string {
     return getEnvVarOrFail("FHIR_CONVERTER_BUCKET_NAME");
   }
+
+  // ENG-536 remove this once we automatically find the discharge summary
+  static getDischargeNotificationSlackUrl(): string {
+    return getEnvVarOrFail("DISCHARGE_NOTIFICATION_SLACK_URL");
+  }
 }

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -207,6 +207,7 @@ export const config: EnvConfigNonSandbox = {
         },
       },
     },
+    dischargeNotificationSlackUrl: "url-to-slack-channel",
   },
   acmCertMonitor: {
     scheduleExpressions: ["cw-schedule-expression"],

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -25,6 +25,8 @@ export interface Hl7NotificationConfig {
     bucketName: string;
   };
   hieConfigs: Record<string, HieConfig>;
+  // ENG-536 remove this once we automatically find the discharge summary
+  dischargeNotificationSlackUrl: string;
 }
 
 export type Hl7NotificationVpnConfig = {

--- a/packages/infra/lib/api-stack/api-service.ts
+++ b/packages/infra/lib/api-stack/api-service.ts
@@ -389,6 +389,10 @@ export function createAPIService({
             ),
           }),
           RUN_PATIENT_JOB_QUEUE_URL: jobAssets.runPatientJobQueue.queueUrl,
+          ...(props.config.hl7Notification?.dischargeNotificationSlackUrl && {
+            DISCHARGE_NOTIFICATION_SLACK_URL:
+              props.config.hl7Notification.dischargeNotificationSlackUrl,
+          }),
         },
       },
       healthCheckGracePeriod: Duration.seconds(60),


### PR DESCRIPTION
Part of ENG-539

Issues:

- https://linear.app/metriport/issue/ENG-539

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/3067

### Description
- Adding FF that will send us a slack notification when certain CX get a discharge ADT

### Testing

- Local
  - [x] Test the URL is correct
- Staging
  - [ ] Trigger ADT for a staging CX that has the FF activated
  - [ ] Deactivate FF, and trigger ADT again
- Production
  - [ ] Monitor in prod

### Release Plan
- [ ] Upstream dependencies are met/released
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Slack notifications for patient discharge events (HL7 A03) when enabled for a customer.
  * Introduced a new feature flag to control discharge Slack notifications on a per-customer basis.
  * Added configuration options to specify the Slack channel for discharge notifications.

* **Chores**
  * Updated environment and configuration settings to support the new Slack notification feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->