### PR TITLE
feat(api): discharge requery behind a ff

### DIFF
--- a/packages/api/src/command/medical/patient/patient-monitoring/discharge-requery/__tests__/create.test.ts
+++ b/packages/api/src/command/medical/patient/patient-monitoring/discharge-requery/__tests__/create.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import * as domainFfsModule from "@metriport/core/command/feature-flags/domain-ffs";
 import { JobStatus, PatientJob } from "@metriport/shared";
 import { defaultRemainingAttempts } from "@metriport/shared/domain/patient/patient-monitoring/utils";
 import dayjs from "dayjs";
@@ -11,6 +12,7 @@ describe("createDischargeRequeryJob", () => {
   const mockDate = new Date("2024-01-01T12:00:00Z");
 
   let createPatientJobMock: jest.SpyInstance;
+  let isFeatureFlagEnabledMock: jest.SpyInstance;
   let getPatientJobMock: jest.SpyInstance;
   let cancelPatientJobMock: jest.SpyInstance;
   let cxId: string;
@@ -31,6 +33,11 @@ describe("createDischargeRequeryJob", () => {
       .spyOn(createJobModule, "createPatientJob")
       .mockResolvedValue(mockJob);
 
+    isFeatureFlagEnabledMock = jest.spyOn(
+      domainFfsModule,
+      "isDischargeRequeryFeatureFlagEnabledForCx"
+    );
+
     getPatientJobMock = jest.spyOn(getJobModule, "getPatientJobs");
     cancelPatientJobMock = jest.spyOn(cancelJobModule, "cancelPatientJob");
   });
@@ -41,6 +48,7 @@ describe("createDischargeRequeryJob", () => {
 
   it("should create a new discharge requery job with default parameters", async () => {
     getPatientJobMock.mockResolvedValue([]);
+    isFeatureFlagEnabledMock.mockResolvedValue(true);
 
     await createDischargeRequeryJob({
       cxId,
@@ -61,6 +69,7 @@ describe("createDischargeRequeryJob", () => {
   });
 
   it("should create a new job with the closest scheduledAt", async () => {
+    isFeatureFlagEnabledMock.mockResolvedValue(true);
     const existingJob = makePatientJob({
       scheduledAt: dayjs(mockDate).add(30, "minutes").toDate(),
       paramsOps: {
@@ -92,6 +101,7 @@ describe("createDischargeRequeryJob", () => {
   });
 
   it("should create a new job with the correct remainingAttempts", async () => {
+    isFeatureFlagEnabledMock.mockResolvedValue(true);
     const existingJob = makePatientJob({
       scheduledAt: dayjs(mockDate).add(2, "minutes").toDate(),
       paramsOps: {

--- a/packages/api/src/command/medical/patient/patient-monitoring/discharge-requery/create.ts
+++ b/packages/api/src/command/medical/patient/patient-monitoring/discharge-requery/create.ts
@@ -1,5 +1,5 @@
+import { isDischargeRequeryFeatureFlagEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
 import { out } from "@metriport/core/util/log";
-import { PatientJob } from "@metriport/shared/domain/job/patient-job";
 import {
   CreateDischargeRequeryParams,
   DischargeRequeryParamsOps,
@@ -37,9 +37,11 @@ export const dischargeRequeryJobType = "discharge-requery";
  */
 export async function createDischargeRequeryJob(
   props: CreateDischargeRequeryParams
-): Promise<PatientJob> {
+): Promise<void> {
   const { cxId, patientId } = props;
   const { log } = out(`createDischargeRequeryJob - cx: ${cxId} pt: ${patientId}`);
+
+  if (!(await isDischargeRequeryFeatureFlagEnabledForCx(cxId))) return;
 
   let remainingAttempts = props.remainingAttempts ?? defaultRemainingAttempts;
   let scheduledAt = calculateScheduledAt(remainingAttempts);
@@ -95,5 +97,5 @@ export async function createDischargeRequeryJob(
   });
 
   log(`created discharge requery job id: ${newDischargeRequeryJob.id}`);
-  return newDischargeRequeryJob;
+  return;
 }

--- a/packages/core/src/command/feature-flags/domain-ffs.ts
+++ b/packages/core/src/command/feature-flags/domain-ffs.ts
@@ -251,3 +251,11 @@ export async function isHl7NotificationWebhookFeatureFlagEnabledForCx(
     await getCxsWithHl7NotificationWebhookFeatureFlag();
   return cxIdsWithHl7NotificationWebhookEnabled.some(i => i === cxId);
 }
+
+export async function getCxsWithDischargeRequeryFeatureFlag(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithDischargeRequeryFeatureFlag");
+}
+export async function isDischargeRequeryFeatureFlagEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithDischargeRequeryEnabled = await getCxsWithDischargeRequeryFeatureFlag();
+  return cxIdsWithDischargeRequeryEnabled.some(i => i === cxId);
+}

--- a/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
+++ b/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
@@ -59,6 +59,7 @@ export const initialFeatureFlags: FeatureFlagDatastore = {
   carequalityFeatureFlag: { enabled: false },
   cxsWithPcpVisitAiSummaryFeatureFlag: { enabled: false, values: [] },
   cxsWithHl7NotificationWebhookFeatureFlag: { enabled: false, values: [] },
+  cxsWithDischargeRequeryFeatureFlag: { enabled: false, values: [] },
 };
 
 /**

--- a/packages/core/src/command/feature-flags/types.ts
+++ b/packages/core/src/command/feature-flags/types.ts
@@ -36,6 +36,7 @@ export const cxBasedFFsSchema = z.object({
   cxsWithAthenaCustomFieldsEnabled: ffStringValuesSchema,
   cxsWithPcpVisitAiSummaryFeatureFlag: ffStringValuesSchema,
   cxsWithHl7NotificationWebhookFeatureFlag: ffStringValuesSchema,
+  cxsWithDischargeRequeryFeatureFlag: ffStringValuesSchema,
 });
 export type CxBasedFFsSchema = z.infer<typeof cxBasedFFsSchema>;
 


### PR DESCRIPTION
Part of ENG-539

Issues:

- https://linear.app/metriport/issue/ENG-539

### Description
- FF for discharge requery 

### Testing

- Staging
  - [ ] Confirm that this creates a job for a CX with enabled FF
  - [ ] Confirm that this doesn't create a job for CX with disabled FF
- Production
  - [ ] Confirm that this creates a job for a CX with enabled FF

### Release Plan
- [ ] Merge this
- [ ] FFs have been set in Staging, Production, and Sandbox


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a feature flag to control discharge requery job creation for specific customers.
  * Added functionality to verify if the discharge requery feature is enabled for a customer.

* **Refactor**
  * Updated discharge requery job creation to respect the new feature flag and no longer return a job object.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->