### PR TITLE
feat(fhir-sdk): fix constant time perf threshold for tests

### DIFF
--- a/packages/fhir-sdk/src/__tests__/fhir-bundle-sdk.test.ts
+++ b/packages/fhir-sdk/src/__tests__/fhir-bundle-sdk.test.ts
@@ -8,7 +8,7 @@ import {
   invalidBundleWrongType,
   invalidBundleWrongBundleType,
   mixedResourceTypesBundle,
-  CONSTANT_TIME_EXPECTED_PERF_THRESHOLD,
+  CONSTANT_TIME_EXPECTED_THRESHOLD_MS,
 } from "./fixtures/fhir-bundles";
 import { Patient } from "@medplum/fhirtypes";
 
@@ -391,7 +391,7 @@ describe("FhirBundleSdk", () => {
         const end = performance.now();
 
         // O(1) resolution should be very fast
-        expect(end - start).toBeLessThan(CONSTANT_TIME_EXPECTED_PERF_THRESHOLD);
+        expect(end - start).toBeLessThan(CONSTANT_TIME_EXPECTED_THRESHOLD_MS);
       });
     });
 

--- a/packages/fhir-sdk/src/__tests__/fhir-bundle-sdk.test.ts
+++ b/packages/fhir-sdk/src/__tests__/fhir-bundle-sdk.test.ts
@@ -8,6 +8,7 @@ import {
   invalidBundleWrongType,
   invalidBundleWrongBundleType,
   mixedResourceTypesBundle,
+  CONSTANT_TIME_EXPECTED_PERF_THRESHOLD,
 } from "./fixtures/fhir-bundles";
 import { Patient } from "@medplum/fhirtypes";
 
@@ -390,7 +391,7 @@ describe("FhirBundleSdk", () => {
         const end = performance.now();
 
         // O(1) resolution should be very fast
-        expect(end - start).toBeLessThan(1);
+        expect(end - start).toBeLessThan(CONSTANT_TIME_EXPECTED_PERF_THRESHOLD);
       });
     });
 

--- a/packages/fhir-sdk/src/__tests__/fixtures/fhir-bundles.ts
+++ b/packages/fhir-sdk/src/__tests__/fixtures/fhir-bundles.ts
@@ -1,12 +1,17 @@
 import {
   Bundle,
+  DiagnosticReport,
+  Encounter,
+  Observation,
   Patient,
   Practitioner,
-  Observation,
-  Encounter,
-  DiagnosticReport,
 } from "@medplum/fhirtypes";
-export const CONSTANT_TIME_EXPECTED_PERF_THRESHOLD = 12;
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+
+dayjs.extend(duration);
+
+export const CONSTANT_TIME_EXPECTED_THRESHOLD_MS = dayjs.duration({ milliseconds: 12 });
 
 /**
  * Valid FHIR bundle with all resource types and proper references

--- a/packages/fhir-sdk/src/__tests__/fixtures/fhir-bundles.ts
+++ b/packages/fhir-sdk/src/__tests__/fixtures/fhir-bundles.ts
@@ -6,6 +6,7 @@ import {
   Encounter,
   DiagnosticReport,
 } from "@medplum/fhirtypes";
+export const CONSTANT_TIME_EXPECTED_PERF_THRESHOLD = 12;
 
 /**
  * Valid FHIR bundle with all resource types and proper references

--- a/packages/fhir-sdk/src/__tests__/phase5-verification.test.ts
+++ b/packages/fhir-sdk/src/__tests__/phase5-verification.test.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { FhirBundleSdk } from "../index";
-import { validCompleteBundle, bundleWithBrokenReferences } from "./fixtures/fhir-bundles";
+import {
+  validCompleteBundle,
+  bundleWithBrokenReferences,
+  CONSTANT_TIME_EXPECTED_PERF_THRESHOLD,
+} from "./fixtures/fhir-bundles";
 
 describe("Phase 5 Verification - Smart Reference Resolution", () => {
   describe("FR-5.1: Resources returned by SDK have additional getter methods for each Reference field", () => {
@@ -124,7 +128,7 @@ describe("Phase 5 Verification - Smart Reference Resolution", () => {
       observation.getSubject();
       const end = performance.now();
 
-      expect(end - start).toBeLessThan(1);
+      expect(end - start).toBeLessThan(CONSTANT_TIME_EXPECTED_PERF_THRESHOLD);
     });
   });
 

--- a/packages/fhir-sdk/src/__tests__/phase5-verification.test.ts
+++ b/packages/fhir-sdk/src/__tests__/phase5-verification.test.ts
@@ -3,7 +3,7 @@ import { FhirBundleSdk } from "../index";
 import {
   validCompleteBundle,
   bundleWithBrokenReferences,
-  CONSTANT_TIME_EXPECTED_PERF_THRESHOLD,
+  CONSTANT_TIME_EXPECTED_THRESHOLD_MS,
 } from "./fixtures/fhir-bundles";
 
 describe("Phase 5 Verification - Smart Reference Resolution", () => {
@@ -128,7 +128,7 @@ describe("Phase 5 Verification - Smart Reference Resolution", () => {
       observation.getSubject();
       const end = performance.now();
 
-      expect(end - start).toBeLessThan(CONSTANT_TIME_EXPECTED_PERF_THRESHOLD);
+      expect(end - start).toBeLessThan(CONSTANT_TIME_EXPECTED_THRESHOLD_MS);
     });
   });
 


### PR DESCRIPTION
### Dependencies

None

### Description

Fixes a silly test error where the LLM wrote tests that thought O(1) meant "should run in less than 1ms". Updated the threshold to error / catch if taking more than 12ms which would be an indicator that maybe too much 'stuff' is happening in one of these operations.

<img width="957" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/84da7e86-bbf1-42f2-9241-cf16df814b21" />

### Testing

Tests pass

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated performance tests to use a configurable threshold for reference resolution, improving consistency and maintainability.
  * Introduced a named constant for performance thresholds in test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->