### PR TITLE
fix(infra): added term server URL to Lambdas

### DIFF
--- a/packages/infra/lib/surescripts/surescripts-stack.ts
+++ b/packages/infra/lib/surescripts/surescripts-stack.ts
@@ -276,6 +276,7 @@ export class SurescriptsNestedStack extends NestedStack {
       alarmAction: props.alarmAction,
       surescripts: props.config.surescripts,
       systemRootOID: props.config.systemRootOID,
+      termServerUrl: props.config.termServerUrl,
       envVars,
     };
 
@@ -424,6 +425,7 @@ export class SurescriptsNestedStack extends NestedStack {
       systemRootOID: string;
       surescriptsReplicaBucket: s3.Bucket;
       pharmacyConversionBucket?: s3.Bucket;
+      termServerUrl?: string;
     }
   ) {
     const { name, entry, lambda: lambdaSettings } = surescriptsLambdaSettings[job];
@@ -438,6 +440,7 @@ export class SurescriptsNestedStack extends NestedStack {
       systemRootOID,
       surescriptsReplicaBucket,
       pharmacyConversionBucket,
+      termServerUrl,
     } = props;
 
     const lambda = createLambda({
@@ -449,6 +452,7 @@ export class SurescriptsNestedStack extends NestedStack {
       envVars: {
         ...envVars,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
+        ...(termServerUrl ? { TERM_SERVER_URL: termServerUrl } : {}),
         SYSTEM_ROOT_OID: systemRootOID,
       },
       layers: [lambdaLayers.shared],
@@ -474,6 +478,7 @@ export class SurescriptsNestedStack extends NestedStack {
       systemRootOID: string;
       surescriptsReplicaBucket: s3.Bucket;
       pharmacyConversionBucket?: s3.Bucket;
+      termServerUrl?: string;
     }
   ): { lambda: Lambda; queue: Queue } {
     const {
@@ -486,6 +491,7 @@ export class SurescriptsNestedStack extends NestedStack {
       systemRootOID,
       surescriptsReplicaBucket,
       pharmacyConversionBucket,
+      termServerUrl,
     } = props;
 
     const {
@@ -516,6 +522,7 @@ export class SurescriptsNestedStack extends NestedStack {
       envVars: {
         ...envVars,
         ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
+        ...(termServerUrl ? { TERM_SERVER_URL: termServerUrl } : {}),
         SYSTEM_ROOT_OID: systemRootOID,
       },
       layers: [lambdaLayers.shared],


### PR DESCRIPTION
metriport/metriport-internal#2995

Issues:

- https://linear.app/metriport/issue/ENG-484

### Dependencies

- Upstream: None
- Downstream: https://github.com/metriport/metriport/pull/4099

### Description

Adds the missing `TERM_SERVER_URL` which ensures that the Surescripts bundle conversion process is able to hydrate NDC-coded medications in the generated bundle with RxNorm codes.

### Testing

Validated to work correctly in staging environment when the TERM_SERVER_URL is set manually, will verify that the correct URL is being set on staging upon patching.

- Local
  - [x] Ran the terminology server and lookup locally
- Staging
  - [x] Correct bundle hydration and crosswalk when environment variable manually added in 
- Production
  - [ ] Run SurescriptsConvertPatientResponse Lambda with a payload identifier, and check the S3 generation date for the output bundle.

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring an optional term server URL for Surescripts-related functionality. This can now be set as an environment variable for relevant Lambda functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->