### PR TITLE
ENG-538: force callers of fhir bundle sdk to await the call to construct the bundle

### DIFF
--- a/packages/fhir-sdk/README.md
+++ b/packages/fhir-sdk/README.md
@@ -7,7 +7,7 @@ TypeScript SDK for parsing, querying, and manipulating FHIR R4 bundles with smar
 ```typescript
 import { FhirBundleSdk } from "@metriport/fhir-sdk";
 
-const sdk = new FhirBundleSdk(fhirBundle);
+const sdk = await FhirBundleSdk.create(fhirBundle);
 ```
 
 ## Core Functionality
@@ -94,8 +94,8 @@ const orgName = sdk.getPatients()[0]?.getManagingOrganization()?.name;
 ### Example Use Case: Processing a bundle
 
 ```typescript
-const processBundle = (bundle: Bundle) => {
-  const sdk = new FhirBundleSdk(bundle);
+const processBundle = async (bundle: Bundle) => {
+  const sdk = await FhirBundleSdk.create(bundle);
 
   const { hasBrokenReferences, brokenReferences } = sdk.lookForBrokenReferences();
 

--- a/packages/fhir-sdk/src/index.ts
+++ b/packages/fhir-sdk/src/index.ts
@@ -280,7 +280,18 @@ export class FhirBundleSdk {
     }
   }
 
-  constructor(bundle: Bundle) {
+  private constructor(bundle: Bundle) {
+    // FR-1.1, FR-1.4: Initialize bundle and create indexes
+    this.bundle = bundle;
+    this.buildResourceIndexes();
+  }
+
+  /**
+   * Create a new FhirBundleSdk instance
+   * FR-1.2: Validate bundle resourceType
+   * FR-1.3: Validate bundle type
+   */
+  static async create(bundle: Bundle): Promise<FhirBundleSdk> {
     // FR-1.2: Validate bundle resourceType
     if (bundle.resourceType !== "Bundle") {
       throw new Error("Invalid bundle: resourceType must be 'Bundle'");
@@ -291,9 +302,7 @@ export class FhirBundleSdk {
       throw new Error("Invalid bundle: type must be 'collection'");
     }
 
-    // FR-1.1, FR-1.4: Initialize bundle and create indexes
-    this.bundle = bundle;
-    this.buildResourceIndexes();
+    return new FhirBundleSdk(bundle);
   }
 
   /**


### PR DESCRIPTION
### Description

The Fhir Bundle Sdk indexes data when constructed. This can be long enough (e.g. on a multi-million resource bundle) that it deserves to be treated as an async operation that can be awaited or run in parallel with other things, so I needed to tweak the syntax a little.

### Before
```
const bundle = new FhirBundleSdk(rawBundle);
```

### After
```
const bundle = await FhirBundleSdk.create(rawBundle)
```

### Testing

Still passes unit tests

### Release Plan

- [ ] Merge this
