### PR TITLE
feat(api): introducing adt encounter to discharge summary association

### DIFF
--- a/packages/api/src/domain/medical/tcm-encounter.ts
+++ b/packages/api/src/domain/medical/tcm-encounter.ts
@@ -12,4 +12,5 @@ export interface TcmEncounter extends BaseDomain {
   dischargeTime: Date | null;
   clinicalInformation: Record<string, unknown>;
   freetextNote: string;
+  dischargeSummaryPath?: string;
 }

--- a/packages/api/src/models/medical/tcm-encounter.ts
+++ b/packages/api/src/models/medical/tcm-encounter.ts
@@ -15,6 +15,7 @@ export class TcmEncounterModel extends BaseModel<TcmEncounterModel> implements T
   declare dischargeTime: Date | null;
   declare clinicalInformation: Record<string, unknown>;
   declare freetextNote: CreationOptional<string>;
+  declare dischargeSummaryPath: string | undefined;
 
   static setup: ModelSetup = (sequelize: Sequelize) => {
     TcmEncounterModel.init(
@@ -61,6 +62,9 @@ export class TcmEncounterModel extends BaseModel<TcmEncounterModel> implements T
           type: DataTypes.TEXT,
           defaultValue: "",
           allowNull: false,
+        },
+        dischargeSummaryPath: {
+          type: DataTypes.TEXT,
         },
       },
       {

--- a/packages/api/src/routes/medical/schemas/tcm-encounter.ts
+++ b/packages/api/src/routes/medical/schemas/tcm-encounter.ts
@@ -19,6 +19,7 @@ export const tcmEncounterBaseSchema = z.strictObject({
     .nullish(),
   clinicalInformation: z.record(z.unknown()).optional().default({}),
   freetextNote: z.string().optional(),
+  dischargeSummaryPath: z.string().optional(),
 });
 
 export const tcmEncounterCreateSchema = tcmEncounterBaseSchema.extend({

--- a/packages/api/src/sequelize/migrations/2025-06-26_00_alter-tcm-encounter-add-discharge-summary-path.ts
+++ b/packages/api/src/sequelize/migrations/2025-06-26_00_alter-tcm-encounter-add-discharge-summary-path.ts
@@ -1,0 +1,25 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "tcm_encounter";
+const columnName = "discharge_summary_path";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.addColumn(
+      tableName,
+      columnName,
+      {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      { transaction }
+    );
+  });
+};
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.removeColumn(tableName, columnName, { transaction });
+  });
+};


### PR DESCRIPTION
Part of ENG-548

Issues:

- https://linear.app/metriport/issue/ENG-548

### Dependencies

- Downstream: https://github.com/metriport/metriport-internal/pull/3067

### Description
- Migration to add a new column to `tcm_encounter` table to keep track of associated discharge summary document
- Updated the sequelize model with the new field

### Testing

- Local
  - [x] Set this from the dash and have it retrieve it back 
- Staging
  - [x] Set this from the dash and have it retrieve it back 
- Production
  - [ ] Set this from the dash and have it retrieve it back 

### Release Plan

- :warning: This contains a DB migration
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing and referencing a discharge summary document in TCM Encounter records. Users can now view and manage a discharge summary path as part of each encounter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->