### PR TITLE
feat(ehr): patch resource ID generation

### DIFF
--- a/packages/core/src/external/ehr/job/create-resource-diff-bundles/steps/compute/ehr-compute-resource-diff-bundles-cloud.ts
+++ b/packages/core/src/external/ehr/job/create-resource-diff-bundles/steps/compute/ehr-compute-resource-diff-bundles-cloud.ts
@@ -25,7 +25,7 @@ export class EhrComputeResourceDiffBundlesCloud implements EhrComputeResourceDif
       await this.sqsClient.sendMessageToQueue(this.ehrComputeResourceDiffQueueUrl, payload, {
         fifo: true,
         messageDeduplicationId: createUuidFromText(payload),
-        messageGroupId: params.cxId,
+        messageGroupId: params.metriportPatientId,
       });
     });
   }

--- a/packages/core/src/external/ehr/job/create-resource-diff-bundles/steps/contribute/ehr-contribute-resource-diff-bundles-cloud.ts
+++ b/packages/core/src/external/ehr/job/create-resource-diff-bundles/steps/contribute/ehr-contribute-resource-diff-bundles-cloud.ts
@@ -27,7 +27,7 @@ export class EhrContributeResourceDiffBundlesCloud
       await this.sqsClient.sendMessageToQueue(this.ehrContributeDiffBundlesQueueUrl, payload, {
         fifo: true,
         messageDeduplicationId: createUuidFromText(payload),
-        messageGroupId: params.cxId,
+        messageGroupId: params.metriportPatientId,
       });
     });
   }

--- a/packages/core/src/external/ehr/job/create-resource-diff-bundles/steps/contribute/ehr-contribute-resource-diff-bundles-direct.ts
+++ b/packages/core/src/external/ehr/job/create-resource-diff-bundles/steps/contribute/ehr-contribute-resource-diff-bundles-direct.ts
@@ -241,7 +241,7 @@ function prepareEhrOnlyResourcesForContribution(
     const oldResourceId = resource.id;
     const newResourceId = isPatient(resource)
       ? metriportPatientId
-      : createUuidFromText(`${ehr}_${oldResourceId}`);
+      : createUuidFromText(`${ehr}_${metriportPatientId}_${oldResourceId}`);
     resourceIdMap.set(newResourceId, oldResourceId);
     preparedEhrOnlyResources = replaceResourceId({
       resources: preparedEhrOnlyResources,

--- a/packages/core/src/external/ehr/job/create-resource-diff-bundles/steps/refresh/ehr-refresh-ehr-bundles-cloud.ts
+++ b/packages/core/src/external/ehr/job/create-resource-diff-bundles/steps/refresh/ehr-refresh-ehr-bundles-cloud.ts
@@ -22,7 +22,7 @@ export class EhrRefreshEhrBundlesCloud implements EhrRefreshEhrBundlesHandler {
       await this.sqsClient.sendMessageToQueue(this.ehrRefreshEhrBundlesQueueUrl, payload, {
         fifo: true,
         messageDeduplicationId: createUuidFromText(payload),
-        messageGroupId: params.cxId,
+        messageGroupId: params.metriportPatientId,
       });
     });
   }


### PR DESCRIPTION
Ref: ENG-139

Issues:

- https://linear.app/metriport/issue/ENG-139

### Description

- the fhir converter determinically creates IDs -- salt these with the patient ID to avoid conflicts in HAPI
- speed flow back up as two patients can run in paralell

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
