### PR TITLE
ENG-532 chore(release): publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28812,7 +28812,7 @@
       }
     },
     "packages/api": {
-      "version": "1.27.10-alpha.0",
+      "version": "1.27.10",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.800.0",
@@ -28897,12 +28897,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "15.0.7-alpha.0",
+      "version": "15.0.7",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.9.10-alpha.0",
-        "@metriport/shared": "^0.23.10-alpha.0",
+        "@metriport/commonwell-sdk": "^5.9.10",
+        "@metriport/shared": "^0.23.10",
         "axios": "^1.8.2",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28966,11 +28966,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.18.10-alpha.0",
+      "version": "1.18.10",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.19.10-alpha.0",
-        "@metriport/shared": "^0.23.10-alpha.0"
+        "@metriport/ihe-gateway-sdk": "^0.19.10",
+        "@metriport/shared": "^0.23.10"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -28978,7 +28978,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.6.10-alpha.0",
+      "version": "1.6.10",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -29002,10 +29002,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.26.12-alpha.0",
+      "version": "1.26.12",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.9.10-alpha.0",
+        "@metriport/commonwell-sdk": "^5.9.10",
         "axios": "^1.8.2",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -29044,10 +29044,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.24.12-alpha.0",
+      "version": "1.24.12",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.9.10-alpha.0",
+        "@metriport/commonwell-sdk": "^5.9.10",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -29079,10 +29079,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.9.10-alpha.0",
+      "version": "5.9.10",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.23.10-alpha.0",
+        "@metriport/shared": "^0.23.10",
         "axios": "^1.8.2",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -29130,7 +29130,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.24.10-alpha.0",
+      "version": "1.24.10",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -29482,7 +29482,7 @@
     "packages/core/packages/shared": {},
     "packages/eslint-rules": {
       "name": "@metriport/eslint-plugin-eslint-rules",
-      "version": "1.0.2-alpha.0",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/rule-tester": "^6.0.0",
@@ -29498,7 +29498,7 @@
     },
     "packages/fhir-sdk": {
       "name": "@metriport/fhir-sdk",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.2.10",
@@ -29622,17 +29622,17 @@
     "packages/fhir-sdk/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.19.10-alpha.0",
+      "version": "0.19.10",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.23.10-alpha.0",
+        "@metriport/shared": "^0.23.10",
         "axios": "^1.8.2",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.22.10-alpha.0",
+      "version": "1.22.10",
       "dependencies": {
         "@metriport/core": "file:packages/core",
         "@metriport/shared": "file:packages/shared",
@@ -29695,7 +29695,7 @@
     "packages/infra/packages/core": {},
     "packages/infra/packages/shared": {},
     "packages/mllp-server": {
-      "version": "0.3.10-alpha.0",
+      "version": "0.3.10",
       "license": "ISC",
       "dependencies": {
         "@medplum/core": "^3.2.33",
@@ -29859,7 +29859,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.23.10-alpha.0",
+      "version": "0.23.10",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -29912,7 +29912,7 @@
       "dev": true
     },
     "packages/utils": {
-      "version": "1.25.10-alpha.0",
+      "version": "1.25.10",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.800.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "15.0.7-alpha.0",
+  "version": "15.0.7",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.9.10-alpha.0",
-    "@metriport/shared": "^0.23.10-alpha.0",
+    "@metriport/commonwell-sdk": "^5.9.10",
+    "@metriport/shared": "^0.23.10",
     "axios": "^1.8.2",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.27.10-alpha.0",
+  "version": "1.27.10",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.18.10-alpha.0",
+  "version": "1.18.10",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.19.10-alpha.0",
-    "@metriport/shared": "^0.23.10-alpha.0"
+    "@metriport/ihe-gateway-sdk": "^0.19.10",
+    "@metriport/shared": "^0.23.10"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.6.10-alpha.0",
+  "version": "1.6.10",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.26.12-alpha.0",
+  "version": "1.26.12",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.9.10-alpha.0",
+    "@metriport/commonwell-sdk": "^5.9.10",
     "axios": "^1.8.2",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.24.12-alpha.0",
+  "version": "1.24.12",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.9.10-alpha.0",
+    "@metriport/commonwell-sdk": "^5.9.10",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.9.10-alpha.0",
+  "version": "5.9.10",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.23.10-alpha.0",
+    "@metriport/shared": "^0.23.10",
     "axios": "^1.8.2",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.24.10-alpha.0",
+  "version": "1.24.10",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/eslint-rules/package.json
+++ b/packages/eslint-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/eslint-plugin-eslint-rules",
-  "version": "1.0.2-alpha.0",
+  "version": "1.0.2",
   "description": "Custom ESLint rules for Metriport's monorepo",
   "main": "index.js",
   "keywords": [

--- a/packages/fhir-sdk/package.json
+++ b/packages/fhir-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/fhir-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "FHIR Bundle SDK for parsing, querying, and manipulating FHIR bundles with reference resolution",
   "author": "Metriport Inc. <contact@metriport.com>",
@@ -56,4 +56,4 @@
     "ts-jest": "29.1.1",
     "typescript": "^4.9.5"
   }
-} 
+}

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.19.10-alpha.0",
+  "version": "0.19.10",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.23.10-alpha.0",
+    "@metriport/shared": "^0.23.10",
     "axios": "^1.8.2",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.22.10-alpha.0",
+  "version": "1.22.10",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mllp-server",
-  "version": "0.3.10-alpha.0",
+  "version": "0.3.10",
   "description": "MLLP server that reads HL7 messages off of a raw tcp connection",
   "main": "app.js",
   "private": true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.23.10-alpha.0",
+  "version": "0.23.10",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.25.10-alpha.0",
+  "version": "1.25.10",
   "description": "",
   "private": true,
   "scripts": {


### PR DESCRIPTION
### Dependencies

- Upstream: [_[this PR points to another PR or depends on its release]_](https://github.com/metriport/metriport/pull/4092)
- Downstream: _[PRs that depend on this one, either point to this or can only be released after this one is released]_

### Description

Ref: #000

 - api@1.27.10
 - @metriport/api-sdk@15.0.7
 - @metriport/carequality-cert-runner@1.18.10
 - @metriport/carequality-sdk@1.6.10
 - @metriport/commonwell-cert-runner@1.26.12
 - @metriport/commonwell-jwt-maker@1.24.12
 - @metriport/commonwell-sdk@5.9.10
 - @metriport/core@1.24.10
 - @metriport/eslint-plugin-eslint-rules@1.0.2
 - @metriport/fhir-sdk@1.0.1
 - @metriport/ihe-gateway-sdk@0.19.10
 - infrastructure@1.22.10
 - mllp-server@0.3.10
 - @metriport/shared@0.23.10
 - utils@1.25.10

### Testing

none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple packages from prerelease (alpha) versions to stable releases.
  * Updated dependencies to use stable versions where applicable.
  * Minor formatting improvements in one package file (trailing whitespace and newline).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->