### PR TITLE
ENG-555 Revamp bulk patient delete

### DIFF
--- a/packages/utils/src/bulk-delete-patients.ts
+++ b/packages/utils/src/bulk-delete-patients.ts
@@ -1,120 +1,105 @@
 import * as dotenv from "dotenv";
 dotenv.config();
 // keep that ^ on top
-import { APIMode, CommonWell, Person } from "@metriport/commonwell-sdk";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { getEnvVarOrFail } from "@metriport/core/util/env-var";
-import { PurposeOfUse } from "@metriport/shared";
+import { sleep } from "@metriport/shared";
 import axios from "axios";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
 import fs from "fs";
+import { elapsedTimeAsStr } from "./shared/duration";
+import { initFile } from "./shared/file";
+import { buildGetDirPathInside, initRunsFolder } from "./shared/folder";
 import { getCxData } from "./shared/get-cx-data";
+import { logErrorToFile } from "./shared/log";
+
+dayjs.extend(duration);
 
 /**
- * This script deletes the specified patients from both Metriport and CW.
- * It will also delete the person in CW corresponding to each patient,
- * only if the person was created by the CX.
+ * This script deletes the specified patients from both Metriport and HIEs.
  *
- * This is useful incase a bunch of patients were registered by a CX with
- * incorrect demographics for whatever reason.
- *
- * Make sure to update the `patientIds` with the list of Patient IDs you
- * want to trigger document queries for, otherwise it will do it for all
- * Patients of the respective customer.
+ * To use it:
+ * - Set the env vars in the .env file.
+ * - Update the `patientIds` array with the list of Patient IDs you want to delete.
+ * - Run the script from the utils folder:
+ *   - `cd packages/utils`
+ *   - `ts-node src/bulk-delete-patients`
  */
 
 // add patient IDs here to kick off queries for specific patient IDs
 const patientIds: string[] = [];
 
-// CW stuff
-const pathToCerts = getEnvVarOrFail("ORG_CERTS_FOLDER");
-const cert = fs.readFileSync(`${pathToCerts}/cert1.pem`, "utf8");
-const privkey = fs.readFileSync(`${pathToCerts}/privkey1.pem`, "utf8");
-const cwApiMode = APIMode.production;
-
-// auth stuff
+const numberOfParallelExecutions = 5;
 const cxId = getEnvVarOrFail("CX_ID");
 const apiUrl = getEnvVarOrFail("API_URL");
+const confirmationTime = dayjs.duration(10, "seconds");
 
-function buildCWPatientId(orgOID: string, patientId: string): string {
-  return `${patientId}%5E%5E%5Eurn%3aoid%3a${orgOID}`;
-}
-
-/**
- * Returns the ID of a person.
- */
-export function getPersonId(object: Person | undefined): string | undefined {
-  if (!object) return undefined;
-  const url = object._links?.self?.href;
-  return getPersonIdFromUrl(url);
-}
-
-/**
- * Returns the ID of a person from its URL.
- *
- * @param personUrl - The person's URL as returned from `Person._links.self.href`
- */
-export function getPersonIdFromUrl(personUrl: string | undefined | null): string | undefined {
-  if (!personUrl) return undefined;
-  return personUrl.substring(personUrl.lastIndexOf("/") + 1);
-}
+const getOutputFileName = buildGetDirPathInside(`bulk-delete-patients`);
 
 async function main() {
+  initRunsFolder();
   const startedAt = Date.now();
-  console.log(`>>> Starting to delete ${patientIds.length} patients...`);
 
-  const { npi, orgName, orgOID, facilityId } = await getCxData(cxId);
+  const { orgName, facilityId } = await getCxData(cxId);
+  const errorFileName = getOutputFileName(orgName) + ".error";
+  initFile(errorFileName);
+  const patientsWithErrors: string[] = [];
 
-  // init CW client
-  const cwApi = new CommonWell(cert, privkey, orgName, "urn:oid:" + orgOID, cwApiMode);
-  const base = {
-    purposeOfUse: PurposeOfUse.TREATMENT,
-    role: "ict",
-    subjectId: `${orgName} System User`,
-  };
-  const queryMeta = {
-    subjectId: base.subjectId,
-    role: base.role,
-    purposeOfUse: base.purposeOfUse,
-    npi: npi,
-  };
-  for (const patientId of patientIds) {
-    try {
-      console.log(`>>> Deleting patient ${patientId} from Metriport and CW...`);
-      await axios.delete(apiUrl + `/internal/patient/${patientId}`, {
-        params: { cxId, facilityId },
-      });
-      console.log(`>>> Checking to see if patient ${patientId} person was created by the CX...`);
-      const cwPatientId = buildCWPatientId(orgOID, patientId);
-      const personResp = await cwApi.searchPersonByPatientDemo(queryMeta, cwPatientId);
-      for (const person of personResp._embedded.person) {
-        console.log(JSON.stringify(person, null, 2));
-      }
-      if (personResp._embedded.person.length > 1) {
-        throw new Error(
-          `Patient ${patientId} doesn't have a single person... needs manual resolution`
-        );
-      }
-      const person = personResp._embedded.person[0];
-
-      const personCreatedByOrg = person.enrollmentSummary?.enroller === orgName;
-      console.log(`>>> Deleting patient ${patientId} from Metriport and CW...`);
-      await axios.delete(apiUrl + `/internal/patient/${patientId}`, {
-        params: { cxId, facilityId },
-      });
-      if (personCreatedByOrg) {
-        const personId = getPersonId(person);
-        if (!personId) {
-          throw new Error(`Could not find person ID for patient ${patientId}`);
-        }
-        console.log(`>>> The person ${personId} was created by CX, deleting...`);
-        await cwApi.deletePerson(queryMeta, personId);
-      }
-    } catch (err) {
-      console.error(`>>> Error deleting patient ${patientId}: ${err}`);
-    }
-    console.log("----------------------------------------------------------");
+  if (!patientIds || patientIds.length < 1) {
+    console.log(`>>> No patient IDs provided, exiting...`);
+    process.exit(0);
   }
 
-  console.log(`>>> Done deleting patients in ${Date.now() - startedAt} ms`);
+  await displayWarningAndConfirmation(patientIds.length, orgName);
+
+  console.log(`>>> Starting to delete ${patientIds.length} patients...`);
+
+  let ptIndex = 0;
+  await executeAsynchronously(
+    patientIds,
+    async patientId => {
+      console.log(`>>> Progress: ${++ptIndex}/${patientIds.length} patients complete`);
+      try {
+        console.log(`>>> Deleting patient ${patientId} from Metriport and HIEs...`);
+        await axios.delete(apiUrl + `/internal/patient/${patientId}`, {
+          params: { cxId, facilityId },
+        });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        const msg = `ERROR processing patient ${patientId}: `;
+        console.log(msg, error.message);
+        patientsWithErrors.push(patientId);
+        logErrorToFile(errorFileName, msg, error);
+        fs.appendFileSync(errorFileName + ".patientIds.txt", `${patientId}\n`);
+      }
+    },
+    { numberOfParallelExecutions }
+  );
+  if (patientsWithErrors.length > 0) {
+    console.log(
+      `>>> Patients with errors (${patientsWithErrors.length}): ${patientsWithErrors.join(", ")}`
+    );
+    console.log(`>>> See file ${errorFileName} for more details.`);
+  } else {
+    console.log(`>>> Yay! All patients were deleted successfully!`);
+  }
+  console.log(`>>> Done deleting ${patientIds.length} patients in ${elapsedTimeAsStr(startedAt)}`);
+  process.exit(0);
+}
+
+async function displayWarningAndConfirmation(patientCount: number, orgName: string) {
+  console.log(``);
+  console.log(
+    `THIS IS SUPER DESTRUCTIVE!! IT WILL DELETE PATIENTS FROM METRIPORT AND HIEs! ONLY CONTINUE IF YOU KNOW WHAT YOU ARE DOING!`
+  );
+  console.log(``);
+  console.log(
+    `Deleting ${patientCount} patients from org/cx ${orgName} in ${confirmationTime.asSeconds()} seconds...`
+  );
+  await sleep(confirmationTime.asMilliseconds());
+  console.log(`ok, continuing...`);
+  await sleep(dayjs.duration(1, "seconds").asMilliseconds());
 }
 
 main();


### PR DESCRIPTION
### Dependencies

none

### Description

Revamp bulk patient delete for the current state of the platform.

### Testing

- Local
  - [x] It calls the delete patient endpoint for each patient ID
  - [x] It stores errors and affecting pt IDs on the "runs" folder
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user confirmation step with a warning and delay before bulk deleting patients.
  * Patient deletions are now performed in parallel with a concurrency limit, improving efficiency.
  * Errors encountered during deletion are logged and summarized at the end of the process.
  * Output folders and log files are automatically created for tracking results.

* **Refactor**
  * Streamlined the bulk patient deletion process for improved clarity and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->