### PR TITLE
fix(core): added another icd10 system identifier to map

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
@@ -24,6 +24,7 @@ const hl7CodingSystemToUrlMap: Record<string, string> = {
   L: LOINC_URL, // LOINC
   I10: ICD_10_URL, // ICD-10
   "ICD-10": ICD_10_URL, // ICD-10
+  ICD10: ICD_10_URL, // ICD-10
   "ICD-10-CM": ICD_10_URL, // ICD-10
   I9: ICD_9_URL, // ICD-9
   "ICD-9": ICD_9_URL, // ICD-9


### PR DESCRIPTION
Part of ENG-557

Issues:

- https://linear.app/metriport/issue/ENG-557

### Description
- Added `ICD10` to the ADT>FHIR system code map 
  - we encountered it in DG1, so it's related to a condition, and therefore, ICD-10-CM

### Testing
N/A

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for HL7 coding systems by recognizing the "ICD10" variant for ICD-10 mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->