### PR TITLE
feat(api): redownload in progress xmls

### DIFF
--- a/packages/api/src/command/medical/admin/populate-fhir.ts
+++ b/packages/api/src/command/medical/admin/populate-fhir.ts
@@ -85,7 +85,7 @@ export async function populateFhirServer({
           cxId,
           patientId: patient.id,
           facilityId: patient.facilityIds[0],
-          override: true,
+          forceDownload: true,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         }).catch((err: any) => {
           log(`Failed to init query of documents for patient ${patient.id}: `, err.message);

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -152,6 +152,7 @@ export async function queryDocumentsAcrossHIEs({
     getDocumentsFromCQ({
       patient: updatedPatient,
       facilityId,
+      forceDownload: isForceRedownloadEnabled,
       requestId,
       cqManagingOrgName,
       forcePatientDiscovery,

--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -50,7 +50,7 @@ export async function queryDocumentsAcrossHIEs({
   patientId,
   facilityId,
   requestId: requestIdParam,
-  override,
+  forceDownload,
   cxDocumentRequestMetadata,
   forceQuery = false,
   forcePatientDiscovery = false,
@@ -63,7 +63,7 @@ export async function queryDocumentsAcrossHIEs({
   patientId: string;
   facilityId?: string;
   requestId?: string | undefined;
-  override?: boolean;
+  forceDownload?: boolean;
   cxDocumentRequestMetadata?: unknown;
   forceQuery?: boolean;
   forcePatientDiscovery?: boolean;
@@ -123,7 +123,8 @@ export async function queryDocumentsAcrossHIEs({
 
   let triggeredDocumentQuery = false;
 
-  const isForceRedownloadEnabled = override ?? (await isXmlRedownloadFeatureFlagEnabledForCx(cxId));
+  const isForceRedownloadEnabled =
+    forceDownload ?? (await isXmlRedownloadFeatureFlagEnabledForCx(cxId));
   /**
    * This is likely safe to remove based on the usage of this function with the `cqManagingOrgName` param.
    * But because it touches a core flow and we don't have time to review/test it now, leaving as is.

--- a/packages/api/src/external/carequality/document/get-non-existent-doc-refs.ts
+++ b/packages/api/src/external/carequality/document/get-non-existent-doc-refs.ts
@@ -4,7 +4,7 @@ import { DocumentReferenceWithId } from "@metriport/core/external/fhir/document/
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { errorToString } from "@metriport/core/util/error/shared";
 import { out } from "@metriport/core/util/log";
-import { isXml } from "@metriport/core/util/mime";
+import { isMimeTypeXML } from "@metriport/core/util/mime";
 import { capture } from "@metriport/core/util/notifications";
 import { uniqBy } from "lodash";
 import { DocumentReferenceWithMetriportId } from "../../../external/carequality/document/shared";
@@ -39,7 +39,7 @@ export async function getNonExistentDocRefs(
     log(
       `Force redownload is enabled for CX. There's currently ${docsToDownload.length} documents to download`
     );
-    const isEligibleForRedownload = existingDocRefs.filter(d => isXml(d.contentType ?? ""));
+    const isEligibleForRedownload = existingDocRefs.filter(d => isMimeTypeXML(d.contentType ?? ""));
     log(`Found ${isEligibleForRedownload.length} XMLs that we're gonna redownload.`);
 
     docsToDownload.push(...isEligibleForRedownload);

--- a/packages/api/src/external/carequality/document/get-non-existent-doc-refs.ts
+++ b/packages/api/src/external/carequality/document/get-non-existent-doc-refs.ts
@@ -121,7 +121,7 @@ async function checkDocRefsExistInS3(
 
 /**
  * Since not all documents have a creation date, we return true if the document
- * has no creation date or if the creation date is more than one year ago.
+ * has no creation date or if the creation date is within the last year.
  */
 function isEligibleForRedownload(creation: string | null | undefined): boolean {
   if (!creation) return true;

--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -42,6 +42,7 @@ export async function processOutboundDocumentQueryResps({
   patientId,
   cxId,
   response,
+  forceDownload,
 }: OutboundDocQueryRespParam): Promise<void> {
   const { log } = out(`CQ DR - requestId ${requestId}, patient ${patientId}`);
 
@@ -66,6 +67,7 @@ export async function processOutboundDocumentQueryResps({
       patientId,
       requestId,
       response,
+      forceDownload,
     });
 
     const docsToDownload = responsesWithDocsToDownload.flatMap(
@@ -90,6 +92,7 @@ export async function processOutboundDocumentQueryResps({
         docsToDownloadCount: docsToDownload.length,
         convertibleCount: convertibleDocCount,
         successCount,
+        forceDownload,
         failureCount,
         ...contentTypeCounts,
       },
@@ -241,6 +244,7 @@ async function getRespWithDocsToDownload({
   patientId,
   requestId,
   response,
+  forceDownload,
 }: OutboundDocQueryRespParam): Promise<DqRespWithDocRefsWithMetriportId[]> {
   const respWithDocsToDownload: DqRespWithDocRefsWithMetriportId[] = [];
   const seenMetriportIds = new Set<string>();
@@ -269,7 +273,8 @@ async function getRespWithDocsToDownload({
         deduplicatedDocRefsWithMetriportId,
         patientId,
         cxId,
-        fhirDocRefs
+        fhirDocRefs,
+        forceDownload
       );
 
       if (docsToDownload.length === 0) {

--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -31,6 +31,7 @@ export async function getDocumentsFromCQ({
   requestId,
   facilityId,
   patient,
+  forceDownload,
   cqManagingOrgName,
   forcePatientDiscovery = false,
   triggerConsolidated = false,
@@ -38,6 +39,7 @@ export async function getDocumentsFromCQ({
   requestId: string;
   facilityId?: string;
   patient: Patient;
+  forceDownload?: boolean;
   cqManagingOrgName?: string;
   forcePatientDiscovery?: boolean;
   triggerConsolidated?: boolean;
@@ -175,6 +177,7 @@ export async function getDocumentsFromCQ({
       patientId: patient.id,
       cxId: patient.cxId,
       numOfGateways: documentQueryRequestsV2.length,
+      forceDownload,
     });
   } catch (error) {
     const msg = `Failed to query and process documents - Carequality`;

--- a/packages/api/src/routes/internal/medical/docs.ts
+++ b/packages/api/src/routes/internal/medical/docs.ts
@@ -359,6 +359,7 @@ router.get(
  * @param req.query.facilityId - Optional; The facility providing NPI for the document query.
  * @param req.query.requestId - Optional; The request ID for the document query.
  * @param req.body Optional metadata to be sent through webhook. {"disableWHFlag": "true"} can be sent here to disable webhook.
+ * @param req.query.override - Optional; Whether to override files already downloaded. Defaults to false.
  * @param req.query.forceQuery - Optional; Whether to force doc query to run. DEFAULTS TRUE.
  * @param req.query.forcePatientDiscovery - Optional; Whether to force patient discovery before document query.
  * @param req.query.cqManagingOrgName - Optional; The CQ managing organization name.
@@ -373,6 +374,7 @@ router.post(
     const patientId = getFrom("query").orFail("patientId", req);
     const facilityId = getFrom("query").optional("facilityId", req);
     const requestId = getFrom("query").optional("requestId", req);
+    const override = getFromQueryAsBoolean("override", req) ?? false;
     const forceQuery = getFromQueryAsBoolean("forceQuery", req) ?? true;
     const forcePatientDiscovery = getFromQueryAsBoolean("forcePatientDiscovery", req);
     const cqManagingOrgName = getFrom("query").optional("cqManagingOrgName", req);
@@ -384,6 +386,7 @@ router.post(
       patientId,
       facilityId,
       requestId,
+      override,
       forceQuery,
       forcePatientDiscovery,
       cqManagingOrgName,

--- a/packages/api/src/routes/internal/medical/docs.ts
+++ b/packages/api/src/routes/internal/medical/docs.ts
@@ -359,7 +359,7 @@ router.get(
  * @param req.query.facilityId - Optional; The facility providing NPI for the document query.
  * @param req.query.requestId - Optional; The request ID for the document query.
  * @param req.body Optional metadata to be sent through webhook. {"disableWHFlag": "true"} can be sent here to disable webhook.
- * @param req.query.override - Optional; Whether to override files already downloaded. Defaults to false.
+ * @param req.query.forceDownload - Optional; Whether to forceDownload files already downloaded. Defaults to false.
  * @param req.query.forceQuery - Optional; Whether to force doc query to run. DEFAULTS TRUE.
  * @param req.query.forcePatientDiscovery - Optional; Whether to force patient discovery before document query.
  * @param req.query.cqManagingOrgName - Optional; The CQ managing organization name.
@@ -374,7 +374,7 @@ router.post(
     const patientId = getFrom("query").orFail("patientId", req);
     const facilityId = getFrom("query").optional("facilityId", req);
     const requestId = getFrom("query").optional("requestId", req);
-    const override = getFromQueryAsBoolean("override", req) ?? false;
+    const forceDownload = getFromQueryAsBoolean("forceDownload", req) ?? false;
     const forceQuery = getFromQueryAsBoolean("forceQuery", req) ?? true;
     const forcePatientDiscovery = getFromQueryAsBoolean("forcePatientDiscovery", req);
     const cqManagingOrgName = getFrom("query").optional("cqManagingOrgName", req);
@@ -386,7 +386,7 @@ router.post(
       patientId,
       facilityId,
       requestId,
-      override,
+      forceDownload,
       forceQuery,
       forcePatientDiscovery,
       cqManagingOrgName,

--- a/packages/api/src/routes/medical/document.ts
+++ b/packages/api/src/routes/medical/document.ts
@@ -129,7 +129,7 @@ router.post(
       cxId,
       patientId,
       facilityId,
-      override,
+      forceDownload: override,
       cxDocumentRequestMetadata: cxDocumentRequestMetadata?.metadata,
       forceCommonwell,
       forceCarequality,

--- a/packages/core/src/command/feature-flags/domain-ffs.ts
+++ b/packages/core/src/command/feature-flags/domain-ffs.ts
@@ -271,3 +271,11 @@ export async function isDischargeRequeryFeatureFlagEnabledForCx(cxId: string): P
   const cxIdsWithDischargeRequeryEnabled = await getCxsWithDischargeRequeryFeatureFlag();
   return cxIdsWithDischargeRequeryEnabled.some(i => i === cxId);
 }
+
+export async function getCxsWithXmlRedownloadFeatureFlag(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithXmlRedownloadFeatureFlag");
+}
+export async function isXmlRedownloadFeatureFlagEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithXmlRedownloadEnabled = await getCxsWithXmlRedownloadFeatureFlag();
+  return cxIdsWithXmlRedownloadEnabled.some(i => i === cxId);
+}

--- a/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
+++ b/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
@@ -61,6 +61,7 @@ export const initialFeatureFlags: FeatureFlagDatastore = {
   cxsWithHl7NotificationWebhookFeatureFlag: { enabled: false, values: [] },
   cxsWithDischargeRequeryFeatureFlag: { enabled: false, values: [] },
   cxsWithDischargeSlackNotificationFeatureFlag: { enabled: false, values: [] },
+  cxsWithXmlRedownloadFeatureFlag: { enabled: false, values: [] },
 };
 
 /**

--- a/packages/core/src/command/feature-flags/types.ts
+++ b/packages/core/src/command/feature-flags/types.ts
@@ -38,6 +38,7 @@ export const cxBasedFFsSchema = z.object({
   cxsWithHl7NotificationWebhookFeatureFlag: ffStringValuesSchema,
   cxsWithDischargeSlackNotificationFeatureFlag: ffStringValuesSchema,
   cxsWithDischargeRequeryFeatureFlag: ffStringValuesSchema,
+  cxsWithXmlRedownloadFeatureFlag: ffStringValuesSchema,
 });
 export type CxBasedFFsSchema = z.infer<typeof cxBasedFFsSchema>;
 

--- a/packages/core/src/external/carequality/ihe-gateway/outbound-result-poller-direct.ts
+++ b/packages/core/src/external/carequality/ihe-gateway/outbound-result-poller-direct.ts
@@ -26,6 +26,7 @@ export type OutboundDocQueryRespParam = {
   cxId: string;
   requestId: string;
   response: OutboundDocumentQueryResp[];
+  forceDownload?: boolean | undefined;
 };
 
 export type OutboundDocRetrievalRespParam = {
@@ -96,13 +97,14 @@ export class OutboundResultPollerDirect extends OutboundResultPoller {
       ...params,
       dbCreds: this.dbCreds,
     });
-    const { requestId, patientId, cxId } = params;
+    const { requestId, patientId, cxId, forceDownload } = params;
 
     const payload: OutboundDocQueryRespParam = {
       requestId,
       patientId,
       cxId,
       response,
+      forceDownload,
     };
 
     // TODO not sure if should retry on timeout

--- a/packages/core/src/external/carequality/ihe-gateway/outbound-result-poller.ts
+++ b/packages/core/src/external/carequality/ihe-gateway/outbound-result-poller.ts
@@ -4,6 +4,7 @@ export type PollOutboundResults = {
   cxId: string;
   numOfGateways: number;
   maxPollingDuration?: number;
+  forceDownload?: boolean;
 };
 
 export abstract class OutboundResultPoller {

--- a/packages/core/src/util/mime.ts
+++ b/packages/core/src/util/mime.ts
@@ -67,3 +67,7 @@ export function getFileExtension(value: string | undefined): string {
   const fileExtension = extension(value);
   return fileExtension ? `.${fileExtension}` : "";
 }
+
+export function isXml(mimeType: string): boolean {
+  return mimeType === XML_APP_MIME_TYPE || mimeType === XML_TXT_MIME_TYPE;
+}

--- a/packages/core/src/util/mime.ts
+++ b/packages/core/src/util/mime.ts
@@ -67,7 +67,3 @@ export function getFileExtension(value: string | undefined): string {
   const fileExtension = extension(value);
   return fileExtension ? `.${fileExtension}` : "";
 }
-
-export function isXml(mimeType: string): boolean {
-  return mimeType === XML_APP_MIME_TYPE || mimeType === XML_TXT_MIME_TYPE;
-}

--- a/packages/lambdas/src/ihe-outbound-document-query.ts
+++ b/packages/lambdas/src/ihe-outbound-document-query.ts
@@ -19,7 +19,7 @@ capture.setExtra({ lambdaName });
 
 // TODO move to capture.wrapHandler()
 export const handler = Sentry.AWSLambda.wrapHandler(
-  async ({ requestId, numOfGateways, patientId, cxId }: PollOutboundResults) => {
+  async ({ requestId, numOfGateways, patientId, cxId, forceDownload }: PollOutboundResults) => {
     console.log(
       `Running with envType: ${getEnvType()}, requestId: ${requestId}, ` +
         `numOfGateways: ${numOfGateways} cxId: ${cxId} patientId: ${patientId}`
@@ -34,6 +34,7 @@ export const handler = Sentry.AWSLambda.wrapHandler(
         cxId,
         numOfGateways,
         maxPollingDuration: parseInt(maxPollingDuration),
+        forceDownload,
       });
     } catch (error) {
       const msg = `Error sending document query results`;


### PR DESCRIPTION
Part of ENG-561

Issues:

- https://linear.app/metriport/issue/ENG-561

### Description
- Added FF for force redownload of all XMLs for a patient
- Affects both, DQ and Requery

### Testing
- Staging
  - [ ] Ensure the regular DQ flow works as expected
  - [ ] Test with the enabled FF for override
- Production
  - [ ] Test with a target CX 

### Release Plan

- [ ] Merge this
- [ ] FFs have been set in Staging, Production, and Sandbox


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a feature flag enabling forced redownload of XML documents for select customers.
  * Introduced an optional forceDownload parameter to the document query endpoints and related APIs, allowing forced redownload of documents when enabled.
  * Enhanced document download logic to conditionally include previously downloaded XML documents based on feature flag or forceDownload parameter.

* **Documentation**
  * Updated API documentation to describe the new forceDownload query parameter for document queries.

* **Refactor**
  * Improved parameter naming and function declarations for clarity and consistency across document query and download processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->