### PR TITLE
ENG-576: improve mllp server debug message write to s3 reliability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29167,6 +29167,7 @@
         "json-stringify-safe": "^5.0.1",
         "langchain": "0.3.6",
         "lodash": "^4.17.21",
+        "nanoid": "^3.3.6",
         "pg": "^8.11.3",
         "pkijs": "^3.0.16",
         "playwright": "1.39.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -137,6 +137,7 @@
     "json-stringify-safe": "^5.0.1",
     "langchain": "0.3.6",
     "lodash": "^4.17.21",
+    "nanoid": "^3.3.6",
     "pg": "^8.11.3",
     "pkijs": "^3.0.16",
     "playwright": "1.39.0",

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
@@ -170,7 +170,7 @@ export function formatDateToHl7(date: Date): string {
   return buildDayjs(date).format("YYYYMMDDHHmmss");
 }
 
-export function createUnpackPidFailureFileKey({
+export function createUnparseableHl7MessageFileKey({
   rawPtIdentifier,
   rawTimestamp,
   messageCode,
@@ -181,5 +181,19 @@ export function createUnpackPidFailureFileKey({
   messageCode: string;
   triggerEvent: string;
 }) {
-  return `unpack-pid-failure/${rawTimestamp}_${rawPtIdentifier}_${messageCode}_${triggerEvent}_${nanoid()}.hl7`;
+  return `parse-failure/${rawTimestamp}_${rawPtIdentifier}_${messageCode}_${triggerEvent}_${nanoid()}.hl7`;
+}
+
+export function createUnparseableHl7MessageErrorMessageFileKey({
+  rawPtIdentifier,
+  rawTimestamp,
+  messageCode,
+  triggerEvent,
+}: {
+  rawPtIdentifier: string;
+  rawTimestamp: string;
+  messageCode: string;
+  triggerEvent: string;
+}) {
+  return `parse-failure/${rawTimestamp}_${rawPtIdentifier}_${messageCode}_${triggerEvent}_${nanoid()}_error.txt`;
 }

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
@@ -1,4 +1,5 @@
 import { Hl7Field, Hl7Message, Hl7Segment } from "@medplum/core";
+import { nanoid } from "nanoid";
 import { MetriportError } from "@metriport/shared";
 import { buildDayjs } from "@metriport/shared/common/date";
 import { capture, out } from "../../../util";
@@ -180,5 +181,5 @@ export function createUnpackPidFailureFileKey({
   messageCode: string;
   triggerEvent: string;
 }) {
-  return `unpack-pid-failure/${rawPtIdentifier}_${rawTimestamp}_${messageCode}_${triggerEvent}_${nanoid()}.hl7`;
+  return `unpack-pid-failure/${rawTimestamp}_${rawPtIdentifier}_${messageCode}_${triggerEvent}_${nanoid()}.hl7`;
 }

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
@@ -168,3 +168,17 @@ export function createFileKeyHl7Message({
 export function formatDateToHl7(date: Date): string {
   return buildDayjs(date).format("YYYYMMDDHHmmss");
 }
+
+export function createUnpackPidFailureFileKey({
+  rawPtIdentifier,
+  rawTimestamp,
+  messageCode,
+  triggerEvent,
+}: {
+  rawPtIdentifier: string;
+  rawTimestamp: string;
+  messageCode: string;
+  triggerEvent: string;
+}) {
+  return `unpack-pid-failure/${rawPtIdentifier}_${rawTimestamp}_${messageCode}_${triggerEvent}_${nanoid()}.hl7`;
+}

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -1,6 +1,3 @@
-import * as dotenv from "dotenv";
-dotenv.config();
-
 import { Hl7Server } from "@medplum/hl7";
 import { buildHl7NotificationWebhookSender } from "@metriport/core/command/hl7-notification/hl7-notification-webhook-sender-factory";
 import {
@@ -15,8 +12,8 @@ import { capture } from "@metriport/core/util";
 import type { Logger } from "@metriport/core/util/log";
 import { out } from "@metriport/core/util/log";
 import { handleParsingError, ParsedHl7Data, parseHl7Message } from "./parsing";
-import { asString, bucketName, s3Utils, withErrorHandling } from "./utils";
 import { initSentry } from "./sentry";
+import { asString, bucketName, s3Utils, withErrorHandling } from "./utils";
 
 initSentry();
 

--- a/packages/mllp-server/src/parsing.ts
+++ b/packages/mllp-server/src/parsing.ts
@@ -1,0 +1,56 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import { Hl7Message } from "@medplum/core";
+import { getSendingApplication } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh";
+import {
+  createUnpackPidFailureFileKey,
+  getCxIdAndPatientIdOrFail,
+  getOptionalValueFromMessage,
+} from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
+import { utcifyHl7Message } from "@metriport/core/external/hl7-notification/datetime";
+import { Logger } from "@metriport/core/util/log";
+import { buildDayjs, ISO_DATE_TIME } from "@metriport/shared/common/date";
+import { Config } from "./config";
+import { asString, bucketName, s3Utils } from "./utils";
+
+const hieTimezoneDictionary = Config.getHieTimezoneDictionary();
+
+export interface ParsedHl7Data {
+  message: Hl7Message;
+  cxId: string;
+  patientId: string;
+}
+
+export async function parseHl7Message(rawMessage: Hl7Message): Promise<ParsedHl7Data> {
+  const sendingApplication = getSendingApplication(rawMessage) ?? "Unknown HIE";
+  const hieTimezone = hieTimezoneDictionary[sendingApplication] ?? "UTC";
+  const message = utcifyHl7Message(rawMessage, hieTimezone);
+
+  const { cxId, patientId } = getCxIdAndPatientIdOrFail(message);
+
+  return {
+    message,
+    cxId,
+    patientId,
+  };
+}
+export async function handleParsingError(rawMessage: Hl7Message, logger: Logger) {
+  const { log } = logger;
+
+  const fileKey = createUnpackPidFailureFileKey({
+    rawPtIdentifier: getOptionalValueFromMessage(rawMessage, "PID", 3, 1) ?? "unknown-patient",
+    rawTimestamp:
+      getOptionalValueFromMessage(rawMessage, "MSH", 7, 1) ?? buildDayjs().format(ISO_DATE_TIME),
+    messageCode: getOptionalValueFromMessage(rawMessage, "MSH", 9, 1) ?? "UNK",
+    triggerEvent: getOptionalValueFromMessage(rawMessage, "MSH", 9, 2) ?? "UNK",
+  });
+
+  log(`Parsing failed, uploading raw HL7 message to S3 with key: ${fileKey}`);
+  await s3Utils.uploadFile({
+    bucket: bucketName,
+    key: fileKey,
+    file: Buffer.from(asString(rawMessage)),
+    contentType: "text/plain",
+  });
+}

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -3,12 +3,12 @@ dotenv.config();
 
 import { Hl7Message } from "@medplum/core";
 import { Hl7Connection } from "@medplum/hl7";
+import { S3Utils } from "@metriport/core/external/aws/s3";
 import { Base64Scrambler } from "@metriport/core/util/base64-scrambler";
 import { Config } from "@metriport/core/util/config";
 import { Logger } from "@metriport/core/util/log";
 import { unpackUuid } from "@metriport/core/util/pack-uuid";
 import * as Sentry from "@sentry/node";
-import { S3Utils } from "@metriport/core/external/aws/s3";
 
 const crypto = new Base64Scrambler(Config.getHl7Base64ScramblerSeed());
 export const s3Utils = new S3Utils(Config.getAWSRegion());

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -8,29 +8,17 @@ import { Config } from "@metriport/core/util/config";
 import { Logger } from "@metriport/core/util/log";
 import { unpackUuid } from "@metriport/core/util/pack-uuid";
 import * as Sentry from "@sentry/node";
-import { getSendingApplication } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh";
-import {
-  getCxIdAndPatientIdOrFail,
-  createUnpackPidFailureFileKey,
-  getOptionalValueFromMessage,
-} from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
-import { utcifyHl7Message } from "@metriport/core/external/hl7-notification/datetime";
-import { buildDayjs, ISO_DATE_TIME } from "@metriport/shared/common/date";
-import { hieTimezoneDictionary, s3Utils, bucketName, asString } from "./app";
+import { S3Utils } from "@metriport/core/external/aws/s3";
 
 const crypto = new Base64Scrambler(Config.getHl7Base64ScramblerSeed());
+export const s3Utils = new S3Utils(Config.getAWSRegion());
+export const bucketName = Config.getHl7IncomingMessageBucketName();
 
-function reformUuid(shortId: string) {
-  return unpackUuid(crypto.unscramble(shortId));
-}
-
-export function unpackPidField(pid: string | undefined) {
-  if (!pid) {
-    return { cxId: "UNK", patientId: "UNK" };
-  }
-
-  const [cxId, patientId] = pid.split("_").map(reformUuid);
-  return { cxId, patientId };
+/**
+ * Avoid using message.toString() as its not stringifying every segment
+ */
+export function asString(message: Hl7Message) {
+  return message.segments.map(s => s.toString()).join("\n");
 }
 
 export function withErrorHandling<T>(
@@ -56,41 +44,15 @@ export function withErrorHandling<T>(
   };
 }
 
-export interface ParsedHl7Data {
-  message: Hl7Message;
-  cxId: string;
-  patientId: string;
+export function unpackPidField(pid: string | undefined) {
+  if (!pid) {
+    return { cxId: "UNK", patientId: "UNK" };
+  }
+
+  const [cxId, patientId] = pid.split("_").map(reformUuid);
+  return { cxId, patientId };
 }
 
-export async function parseHl7Message(rawMessage: Hl7Message): Promise<ParsedHl7Data> {
-  const sendingApplication = getSendingApplication(rawMessage) ?? "Unknown HIE";
-  const hieTimezone = hieTimezoneDictionary[sendingApplication] ?? "UTC";
-  const message = utcifyHl7Message(rawMessage, hieTimezone);
-
-  const { cxId, patientId } = getCxIdAndPatientIdOrFail(message);
-
-  return {
-    message,
-    cxId,
-    patientId,
-  };
-}
-export async function handleParsingError(rawMessage: Hl7Message, logger: Logger) {
-  const { log } = logger;
-
-  const fileKey = createUnpackPidFailureFileKey({
-    rawPtIdentifier: getOptionalValueFromMessage(rawMessage, "PID", 3, 1) ?? "unknown-patient",
-    rawTimestamp:
-      getOptionalValueFromMessage(rawMessage, "MSH", 7, 1) ?? buildDayjs().format(ISO_DATE_TIME),
-    messageCode: getOptionalValueFromMessage(rawMessage, "MSH", 9, 1) ?? "UNK",
-    triggerEvent: getOptionalValueFromMessage(rawMessage, "MSH", 9, 2) ?? "UNK",
-  });
-
-  log(`Parsing failed, uploading raw HL7 message to S3 with key: ${fileKey}`);
-  await s3Utils.uploadFile({
-    bucket: bucketName,
-    key: fileKey,
-    file: Buffer.from(asString(rawMessage)),
-    contentType: "text/plain",
-  });
+function reformUuid(shortId: string) {
+  return unpackUuid(crypto.unscramble(shortId));
 }

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -8,6 +8,15 @@ import { Config } from "@metriport/core/util/config";
 import { Logger } from "@metriport/core/util/log";
 import { unpackUuid } from "@metriport/core/util/pack-uuid";
 import * as Sentry from "@sentry/node";
+import { getSendingApplication } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh";
+import {
+  getCxIdAndPatientIdOrFail,
+  createUnpackPidFailureFileKey,
+  getOptionalValueFromMessage,
+} from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
+import { utcifyHl7Message } from "@metriport/core/external/hl7-notification/datetime";
+import { buildDayjs, ISO_DATE_TIME } from "@metriport/shared/common/date";
+import { hieTimezoneDictionary, s3Utils, bucketName, asString } from "./app";
 
 const crypto = new Base64Scrambler(Config.getHl7Base64ScramblerSeed());
 
@@ -45,4 +54,43 @@ export function withErrorHandling<T>(
       }
     });
   };
+}
+
+export interface ParsedHl7Data {
+  message: Hl7Message;
+  cxId: string;
+  patientId: string;
+}
+
+export async function parseHl7Message(rawMessage: Hl7Message): Promise<ParsedHl7Data> {
+  const sendingApplication = getSendingApplication(rawMessage) ?? "Unknown HIE";
+  const hieTimezone = hieTimezoneDictionary[sendingApplication] ?? "UTC";
+  const message = utcifyHl7Message(rawMessage, hieTimezone);
+
+  const { cxId, patientId } = getCxIdAndPatientIdOrFail(message);
+
+  return {
+    message,
+    cxId,
+    patientId,
+  };
+}
+export async function handleParsingError(rawMessage: Hl7Message, logger: Logger) {
+  const { log } = logger;
+
+  const fileKey = createUnpackPidFailureFileKey({
+    rawPtIdentifier: getOptionalValueFromMessage(rawMessage, "PID", 3, 1) ?? "unknown-patient",
+    rawTimestamp:
+      getOptionalValueFromMessage(rawMessage, "MSH", 7, 1) ?? buildDayjs().format(ISO_DATE_TIME),
+    messageCode: getOptionalValueFromMessage(rawMessage, "MSH", 9, 1) ?? "UNK",
+    triggerEvent: getOptionalValueFromMessage(rawMessage, "MSH", 9, 2) ?? "UNK",
+  });
+
+  log(`Parsing failed, uploading raw HL7 message to S3 with key: ${fileKey}`);
+  await s3Utils.uploadFile({
+    bucket: bucketName,
+    key: fileKey,
+    file: Buffer.from(asString(rawMessage)),
+    contentType: "text/plain",
+  });
 }


### PR DESCRIPTION
### Dependencies

None

### Description

On initial message read failures, we never write the debug message out to S3. This makes it difficult to debug malformed messages and other data quality issues.

This PR catches errors during parsing and writes the message to s3 anyway if so.

Note to self: ensure 'request log' style logs are written in a way that guarantees they'll be persisted, even when errors are thrown.

See slack thread: [link](https://metriport.slack.com/archives/C04T256DQPQ/p1751402848716129?thread_ts=1751392892.801369&cid=C04T256DQPQ)

### Testing

- Local
  - [x] Verify bad pid still has file written to S3
- Staging
  - [ ] Verify bad pid still has file written to S3
- Production
  - [ ] Verify bad pid still has file written to S3

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved HL7 message parsing with a dedicated utility that extracts key identifiers and handles timezones more accurately.
  * Enhanced error handling for HL7 message parsing failures, including logging and uploading failed messages for review.
  * Added unique file key generation for failed HL7 PID unpacking messages.

* **Refactor**
  * Streamlined HL7 message processing for better structure and maintainability.
  * Improved logging to include additional message details.

* **Chores**
  * Exported several previously internal constants and functions for broader use within the application.
  * Updated core package dependencies with a new utility for unique ID generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->