### PR TITLE
ENG-579 Convert number to string before calling .trim()

### DIFF
--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html-bmi.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html-bmi.ts
@@ -874,11 +874,13 @@ const listOfConditionNames = [
   "Atherosclerotic cardiovascular disease",
 ];
 
-const matchesCode = (codingCode: string | undefined, listOfCodes: string[]): boolean =>
-  !!codingCode &&
-  listOfCodes.some(code => code.trim().toLowerCase() === codingCode.trim().toLowerCase());
-
-const matchesDisplay = (codingDisplay: string | undefined, listOfNames: string[]): boolean => {
+function matchesCode(codingCode: string | undefined, listOfCodes: string[]): boolean {
+  return (
+    !!codingCode &&
+    listOfCodes.some(code => code.trim().toLowerCase() === String(codingCode).trim().toLowerCase())
+  );
+}
+function matchesDisplay(codingDisplay: string | undefined, listOfNames: string[]): boolean {
   const display = codingDisplay?.trim().toLowerCase();
 
   return (
@@ -887,9 +889,9 @@ const matchesDisplay = (codingDisplay: string | undefined, listOfNames: string[]
       .map(name => name.trim().toLowerCase())
       .some(name => display.includes(name) || name.includes(display))
   );
-};
+}
 
-const matchesText = (codeText: string | undefined, listOfNames: string[]): boolean => {
+function matchesText(codeText: string | undefined, listOfNames: string[]): boolean {
   const text = codeText?.trim().toLowerCase();
   return (
     !!text &&
@@ -897,7 +899,7 @@ const matchesText = (codeText: string | undefined, listOfNames: string[]): boole
       .map(name => name.trim().toLowerCase())
       .some(name => text.includes(name) || name.includes(text))
   );
-};
+}
 
 function createWeightComoborbidities(
   conditions: Condition[],


### PR DESCRIPTION
### Dependencies

none

### Description

Convert number to string before calling `.trim()`.

### Testing

- Local
  - [x] Generate MR from affecting bundle
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal consistency and reliability of code matching logic for case-insensitive searches. No changes to visible app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->