### PR TITLE
ENG-562: Fix parsing error file contents

### DIFF
--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -15,7 +15,7 @@ import { capture } from "@metriport/core/util";
 import type { Logger } from "@metriport/core/util/log";
 import { out } from "@metriport/core/util/log";
 import { basicToExtendedIso8601 } from "@metriport/shared/common/date";
-import { ParsedHl7Data, parseHl7Message, persistHl7MessageToErrorPath } from "./parsing";
+import { ParsedHl7Data, parseHl7Message, persistHl7MessageError } from "./parsing";
 import { initSentry } from "./sentry";
 import { asString, bucketName, s3Utils, withErrorHandling } from "./utils";
 
@@ -34,8 +34,8 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
 
         try {
           parsedData = await parseHl7Message(rawMessage);
-        } catch (parseError) {
-          await persistHl7MessageToErrorPath(rawMessage, logger);
+        } catch (parseError: unknown) {
+          await persistHl7MessageError(rawMessage, parseError, logger);
           throw parseError;
         }
 

--- a/packages/mllp-server/src/parsing.ts
+++ b/packages/mllp-server/src/parsing.ts
@@ -65,7 +65,6 @@ export async function persistHl7MessageError(
   });
 
   log(`Parsing failed, uploading error message to S3 with key: ${errorFileKey}`);
-  console.log(errorToString(parseError));
   await s3Utils.uploadFile({
     bucket: bucketName,
     key: errorFileKey,

--- a/packages/mllp-server/src/parsing.ts
+++ b/packages/mllp-server/src/parsing.ts
@@ -14,7 +14,7 @@ import { Logger } from "@metriport/core/util/log";
 import { buildDayjs, ISO_DATE_TIME } from "@metriport/shared/common/date";
 import { Config } from "./config";
 import { asString, bucketName, s3Utils } from "./utils";
-import { errorToString } from "@metriport/shared/dist/error/shared";
+import { errorToString } from "@metriport/shared";
 
 const hieTimezoneDictionary = Config.getHieTimezoneDictionary();
 


### PR DESCRIPTION
### Dependencies

None

### Description

Fixes contents of PR currently on staging to ensure file written to s3 during parsing failure contains an error. 

https://github.com/metriport/metriport/pull/4144

### Testing

- Local
  - [ ] Check s3 parsing failure 
- Staging
  - [ ] Check s3 parsing failure 
- Production
  - [ ] Check s3 parsing failure 

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for HL7 message parsing by capturing and storing detailed error information.

* **Chores**
  * Updated error persistence to include comprehensive error details for improved traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->