### PR TITLE
feat(ehr): re-running dq on appointment fetching past cooldown

### DIFF
--- a/packages/api/src/external/ehr/athenahealth/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/athenahealth/command/process-patients-from-appointments.ts
@@ -253,5 +253,6 @@ async function syncPatient({
     patientId: athenaPatientId,
     departmentId: athenaDepartmentId,
     triggerDq: true,
+    isAppointment: true,
   });
 }

--- a/packages/api/src/external/ehr/canvas/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/canvas/command/process-patients-from-appointments.ts
@@ -138,5 +138,6 @@ async function syncPatient({
     practiceId: canvasPracticeId,
     patientId: canvasPatientId,
     triggerDq: true,
+    isAppointment: true,
   });
 }

--- a/packages/api/src/external/ehr/elation/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/elation/command/process-patients-from-appointments.ts
@@ -201,5 +201,6 @@ async function syncPatient({
     practiceId: elationPracticeId,
     patientId: elationPatientId,
     triggerDq: true,
+    isAppointment: true,
   });
 }

--- a/packages/api/src/external/ehr/healthie/command/process-patients-from-appointments.ts
+++ b/packages/api/src/external/ehr/healthie/command/process-patients-from-appointments.ts
@@ -265,5 +265,6 @@ async function syncPatient({
     practiceId: healthiePracticeId,
     patientId: healthiePatientId,
     triggerDq: true,
+    isAppointment: true,
   });
 }

--- a/packages/api/src/external/ehr/shared/utils/patient.ts
+++ b/packages/api/src/external/ehr/shared/utils/patient.ts
@@ -78,8 +78,8 @@ export function isDqCooldownExpired(patient: Patient): boolean {
   const lastDqStartedAt = patient.data.documentQueryProgress?.startedAt;
   if (!lastDqStartedAt) return true;
   const lastStartedAt = buildDayjs(lastDqStartedAt);
-  const diff = buildDayjs().diff(lastStartedAt, "days");
-  if (diff > patientDqCooldown.asDays()) {
+  const diff = buildDayjs().diff(lastStartedAt, "hours");
+  if (diff > patientDqCooldown.asHours()) {
     return true;
   } else {
     return false;

--- a/packages/api/src/external/ehr/shared/utils/patient.ts
+++ b/packages/api/src/external/ehr/shared/utils/patient.ts
@@ -1,8 +1,15 @@
-import { PatientDemoData } from "@metriport/core/domain/patient";
+import { Patient, PatientDemoData } from "@metriport/core/domain/patient";
+import { buildDayjs } from "@metriport/shared/common/date";
 import { EhrSource } from "@metriport/shared/interface/external/ehr/source";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
 import { getFacilityMapping, getFacilityMappingOrFail } from "../../../../command/mapping/facility";
 import { createPatient } from "../../../../command/medical/patient/create-patient";
 import { PatientWithIdentifiers } from "../../../../command/medical/patient/get-patient";
+
+dayjs.extend(duration);
+
+const patientDqCooldown = dayjs.duration(1, "days");
 
 export type HandleMetriportSyncParams = {
   cxId: string;
@@ -65,4 +72,16 @@ async function getFacilityId({
 
 function createFacilityStateExternalId(practiceId: string, state: string): string {
   return `${practiceId}-${state}`;
+}
+
+export function isDqCooldownExpired(patient: Patient): boolean {
+  const lastDqStartedAt = patient.data.documentQueryProgress?.startedAt;
+  if (!lastDqStartedAt) return true;
+  const lastStartedAt = buildDayjs(lastDqStartedAt);
+  const diff = buildDayjs().diff(lastStartedAt, "days");
+  if (diff > patientDqCooldown.asDays()) {
+    return true;
+  } else {
+    return false;
+  }
 }

--- a/packages/api/src/routes/internal/ehr/athenahealth/patient.ts
+++ b/packages/api/src/routes/internal/ehr/athenahealth/patient.ts
@@ -84,12 +84,14 @@ router.post(
     const athenaPracticeId = getFromQueryOrFail("practiceId", req);
     const athenaDepartmentId = getFromQueryOrFail("departmentId", req);
     const triggerDq = getFromQueryAsBoolean("triggerDq", req);
+    const isAppointment = getFromQueryAsBoolean("isAppointment", req);
     syncAthenaPatientIntoMetriport({
       cxId,
       athenaPracticeId,
       athenaPatientId,
       athenaDepartmentId,
       triggerDq,
+      triggerDqForExistingPatient: isAppointment,
     }).catch(processAsyncError("AthenaHealth syncAthenaPatientIntoMetriport"));
     return res.sendStatus(httpStatus.OK);
   })

--- a/packages/api/src/routes/internal/ehr/canvas/patient.ts
+++ b/packages/api/src/routes/internal/ehr/canvas/patient.ts
@@ -45,11 +45,13 @@ router.post(
     const canvasPatientId = getFromQueryOrFail("patientId", req);
     const canvasPracticeId = getFromQueryOrFail("practiceId", req);
     const triggerDq = getFromQueryAsBoolean("triggerDq", req);
+    const isAppointment = getFromQueryAsBoolean("isAppointment", req);
     syncCanvasPatientIntoMetriport({
       cxId,
       canvasPracticeId,
       canvasPatientId,
       triggerDq,
+      triggerDqForExistingPatient: isAppointment,
     }).catch(processAsyncError("Canvas syncCanvasPatientIntoMetriport"));
     return res.sendStatus(httpStatus.OK);
   })

--- a/packages/api/src/routes/internal/ehr/elation/patient.ts
+++ b/packages/api/src/routes/internal/ehr/elation/patient.ts
@@ -48,11 +48,13 @@ router.post(
     const elationPatientId = getFromQueryOrFail("patientId", req);
     const elationPracticeId = getFromQueryOrFail("practiceId", req);
     const triggerDq = getFromQueryAsBoolean("triggerDq", req);
+    const isAppointment = getFromQueryAsBoolean("isAppointment", req);
     syncElationPatientIntoMetriport({
       cxId,
       elationPracticeId,
       elationPatientId,
       triggerDq,
+      triggerDqForExistingPatient: isAppointment,
     }).catch(processAsyncError("Elation syncElationPatientIntoMetriport"));
     return res.sendStatus(httpStatus.OK);
   })

--- a/packages/api/src/routes/internal/ehr/healthie/patient.ts
+++ b/packages/api/src/routes/internal/ehr/healthie/patient.ts
@@ -64,11 +64,13 @@ router.post(
     const healthiePatientId = getFromQueryOrFail("patientId", req);
     const healthiePracticeId = getFromQueryOrFail("practiceId", req);
     const triggerDq = getFromQueryAsBoolean("triggerDq", req);
+    const isAppointment = getFromQueryAsBoolean("isAppointment", req);
     syncHealthiePatientIntoMetriport({
       cxId,
       healthiePracticeId,
       healthiePatientId,
       triggerDq,
+      triggerDqForExistingPatient: isAppointment,
     }).catch(processAsyncError("Healthie syncHealthiePatientIntoMetriport"));
     return res.sendStatus(httpStatus.OK);
   })

--- a/packages/core/src/external/ehr/api/sync-patient.ts
+++ b/packages/core/src/external/ehr/api/sync-patient.ts
@@ -6,6 +6,7 @@ import { ApiBaseParams, validateAndLogResponse } from "./api-shared";
 
 export type SyncPatientParams = ApiBaseParams & {
   triggerDq: boolean;
+  isAppointment?: boolean;
 };
 
 /**
@@ -25,6 +26,7 @@ export async function syncPatient({
   departmentId,
   patientId,
   triggerDq,
+  isAppointment,
 }: SyncPatientParams): Promise<void> {
   const { log, debug } = out(`Ehr syncPatient - cxId ${cxId}`);
   const api = axios.create({ baseURL: Config.getApiUrl() });
@@ -34,6 +36,7 @@ export async function syncPatient({
     patientId,
     triggerDq: triggerDq.toString(),
     ...(departmentId ? { departmentId } : {}),
+    ...(isAppointment ? { isAppointment: isAppointment.toString() } : {}),
   });
   const syncPatientUrl = `/internal/ehr/${ehr}/patient?${queryParams.toString()}`;
   try {

--- a/packages/core/src/external/ehr/command/sync-patient/ehr-sync-patient-cloud.ts
+++ b/packages/core/src/external/ehr/command/sync-patient/ehr-sync-patient-cloud.ts
@@ -5,14 +5,10 @@ import { Config } from "../../../../util/config";
 import { EhrSyncPatientHandler, ProcessSyncPatientRequest } from "./ehr-sync-patient";
 
 export class EhrSyncPatientCloud implements EhrSyncPatientHandler {
-  private readonly sqsClient: SQSClient;
-
   constructor(
-    private readonly ehrSyncPatientQueueUrl: string,
-    sqsClient: SQSClient = new SQSClient({ region: Config.getAWSRegion() })
-  ) {
-    this.sqsClient = sqsClient;
-  }
+    private readonly ehrSyncPatientQueueUrl: string = Config.getEhrSyncPatientQueueUrl(),
+    private readonly sqsClient: SQSClient = new SQSClient({ region: Config.getAWSRegion() })
+  ) {}
 
   async processSyncPatient(params: ProcessSyncPatientRequest): Promise<void> {
     const { cxId } = params;

--- a/packages/core/src/external/ehr/command/sync-patient/ehr-sync-patient-direct.ts
+++ b/packages/core/src/external/ehr/command/sync-patient/ehr-sync-patient-direct.ts
@@ -2,8 +2,8 @@ import { sleep } from "@metriport/shared";
 import { syncPatient } from "../../api/sync-patient";
 import { EhrSyncPatientHandler, ProcessSyncPatientRequest } from "./ehr-sync-patient";
 
-export class EhrSyncPatientLocal implements EhrSyncPatientHandler {
-  constructor(private readonly waitTimeInMillis: number) {}
+export class EhrSyncPatientDirect implements EhrSyncPatientHandler {
+  constructor(private readonly waitTimeInMillis: number = 0) {}
 
   async processSyncPatient({
     ehr,
@@ -12,6 +12,7 @@ export class EhrSyncPatientLocal implements EhrSyncPatientHandler {
     departmentId,
     patientId,
     triggerDq,
+    isAppointment,
   }: ProcessSyncPatientRequest): Promise<void> {
     await syncPatient({
       ehr,
@@ -20,6 +21,7 @@ export class EhrSyncPatientLocal implements EhrSyncPatientHandler {
       patientId,
       triggerDq,
       ...(departmentId ? { departmentId } : {}),
+      ...(isAppointment ? { isAppointment } : {}),
     });
     if (this.waitTimeInMillis > 0) await sleep(this.waitTimeInMillis);
   }

--- a/packages/core/src/external/ehr/command/sync-patient/ehr-sync-patient-factory.ts
+++ b/packages/core/src/external/ehr/command/sync-patient/ehr-sync-patient-factory.ts
@@ -1,13 +1,11 @@
 import { Config } from "../../../../util/config";
 import { EhrSyncPatientHandler } from "./ehr-sync-patient";
 import { EhrSyncPatientCloud } from "./ehr-sync-patient-cloud";
-import { EhrSyncPatientLocal } from "./ehr-sync-patient-local";
+import { EhrSyncPatientDirect } from "./ehr-sync-patient-direct";
 
 export function buildEhrSyncPatientHandler(): EhrSyncPatientHandler {
   if (Config.isDev()) {
-    const waitTimeAtTheEndInMillis = 0;
-    return new EhrSyncPatientLocal(waitTimeAtTheEndInMillis);
+    return new EhrSyncPatientDirect();
   }
-  const ehrSyncPatientQueueUrl = Config.getEhrSyncPatientQueueUrl();
-  return new EhrSyncPatientCloud(ehrSyncPatientQueueUrl);
+  return new EhrSyncPatientCloud();
 }

--- a/packages/core/src/external/ehr/command/sync-patient/ehr-sync-patient.ts
+++ b/packages/core/src/external/ehr/command/sync-patient/ehr-sync-patient.ts
@@ -7,6 +7,7 @@ export type ProcessSyncPatientRequest = {
   departmentId?: string;
   patientId: string;
   triggerDq: boolean;
+  isAppointment?: boolean;
 };
 
 export interface EhrSyncPatientHandler {

--- a/packages/lambdas/src/shared/ehr.ts
+++ b/packages/lambdas/src/shared/ehr.ts
@@ -1,54 +1,8 @@
-import { ProcessSyncPatientRequest } from "@metriport/core/external/ehr/command/sync-patient/ehr-sync-patient";
 import { ProcessLinkPatientRequest as ElationProcessLinkPatientRequest } from "@metriport/core/external/ehr/elation/command/link-patient/elation-link-patient";
 import { ProcessLinkPatientRequest as HealthieProcessLinkPatientRequest } from "@metriport/core/external/ehr/healthie/command/link-patient/healthie-link-patient";
 import { MetriportError } from "@metriport/shared";
-import { EhrSources, isEhrSource } from "@metriport/shared/interface/external/ehr/source";
+import { EhrSources } from "@metriport/shared/interface/external/ehr/source";
 import { z } from "zod";
-
-interface SyncPatientPayload {
-  cxId: unknown;
-  ehr: unknown;
-  practiceId: unknown;
-  patientId: unknown;
-  departmentId?: unknown;
-  triggerDq: unknown;
-}
-
-export function parseSyncPatient(bodyAsJson: SyncPatientPayload): ProcessSyncPatientRequest {
-  const cxIdRaw = bodyAsJson.cxId;
-  if (!cxIdRaw) throw new MetriportError("Missing cxId");
-  if (typeof cxIdRaw !== "string") throw new MetriportError("Invalid cxId");
-
-  const ehrRaw = bodyAsJson.ehr;
-  if (!ehrRaw) throw new MetriportError("Missing ehr");
-  if (typeof ehrRaw !== "string") throw new MetriportError("Invalid ehr");
-  if (!isEhrSource(ehrRaw)) throw new MetriportError("Invalid ehr", undefined, { ehrRaw });
-
-  const practiceIdRaw = bodyAsJson.practiceId;
-  if (!practiceIdRaw) throw new MetriportError("Missing practiceId");
-  if (typeof practiceIdRaw !== "string") throw new MetriportError("Invalid practiceId");
-
-  const patientIdRaw = bodyAsJson.patientId;
-  if (!patientIdRaw) throw new MetriportError("Missing patientId");
-  if (typeof patientIdRaw !== "string") throw new MetriportError("Invalid patientId");
-
-  const departmentIdRaw = bodyAsJson.departmentId;
-  const isValidDeparmentId = departmentIdRaw === undefined || typeof departmentIdRaw === "string";
-  if (!isValidDeparmentId) throw new MetriportError("Invalid departmentId");
-
-  const triggerDqRaw = bodyAsJson.triggerDq;
-  if (triggerDqRaw === undefined) throw new MetriportError("Missing triggerDq");
-  if (typeof triggerDqRaw !== "boolean") throw new MetriportError("Invalid triggerDq");
-
-  return {
-    cxId: cxIdRaw,
-    ehr: ehrRaw,
-    practiceId: practiceIdRaw,
-    patientId: patientIdRaw,
-    departmentId: departmentIdRaw,
-    triggerDq: triggerDqRaw,
-  };
-}
 
 interface LinkPatientPayload {
   cxId: unknown;
@@ -77,6 +31,16 @@ export function parseLinkPatient(
     patientId: patientIdRaw,
   };
 }
+
+export const ehrSyncPatientSchema = z.object({
+  ehr: z.nativeEnum(EhrSources),
+  cxId: z.string(),
+  practiceId: z.string(),
+  departmentId: z.string().optional(),
+  patientId: z.string(),
+  triggerDq: z.boolean(),
+  isAppointment: z.boolean().optional(),
+});
 
 export const ehrCreateResourceDiffBundlesSchema = z.object({
   ehr: z.nativeEnum(EhrSources),


### PR DESCRIPTION
Ref: ENG-587

Issues:

- https://linear.app/metriport/issue/ENG-587

### Description

- add an isAppointment flag to the sync patient command
- if the patient already exists, but the sync if from an appointment, and the patient hasn't run dq in 24hrs, run DQ

### Testing

- Local
  - [x] already linked patient has DQ run once
  - [x] already linked patient *does not* have DQ run again
- Staging
  - [ ] already linked patient has DQ run once
  - [ ] already linked patient *does not* have DQ run again
- Sandbox
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Production
  - [ ] already linked patient has DQ run once
  - [ ] already linked patient *does not* have DQ run again

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional "isAppointment" flag when syncing patients, allowing appointment-related syncs to be explicitly marked.
  * Enhanced patient sync endpoints to accept and process the "isAppointment" parameter.

* **Improvements**
  * Introduced a mechanism to trigger document queries for existing patients if a cooldown period has expired, improving data freshness.
  * Added a utility to determine if the document query cooldown has expired for a patient.

* **Refactor**
  * Streamlined patient sync handler classes and constructors for improved maintainability.
  * Replaced manual payload validation with schema-based validation for patient sync requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->