### PR TITLE
ENG-590: Fix flaky e2e test

### DIFF
--- a/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/patient.test.e2e.ts
+++ b/packages/api/src/routes/medical/__tests__/fhir-r4/e2e/patient.test.e2e.ts
@@ -6,7 +6,7 @@ import { makePatient } from "@metriport/core/external/fhir/__tests__/patient";
 import { AxiosResponse } from "axios";
 import { api } from "../../../../../__tests__/e2e/shared";
 
-jest.setTimeout(15000);
+jest.setTimeout(25000);
 
 const patient = makePatient({ firstName: `${faker.person.firstName()}_${faker.string.nanoid()}` });
 
@@ -29,9 +29,7 @@ describe("Integration FHIR Patient", () => {
     if (!patient.name || patient.name.length < 1) throw new Error("Patient must have a name");
     if (!patient.name[0].given || patient.name[0].given.length < 1)
       throw new Error("Patient must have a given name");
-    const res = await api.get(`/fhir/R4/Patient/?name=${patient.name[0].given[0]}`, {
-      timeout: 30000,
-    });
+    const res = await api.get(`/fhir/R4/Patient/?name=${patient.name[0].given[0]}`);
     expect(res.status).toBe(200);
     const body = res.data;
     expect(body.resourceType).toBeTruthy();


### PR DESCRIPTION
### Dependencies

None

### Description

Fix flakiness in e2e test

### Testing

None

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for patient search tests to 25 seconds to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->