### PR TITLE
fix(lambdas): added check for conversion eligibility

### DIFF
--- a/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
+++ b/packages/api/src/external/carequality/document/process-outbound-document-query-resps.ts
@@ -78,7 +78,9 @@ export async function processOutboundDocumentQueryResps({
       isConvertible(doc.contentType || undefined)
     ).length;
 
-    log(`I have ${docsToDownload.length} docs to download (${convertibleDocCount} convertible)`);
+    log(
+      `I have ${docsToDownload.length} docs to download (${convertibleDocCount} convertible (based on the contentType))`
+    );
 
     analytics({
       distinctId: cxId,

--- a/packages/core/src/external/cda/is-convertible.ts
+++ b/packages/core/src/external/cda/is-convertible.ts
@@ -1,31 +1,56 @@
+import { S3Utils } from "../aws/s3";
+
 /**
- * Checks if the XML payload is a convertible CDA document.
+ * Checks whether the CDA document on S3 is convertible.
  *
- * @param payloadRaw - The raw XML content as string
- * @param s3FileName - The filename for logging purposes
+ * @param bucketName - The name of the S3 bucket
+ * @param fileKey - The key of the CDA document on S3
+ * @param s3Utils - The S3Utils instance
  *
- * @returns Object with validation result and reason if invalid
+ * @returns If the CDA is convertible, returns its contents. If not, returns the reason why.
  */
-export function isConvertible(
-  payloadRaw: string,
-  s3FileName: string
-): {
-  isValid: boolean;
-  reason?: string;
-} {
-  if (payloadRaw.includes("nonXMLBody")) {
+export async function isConvertibleFromS3({
+  bucketName,
+  fileKey,
+  s3Utils,
+}: {
+  bucketName: string;
+  fileKey: string;
+  s3Utils: S3Utils;
+}): Promise<{ isValid: true; contents: string } | { isValid: false; reason: string }> {
+  const [fileInfo, payloadRaw] = await Promise.all([
+    s3Utils.getFileInfoFromS3(fileKey, bucketName),
+    s3Utils.getFileContentsAsString(bucketName, fileKey),
+  ]);
+
+  const { isValid, reason } = isConvertible(payloadRaw);
+  if (!isValid) {
     return {
       isValid: false,
-      reason: `XML document is unstructured CDA with nonXMLBody - Filename: ${s3FileName}`,
+      reason: `Non-convertible: ${reason} - Filename: ${fileKey}, Size: ${fileInfo.size} bytes`,
     };
+  }
+
+  return { isValid: true, contents: payloadRaw };
+}
+
+/**
+ * Checks whether the CDA document is convertible.
+ *
+ * @param payloadRaw - The raw XML content as string
+ *
+ * @returns If the CDA is convertible, returns its contents. If not, returns the reason why.
+ */
+export function isConvertible(
+  payloadRaw: string
+): { isValid: true; reason: undefined } | { isValid: false; reason: string } {
+  if (payloadRaw.includes("nonXMLBody")) {
+    return { isValid: false, reason: "XML document is unstructured CDA with nonXMLBody" };
   }
 
   if (!payloadRaw.includes("ClinicalDocument")) {
-    return {
-      isValid: false,
-      reason: `XML document is not a clinical document - Filename: ${s3FileName}`,
-    };
+    return { isValid: false, reason: "XML document is not a clinical document" };
   }
 
-  return { isValid: true };
+  return { isValid: true, reason: undefined };
 }

--- a/packages/core/src/external/cda/is-convertible.ts
+++ b/packages/core/src/external/cda/is-convertible.ts
@@ -1,0 +1,31 @@
+/**
+ * Checks if the XML payload is a convertible CDA document.
+ *
+ * @param payloadRaw - The raw XML content as string
+ * @param s3FileName - The filename for logging purposes
+ *
+ * @returns Object with validation result and reason if invalid
+ */
+export function isConvertible(
+  payloadRaw: string,
+  s3FileName: string
+): {
+  isValid: boolean;
+  reason?: string;
+} {
+  if (payloadRaw.includes("nonXMLBody")) {
+    return {
+      isValid: false,
+      reason: `XML document is unstructured CDA with nonXMLBody - Filename: ${s3FileName}`,
+    };
+  }
+
+  if (!payloadRaw.includes("ClinicalDocument")) {
+    return {
+      isValid: false,
+      reason: `XML document is not a clinical document - Filename: ${s3FileName}`,
+    };
+  }
+
+  return { isValid: true };
+}

--- a/packages/fhir-converter/src/lib/inputProcessor/dateProcessor.js
+++ b/packages/fhir-converter/src/lib/inputProcessor/dateProcessor.js
@@ -69,7 +69,7 @@ function extractEncounterTimePeriod(srcData) {
 function getEncompassingEncounterId(srcData) {
   const jsonObj = parser.parse(srcData);
   const encompassingEncounter = jsonObj.ClinicalDocument?.componentOf?.encompassingEncounter;
-  if (encompassingEncounter) {
+  if (encompassingEncounter && encompassingEncounter.id) {
     const extIdRef = encompassingEncounter.id;
     const externalId = {
       ...(extIdRef.root && { root: extIdRef?.root }),

--- a/packages/lambdas/src/sqs-to-converter.ts
+++ b/packages/lambdas/src/sqs-to-converter.ts
@@ -26,6 +26,7 @@ import { executeWithRetriesS3, S3Utils } from "@metriport/core/external/aws/s3";
 import { partitionPayload } from "@metriport/core/external/cda/partition-payload";
 import { processAttachments } from "@metriport/core/external/cda/process-attachments";
 import { removeBase64PdfEntries } from "@metriport/core/external/cda/remove-b64";
+import { isConvertible } from "@metriport/core/external/cda/is-convertible";
 import { hydrate } from "@metriport/core/external/fhir/consolidated/hydrate";
 import { normalize } from "@metriport/core/external/fhir/consolidated/normalize";
 import { FHIR_APP_MIME_TYPE, TXT_MIME_TYPE } from "@metriport/core/util/mime";
@@ -471,35 +472,4 @@ async function sendConversionResult({
     source: medicalDataSource,
     status: "success",
   });
-}
-
-/**
- * Checks if the XML payload is a convertible CDA document
- * @param payloadRaw - The raw XML content as string
- * @param s3FileName - The filename for logging purposes
- *
- * @returns Object with validation result and reason if invalid
- */
-function isConvertible(
-  payloadRaw: string,
-  s3FileName: string
-): {
-  isValid: boolean;
-  reason?: string;
-} {
-  if (payloadRaw.includes("nonXMLBody")) {
-    return {
-      isValid: false,
-      reason: `XML document is unstructured CDA with nonXMLBody - Filename: ${s3FileName}`,
-    };
-  }
-
-  if (!payloadRaw.includes("ClinicalDocument")) {
-    return {
-      isValid: false,
-      reason: `XML document is not a clinical document - Filename: ${s3FileName}`,
-    };
-  }
-
-  return { isValid: true };
 }


### PR DESCRIPTION
Part of ENG-592

Issues:

- https://linear.app/metriport/issue/ENG-592

### Description
- If XML doesn't include `<ClinicalDocument>`, we shouldn't attempt to convert it
- Added a check for the existence of `encompassingEncounter.id`

### Testing

- Local
  - [x] Use new function on the FHIR integration test script
  - [x] Run the Converter on some of the CDAs that were failing to convert
- Staging
  - [ ] Try to convert some convertible and non-convertible XMLs
- Production
  - [ ] Monitor DLQ

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved validation for document conversion by introducing enhanced checks to determine if a document is suitable for processing.
* **Bug Fixes**
  * More robust handling of unstructured or invalid documents, preventing unnecessary processing and improving reliability.
  * Prevented potential runtime errors by refining checks on encounter data.
* **Tests**
  * Updated integration tests to filter out non-convertible documents before attempting conversion, ensuring test accuracy.
* **Style**
  * Clarified log messages to provide more descriptive information about document convertibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->