### PR TITLE
ENG-590: Fix flaky fhir sdk test

### DIFF
--- a/packages/fhir-sdk/src/__tests__/fhir-bundle-sdk.test.ts
+++ b/packages/fhir-sdk/src/__tests__/fhir-bundle-sdk.test.ts
@@ -542,7 +542,7 @@ describe("FhirBundleSdk", () => {
         observations[0]?.getSubject();
         const end = performance.now();
 
-        expect(end - start).toBeLessThan(1);
+        expect(end - start).toBeLessThan(CONSTANT_TIME_EXPECTED_THRESHOLD_MS);
       });
     });
   });


### PR DESCRIPTION
### Dependencies

None

### Description

Changes perf threshold to avoid test from flaking.

### Testing

N/A

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated performance test to use a configurable threshold for reference resolution time instead of a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->