### PR TITLE
fix(core): wrapping os fhir ingester with network retries

### DIFF
--- a/packages/core/src/external/opensearch/fhir-ingestor.ts
+++ b/packages/core/src/external/opensearch/fhir-ingestor.ts
@@ -20,7 +20,7 @@ import { getEntryId } from "./shared/id";
 
 dayjs.extend(duration);
 
-const ERROR_CODES_TO_RETRY = [409, 504];
+const ERROR_CODES_TO_RETRY = [409, 503];
 const MAX_RETRY_ATTEMPTS = 3;
 const INITIAL_WAIT_TIME_BETWEEN_RETRIES = dayjs.duration({ seconds: 0.2 });
 const DEFAULT_BULK_INGESTION_TIMEOUT = dayjs.duration(2, "minute").asMilliseconds();

--- a/packages/core/src/external/opensearch/fhir-ingestor.ts
+++ b/packages/core/src/external/opensearch/fhir-ingestor.ts
@@ -21,8 +21,7 @@ import { getEntryId } from "./shared/id";
 dayjs.extend(duration);
 
 const ERROR_CODES_TO_RETRY = [409, 503];
-const MAX_RETRY_ATTEMPTS = 3;
-const INITIAL_WAIT_TIME_BETWEEN_RETRIES = dayjs.duration({ seconds: 0.2 });
+const INITIAL_WAIT_TIME_BETWEEN_RETRIES = dayjs.duration({ milliseconds: 200 });
 const DEFAULT_BULK_INGESTION_TIMEOUT = dayjs.duration(2, "minute").asMilliseconds();
 const MAX_BULK_RETRIES = 3;
 
@@ -193,7 +192,7 @@ export class OpenSearchFhirIngestor {
       {
         httpStatusCodesToRetry: ERROR_CODES_TO_RETRY,
         initialDelay: INITIAL_WAIT_TIME_BETWEEN_RETRIES.asMilliseconds(),
-        maxAttempts: MAX_RETRY_ATTEMPTS,
+        maxAttempts: 3,
       }
     );
 
@@ -225,7 +224,7 @@ export class OpenSearchFhirIngestor {
         {
           httpStatusCodesToRetry: ERROR_CODES_TO_RETRY,
           initialDelay: INITIAL_WAIT_TIME_BETWEEN_RETRIES.asMilliseconds(),
-          maxAttempts: MAX_RETRY_ATTEMPTS,
+          maxAttempts: 10,
         }
       );
       const time = Date.now() - startedAt;

--- a/packages/core/src/external/opensearch/fhir-ingestor.ts
+++ b/packages/core/src/external/opensearch/fhir-ingestor.ts
@@ -1,5 +1,5 @@
 import { Resource } from "@medplum/fhirtypes";
-import { errorToString, MetriportError } from "@metriport/shared";
+import { errorToString, executeWithNetworkRetries, MetriportError } from "@metriport/shared";
 import { buildDayjs } from "@metriport/shared/common/date";
 import { Client } from "@opensearch-project/opensearch";
 import dayjs from "dayjs";
@@ -20,6 +20,9 @@ import { getEntryId } from "./shared/id";
 
 dayjs.extend(duration);
 
+const ERROR_CODES_TO_RETRY = [409, 504];
+const MAX_RETRY_ATTEMPTS = 3;
+const INITIAL_WAIT_TIME_BETWEEN_RETRIES = dayjs.duration({ seconds: 0.2 });
 const DEFAULT_BULK_INGESTION_TIMEOUT = dayjs.duration(2, "minute").asMilliseconds();
 const MAX_BULK_RETRIES = 3;
 
@@ -180,10 +183,20 @@ export class OpenSearchFhirIngestor {
     }
 
     const startedAt = Date.now();
-    const response = await client.bulk(
-      { index: indexName, body: bulkRequest },
-      { requestTimeout: DEFAULT_BULK_INGESTION_TIMEOUT, maxRetries: MAX_BULK_RETRIES }
+
+    const response = await executeWithNetworkRetries(
+      async () =>
+        client.bulk(
+          { index: indexName, body: bulkRequest },
+          { requestTimeout: DEFAULT_BULK_INGESTION_TIMEOUT, maxRetries: MAX_BULK_RETRIES }
+        ),
+      {
+        httpStatusCodesToRetry: ERROR_CODES_TO_RETRY,
+        initialDelay: INITIAL_WAIT_TIME_BETWEEN_RETRIES.asMilliseconds(),
+        maxAttempts: MAX_RETRY_ATTEMPTS,
+      }
     );
+
     const time = Date.now() - startedAt;
 
     const errorCount = processErrorsFromBulkResponse(response, operation, onItemError);
@@ -202,10 +215,19 @@ export class OpenSearchFhirIngestor {
       log(`Deleting resources from index ${indexName}...`);
       const startedAt = Date.now();
 
-      await client.deleteByQuery({
-        index: indexName,
-        body: createDeleteQuery({ cxId, patientId }),
-      });
+      await executeWithNetworkRetries(
+        async () => {
+          await client.deleteByQuery({
+            index: indexName,
+            body: createDeleteQuery({ cxId, patientId }),
+          });
+        },
+        {
+          httpStatusCodesToRetry: ERROR_CODES_TO_RETRY,
+          initialDelay: INITIAL_WAIT_TIME_BETWEEN_RETRIES.asMilliseconds(),
+          maxAttempts: MAX_RETRY_ATTEMPTS,
+        }
+      );
       const time = Date.now() - startedAt;
       log(`Successfully deleted in ${time} milliseconds`);
     } finally {


### PR DESCRIPTION
Part of ENG-595

Issues:

- https://linear.app/metriport/issue/ENG-595

### Description
- Retry on 409 and 503 - https://docs.aws.amazon.com/opensearch-service/latest/APIReference/CommonErrors.html
- Wrapped OS Fhir ingester `deleteByQuery` method with `executeWithNetworkRetries`
- Wrapped OS Fhir ingester `bulk` method with `executeWithNetworkRetries`

### Testing

- Local
  - N/A
- Staging
  - [ ] Run some searches on staging dash
- Production
  - [ ] Confirm search works on prod

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of network operations by adding automatic retries with exponential backoff for certain errors when interacting with OpenSearch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->