### PR TITLE
ENG-598: Fix bad performance of addMissingReferences for many missingReferences

### DIFF
--- a/packages/core/src/command/consolidated/consolidated-filter.ts
+++ b/packages/core/src/command/consolidated/consolidated-filter.ts
@@ -142,9 +142,13 @@ function getResourcesFromBundle(
   references: ReferenceWithIdAndType[],
   originalBundle: Bundle<Resource>
 ): Resource[] {
+  const bundleResourceIndex = new Map(
+    originalBundle.entry?.map(e => [e.resource?.id, e.resource]) ?? []
+  );
+
   const resourcesToAdd: Resource[] = [];
   for (const missingRef of references) {
-    const resource = originalBundle.entry?.find(e => e.resource?.id === missingRef.id)?.resource;
+    const resource = bundleResourceIndex.get(missingRef.id);
     if (resource) resourcesToAdd.push(resource);
   }
   return resourcesToAdd;

--- a/packages/utils/src/consolidated/add-missing-references-consolidated.ts
+++ b/packages/utils/src/consolidated/add-missing-references-consolidated.ts
@@ -1,0 +1,69 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+import { Bundle } from "@medplum/fhirtypes";
+import { addMissingReferences } from "@metriport/core/command/consolidated/consolidated-filter";
+import { createConsolidatedDataFileNameWithSuffix } from "@metriport/core/domain/consolidated/filename";
+import { S3Utils } from "@metriport/core/external/aws/s3";
+import { getFileContents } from "@metriport/core/util/fs";
+import { out } from "@metriport/core/util/log";
+import { getEnvVarOrFail, sleep } from "@metriport/shared";
+import { initTimer } from "@metriport/shared/common/timer";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import { initRunsFolder } from "../shared/folder";
+
+dayjs.extend(duration);
+
+/**
+ * This script adds missing references to a patient's consolidated data using the addMissingReferences() function
+ * from packages/core.
+ *
+ * Either set the bundleFilePath or the cxId and patientId.
+ *
+ * Execute this with:
+ * $ ts-node src/consolidated/add-missing-references-consolidated.ts
+ */
+
+// If set, the script will use the bundle file in the given path instead of downloading it from S3.
+const bundleFilePath: string | undefined = "";
+
+// If the bundle file path is not set, the script will download the consolidated data from S3 using this props
+const cxId = "";
+const patientId = "";
+
+const medicalDocsBucketName = getEnvVarOrFail("MEDICAL_DOCUMENTS_BUCKET_NAME");
+
+const region = getEnvVarOrFail("AWS_REGION");
+const s3Utils = new S3Utils(region);
+
+async function main() {
+  await sleep(100);
+  initRunsFolder();
+  const { log } = out("");
+
+  log(`>>> Starting...`);
+
+  const fileKey = createConsolidatedDataFileNameWithSuffix(cxId, patientId) + ".json";
+
+  log(`>>> Using bucket ${medicalDocsBucketName}`);
+  log(`>>> Getting contents from ${fileKey}...`);
+  const contents = bundleFilePath
+    ? getFileContents(bundleFilePath)
+    : await s3Utils.getFileContentsAsString(medicalDocsBucketName, fileKey);
+
+  const bundle = JSON.parse(contents) as Bundle;
+
+  try {
+    log(`>>> Adding missing references...`);
+    const timer = initTimer();
+    addMissingReferences(bundle, bundle, addMissingReferences);
+    log(`>>> Finished addMissingReferences() in ${timer.getElapsedTime()} ms`);
+  } catch (error) {
+    log(`>>> Error: ${error}`);
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
### Dependencies

None

### Description

The problem patient bundle had a LOT of "missingReferences".

Fixes slow consolidated query snapshots for large bundles / bundles with many missing references. We were doing an O(n*k) operation instead of an O(n + k) operation.

### Testing

- [x] Verified performance improvement on local. 6300 ms -> 200 ms
- [x] Verify page loads with proper consolidated snapshot on staging
- [x] Verify problem patient loads faster (verify via cloudwatch logs) on production

### Release Plan

- [ ] Merge this
- [ ] Rerun consolidated query in production, check cloudwatch log timestamps to see if addMissingReferences performance improved for problem patient in cloud environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a script to add missing references to a patient's consolidated data bundle, supporting both local files and AWS S3 sources.

* **Performance Improvements**
  * Optimized resource lookup within data bundles for faster processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->