### PR TITLE
fix(api): add path to consolidated data on adt notifs on slack

### DIFF
--- a/packages/api/src/command/medical/patient/hl7-fhir-webhook.ts
+++ b/packages/api/src/command/medical/patient/hl7-fhir-webhook.ts
@@ -2,6 +2,7 @@ import {
   isDischargeSlackNotificationFeatureFlagEnabledForCx,
   isHl7NotificationWebhookFeatureFlagEnabledForCx,
 } from "@metriport/core/command/feature-flags/domain-ffs";
+import { createConsolidatedDataFileNameWithSuffix } from "@metriport/core/domain/consolidated/filename";
 import { sendToSlack, SlackMessage } from "@metriport/core/external/slack/index";
 import { capture, out } from "@metriport/core/util";
 import { Config } from "@metriport/core/util/config";
@@ -57,12 +58,14 @@ export async function processHl7FhirBundleWebhook({
       triggerEvent === "A03" &&
       (await isDischargeSlackNotificationFeatureFlagEnabledForCx(cxId))
     ) {
+      const consolidatedBundleFilePath = createConsolidatedDataFileNameWithSuffix(cxId, patientId);
       try {
         const messagePayload = {
           cxId,
           patientId,
           admitTimestamp,
           dischargeTimestamp,
+          consolidatedBundleFilePath,
         };
 
         const message: SlackMessage = {


### PR DESCRIPTION
Part of ENG-601

Issues:

- https://linear.app/metriport/issue/ENG-601

### Description
- Added filepath to consolidated data on adt slack notif

### Testing
- N/A

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discharge notifications now include a consolidated bundle file path in Slack messages when the relevant feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->