### PR TITLE
fix(api): introduce automated goal checking for discharge requery jobs

### DIFF
--- a/packages/api/src/command/medical/patient/patient-monitoring/discharge-requery/__tests__/create.test.ts
+++ b/packages/api/src/command/medical/patient/patient-monitoring/discharge-requery/__tests__/create.test.ts
@@ -53,6 +53,7 @@ describe("createDischargeRequeryJob", () => {
     await createDischargeRequeryJob({
       cxId,
       patientId,
+      goals: [],
     });
 
     expect(createPatientJobMock).toHaveBeenCalledWith(
@@ -82,6 +83,7 @@ describe("createDischargeRequeryJob", () => {
     await createDischargeRequeryJob({
       cxId,
       patientId,
+      goals: [],
     });
 
     expect(cancelPatientJobMock).toHaveBeenCalledWith(
@@ -114,6 +116,7 @@ describe("createDischargeRequeryJob", () => {
     await createDischargeRequeryJob({
       cxId,
       patientId,
+      goals: [],
     });
 
     expect(cancelPatientJobMock).toHaveBeenCalledWith(

--- a/packages/api/src/command/medical/patient/patient-monitoring/discharge-requery/create.ts
+++ b/packages/api/src/command/medical/patient/patient-monitoring/discharge-requery/create.ts
@@ -38,7 +38,7 @@ export const dischargeRequeryJobType = "discharge-requery";
 export async function createDischargeRequeryJob(
   props: CreateDischargeRequeryParams
 ): Promise<void> {
-  const { cxId, patientId } = props;
+  const { cxId, patientId, goals } = props;
   const { log } = out(`createDischargeRequeryJob - cx: ${cxId} pt: ${patientId}`);
 
   if (!(await isDischargeRequeryFeatureFlagEnabledForCx(cxId))) return;
@@ -72,6 +72,7 @@ export async function createDischargeRequeryJob(
         remainingAttempts
       );
       scheduledAt = pickEarliestScheduledAt(existingRequeryJob.scheduledAt, scheduledAt);
+      goals.push(...existingRequeryJob.paramsOps.goals);
 
       log(`cancelling existing job ${existingJob.id}`);
       await cancelPatientJob({
@@ -84,6 +85,7 @@ export async function createDischargeRequeryJob(
 
   const paramsOps: DischargeRequeryParamsOps = {
     remainingAttempts,
+    goals,
   };
   const newDischargeRequeryJob = await createPatientJob({
     cxId,

--- a/packages/api/src/routes/internal/medical/patient-monitoring/discharge-requery.ts
+++ b/packages/api/src/routes/internal/medical/patient-monitoring/discharge-requery.ts
@@ -1,3 +1,4 @@
+import { dischargeRequeryGoalsSchema } from "@metriport/shared/domain/patient/patient-monitoring/discharge-requery";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import httpStatus from "http-status";
@@ -23,7 +24,9 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const patientId = getUUIDFrom("query", req, "patientId").orFail();
-    await createDischargeRequeryJob({ cxId, patientId });
+    const goals = dischargeRequeryGoalsSchema.parse(req.body);
+
+    await createDischargeRequeryJob({ cxId, patientId, goals });
 
     return res.sendStatus(httpStatus.OK);
   })

--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -1,7 +1,6 @@
 import { Hl7Message } from "@medplum/core";
 import { Bundle, CodeableConcept, Resource } from "@medplum/fhirtypes";
 import { executeWithNetworkRetries } from "@metriport/shared";
-import { CreateDischargeRequeryParams } from "@metriport/shared/src/domain/patient/patient-monitoring/discharge-requery";
 import axios from "axios";
 import dayjs from "dayjs";
 import { S3Utils } from "../../external/aws/s3";
@@ -146,15 +145,22 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
 
     log(`Sending Discharge Requery kickoff...`);
     if (triggerEvent === dischargeEventCode) {
-      const params: CreateDischargeRequeryParams = {
+      const goals = encounterPeriod?.end ? [{ endDate: encounterPeriod.end }] : [];
+
+      const params = {
         cxId,
         patientId,
       };
+
       await executeWithNetworkRetries(
         async () =>
-          await axios.post(internalDischargeRequeryRouteUrl, undefined, {
-            params,
-          })
+          await axios.post(
+            internalDischargeRequeryRouteUrl,
+            { goals },
+            {
+              params,
+            }
+          )
       );
     }
 

--- a/packages/shared/src/domain/job/types.ts
+++ b/packages/shared/src/domain/job/types.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
 export type JobParamsCx = Record<string, string | boolean>;
-export type JobParamsOps = Record<string, string | boolean | number>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type JobParamsOps = Record<string, any>;
 
 const failed = "failed" as const;
 const successful = "successful" as const;

--- a/packages/shared/src/domain/patient/patient-monitoring/discharge-requery.ts
+++ b/packages/shared/src/domain/patient/patient-monitoring/discharge-requery.ts
@@ -3,17 +3,23 @@ import { z } from "zod";
 import { defaultRemainingAttempts } from "./utils";
 
 export const remainingAttemptsSchema = z.number().max(defaultRemainingAttempts);
+export const dischargeRequeryGoalSchema = z.object({ encounterEndDate: z.string() });
+export const dischargeRequeryGoalsSchema = z.array(dischargeRequeryGoalSchema);
+export type DischargeRequeryGoal = z.infer<typeof dischargeRequeryGoalSchema>;
+export type DischargeRequeryGoals = z.infer<typeof dischargeRequeryGoalsSchema>;
 
 export const createDischargeRequeryParamsSchema = z.object({
   patientId: z.string(),
   cxId: z.string(),
   remainingAttempts: remainingAttemptsSchema.optional(),
+  goals: dischargeRequeryGoalsSchema,
 });
 
 export type CreateDischargeRequeryParams = z.infer<typeof createDischargeRequeryParamsSchema>;
 
 export const dischargeRequeryParamsOpsSchema = z.object({
   remainingAttempts: remainingAttemptsSchema,
+  goals: dischargeRequeryGoalsSchema,
 });
 
 export type DischargeRequeryParamsOps = z.infer<typeof dischargeRequeryParamsOpsSchema>;


### PR DESCRIPTION
Part of ENG-601

Issues:

- https://linear.app/metriport/issue/ENG-601

### Description
- Added `goals` to Discharge Requery jobs
- Automatic check in Consolidated Payload to see if the discharge summary was found
- WIP: Unit tests
- WIP: code cleanup

### Testing

- Local
  - [ ] TBA
- Staging
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Sandbox
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Production
  - [ ] _testing step 1_
  - [ ] _testing step 2_

### Release Plan
- [ ] Merge this
