### PR TITLE
ENG-608 Distinctive log on recreateConsolidated + other goodies

### DIFF
--- a/packages/api/src/command/medical/patient/consolidated-recreate.ts
+++ b/packages/api/src/command/medical/patient/consolidated-recreate.ts
@@ -43,8 +43,11 @@ export async function recreateConsolidated({
   }
   try {
     if (conversionType) {
+      log(`Getting consolidated bundle with conversion type ${conversionType} (sync)`);
       await getConsolidated({ patient, conversionType });
+      log(`Consolidated recreated`);
     } else {
+      log(`Building consolidated bundle without conversion (async)`);
       const payload: ConsolidatedSnapshotRequestSync = {
         patient,
         isAsync: false,
@@ -52,9 +55,8 @@ export async function recreateConsolidated({
       };
       const connector = buildConsolidatedSnapshotConnector();
       await connector.execute(payload);
+      log(`Consolidated triggered`);
     }
-
-    log(`Consolidated recreated`);
 
     const ingestor = makeIngestConsolidated();
     ingestor

--- a/packages/api/src/external/commonwell/patient.ts
+++ b/packages/api/src/external/commonwell/patient.ts
@@ -260,11 +260,12 @@ async function registerAndLinkPatientInCW({
     );
     capture.error(msg, {
       extra: {
+        cxId: patient.cxId,
         facilityId,
         patientId: patient.id,
         cwReference: cwRef,
         context: createContext,
-        error,
+        error: errorToString(error),
       },
     });
     throw error;
@@ -439,11 +440,12 @@ async function updatePatientAndLinksInCw({
     log(`${msg} ${patient.id}:. Cause: ${errorToString(error)}. CW Reference: ${cwRef}`);
     capture.error(msg, {
       extra: {
+        cxId: patient.cxId,
         facilityId,
         patientId: patient.id,
         cwReference: cwRef,
         context: updateContext,
-        error,
+        error: errorToString(error),
       },
     });
     throw error;
@@ -708,10 +710,12 @@ export async function get(
     );
     capture.error(msg, {
       extra: {
+        cxId: patient.cxId,
         facilityId,
         patientId: patient.id,
         cwReference: cwRef,
         context: getContext,
+        error: errorToString(error),
       },
     });
     throw error;
@@ -748,11 +752,12 @@ export async function remove(patient: Patient, facilityId: string): Promise<void
     );
     capture.error(msg, {
       extra: {
+        cxId: patient.cxId,
         facilityId,
         patientId: patient.id,
         cwReference: cwRef,
         context: deleteContext,
-        error,
+        error: errorToString(error),
       },
     });
     throw error;

--- a/packages/core/src/domain/organization.ts
+++ b/packages/core/src/domain/organization.ts
@@ -1,6 +1,9 @@
 import { BaseDomain, BaseDomainCreate } from "./base-domain";
 import { AddressStrict } from "./location-address";
 
+/**
+ * @deprecated Use shared's version instead.
+ */
 export enum OrganizationBizType {
   healthcareProvider = "healthcare_provider",
   healthcareITVendor = "healthcare_it_vendor",
@@ -18,7 +21,9 @@ export enum OrgType {
   postAcuteCare = "postAcuteCare",
 }
 
-// TODO: Update all instances of OrgType to TreatmentType
+/**
+ * @deprecated Use shared's version instead.
+ */
 export enum TreatmentType {
   acuteCare = "acuteCare",
   ambulatory = "ambulatory",

--- a/packages/shared/src/domain/organization.ts
+++ b/packages/shared/src/domain/organization.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+// TODO if you update this, make sure to update core's too (unless it has been removed)
 export enum TreatmentType {
   acuteCare = "acuteCare",
   ambulatory = "ambulatory",
@@ -9,6 +10,7 @@ export enum TreatmentType {
   postAcuteCare = "postAcuteCare",
 }
 
+// TODO if you update this, make sure to update core's too (unless it has been removed)
 export enum OrganizationBizType {
   healthcareProvider = "healthcare_provider",
   healthcareITVendor = "healthcare_it_vendor",

--- a/packages/utils/src/coverage-assessment.ts
+++ b/packages/utils/src/coverage-assessment.ts
@@ -41,12 +41,14 @@ dayjs.extend(duration);
 
 // add patient IDs here to kick off queries for specific patient IDs
 const patientIds: string[] = [];
-// In case there are too many IDs - e.g., when we export them from the DB
+// In case there are too many IDs - e.g., when we export them from the DB (make sure to only export the IDs)
 // Single ID per line
 // const patientIds: string[] = fs
 //   .readFileSync("", "utf-8")
 //   .split("\n")
-//   .filter(id => id.trim().length > 0);
+//   .filter(id => id.trim().length > 0)
+//   .map(id => id.replaceAll('"', ""))
+//   .filter(id => id !== "id");
 
 // auth stuff
 const cxId = getEnvVarOrFail("CX_ID");

--- a/packages/utils/src/open-search/search-consolidated.ts
+++ b/packages/utils/src/open-search/search-consolidated.ts
@@ -16,6 +16,10 @@ dayjs.extend(duration);
  * Script to search a patient's consolidated resources using OpenSearch search.
  *
  * If you want to test the `paginatedSearch` function, use the `paginated-search.ts` script.
+ *
+ * Usage:
+ * - Set the environment variables in the .env file
+ * - Run: `ts-node src/open-search/search-consolidated.ts <search-query>`
  */
 
 const cxId = getEnvVarOrFail("CX_ID");


### PR DESCRIPTION
### Dependencies

none

### Description

- distinctive log on recreateConsolidated: reason is so we can more easily distinct between the two flows while recreating consolidated
- add cxId to capture on CW patient: reason is so we can more easily trigger PD for pts that failed to create on CW because of issues on their end
- flag dups of Org's TreatmentType and OrganizationBizType
- comments/small fixes on a couple of scripts

### Testing

- Local
  - none
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for patient-related actions by including additional patient identifiers and ensuring errors are logged as readable strings.

* **Chores**
  * Enhanced logging for medical patient bundle recreation, providing more detailed logs around key operations.
  * Added deprecation notices for certain organization-related enums to guide future usage.
  * Updated example code for handling patient ID exports to better manage formatting issues.
  * Expanded script documentation with usage instructions for search functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->