### PR TITLE
ENG 602 feat(analytics-platform): base-infra

### DIFF
--- a/packages/core/src/external/snowflake/creds.ts
+++ b/packages/core/src/external/snowflake/creds.ts
@@ -1,0 +1,19 @@
+import { MetriportError } from "@metriport/shared";
+import { z } from "zod";
+import { Config } from "../../util/config";
+
+const snowflakeCredsSchema = z.object({
+  account: z.string(),
+  user: z.string(),
+  password: z.string(),
+});
+type SnowflakeCreds = z.infer<typeof snowflakeCredsSchema>;
+
+export function getSnowflakeCreds(): SnowflakeCreds {
+  try {
+    const snowflakeCreds = Config.getSnowflakeCreds();
+    return snowflakeCredsSchema.parse(snowflakeCreds);
+  } catch (error) {
+    throw new MetriportError("Invalid snowflake creds", error);
+  }
+}

--- a/packages/core/src/external/snowflake/creds.ts
+++ b/packages/core/src/external/snowflake/creds.ts
@@ -1,19 +1,8 @@
-import { MetriportError } from "@metriport/shared";
 import { z } from "zod";
-import { Config } from "../../util/config";
 
-const snowflakeCredsSchema = z.object({
+export const snowflakeCredsSchema = z.object({
   account: z.string(),
   user: z.string(),
   password: z.string(),
 });
-type SnowflakeCreds = z.infer<typeof snowflakeCredsSchema>;
-
-export function getSnowflakeCreds(): SnowflakeCreds {
-  try {
-    const snowflakeCreds = Config.getSnowflakeCreds();
-    return snowflakeCredsSchema.parse(snowflakeCreds);
-  } catch (error) {
-    throw new MetriportError("Invalid snowflake creds", error);
-  }
-}
+export type SnowflakeCreds = z.infer<typeof snowflakeCredsSchema>;

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -1,5 +1,6 @@
 import { getEnvVarAsRecordOrFail } from "@metriport/shared/common/env-var";
 import { getEnvVar, getEnvVarOrFail } from "./env-var";
+import { snowflakeCredsSchema, SnowflakeCreds } from "../external/snowflake/creds";
 
 /**
  * Shared configs, still defining how to work with this. For now:
@@ -335,7 +336,7 @@ export class Config {
     return getEnvVarOrFail("DISCHARGE_NOTIFICATION_SLACK_URL");
   }
 
-  static getSnowflakeCreds(): Record<string, string> {
-    return getEnvVarAsRecordOrFail("SNOWFLAKE_CREDS");
+  static getSnowflakeCreds(): SnowflakeCreds {
+    return snowflakeCredsSchema.parse(getEnvVarAsRecordOrFail("SNOWFLAKE_CREDS"));
   }
 }

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -334,4 +334,8 @@ export class Config {
   static getDischargeNotificationSlackUrl(): string {
     return getEnvVarOrFail("DISCHARGE_NOTIFICATION_SLACK_URL");
   }
+
+  static getSnowflakeCreds(): Record<string, string> {
+    return getEnvVarAsRecordOrFail("SNOWFLAKE_CREDS");
+  }
 }

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -1,6 +1,6 @@
 import { getEnvVarAsRecordOrFail } from "@metriport/shared/common/env-var";
+import { SnowflakeCreds, snowflakeCredsSchema } from "../external/snowflake/creds";
 import { getEnvVar, getEnvVarOrFail } from "./env-var";
-import { snowflakeCredsSchema, SnowflakeCreds } from "../external/snowflake/creds";
 
 /**
  * Shared configs, still defining how to work with this. For now:

--- a/packages/infra/config/analytics-platform-config.ts
+++ b/packages/infra/config/analytics-platform-config.ts
@@ -1,0 +1,6 @@
+export interface AnalyticsPlatformConfig {
+  bucketName: string;
+  secrets: {
+    SNOWFLAKE_CREDS: string;
+  };
+}

--- a/packages/infra/config/env-config.ts
+++ b/packages/infra/config/env-config.ts
@@ -1,5 +1,6 @@
 import { CqDirectorySimplifiedOrg } from "@metriport/shared/interface/external/carequality/directory/simplified-org";
 import { EnvType } from "../lib/env-type";
+import { AnalyticsPlatformConfig } from "./analytics-platform-config";
 import { RDSAlarmThresholds } from "./aws/rds";
 import { Hl7NotificationConfig } from "./hl7-notification-config";
 import { IHEGatewayProps } from "./ihe-gateway-config";
@@ -299,6 +300,7 @@ export type EnvConfigNonSandbox = EnvConfigBase & {
   engineeringCxId: string;
   hl7Notification: Hl7NotificationConfig;
   fhirConversionBucketName: string;
+  analyticsPlatform: AnalyticsPlatformConfig;
 };
 
 export type EnvConfigSandbox = EnvConfigBase & {

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -235,5 +235,11 @@ export const config: EnvConfigNonSandbox = {
     startScheduledPatientJobsScheduleExpression: "0/5 * * * ? *",
     startScheduledPatientJobsSchedulerUrl: "/internal/patient/job/scheduler/start",
   },
+  analyticsPlatform: {
+    bucketName: "test-bucket",
+    secrets: {
+      SNOWFLAKE_CREDS: "your-snowflake-creds-as-json",
+    },
+  },
 };
 export default config;

--- a/packages/infra/lib/analytics-platform/analytics-platform-stack.ts
+++ b/packages/infra/lib/analytics-platform/analytics-platform-stack.ts
@@ -1,0 +1,28 @@
+import { NestedStack, NestedStackProps } from "aws-cdk-lib";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { Construct } from "constructs";
+import { EnvConfigNonSandbox } from "../../config/env-config";
+
+interface AnalyticsPlatformsNestedStackProps extends NestedStackProps {
+  config: EnvConfigNonSandbox;
+}
+
+export class AnalyticsPlatformsNestedStack extends NestedStack {
+  constructor(scope: Construct, id: string, props: AnalyticsPlatformsNestedStackProps) {
+    super(scope, id, props);
+
+    this.terminationProtection = true;
+
+    new s3.Bucket(this, "AnalyticsPlatformBucket", {
+      bucketName: props.config.analyticsPlatform.bucketName,
+      publicReadAccess: false,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      versioned: true,
+    });
+
+    new ecr.Repository(this, "AnalyticsPlatformRepository", {
+      repositoryName: "metriport/analytics-platform",
+    });
+  }
+}

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -507,7 +507,7 @@ export class APIStack extends Stack {
     // Analytics Platform
     //-------------------------------------------
     if (!isSandbox(props.config)) {
-      new AnalyticsPlatformsNestedStack(this, "AnalyticsPlatformsNestedStack", {
+      new AnalyticsPlatformsNestedStack(this, "AnalyticsPlatforms", {
         config: props.config,
       });
     }

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -8,7 +8,6 @@ import {
   aws_wafv2 as wafv2,
 } from "aws-cdk-lib";
 import * as apig from "aws-cdk-lib/aws-apigateway";
-import { IQueue } from "aws-cdk-lib/aws-sqs";
 import { BackupResource } from "aws-cdk-lib/aws-backup";
 import * as cert from "aws-cdk-lib/aws-certificatemanager";
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
@@ -29,8 +28,10 @@ import * as s3 from "aws-cdk-lib/aws-s3";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import * as sns from "aws-cdk-lib/aws-sns";
 import { ITopic } from "aws-cdk-lib/aws-sns";
+import { IQueue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
 import { EnvConfig, EnvConfigSandbox } from "../config/env-config";
+import { AnalyticsPlatformsNestedStack } from "./analytics-platform/analytics-platform-stack";
 import { AlarmSlackBot } from "./api-stack/alarm-slack-chatbot";
 import { createScheduledAPIQuotaChecker } from "./api-stack/api-quota-checker";
 import { createAPIService } from "./api-stack/api-service";
@@ -501,6 +502,15 @@ export class APIStack extends Stack {
       alarmAction: slackNotification?.alarmAction,
       lambdaLayers,
     });
+
+    //-------------------------------------------
+    // Analytics Platform
+    //-------------------------------------------
+    if (!isSandbox(props.config)) {
+      new AnalyticsPlatformsNestedStack(this, "AnalyticsPlatformsNestedStack", {
+        config: props.config,
+      });
+    }
 
     //-------------------------------------------
     // Rate Limiting

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -111,6 +111,13 @@ export class SecretsStack extends Stack {
         });
         logSecretInfo(this, secret, secretName);
       }
+
+      if (props.config.analyticsPlatform) {
+        for (const secretName of Object.values(props.config.analyticsPlatform.secrets)) {
+          const secret = makeSecret(secretName);
+          logSecretInfo(this, secret, secretName);
+        }
+      }
     }
   }
 }

--- a/packages/infra/lib/shared/secrets.ts
+++ b/packages/infra/lib/shared/secrets.ts
@@ -2,6 +2,7 @@ import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 import { EnvConfig } from "../../config/env-config";
+import { isSandbox } from "./util";
 
 export type Secrets = { [key: string]: secret.ISecret };
 
@@ -41,6 +42,7 @@ export function getSecrets(scope: Construct, config: EnvConfig): Secrets {
     ...(config.hl7Notification?.secrets
       ? buildSecrets(scope, config.hl7Notification?.secrets)
       : undefined),
+    ...(!isSandbox(config) ? buildSecrets(scope, config.analyticsPlatform.secrets) : undefined),
   };
   return secrets;
 }


### PR DESCRIPTION
Ref: ENG-602

Issues:

- https://linear.app/metriport/issue/ENG-602

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/3094

### Description

- adding bucket + ecr directory + secrets

### Testing

- Local
  - [ ] N/A
- Staging
  - [ ] resources deployed
- Sandbox
  - [ ] N/A
- Production
  - [ ] resources deployed

### Release Plan

- [ ] Upstream dependencies are met/released
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for managing Snowflake credentials, including validation and retrieval from configuration.
  * Introduced a new configuration section for analytics platform settings, including S3 bucket and secret management.
  * Provisioned an S3 bucket and ECR repository for analytics platform infrastructure in non-sandbox environments.

* **Infrastructure**
  * Enhanced secret management to include analytics platform secrets when not in a sandbox environment.
  * Updated infrastructure stacks to conditionally deploy analytics platform resources outside of sandbox environments.

* **Documentation**
  * Expanded configuration examples and type definitions to cover new analytics platform settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->