### PR TITLE
feat(ap): adding snowflake s3 integration role

### DIFF
--- a/packages/infra/config/analytics-platform-config.ts
+++ b/packages/infra/config/analytics-platform-config.ts
@@ -3,4 +3,8 @@ export interface AnalyticsPlatformConfig {
   secrets: {
     SNOWFLAKE_CREDS: string;
   };
+  snowflake: {
+    integrationUserArn: string;
+    integrationExternalId: string;
+  };
 }

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -240,6 +240,10 @@ export const config: EnvConfigNonSandbox = {
     secrets: {
       SNOWFLAKE_CREDS: "your-snowflake-creds-as-json",
     },
+    snowflake: {
+      integrationUserArn: "arn:aws:iam::000000000000:role/SnowflakeIntegrationRole",
+      integrationExternalId: "000000000000",
+    },
   },
 };
 export default config;

--- a/packages/infra/lib/analytics-platform/analytics-platform-stack.ts
+++ b/packages/infra/lib/analytics-platform/analytics-platform-stack.ts
@@ -29,6 +29,7 @@ export class AnalyticsPlatformsNestedStack extends NestedStack {
     // Snowflake access via S3 Integration https://docs.snowflake.com/en/user-guide/data-load-s3-config-storage-integration
     const snowflakePrefix = "snowflake";
     const s3Policy = new iam.Policy(this, "SnowflakeAnalyticsPlatformS3Policy", {
+      policyName: `SnowflakeAnalyticsPlatformS3Policy-${props.config.environmentType}`,
       statements: [
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
@@ -54,6 +55,7 @@ export class AnalyticsPlatformsNestedStack extends NestedStack {
       ],
     });
     new iam.Role(this, "SnowflakeIntegrationRole", {
+      roleName: `SnowflakeIntegrationRole-${props.config.environmentType}`,
       assumedBy: new iam.AccountPrincipal(
         props.config.analyticsPlatform.snowflake.integrationUserArn
       ),

--- a/packages/infra/lib/analytics-platform/analytics-platform-stack.ts
+++ b/packages/infra/lib/analytics-platform/analytics-platform-stack.ts
@@ -1,5 +1,6 @@
 import { NestedStack, NestedStackProps } from "aws-cdk-lib";
 import * as ecr from "aws-cdk-lib/aws-ecr";
+import * as iam from "aws-cdk-lib/aws-iam";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import { EnvConfigNonSandbox } from "../../config/env-config";
@@ -14,7 +15,7 @@ export class AnalyticsPlatformsNestedStack extends NestedStack {
 
     this.terminationProtection = true;
 
-    new s3.Bucket(this, "AnalyticsPlatformBucket", {
+    const analyticsPlatformBucket = new s3.Bucket(this, "AnalyticsPlatformBucket", {
       bucketName: props.config.analyticsPlatform.bucketName,
       publicReadAccess: false,
       encryption: s3.BucketEncryption.S3_MANAGED,
@@ -23,6 +24,43 @@ export class AnalyticsPlatformsNestedStack extends NestedStack {
 
     new ecr.Repository(this, "AnalyticsPlatformRepository", {
       repositoryName: "metriport/analytics-platform",
+    });
+
+    // Snowflake access via S3 Integration https://docs.snowflake.com/en/user-guide/data-load-s3-config-storage-integration
+    const snowflakePrefix = "snowflake";
+    const s3Policy = new iam.Policy(this, "SnowflakeAnalyticsPlatformS3Policy", {
+      statements: [
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: [
+            "s3:PutObject",
+            "s3:GetObject",
+            "s3:GetObjectVersion",
+            "s3:DeleteObject",
+            "s3:DeleteObjectVersion",
+          ],
+          resources: [analyticsPlatformBucket.bucketArn + "/" + snowflakePrefix + "/*"],
+        }),
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ["s3:ListBucket", "s3:GetBucketLocation"],
+          resources: [analyticsPlatformBucket.bucketArn],
+          conditions: {
+            StringLike: {
+              "s3:prefix": [`${snowflakePrefix}/*`],
+            },
+          },
+        }),
+      ],
+    });
+    new iam.Role(this, "SnowflakeIntegrationRole", {
+      assumedBy: new iam.AccountPrincipal(
+        props.config.analyticsPlatform.snowflake.integrationUserArn
+      ),
+      externalIds: [props.config.analyticsPlatform.snowflake.integrationExternalId],
+      inlinePolicies: {
+        SnowflakeAnalyticsPlatformS3Policy: s3Policy.document,
+      },
     });
   }
 }


### PR DESCRIPTION
Ref: ENG-602

Issues:

- https://linear.app/metriport/issue/ENG-602

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/3096

### Description

- adding role that will be assumed by Snowflake + policy
- current principal is our own account in the upstream (to be updated later)

### Testing

- Local
  - [ ] N/A
- Staging
  - [ ] role is created w/ policy
- Sandbox
  - [ ] N/A
- Production
  - [ ] role is created w/ policy

### Release Plan

- [ ] Upstream dependencies are met/released
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Snowflake integration, including configuration options for integration user and external ID.
  * Enabled secure Snowflake access to S3 data through new IAM roles and policies.

* **Documentation**
  * Updated configuration examples to include new Snowflake integration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->