### PR TITLE
ENG-453: Update infra + mllp server to do tz conversion based on ip addr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17010,6 +17010,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "devOptional": true,
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -17021,19 +17022,8 @@
     "node_modules/ip-address/node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
-    },
-    "node_modules/ip-cidr": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ip-cidr/-/ip-cidr-4.0.2.tgz",
-      "integrity": "sha512-KifhLKBjdS/hB3TD4UUOalVp1BpzPFvRpgJvXcP0Ya98tuSQTUQ71iI7EW7CKddkBJTYB3GfTWl5eJwpLOXj2A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^9.0.5"
-      },
-      "engines": {
-        "node": ">=16.14.0"
-      }
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "devOptional": true
     },
     "node_modules/ip-regex": {
       "version": "4.3.0",
@@ -29714,7 +29704,7 @@
         "@metriport/shared": "file:packages/shared",
         "@sentry/cli": "^2.42.1",
         "dotenv": "^16.4.5",
-        "ip-cidr": "^4.0.2",
+        "ip-cidr": "^3.1.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -29825,6 +29815,38 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "packages/mllp-server/node_modules/ip-address": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-7.1.0.tgz",
+      "integrity": "sha512-V9pWC/VJf2lsXqP7IWJ+pe3P1/HCYGBMZrrnT62niLGjAfCbeiwXMUxaeHvnVlz19O27pvXP4azs+Pj/A0x+SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/mllp-server/node_modules/ip-cidr": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ip-cidr/-/ip-cidr-3.1.0.tgz",
+      "integrity": "sha512-HUCn4snshEX1P8cja/IyU3qk8FVDW8T5zZcegDFbu4w7NojmAhk5NcOgj3M8+0fmumo1afJTPDtJlzsxLdOjtg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^7.1.0",
+        "jsbn": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "packages/mllp-server/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "license": "BSD-3-Clause"
     },
     "packages/mllp-server/node_modules/typescript": {
       "version": "5.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17010,7 +17010,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "devOptional": true,
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -17022,8 +17021,19 @@
     "node_modules/ip-address/node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "devOptional": true
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+    },
+    "node_modules/ip-cidr": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ip-cidr/-/ip-cidr-4.0.2.tgz",
+      "integrity": "sha512-KifhLKBjdS/hB3TD4UUOalVp1BpzPFvRpgJvXcP0Ya98tuSQTUQ71iI7EW7CKddkBJTYB3GfTWl5eJwpLOXj2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      }
     },
     "node_modules/ip-regex": {
       "version": "4.3.0",
@@ -18704,8 +18714,7 @@
     "node_modules/jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "devOptional": true
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -29704,7 +29713,9 @@
         "@metriport/core": "file:packages/core",
         "@metriport/shared": "file:packages/shared",
         "@sentry/cli": "^2.42.1",
-        "dotenv": "^16.4.5"
+        "dotenv": "^16.4.5",
+        "ip-cidr": "^4.0.2",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@metriport/eslint-rules": "file:packages/eslint-rules",

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -1,6 +1,7 @@
 import { USState } from "@metriport/shared";
 import { Patient } from "../../domain/patient";
 import { Hl7v2Subscription } from "../../domain/patient-settings";
+import { HieIANATimezone } from "../../external/hl7-notification/hie-timezone";
 
 export type SftpConfig = {
   host: string;
@@ -48,7 +49,7 @@ export type HieConfig = {
   name: string;
   gatewayPublicIp: string;
   internalCidrBlock: string;
-  timezone: "America/Los_Angeles" | "America/Denver" | "America/Chicago" | "America/New_York";
+  timezone: HieIANATimezone;
   states: USState[];
   subscriptions: Hl7v2Subscription[];
   cron: string;

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -46,8 +46,9 @@ export type HiePatientRosterMapping = {
 
 export type HieConfig = {
   name: string;
-  identifierInMshSegment?: string;
-  timezone?: string;
+  gatewayPublicIp: string;
+  internalCidrBlock: string;
+  timezone: "America/Los_Angeles" | "America/Denver" | "America/Chicago" | "America/New_York";
   states: USState[];
   subscriptions: Hl7v2Subscription[];
   cron: string;

--- a/packages/core/src/external/hl7-notification/hie-timezone.ts
+++ b/packages/core/src/external/hl7-notification/hie-timezone.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const hieTimezoneDictionarySchema = z.record(
+  z.string(),
+  z.object({
+    cidrBlock: z.string(), // e.g. "10.0.0.0/16"
+    timezone: z.string(), // e.g. "America/New_York"
+  })
+);
+
+export type HieTimezoneDictionary = z.infer<typeof hieTimezoneDictionarySchema>;

--- a/packages/core/src/external/hl7-notification/hie-timezone.ts
+++ b/packages/core/src/external/hl7-notification/hie-timezone.ts
@@ -1,11 +1,20 @@
 import { z } from "zod";
 import { Config } from "../../util/config";
 
+export const hieIANATimezoneSchema = z.enum([
+  "America/Los_Angeles",
+  "America/Denver",
+  "America/Chicago",
+  "America/New_York",
+]);
+
+export type HieIANATimezone = z.infer<typeof hieIANATimezoneSchema>;
+
 export const hieTimezoneDictionarySchema = z.record(
   z.string(),
   z.object({
     cidrBlock: z.string(), // e.g. "10.0.0.0/16"
-    timezone: z.string(), // e.g. "America/New_York"
+    timezone: hieIANATimezoneSchema,
   })
 );
 

--- a/packages/core/src/external/hl7-notification/hie-timezone.ts
+++ b/packages/core/src/external/hl7-notification/hie-timezone.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { Config } from "../../util/config";
 
 export const hieTimezoneDictionarySchema = z.record(
   z.string(),
@@ -9,3 +10,7 @@ export const hieTimezoneDictionarySchema = z.record(
 );
 
 export type HieTimezoneDictionary = z.infer<typeof hieTimezoneDictionarySchema>;
+
+export function getHieTimezoneDictionary(): HieTimezoneDictionary {
+  return hieTimezoneDictionarySchema.parse(Config.getHieTimezoneDictionary());
+}

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -107,8 +107,8 @@ export class Config {
   static getHl7NotificationQueueUrl(): string {
     return getEnvVarOrFail("HL7_NOTIFICATION_QUEUE_URL");
   }
-  static getHieTimezoneDictionary(): string {
-    return getEnvVarOrFail("HIE_TIMEZONE_DICTIONARY");
+  static getHieTimezoneDictionary(): Record<string, unknown> {
+    return getEnvVarAsRecordOrFail("HIE_TIMEZONE_DICTIONARY");
   }
 
   static getCdaToFhirConversionBucketName(): string | undefined {

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -1,6 +1,10 @@
 import { getEnvVarAsRecordOrFail } from "@metriport/shared/common/env-var";
 import { SnowflakeCreds, snowflakeCredsSchema } from "../external/snowflake/creds";
 import { getEnvVar, getEnvVarOrFail } from "./env-var";
+import {
+  HieTimezoneDictionary,
+  hieTimezoneDictionarySchema,
+} from "../external/hl7-notification/hie-timezone";
 
 /**
  * Shared configs, still defining how to work with this. For now:
@@ -107,8 +111,8 @@ export class Config {
   static getHl7NotificationQueueUrl(): string {
     return getEnvVarOrFail("HL7_NOTIFICATION_QUEUE_URL");
   }
-  static getHieTimezoneDictionary(): Record<string, string> {
-    return getEnvVarAsRecordOrFail("HIE_TIMEZONE_DICTIONARY");
+  static getHieTimezoneDictionary(): HieTimezoneDictionary {
+    return hieTimezoneDictionarySchema.parse(getEnvVarAsRecordOrFail("HIE_TIMEZONE_DICTIONARY"));
   }
 
   static getCdaToFhirConversionBucketName(): string | undefined {

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -1,10 +1,6 @@
 import { getEnvVarAsRecordOrFail } from "@metriport/shared/common/env-var";
 import { SnowflakeCreds, snowflakeCredsSchema } from "../external/snowflake/creds";
 import { getEnvVar, getEnvVarOrFail } from "./env-var";
-import {
-  HieTimezoneDictionary,
-  hieTimezoneDictionarySchema,
-} from "../external/hl7-notification/hie-timezone";
 
 /**
  * Shared configs, still defining how to work with this. For now:
@@ -111,8 +107,8 @@ export class Config {
   static getHl7NotificationQueueUrl(): string {
     return getEnvVarOrFail("HL7_NOTIFICATION_QUEUE_URL");
   }
-  static getHieTimezoneDictionary(): HieTimezoneDictionary {
-    return hieTimezoneDictionarySchema.parse(getEnvVarAsRecordOrFail("HIE_TIMEZONE_DICTIONARY"));
+  static getHieTimezoneDictionary(): string {
+    return getEnvVarOrFail("HIE_TIMEZONE_DICTIONARY");
   }
 
   static getCdaToFhirConversionBucketName(): string | undefined {

--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -63,12 +63,12 @@ async function deploy(config: EnvConfig) {
       version,
     });
 
-    config.hl7Notification.vpnConfigs.forEach((config, index) => {
-      const vpnStack = new VpnStack(app, `VpnStack-${config.partnerName}`, {
-        vpnConfig: { ...config },
+    Object.values(config.hl7Notification.hieConfigs).forEach((hieConfig, index) => {
+      const vpnStack = new VpnStack(app, `VpnStack-${hieConfig.name}`, {
+        hieConfig,
         index,
         networkStackId: "NestedNetworkStack",
-        description: `VPN Configuration for routing HL7 messages from ${config.partnerName}`,
+        description: `VPN Configuration for routing HL7 messages from ${hieConfig.name}`,
       });
 
       vpnStack.addDependency(hl7NotificationStack);

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -182,7 +182,7 @@ export const config: EnvConfigNonSandbox = {
         name: "YOUR_HIE_NAME",
         cron: "cron(0 0 ? * SAT *)",
         states: [USState.TX],
-        timezone: "America/New_York",
+        timezone: "America/Chicago",
         gatewayPublicIp: "200.1.1.1",
         internalCidrBlock: "10.10.0.0/16",
         subscriptions: ["adt"],

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -165,13 +165,6 @@ export const config: EnvConfigNonSandbox = {
     secrets: {
       HL7_BASE64_SCRAMBLER_SEED: "your-base64-scrambler-seed",
     },
-    vpnConfigs: [
-      {
-        partnerName: "SampleHIE",
-        partnerGatewayPublicIp: "200.54.1.1",
-        partnerInternalCidrBlock: "10.10.0.0/16",
-      },
-    ],
     mllpServer: {
       sentryDSN: "your-sentry-dsn",
       fargateCpu: 1 * vCPU,
@@ -189,6 +182,9 @@ export const config: EnvConfigNonSandbox = {
         name: "YOUR_HIE_NAME",
         cron: "cron(0 0 ? * SAT *)",
         states: [USState.TX],
+        timezone: "America/New_York",
+        gatewayPublicIp: "200.1.1.1",
+        internalCidrBlock: "10.10.0.0/16",
         subscriptions: ["adt"],
         mapping: {
           ID: "scrambledId",

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -12,7 +12,6 @@ export interface Hl7NotificationConfig {
     arn: string;
     url: string;
   };
-  vpnConfigs: Hl7NotificationVpnConfig[];
   mllpServer: {
     sentryDSN: string;
     fargateCpu: number;

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -28,9 +28,3 @@ export interface Hl7NotificationConfig {
   // ENG-536 remove this once we automatically find the discharge summary
   dischargeNotificationSlackUrl: string;
 }
-
-export type Hl7NotificationVpnConfig = {
-  partnerName: string;
-  partnerGatewayPublicIp: string;
-  partnerInternalCidrBlock: string;
-};

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -46,6 +46,7 @@ const setupNlb = (identifier: string, vpc: ec2.Vpc, nlb: elbv2.NetworkLoadBalanc
   const targetGroup = listener.addTargets(`MllpTargets${identifier}`, {
     port: MLLP_DEFAULT_PORT,
     protocol: elbv2.Protocol.TCP,
+    preserveClientIp: true,
     healthCheck: {
       port: MLLP_DEFAULT_PORT.toString(),
       protocol: elbv2.Protocol.TCP,

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -14,6 +14,7 @@ import { EnvConfigNonSandbox } from "../../config/env-config";
 import { buildSecrets, secretsToECS } from "../shared/secrets";
 import { MLLP_DEFAULT_PORT } from "./constants";
 import { HieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
+import { HieTimezoneDictionary } from "@metriport/core/external/hl7-notification/hie-timezone";
 
 interface MllpStackProps extends cdk.StackProps {
   config: EnvConfigNonSandbox;
@@ -60,15 +61,14 @@ const setupNlb = (identifier: string, vpc: ec2.Vpc, nlb: elbv2.NetworkLoadBalanc
   return targetGroup;
 };
 
-const createHieTimezoneMap = (hieConfigs: Record<string, HieConfig>) => {
+const createHieTimezoneMap = (hieConfigs: Record<string, HieConfig>): HieTimezoneDictionary => {
   return Object.values(hieConfigs).reduce((acc, item) => {
-    const key = item.identifierInMshSegment;
-    const val = item.timezone;
-    if (key && val) {
-      acc[key] = val;
-    }
+    acc[item.name] = {
+      cidrBlock: item.internalCidrBlock,
+      timezone: item.timezone,
+    };
     return acc;
-  }, {} as Record<string, string>);
+  }, {} as HieTimezoneDictionary);
 };
 
 export class MllpStack extends cdk.NestedStack {

--- a/packages/infra/lib/hl7-notification-stack/vpn.ts
+++ b/packages/infra/lib/hl7-notification-stack/vpn.ts
@@ -3,13 +3,13 @@ import { Fn } from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
-import { Hl7NotificationVpnConfig } from "../../config/hl7-notification-config";
 import { MLLP_DEFAULT_PORT } from "./constants";
+import { HieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
 
 const IPSEC_1 = "ipsec.1";
 
 export interface VpnStackProps extends cdk.NestedStackProps {
-  vpnConfig: Hl7NotificationVpnConfig;
+  hieConfig: HieConfig;
   networkStackId: string;
   index: number;
 }
@@ -22,24 +22,24 @@ export class VpnStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: VpnStackProps) {
     super(scope, id, props);
 
-    const { partnerName, partnerInternalCidrBlock } = props.vpnConfig;
+    const { name: hieName, internalCidrBlock } = props.hieConfig;
 
     const networkAcl = ec2.NetworkAcl.fromNetworkAclId(
       this,
-      `NetworkAcl-${partnerName}`,
+      `NetworkAcl-${hieName}`,
       Fn.importValue(`${props.networkStackId}-NetworkAclId`)
     );
 
     const vgwId = Fn.importValue(`${props.networkStackId}-VgwId`);
 
-    const customerGateway = new ec2.CfnCustomerGateway(this, `CustomerGateway-${partnerName}`, {
-      ipAddress: props.vpnConfig.partnerGatewayPublicIp,
+    const customerGateway = new ec2.CfnCustomerGateway(this, `CustomerGateway-${hieName}`, {
+      ipAddress: props.hieConfig.gatewayPublicIp,
       type: IPSEC_1,
       bgpAsn: 65000,
       tags: [
         {
           key: "Name",
-          value: `${partnerName}-cgw`,
+          value: `${hieName}-cgw`,
         },
       ],
     });
@@ -47,7 +47,7 @@ export class VpnStack extends cdk.Stack {
     /**
      * Add new rules to the NACL for the static IPs we're using for this VPN.
      */
-    this.addIngressRules(networkAcl, partnerInternalCidrBlock, [
+    this.addIngressRules(networkAcl, internalCidrBlock, [
       {
         ruleNumber: 120 + props.index * 10,
         traffic: ec2.AclTraffic.tcpPort(MLLP_DEFAULT_PORT),
@@ -62,7 +62,7 @@ export class VpnStack extends cdk.Stack {
       },
     ]);
 
-    this.addEgressRules(networkAcl, partnerInternalCidrBlock, [
+    this.addEgressRules(networkAcl, internalCidrBlock, [
       // Outbound TCP handshake traffic
       {
         ruleNumber: 120 + props.index * 10,
@@ -78,18 +78,18 @@ export class VpnStack extends cdk.Stack {
 
     const presharedKey1 = secret.Secret.fromSecretNameV2(
       this,
-      `PresharedKey1-${partnerName}`,
-      `PresharedKey1-${partnerName}`
+      `PresharedKey1-${hieName}`,
+      `PresharedKey1-${hieName}`
     );
     const presharedKey2 = secret.Secret.fromSecretNameV2(
       this,
-      `PresharedKey2-${partnerName}`,
-      `PresharedKey2-${partnerName}`
+      `PresharedKey2-${hieName}`,
+      `PresharedKey2-${hieName}`
     );
     /**
      * We use 2 tunnels here because state HIEs often have a failover to a backup IP..
      */
-    const vpnConnection = new ec2.CfnVPNConnection(this, `VpnConnection-${partnerName}`, {
+    const vpnConnection = new ec2.CfnVPNConnection(this, `VpnConnection-${hieName}`, {
       type: IPSEC_1,
       vpnGatewayId: vgwId,
       customerGatewayId: customerGateway.ref,
@@ -97,7 +97,7 @@ export class VpnStack extends cdk.Stack {
       tags: [
         {
           key: "Name",
-          value: `${partnerName}-vpn`,
+          value: `${hieName}-vpn`,
         },
       ],
       vpnTunnelOptionsSpecifications: [
@@ -114,20 +114,20 @@ export class VpnStack extends cdk.Stack {
       ],
     });
 
-    new ec2.CfnVPNConnectionRoute(this, `VpnConnectionRoute-${partnerName}`, {
-      destinationCidrBlock: props.vpnConfig.partnerInternalCidrBlock,
+    new ec2.CfnVPNConnectionRoute(this, `VpnConnectionRoute-${hieName}`, {
+      destinationCidrBlock: props.hieConfig.internalCidrBlock,
       vpnConnectionId: vpnConnection.ref,
     });
 
-    new cdk.CfnOutput(this, `VpnConnectionId-${partnerName}`, {
+    new cdk.CfnOutput(this, `VpnConnectionId-${hieName}`, {
       value: vpnConnection.ref,
-      description: `VPN Connection for ${partnerName}`,
+      description: `VPN Connection for ${hieName}`,
     });
   }
 
   private setNaclRules(
     networkAcl: ec2.INetworkAcl,
-    partnerInternalCidrBlock: string,
+    internalCidrBlock: string,
     direction: ec2.TrafficDirection,
     rules: {
       ruleNumber: number;
@@ -135,7 +135,7 @@ export class VpnStack extends cdk.Stack {
       ruleAction: ec2.Action;
     }[]
   ) {
-    const cidr = ec2.AclCidr.ipv4(partnerInternalCidrBlock);
+    const cidr = ec2.AclCidr.ipv4(internalCidrBlock);
 
     rules.forEach(rule => {
       const ruleName = `${direction === ec2.TrafficDirection.INGRESS ? "Ingress" : "Egress"}Rule${
@@ -153,25 +153,25 @@ export class VpnStack extends cdk.Stack {
 
   private addIngressRules(
     networkAcl: ec2.INetworkAcl,
-    partnerInternalCidrBlock: string,
+    internalCidrBlock: string,
     rules: {
       ruleNumber: number;
       traffic: ec2.AclTraffic;
       ruleAction: ec2.Action;
     }[]
   ) {
-    this.setNaclRules(networkAcl, partnerInternalCidrBlock, ec2.TrafficDirection.INGRESS, rules);
+    this.setNaclRules(networkAcl, internalCidrBlock, ec2.TrafficDirection.INGRESS, rules);
   }
 
   private addEgressRules(
     networkAcl: ec2.INetworkAcl,
-    partnerInternalCidrBlock: string,
+    internalCidrBlock: string,
     rules: {
       ruleNumber: number;
       traffic: ec2.AclTraffic;
       ruleAction: ec2.Action;
     }[]
   ) {
-    this.setNaclRules(networkAcl, partnerInternalCidrBlock, ec2.TrafficDirection.EGRESS, rules);
+    this.setNaclRules(networkAcl, internalCidrBlock, ec2.TrafficDirection.EGRESS, rules);
   }
 }

--- a/packages/infra/lib/hl7-notification-stack/vpn.ts
+++ b/packages/infra/lib/hl7-notification-stack/vpn.ts
@@ -22,7 +22,7 @@ export class VpnStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: VpnStackProps) {
     super(scope, id, props);
 
-    const { name: hieName, internalCidrBlock } = props.hieConfig;
+    const { name: hieName, internalCidrBlock, gatewayPublicIp } = props.hieConfig;
 
     const networkAcl = ec2.NetworkAcl.fromNetworkAclId(
       this,
@@ -33,7 +33,7 @@ export class VpnStack extends cdk.Stack {
     const vgwId = Fn.importValue(`${props.networkStackId}-VgwId`);
 
     const customerGateway = new ec2.CfnCustomerGateway(this, `CustomerGateway-${hieName}`, {
-      ipAddress: props.hieConfig.gatewayPublicIp,
+      ipAddress: gatewayPublicIp,
       type: IPSEC_1,
       bgpAsn: 65000,
       tags: [
@@ -115,7 +115,7 @@ export class VpnStack extends cdk.Stack {
     });
 
     new ec2.CfnVPNConnectionRoute(this, `VpnConnectionRoute-${hieName}`, {
-      destinationCidrBlock: props.hieConfig.internalCidrBlock,
+      destinationCidrBlock: internalCidrBlock,
       vpnConnectionId: vpnConnection.ref,
     });
 

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -98,10 +98,9 @@ export class SecretsStack extends Stack {
         logSecretInfo(this, secret, secretName);
       }
 
-      const vpnTunnelSecretNames = props.config.hl7Notification.vpnConfigs.flatMap(config => [
-        `PresharedKey1-${config.partnerName}`,
-        `PresharedKey2-${config.partnerName}`,
-      ]);
+      const vpnTunnelSecretNames = Object.values(props.config.hl7Notification.hieConfigs).flatMap(
+        config => [`PresharedKey1-${config.name}`, `PresharedKey2-${config.name}`]
+      );
       for (const secretName of vpnTunnelSecretNames) {
         const secret = makeSecret(secretName, {
           generateSecretString: {

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -33,7 +33,9 @@
     "@metriport/core": "file:packages/core",
     "@metriport/shared": "file:packages/shared",
     "@sentry/cli": "^2.42.1",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "ip-cidr": "^4.0.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@metriport/eslint-rules": "file:packages/eslint-rules",

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -34,7 +34,7 @@
     "@metriport/shared": "file:packages/shared",
     "@sentry/cli": "^2.42.1",
     "dotenv": "^16.4.5",
-    "ip-cidr": "^4.0.2",
+    "ip-cidr": "^3.1.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -27,14 +27,13 @@ import {
 } from "./utils";
 import { Config } from "@metriport/core/util/config";
 
-const hieTimezoneDictionary = Config.getHieTimezoneDictionary();
-
 initSentry();
 
 const MLLP_DEFAULT_PORT = 2575;
 
 async function createHl7Server(logger: Logger): Promise<Hl7Server> {
   const { log } = logger;
+  const hieTimezoneDictionary = Config.getHieTimezoneDictionary();
 
   const server = new Hl7Server(connection => {
     connection.addEventListener(
@@ -131,8 +130,14 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
 
 async function main() {
   const logger = out("MLLP Server");
-  const server = await createHl7Server(logger);
-  server.start(MLLP_DEFAULT_PORT);
+  try {
+    const server = await createHl7Server(logger);
+    server.start(MLLP_DEFAULT_PORT);
+  } catch (error) {
+    logger.log("Error starting MLLP server", error);
+    capture.error(error);
+    process.exit(1);
+  }
 }
 
 main();

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -31,6 +31,9 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
       "message",
       withErrorHandling(connection, logger, async ({ message: rawMessage }) => {
         let parsedData: ParsedHl7Data;
+        log(
+          `New message over socket from ${connection.socket.remoteAddress}:${connection.socket.remotePort}`
+        );
 
         try {
           parsedData = await parseHl7Message(rawMessage);

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -11,6 +11,7 @@ import {
 } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh";
 import { createFileKeyHl7Message } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
 import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
+import { getHieTimezoneDictionary } from "@metriport/core/external/hl7-notification/hie-timezone";
 import { capture } from "@metriport/core/util";
 import type { Logger } from "@metriport/core/util/log";
 import { out } from "@metriport/core/util/log";
@@ -25,7 +26,6 @@ import {
   s3Utils,
   withErrorHandling,
 } from "./utils";
-import { Config } from "@metriport/core/util/config";
 
 initSentry();
 
@@ -33,7 +33,7 @@ const MLLP_DEFAULT_PORT = 2575;
 
 async function createHl7Server(logger: Logger): Promise<Hl7Server> {
   const { log } = logger;
-  const hieTimezoneDictionary = Config.getHieTimezoneDictionary();
+  const hieTimezoneDictionary = getHieTimezoneDictionary();
 
   const server = new Hl7Server(connection => {
     connection.addEventListener(

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -17,7 +17,7 @@ import { out } from "@metriport/core/util/log";
 import { basicToExtendedIso8601 } from "@metriport/shared/common/date";
 import { ParsedHl7Data, parseHl7Message, persistHl7MessageError } from "./parsing";
 import { initSentry } from "./sentry";
-import { asString, bucketName, s3Utils, withErrorHandling } from "./utils";
+import { asString, bucketName, getCleanIpAddress, s3Utils, withErrorHandling } from "./utils";
 
 initSentry();
 
@@ -31,9 +31,10 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
       "message",
       withErrorHandling(connection, logger, async ({ message: rawMessage }) => {
         let parsedData: ParsedHl7Data;
-        log(
-          `New message over socket from ${connection.socket.remoteAddress}:${connection.socket.remotePort}`
-        );
+        const clientIp = getCleanIpAddress(connection.socket.remoteAddress);
+        const clientPort = connection.socket.remotePort;
+
+        log(`New message from sender ${clientIp}:${clientPort}`);
 
         try {
           parsedData = await parseHl7Message(rawMessage);

--- a/packages/mllp-server/src/parsing.ts
+++ b/packages/mllp-server/src/parsing.ts
@@ -2,7 +2,6 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 import { Hl7Message } from "@medplum/core";
-import { getSendingApplication } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh";
 import {
   createUnparseableHl7MessageErrorMessageFileKey,
   createUnparseableHl7MessageFileKey,
@@ -11,22 +10,19 @@ import {
 } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
 import { utcifyHl7Message } from "@metriport/core/external/hl7-notification/datetime";
 import { Logger } from "@metriport/core/util/log";
-import { buildDayjs, ISO_DATE_TIME } from "@metriport/shared/common/date";
-import { Config } from "./config";
-import { asString, bucketName, s3Utils } from "./utils";
 import { errorToString } from "@metriport/shared";
-
-const hieTimezoneDictionary = Config.getHieTimezoneDictionary();
-
+import { buildDayjs, ISO_DATE_TIME } from "@metriport/shared/common/date";
+import { asString, bucketName, s3Utils } from "./utils";
 export interface ParsedHl7Data {
   message: Hl7Message;
   cxId: string;
   patientId: string;
 }
 
-export async function parseHl7Message(rawMessage: Hl7Message): Promise<ParsedHl7Data> {
-  const sendingApplication = getSendingApplication(rawMessage) ?? "Unknown HIE";
-  const hieTimezone = hieTimezoneDictionary[sendingApplication] ?? "UTC";
+export async function parseHl7Message(
+  rawMessage: Hl7Message,
+  hieTimezone: string
+): Promise<ParsedHl7Data> {
   const message = utcifyHl7Message(rawMessage, hieTimezone);
 
   const { cxId, patientId } = getCxIdAndPatientIdOrFail(message);

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -12,6 +12,7 @@ import IPCIDR from "ip-cidr";
 
 import * as Sentry from "@sentry/node";
 import { HieTimezoneDictionary } from "@metriport/core/external/hl7-notification/hie-timezone";
+import { MetriportError } from "@metriport/shared/dist/error/metriport-error";
 
 const crypto = new Base64Scrambler(Config.getHl7Base64ScramblerSeed());
 export const s3Utils = new S3Utils(Config.getAWSRegion());
@@ -81,7 +82,10 @@ export function lookupHieTzEntryForIp(hieTimezoneDictionary: HieTimezoneDictiona
   );
   const hieRow = cidrToTimezoneRows.find(({ cidrBlock }) => isIpInRange(cidrBlock, ip));
   if (!hieRow) {
-    throw new Error(`IP ${ip} not found in any CIDR block`);
+    throw new MetriportError(`Sender IP not found in any CIDR block`, {
+      cause: undefined,
+      additionalInfo: { ip, hieTimezoneDictionary },
+    });
   }
   return hieRow;
 }

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -56,3 +56,18 @@ export function unpackPidField(pid: string | undefined) {
 function reformUuid(shortId: string) {
   return unpackUuid(crypto.unscramble(shortId));
 }
+
+/**
+ * Extract clean IP address from IPv4-mapped IPv6 address
+ * Removes the ::ffff: prefix if present
+ */
+export function getCleanIpAddress(address: string | undefined): string {
+  if (!address) return "unknown";
+
+  // Remove IPv4-mapped IPv6 prefix if present
+  if (address.startsWith("::ffff:")) {
+    return address.substring(7);
+  }
+
+  return address;
+}

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -61,6 +61,8 @@ function reformUuid(shortId: string) {
   return unpackUuid(crypto.unscramble(shortId));
 }
 
+const ipv4MappedIpv6Prefix = "::ffff:";
+
 /**
  * Extract clean IP address from IPv4-mapped IPv6 address
  * Removes the ::ffff: prefix if present
@@ -71,9 +73,10 @@ export function getCleanIpAddress(address: string | undefined): string {
       context: "mllp-server.getCleanIpAddress",
     });
   }
-  // Remove IPv4-mapped IPv6 prefix if present
-  if (address.startsWith("::ffff:")) {
-    return address.substring(7);
+
+  // Trim to just the IPv4 address if possible
+  if (address.startsWith(ipv4MappedIpv6Prefix)) {
+    return address.substring(ipv4MappedIpv6Prefix.length);
   }
 
   return address;
@@ -87,7 +90,7 @@ export function lookupHieTzEntryForIp(hieTimezoneDictionary: HieTimezoneDictiona
   if (!hieRow) {
     throw new MetriportError(`Sender IP not found in any CIDR block`, {
       cause: undefined,
-      additionalInfo: { ip, hieTimezoneDictionary },
+      additionalInfo: { context: "mllp-server.lookupHieTzEntryForIp", ip, hieTimezoneDictionary },
     });
   }
   return hieRow;

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -66,8 +66,11 @@ function reformUuid(shortId: string) {
  * Removes the ::ffff: prefix if present
  */
 export function getCleanIpAddress(address: string | undefined): string {
-  if (!address) return "unknown";
-
+  if (!address) {
+    throw new MetriportError("IP address is undefined", undefined, {
+      context: "mllp-server.getCleanIpAddress",
+    });
+  }
   // Remove IPv4-mapped IPv6 prefix if present
   if (address.startsWith("::ffff:")) {
     return address.substring(7);

--- a/packages/shared/src/common/env-var.ts
+++ b/packages/shared/src/common/env-var.ts
@@ -28,10 +28,10 @@ export function getEnvAsIntOrFail(varName: string): number {
   return int;
 }
 
-export function getEnvVarAsRecordOrFail(varName: string): Record<string, string> {
+export function getEnvVarAsRecordOrFail<T>(varName: string): Record<string, T> {
   const value = getEnvVarOrFail(varName);
   try {
-    return JSON.parse(value) as Record<string, string>;
+    return JSON.parse(value) as Record<string, T>;
   } catch (error) {
     throw new Error(`Failed to parse ${varName} env var`);
   }


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/3100

### Description

- Updates the HieTimezoneDictionary so it now is hieName: { incomingCidr, timezone }
- Uses this HieTimezoneDictionary in the mllp server to identify the sender of the message (which hie).

### Testing

- Local
  - [x] Branch to staging + verify that message is properly mapped to corresponding HIE in config / from env vars
  - [x] Verify that tz is converted from America/Chicago to UTC (+5 hours)
- Staging
  - [ ] Verify that message is properly mapped to corresponding HIE in config / from env vars
  - [ ] Verify that tz is converted from America/Chicago to UTC (+5 hours)
- Production
  - [ ] Verify that message is properly mapped to corresponding HIE in config / from env vars
  - [ ] Verify that tz is converted from America/Chicago to UTC (+5 hours)

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced timezone handling for HL7 message processing by mapping client IP addresses to specific timezones and HIE names.
  * Added runtime validation for HIE timezone configuration to ensure data integrity.
  * Introduced utilities for IP address normalization and CIDR-based timezone lookup.

* **Refactor**
  * Updated configuration structure to consolidate VPN and HIE settings, simplifying property names and types.
  * Streamlined VPN and secret management to use unified HIE configuration.
  * Improved network load balancer setup with client IP preservation.

* **Chores**
  * Added new dependencies for IP address and schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->