### PR TITLE
Eng 535 athena encounter update

### DIFF
--- a/packages/core/src/external/ehr/athenahealth/index.ts
+++ b/packages/core/src/external/ehr/athenahealth/index.ts
@@ -1962,7 +1962,7 @@ class AthenaHealthApi {
       },
       {
         numberOfParallelExecutions: parallelRequests,
-        delay: delayBetweenRequestBatches.asMilliseconds(),
+        maxJitterMillis: maxJitter.asMilliseconds(),
       }
     );
     if (processEncountersErrors.length > 0) {

--- a/packages/core/src/external/ehr/bundle/bundle-shared.ts
+++ b/packages/core/src/external/ehr/bundle/bundle-shared.ts
@@ -4,33 +4,14 @@ import { S3Utils } from "../../aws/s3";
 import { supportedAthenaHealthResources } from "../athenahealth";
 import { supportedCanvasResources } from "../canvas";
 import { supportedElationResources } from "../elation";
+import { createPrefix, CreatePrefixParams } from "../shared";
 
 const globalPrefix = "bundle";
-const globalCcdaPrefix = "ccda";
 const region = Config.getAWSRegion();
 
-type CreateBundlePrefixParams = {
-  ehr: EhrSource;
-  cxId: string;
-  metriportPatientId: string;
-  ehrPatientId: string;
-  resourceType: string;
-  jobId?: string | undefined;
+type CreateBundlePrefixParams = CreatePrefixParams & {
   resourceId?: string | undefined;
 };
-
-type CreateCcdaPrefixParams = Omit<CreateBundlePrefixParams, "resourceId">;
-
-function createPrefix(
-  prefix: string,
-  params: Omit<CreateBundlePrefixParams, "resourceId">
-): string {
-  return `${prefix}/ehr=${params.ehr}/cxid=${params.cxId}/metriportpatientid=${
-    params.metriportPatientId
-  }/ehrpatientid=${params.ehrPatientId}/resourcetype=${params.resourceType}/jobId=${
-    params.jobId ?? "latest"
-  }`;
-}
 
 function createBundlePrefix({
   ehr,
@@ -51,24 +32,6 @@ function createBundlePrefix({
   })}${resourceId ? `/resourceid=${resourceId}` : ""}`;
 }
 
-function createCcdaPrefix({
-  ehr,
-  cxId,
-  metriportPatientId,
-  ehrPatientId,
-  resourceType,
-  jobId,
-}: CreateCcdaPrefixParams): string {
-  return `${createPrefix(globalCcdaPrefix, {
-    ehr,
-    cxId,
-    metriportPatientId,
-    ehrPatientId,
-    resourceType,
-    jobId,
-  })}`;
-}
-
 export function createFileKeyEhr(params: CreateBundlePrefixParams): string {
   return `${createBundlePrefix(params)}/ehr.json`;
 }
@@ -87,10 +50,6 @@ export function createFileKeyEhrOnly(params: CreateBundlePrefixParams): string {
 
 export function createFileKeyMetriportOnly(params: CreateBundlePrefixParams): string {
   return `${createBundlePrefix(params)}/metriport-only.json`;
-}
-
-export function createFileKeyCcda(params: CreateCcdaPrefixParams): string {
-  return `${createCcdaPrefix(params)}/ccda.xml`;
 }
 
 export function createFileKeyResourceDiffDataContribution(

--- a/packages/core/src/external/ehr/document/command/create-or-replace-document.ts
+++ b/packages/core/src/external/ehr/document/command/create-or-replace-document.ts
@@ -1,38 +1,47 @@
-import { errorToString, executeWithNetworkRetries, MetriportError } from "@metriport/shared";
+import {
+  BadRequestError,
+  errorToString,
+  executeWithNetworkRetries,
+  MetriportError,
+} from "@metriport/shared";
 import { Config } from "../../../../util/config";
 import { out } from "../../../../util/log";
-import { BundleKeyBaseParams, createFileKeyCcda, getS3UtilsInstance } from "../bundle-shared";
+import {
+  createKeyAndExtensionMap,
+  DocumentKeyBaseParams,
+  getS3UtilsInstance,
+} from "../document-shared";
 
-export type CreateOrReplaceCcdaParams = Omit<
-  BundleKeyBaseParams,
-  "bundleType" | "resourceId" | "getLastModified"
-> & {
+export type CreateOrReplaceDocumentParams = DocumentKeyBaseParams & {
   payload: string;
 };
 
 /**
- * Creates or replaces a CCDA file.
+ * Creates or replaces a document.
  *
  * @param ehr - The EHR source.
  * @param cxId - The CX ID.
  * @param metriportPatientId - The Metriport ID.
  * @param ehrPatientId - The EHR patient ID.
+ * @param documentType - The type of the document.
+ * @param payload - The payload of the document.
  * @param resourceType - The resource type of the CCDA file.
  * @param jobId - The job ID of the CCDA file. If not provided, the tag 'latest' will be used.
+ * @param resourceId - The resource ID of the document.
  * @param s3BucketName - The S3 bucket name (optional, defaults to the EHR bundle bucket)
- * @param payload - The payload of the CCDA file.
- * @param s3FileName - The S3 file name of the CCDA file.
  */
-export async function createOrReplaceCcda({
+export async function createOrReplaceDocument({
   ehr,
   cxId,
   metriportPatientId,
   ehrPatientId,
+  documentType,
   payload,
   resourceType,
   jobId,
+  resourceId,
   s3BucketName = Config.getEhrBundleBucketName(),
-}: CreateOrReplaceCcdaParams): Promise<{
+}: CreateOrReplaceDocumentParams): Promise<{
   s3key: string;
   s3BucketName: string;
 }> {
@@ -40,13 +49,17 @@ export async function createOrReplaceCcda({
     `Ehr createOrReplaceCcda - ehr ${ehr} cxId ${cxId} ehrPatientId ${ehrPatientId}`
   );
   const s3Utils = getS3UtilsInstance();
-  const key = createFileKeyCcda({
+  const createKeyAndExtension = createKeyAndExtensionMap[documentType];
+  if (!createKeyAndExtension)
+    throw new BadRequestError("Invalid document type", undefined, { documentType });
+  const key = createKeyAndExtension.key({
     ehr,
     cxId,
     metriportPatientId,
     ehrPatientId,
     resourceType,
     jobId,
+    resourceId,
   });
   try {
     await executeWithNetworkRetries(async () => {
@@ -54,12 +67,12 @@ export async function createOrReplaceCcda({
         bucket: s3BucketName,
         key,
         file: Buffer.from(payload, "utf8"),
-        contentType: "application/xml",
+        contentType: createKeyAndExtension.extension,
       });
     });
     return { s3key: key, s3BucketName };
   } catch (error) {
-    const msg = "Failure while creating or replacing CCDA file @ S3";
+    const msg = `Failure while creating or replacing EHR document @ S3`;
     log(`${msg}. Cause: ${errorToString(error)}`);
     throw new MetriportError(msg, error, {
       ehr,
@@ -68,7 +81,8 @@ export async function createOrReplaceCcda({
       ehrPatientId,
       resourceType,
       key,
-      context: "ehr.createOrReplaceCcda",
+      extension: createKeyAndExtension.extension,
+      context: "ehr.createOrReplaceDocument",
     });
   }
 }

--- a/packages/core/src/external/ehr/document/document-shared.ts
+++ b/packages/core/src/external/ehr/document/document-shared.ts
@@ -1,0 +1,87 @@
+import { EhrSource } from "@metriport/shared/interface/external/ehr/source";
+import { Config } from "../../../util/config";
+import { S3Utils } from "../../aws/s3";
+import { createPrefix, CreatePrefixParams } from "../shared";
+
+const globalCcdaPrefix = "ccda";
+const globalHtmlPrefix = "html";
+const region = Config.getAWSRegion();
+
+type CreateDocumentPrefixParams = CreatePrefixParams & {
+  resourceId?: string | undefined;
+};
+
+function createCcdaPrefix({
+  ehr,
+  cxId,
+  metriportPatientId,
+  ehrPatientId,
+  resourceType,
+  jobId,
+  resourceId,
+}: CreateDocumentPrefixParams): string {
+  return `${createPrefix(globalCcdaPrefix, {
+    ehr,
+    cxId,
+    metriportPatientId,
+    ehrPatientId,
+    resourceType,
+    jobId,
+  })}${resourceId ? `/resourceid=${resourceId}` : ""}`;
+}
+
+function createHtmlPrefix({
+  ehr,
+  cxId,
+  metriportPatientId,
+  ehrPatientId,
+  resourceType,
+  jobId,
+  resourceId,
+}: CreateDocumentPrefixParams): string {
+  return `${createPrefix(globalHtmlPrefix, {
+    ehr,
+    cxId,
+    metriportPatientId,
+    ehrPatientId,
+    resourceType,
+    jobId,
+  })}${resourceId ? `/resourceid=${resourceId}` : ""}`;
+}
+
+export function createFileKeyCcda(params: CreateDocumentPrefixParams): string {
+  return `${createCcdaPrefix(params)}/ccda.xml`;
+}
+
+export function createFileKeyHtml(params: CreatePrefixParams): string {
+  return `${createHtmlPrefix(params)}/html.html`;
+}
+
+export enum DocumentType {
+  CCDA = "ccda",
+  HTML = "html",
+}
+
+export const createKeyAndExtensionMap: Record<
+  DocumentType,
+  { key: (params: CreateDocumentPrefixParams) => string; extension: string }
+> = {
+  [DocumentType.CCDA]: { key: createFileKeyCcda, extension: "application/xml" },
+  [DocumentType.HTML]: { key: createFileKeyHtml, extension: "text/html" },
+};
+
+export function getS3UtilsInstance(): S3Utils {
+  return new S3Utils(region);
+}
+
+export type DocumentKeyBaseParams = {
+  ehr: EhrSource;
+  cxId: string;
+  metriportPatientId: string;
+  ehrPatientId: string;
+  documentType: DocumentType;
+  resourceType: string;
+  jobId?: string | undefined;
+  resourceId?: string | undefined;
+  s3BucketName?: string;
+};

--- a/packages/core/src/external/ehr/elation/index.ts
+++ b/packages/core/src/external/ehr/elation/index.ts
@@ -34,7 +34,8 @@ import axios, { AxiosInstance } from "axios";
 import { z } from "zod";
 import { Config } from "../../../util/config";
 import { out } from "../../../util/log";
-import { createOrReplaceCcda } from "../bundle/command/create-or-replace-ccda";
+import { createOrReplaceDocument } from "../document/command/create-or-replace-document";
+import { DocumentType } from "../document/document-shared";
 import {
   ApiConfig,
   convertEhrBundleToValidEhrStrictBundle,
@@ -355,11 +356,12 @@ class ElationApi {
       patientId: elationPatientId,
       resourceType,
     });
-    const { s3key, s3BucketName } = await createOrReplaceCcda({
+    const { s3key, s3BucketName } = await createOrReplaceDocument({
       ehr: EhrSources.elation,
       cxId,
       metriportPatientId,
       ehrPatientId: elationPatientId,
+      documentType: DocumentType.CCDA,
       payload,
       resourceType,
     });

--- a/packages/core/src/external/ehr/shared.ts
+++ b/packages/core/src/external/ehr/shared.ts
@@ -296,6 +296,26 @@ export function isNotRetriableAxiosError(error: unknown): boolean {
   );
 }
 
+export type CreatePrefixParams = {
+  ehr: EhrSource;
+  cxId: string;
+  metriportPatientId: string;
+  ehrPatientId: string;
+  resourceType: string;
+  jobId?: string | undefined;
+};
+
+export function createPrefix(
+  prefix: string,
+  params: Omit<CreatePrefixParams, "resourceId">
+): string {
+  return `${prefix}/ehr=${params.ehr}/cxid=${params.cxId}/metriportpatientid=${
+    params.metriportPatientId
+  }/ehrpatientid=${params.ehrPatientId}/resourcetype=${params.resourceType}/jobId=${
+    params.jobId ?? "latest"
+  }`;
+}
+
 // TYPES FROM DASHBOARD
 export type MedicationWithRefs = {
   medication: Medication;
@@ -726,7 +746,7 @@ export async function saveEhrReferenceBundle({
   metriportPatientId: string;
   ehrPatientId: string;
   referenceBundle: EhrFhirResourceBundle;
-}) {
+}): Promise<void> {
   const { log } = out(
     `saveReferenceBundle - cxId ${cxId} metriportPatientId ${metriportPatientId} ehrPatientId ${ehrPatientId}`
   );

--- a/packages/shared/src/interface/external/ehr/athenahealth/appointment.ts
+++ b/packages/shared/src/interface/external/ehr/athenahealth/appointment.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
 
+export const appointmentSchema = z.object({
+  patientid: z.string(),
+  departmentid: z.string(),
+  appointmenttypeid: z.string(),
+});
+export type Appointment = z.infer<typeof appointmentSchema>;
+
 export const bookedAppointmentSchema = z.object({
   patientid: z.string(),
   departmentid: z.string(),

--- a/packages/shared/src/interface/external/ehr/athenahealth/encounter.ts
+++ b/packages/shared/src/interface/external/ehr/athenahealth/encounter.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const encounterSchema = z.object({
+  encounterid: z.string(),
+  appointmentid: z.string(),
+  patientid: z.string(),
+  departmentid: z.string(),
+});
+export type Encounter = z.infer<typeof encounterSchema>;
+
+export const encounterSummarySchema = z.object({
+  summaryhtml: z.string(),
+});
+export type EncounterSummary = z.infer<typeof encounterSummarySchema>;

--- a/packages/shared/src/interface/external/ehr/athenahealth/index.ts
+++ b/packages/shared/src/interface/external/ehr/athenahealth/index.ts
@@ -12,3 +12,4 @@ export * from "./vaccine";
 export * from "./clinical-document";
 export * from "./allergy";
 export * from "./surgical-history";
+export * from "./encounter";


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-535

### Description

- saving off encounter appointment type ID info and summary htmls (both unused in PR for now but need to get it live for Athena monitoring period).

### Testing

- Local
  - [ ] test encounter html saves
  - [ ] test encounter apppointment type ID saves
- Staging
  - [ ] test encounter html saves
  - [ ] test encounter apppointment type ID saves
- Sandbox
  - [ ] N/A
- Production
  - [ ] encounter html saves
  - [ ] encounter apppointment type ID saves

### Release Plan

- [ ] Merge this
