### PR TITLE
feat(fhir-converter): added plan of treatment conversion into fhir careplan

### DIFF
--- a/packages/core/src/external/fhir/bundle/bundle.ts
+++ b/packages/core/src/external/fhir/bundle/bundle.ts
@@ -4,6 +4,7 @@ import {
   Bundle,
   BundleEntry,
   BundleEntryRequest,
+  CarePlan,
   Communication,
   Composition,
   Condition,
@@ -362,6 +363,7 @@ export type ExtractedFhirTypes = {
   communications: Communication[];
   consents: Consent[];
   devices: Device[];
+  carePlans: CarePlan[];
   goals: Goal[];
   serviceRequests: ServiceRequest[];
   documentReferences: DocumentReference[];
@@ -408,6 +410,7 @@ export function extractFhirTypesFromBundle(bundle: Bundle): ExtractedFhirTypes {
   const communications: Communication[] = [];
   const consents: Consent[] = [];
   const devices: Device[] = [];
+  const carePlans: CarePlan[] = [];
   const goals: Goal[] = [];
   const serviceRequests: ServiceRequest[] = [];
   const documentReferences: DocumentReference[] = [];
@@ -485,6 +488,8 @@ export function extractFhirTypesFromBundle(bundle: Bundle): ExtractedFhirTypes {
         consents.push(resource as Consent);
       } else if (resource?.resourceType === "Device") {
         devices.push(resource as Device);
+      } else if (resource?.resourceType === "CarePlan") {
+        carePlans.push(resource as CarePlan);
       } else if (resource?.resourceType === "Goal") {
         goals.push(resource as Goal);
       } else if (resource?.resourceType === "ServiceRequest") {
@@ -525,6 +530,7 @@ export function extractFhirTypesFromBundle(bundle: Bundle): ExtractedFhirTypes {
     communications,
     consents,
     devices,
+    carePlans,
     goals,
     serviceRequests,
     documentReferences,

--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -7,6 +7,7 @@ import {
 } from "../external/fhir/bundle/bundle";
 import { capture } from "../util";
 import { deduplicateAllergyIntolerances } from "./resources/allergy-intolerance";
+import { deduplicateCarePlans } from "./resources/care-plan";
 import { deduplicateCompositions } from "./resources/composition";
 import { deduplicateConditions } from "./resources/condition";
 import { deduplicateCoverages } from "./resources/coverage";
@@ -89,7 +90,7 @@ export function dangerouslyDeduplicateFhir(
   resourceArrays = replaceResourceReferences(
     resourceArrays,
     new Map<string, string>([...practitionersResult.refReplacementMap]),
-    ["diagnosticReports"]
+    ["diagnosticReports", "carePlans"]
   );
 
   const conditionsResult = deduplicateConditions(resourceArrays.conditions);
@@ -133,6 +134,9 @@ export function dangerouslyDeduplicateFhir(
   );
   resourceArrays.familyMemberHistories = famMemHistoriesResult.combinedResources;
 
+  const carePlansResult = deduplicateCarePlans(resourceArrays.carePlans);
+  resourceArrays.carePlans = carePlansResult.combinedResources;
+
   resourceArrays = replaceResourceReferences(resourceArrays, medicationsResult.refReplacementMap, [
     "coverages",
   ]);
@@ -162,6 +166,7 @@ export function dangerouslyDeduplicateFhir(
     ...relatedPersonsResult.danglingReferences,
     ...famMemHistoriesResult.danglingReferences,
     ...coveragesResult.danglingReferences,
+    ...carePlansResult.danglingReferences,
   ]);
 
   // Combine all the remaining replacementMaps into one map
@@ -185,6 +190,7 @@ export function dangerouslyDeduplicateFhir(
     ...relatedPersonsResult.refReplacementMap,
     ...famMemHistoriesResult.refReplacementMap,
     ...coveragesResult.refReplacementMap,
+    ...carePlansResult.refReplacementMap,
   ]);
 
   resourceArrays = replaceResourceReferences(resourceArrays, combinedReplacementMap);
@@ -562,7 +568,11 @@ function replaceResourceReference<T extends Resource>(
     });
   }
 
-  if ("author" in entry && Array.isArray(entry.author) && entry.resourceType === "Composition") {
+  if (
+    "author" in entry &&
+    Array.isArray(entry.author) &&
+    (entry.resourceType === "Composition" || entry.resourceType === "CarePlan")
+  ) {
     entry.author = entry.author.map(author => {
       if (author.reference) {
         const newReference = referenceMap.get(author.reference);
@@ -663,6 +673,22 @@ function replaceResourceReference<T extends Resource>(
       }
       return reason;
     }) as typeof entry.reasonReference;
+  }
+
+  if (entry.resourceType === "CarePlan" && "activity" in entry) {
+    entry.activity = entry.activity?.map(activity => {
+      activity.detail?.performer?.forEach(performer => {
+        if (performer.reference) {
+          const newReference = referenceMap.get(performer.reference);
+          if (newReference) performer.reference = newReference;
+        }
+      });
+      if (activity.detail?.location?.reference) {
+        const newReference = referenceMap.get(activity.detail.location.reference);
+        if (newReference) activity.detail.location.reference = newReference;
+      }
+      return activity;
+    });
   }
 
   if (entry.resourceType === "Composition" && "section" in entry) {

--- a/packages/core/src/fhir-deduplication/resources/care-plan.ts
+++ b/packages/core/src/fhir-deduplication/resources/care-plan.ts
@@ -70,10 +70,7 @@ export function groupSameCarePlans(carePlans: CarePlan[]): {
         targetResource: carePlan,
         refReplacementMap,
         onPostmerge: (master: CarePlan) => {
-          const dedupedActivity = _.uniqBy(
-            master.activity,
-            "detail.performer.scheduledPeriod.start"
-          );
+          const dedupedActivity = _.uniqBy(master.activity, "detail.scheduledPeriod.start");
           master.activity = dedupedActivity;
           return master;
         },

--- a/packages/core/src/fhir-deduplication/resources/care-plan.ts
+++ b/packages/core/src/fhir-deduplication/resources/care-plan.ts
@@ -1,0 +1,91 @@
+import { CarePlan } from "@medplum/fhirtypes";
+import _ from "lodash";
+import { DeduplicationResult, createKeysFromObjectArray, createRef, fillL1L2Maps } from "../shared";
+
+export function deduplicateCarePlans(carePlans: CarePlan[]): DeduplicationResult<CarePlan> {
+  const { carePlansMap, refReplacementMap, danglingReferences } = groupSameCarePlans(carePlans);
+  return {
+    combinedResources: Array.from(carePlansMap.values()),
+    refReplacementMap,
+    danglingReferences,
+  };
+}
+
+export function groupSameCarePlans(carePlans: CarePlan[]): {
+  carePlansMap: Map<string, CarePlan>;
+  refReplacementMap: Map<string, string>;
+  danglingReferences: Set<string>;
+} {
+  const l1CarePlansMap = new Map<string, string>();
+  const l2CarePlansMap = new Map<string, CarePlan>();
+
+  const refReplacementMap = new Map<string, string>();
+  const danglingReferences = new Set<string>();
+
+  for (const carePlan of carePlans) {
+    const setterKeys: string[] = [];
+    const getterKeys: string[] = [];
+
+    carePlan.activity?.forEach(act => {
+      const dateTime = act.detail?.scheduledPeriod?.start;
+      if (!dateTime) return;
+
+      const performers = act.detail?.performer?.flatMap(p => {
+        if (!p.reference || !p.reference.includes("Practitioner")) return [];
+
+        return p.reference;
+      });
+
+      if (performers && performers.length > 0) {
+        const dateAndPractitionerKeys = createKeysFromObjectArray(
+          { dateTime },
+          performers.map(p => ({ performer: p }))
+        );
+
+        // flagging the care plan with the date and each unique practitioner reference
+        setterKeys.push(...dateAndPractitionerKeys);
+        // the care plan will dedup using the date and the same practitioner reference
+        getterKeys.push(...dateAndPractitionerKeys);
+
+        // flagging the care plan with the date and 1 performer bit (meaning it has > 0 performers)
+        setterKeys.push(JSON.stringify({ dateTime, performer: 1 }));
+        // the care plan will dedup against ones that don't have the performer as long as they have a matching date
+        getterKeys.push(JSON.stringify({ dateTime, performer: 0 }));
+      } else {
+        // flagging the care plan with the date and 0 performer bit (meaning it has 0 performers)
+        setterKeys.push(JSON.stringify({ dateTime, performer: 0 }));
+        // the care plan will dedup against ones that don't have the performer as long as they have a matching date
+        getterKeys.push(JSON.stringify({ dateTime, performer: 0 }));
+        // the care plan will also dedup against ones that have the performer as long as they have a matching date
+        getterKeys.push(JSON.stringify({ dateTime, performer: 1 }));
+      }
+    });
+
+    if (setterKeys.length > 0) {
+      fillL1L2Maps({
+        map1: l1CarePlansMap,
+        map2: l2CarePlansMap,
+        getterKeys,
+        setterKeys,
+        targetResource: carePlan,
+        refReplacementMap,
+        onPostmerge: (master: CarePlan) => {
+          const dedupedActivity = _.uniqBy(
+            master.activity,
+            "detail.performer.scheduledPeriod.start"
+          );
+          master.activity = dedupedActivity;
+          return master;
+        },
+      });
+    } else {
+      danglingReferences.add(createRef(carePlan));
+    }
+  }
+
+  return {
+    carePlansMap: l2CarePlansMap,
+    refReplacementMap,
+    danglingReferences,
+  };
+}

--- a/packages/fhir-converter/src/lib/handlebars-converter/__tests__/generate-location-id-template.test.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/__tests__/generate-location-id-template.test.js
@@ -1,0 +1,345 @@
+const fs = require("fs");
+const path = require("path");
+const Handlebars = require("handlebars");
+const helpers = require("../handlebars-helpers").external;
+const functions = require("../handlebars-helpers").internal;
+
+describe("GenerateLocationId.hbs template vs generateLocationId helper function", function () {
+  let handlebarsInstance;
+  let generateLocationIdTemplate;
+
+  beforeAll(() => {
+    handlebarsInstance = Handlebars.create();
+
+    helpers.forEach(helper => {
+      handlebarsInstance.registerHelper(helper.name, helper.func);
+    });
+
+    const templatePath = path.join(
+      __dirname,
+      "../../../templates/cda/Utils/GenerateLocationId.hbs"
+    );
+    const templateContent = fs.readFileSync(templatePath, "utf8");
+    generateLocationIdTemplate = handlebarsInstance.compile(templateContent);
+  });
+
+  const renderLocationId = locationData => {
+    try {
+      const result = generateLocationIdTemplate({ location: locationData });
+      // Clean up the templateRes by removing trailing comma and parsing JSON
+      const cleanResult = result.replace(/,\s*}/g, "}").replace(/,\s*$/, "");
+      return JSON.parse(cleanResult);
+    } catch (error) {
+      console.error("Error parsing template result");
+      return undefined;
+    }
+  };
+
+  describe("Location with location.location.addr (primary case)", () => {
+    it("should generate UUID from location.location.addr, location.location.name, and location.code", () => {
+      const locationData = {
+        location: {
+          addr: {
+            streetAddressLine: ["123 Main St"],
+            city: "Anytown",
+            state: "CA",
+            postalCode: "12345",
+          },
+          name: "General Hospital",
+        },
+        code: {
+          code: "HOSP",
+          codeSystem: "2.16.840.1.113883.5.110",
+        },
+      };
+
+      const templateRes = renderLocationId(locationData);
+      const helperRes = functions.generateLocationId(locationData);
+
+      expect(templateRes).toBeDefined();
+      expect(helperRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+    });
+
+    it("should handle missing location.location.name and location.code", () => {
+      const locationData = {
+        location: {
+          addr: {
+            streetAddressLine: ["456 Oak Ave"],
+            city: "Somewhere",
+            state: "NY",
+            postalCode: "67890",
+          },
+        },
+      };
+
+      const templateRes = renderLocationId(locationData);
+      const helperRes = functions.generateLocationId(locationData);
+
+      expect(templateRes).toBeDefined();
+      expect(helperRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+    });
+  });
+
+  describe("Location with location.addr (fallback case)", () => {
+    it("should generate UUID from location.addr, location.playingEntity.name, and location.code", () => {
+      const locationData = {
+        addr: {
+          streetAddressLine: ["789 Pine St"],
+          city: "Elsewhere",
+          state: "TX",
+          postalCode: "11111",
+        },
+        playingEntity: {
+          name: "Medical Center",
+        },
+        code: {
+          code: "CLINIC",
+          codeSystem: "2.16.840.1.113883.5.110",
+        },
+      };
+
+      const templateRes = renderLocationId(locationData);
+      const helperRes = functions.generateLocationId(locationData);
+
+      expect(templateRes).toBeDefined();
+      expect(helperRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+    });
+
+    it("should handle missing location.playingEntity.name and location.code", () => {
+      const locationData = {
+        addr: {
+          streetAddressLine: ["321 Elm St"],
+          city: "Nowhere",
+          state: "FL",
+          postalCode: "22222",
+        },
+      };
+
+      const templateRes = renderLocationId(locationData);
+      const helperRes = functions.generateLocationId(locationData);
+
+      expect(templateRes).toBeDefined();
+      expect(helperRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+    });
+  });
+
+  describe("Location with location.playingEntity.name (final fallback case)", () => {
+    it("should generate UUID from location.playingEntity.name when no addr", () => {
+      const locationData = {
+        playingEntity: {
+          name: "Urgent Care Facility",
+        },
+      };
+
+      const templateRes = renderLocationId(locationData);
+      const helperRes = functions.generateLocationId(locationData);
+
+      expect(templateRes).toBeDefined();
+      expect(helperRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+    });
+
+    it("should generate consistent UUIDs for same name data", () => {
+      const locationData = {
+        playingEntity: {
+          name: "Consistent Facility Name",
+        },
+      };
+
+      const templateRes1 = renderLocationId(locationData);
+      const templateRes2 = renderLocationId(locationData);
+      const helperRes1 = functions.generateLocationId(locationData);
+      const helperRes2 = functions.generateLocationId(locationData);
+
+      expect(templateRes1.Id).toBe(templateRes2.Id);
+      expect(helperRes1).toBe(helperRes2);
+      expect(templateRes1.Id).toBe(helperRes1);
+    });
+  });
+
+  describe("Edge cases and error handling", () => {
+    it("should handle empty location object", () => {
+      const locationData = {};
+
+      const templateRes = renderLocationId(locationData);
+      const helperRes = functions.generateLocationId(locationData);
+
+      expect(templateRes).toEqual({});
+      expect(templateRes).toEqual(helperRes);
+    });
+
+    it("should handle null location", () => {
+      const locationData = null;
+
+      const templateRes = renderLocationId(locationData);
+      const helperRes = functions.generateLocationId(locationData);
+
+      expect(templateRes).toEqual({});
+      expect(templateRes).toEqual(helperRes);
+    });
+  });
+
+  describe("Priority handling", () => {
+    it("should prioritize location.location.addr over location.addr when both exist", () => {
+      const locationData = {
+        location: {
+          addr: {
+            streetAddressLine: ["Priority Address"],
+            city: "Priority City",
+          },
+          name: "Priority Facility",
+        },
+        addr: {
+          streetAddressLine: ["Should Be Ignored"],
+          city: "Ignored City",
+        },
+        playingEntity: {
+          name: "Should Also Be Ignored",
+        },
+      };
+
+      const templateRes = renderLocationId(locationData);
+      const helperRes = functions.generateLocationId(locationData);
+
+      expect(templateRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+
+      const addrOnlyData = {
+        addr: {
+          streetAddressLine: ["Should Be Ignored"],
+          city: "Ignored City",
+        },
+        playingEntity: {
+          name: "Should Also Be Ignored",
+        },
+      };
+      const addrOnlyResult = functions.generateLocationId(addrOnlyData);
+      expect(templateRes.Id).not.toBe(addrOnlyResult);
+    });
+
+    it("should prioritize location.addr over location.playingEntity.name when both exist", () => {
+      const locationData = {
+        addr: {
+          streetAddressLine: ["Secondary Priority"],
+          city: "Secondary City",
+        },
+        playingEntity: {
+          name: "Should Be Ignored",
+        },
+      };
+
+      const templateRes = renderLocationId(locationData);
+      const helperRes = functions.generateLocationId(locationData);
+
+      expect(templateRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+
+      const nameOnlyData = {
+        playingEntity: {
+          name: "Should Be Ignored",
+        },
+      };
+      const nameOnlyResult = functions.generateLocationId(nameOnlyData);
+      expect(templateRes.Id).not.toBe(nameOnlyResult);
+    });
+  });
+
+  describe("Integration with helper functions", () => {
+    it("should use generateUUID helper correctly", () => {
+      const locationData = {
+        location: {
+          addr: {
+            streetAddressLine: ["UUID Test Address"],
+            city: "UUID City",
+          },
+          name: "UUID Test Facility",
+        },
+        code: {
+          code: "TEST",
+          codeSystem: "2.16.840.1.113883.5.110",
+        },
+      };
+
+      const combined = [
+        JSON.stringify(locationData.location.addr),
+        JSON.stringify(locationData.location.name),
+        JSON.stringify(locationData.code),
+      ].join("");
+      const expectedUuid = require("uuid/v3")(combined, require("uuid/v3").URL);
+
+      const templateRes = renderLocationId(locationData);
+      const helperRes = functions.generateLocationId(locationData);
+
+      expect(templateRes.Id).toBe(expectedUuid);
+      expect(helperRes).toBe(expectedUuid);
+      expect(templateRes.Id).toBe(helperRes);
+    });
+
+    it("should use concatDefined helper correctly for address-based generation", () => {
+      const locationData = {
+        addr: {
+          streetAddressLine: ["Concat Test"],
+          city: "Concat City",
+        },
+        playingEntity: {
+          name: "Concat Facility",
+        },
+        code: {
+          code: "CONCAT",
+          codeSystem: "2.16.840.1.113883.5.110",
+        },
+      };
+
+      const templateRes = renderLocationId(locationData);
+      const helperRes = functions.generateLocationId(locationData);
+
+      expect(templateRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+
+      const expectedCombined = [
+        JSON.stringify(locationData.addr),
+        JSON.stringify(locationData.playingEntity.name),
+        JSON.stringify(locationData.code),
+      ].join("");
+      const expectedUuid = require("uuid/v3")(expectedCombined, require("uuid/v3").URL);
+
+      expect(templateRes.Id).toBe(expectedUuid);
+    });
+  });
+
+  describe("Template structure validation", () => {
+    it("should produce valid JSON structure", () => {
+      const locationData = {
+        location: {
+          addr: {
+            streetAddressLine: ["Structure Test"],
+            city: "Structure City",
+          },
+          name: "Structure Facility",
+        },
+      };
+
+      const templateRes = renderLocationId(locationData);
+
+      expect(() => JSON.stringify(templateRes)).not.toThrow();
+      expect(typeof templateRes).toBe("object");
+      expect(templateRes).not.toBeNull();
+      expect(templateRes).toHaveProperty("Id");
+    });
+
+    it("should handle template compilation without errors", () => {
+      expect(() => {
+        const templatePath = path.join(
+          __dirname,
+          "../../../templates/cda/Utils/GenerateLocationId.hbs"
+        );
+        const templateContent = fs.readFileSync(templatePath, "utf8");
+        handlebarsInstance.compile(templateContent);
+      }).not.toThrow();
+    });
+  });
+});

--- a/packages/fhir-converter/src/lib/handlebars-converter/__tests__/generate-practitioner-id-template.test.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/__tests__/generate-practitioner-id-template.test.js
@@ -1,0 +1,296 @@
+const fs = require("fs");
+const path = require("path");
+const Handlebars = require("handlebars");
+const helpers = require("../handlebars-helpers").external;
+const functions = require("../handlebars-helpers").internal;
+
+describe("GeneratePractitionerId.hbs template vs generatePractitionerId helper function", function () {
+  let handlebarsInstance;
+  let generatePractitionerIdTemplate;
+
+  beforeAll(() => {
+    handlebarsInstance = Handlebars.create();
+
+    helpers.forEach(helper => {
+      handlebarsInstance.registerHelper(helper.name, helper.func);
+    });
+
+    const templatePath = path.join(
+      __dirname,
+      "../../../templates/cda/Utils/GeneratePractitionerId.hbs"
+    );
+    const templateContent = fs.readFileSync(templatePath, "utf8");
+    generatePractitionerIdTemplate = handlebarsInstance.compile(templateContent);
+  });
+
+  const renderPractitionerId = practitionerData => {
+    try {
+      const result = generatePractitionerIdTemplate({ obj: practitionerData });
+      // Clean up the templateRes by removing trailing comma and parsing JSON
+      const cleanResult = result.replace(/,\s*}/g, "}").replace(/,\s*$/, "");
+      return JSON.parse(cleanResult);
+    } catch (error) {
+      return undefined;
+    }
+  };
+
+  describe("Practitioner with both root and extension IDs", () => {
+    it("should generate UUID from root and extension when both exist", () => {
+      const practitionerData = {
+        id: [
+          {
+            root: "2.16.840.1.113883.19.5",
+            extension: "12345",
+          },
+        ],
+      };
+
+      const templateRes = renderPractitionerId(practitionerData);
+      const helperRes = functions.generatePractitionerId(practitionerData);
+
+      expect(templateRes).toBeDefined();
+      expect(helperRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+    });
+
+    it("should handle single ID object (not array)", () => {
+      const practitionerData = {
+        id: {
+          root: "2.16.840.1.113883.19.5",
+          extension: "67890",
+        },
+      };
+
+      const templateRes = renderPractitionerId(practitionerData);
+      const helperRes = functions.generatePractitionerId(practitionerData);
+
+      expect(templateRes).toBeDefined();
+      expect(helperRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+    });
+  });
+
+  describe("Practitioner with no ID field", () => {
+    it("should not generate UUID when no id field exists, even with assignedPerson.name", () => {
+      const practitionerData = {
+        assignedPerson: {
+          name: {
+            given: ["John"],
+            family: "Doe",
+          },
+        },
+        addr: {
+          streetAddressLine: ["123 Main St"],
+          city: "Anytown",
+          state: "CA",
+          postalCode: "12345",
+        },
+        telecom: [
+          {
+            value: "tel:+1-555-123-4567",
+          },
+        ],
+      };
+
+      const templateRes = renderPractitionerId(practitionerData);
+      const helperRes = functions.generatePractitionerId(practitionerData);
+
+      expect(templateRes).toBeUndefined();
+      expect(helperRes).toBeUndefined();
+    });
+  });
+
+  describe("Practitioner with ID field but invalid root/extension - fallback to name", () => {
+    it("should fall back to name-based generation when ID exists but missing root", () => {
+      const practitionerData = {
+        id: [
+          {
+            extension: "12345",
+          },
+        ],
+        assignedPerson: {
+          name: {
+            given: ["Should"],
+            family: "BeUsed",
+          },
+        },
+        addr: {
+          city: "SomeCity",
+        },
+        telecom: [
+          {
+            value: "tel:+1-555-999-9999",
+          },
+        ],
+      };
+
+      const templateRes = renderPractitionerId(practitionerData);
+      const helperRes = functions.generatePractitionerId(practitionerData);
+
+      expect(templateRes).toBeDefined();
+      expect(helperRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+      expect(typeof templateRes.Id).toBe("string");
+    });
+
+    it("should fall back to name-based generation when ID exists but missing extension", () => {
+      const practitionerData = {
+        id: [
+          {
+            root: "2.16.840.1.113883.19.5",
+          },
+        ],
+        assignedPerson: {
+          name: {
+            given: ["Should"],
+            family: "BeUsed",
+          },
+        },
+        addr: {
+          city: "SomeCity",
+        },
+        telecom: [
+          {
+            value: "tel:+1-555-999-9999",
+          },
+        ],
+      };
+
+      const templateRes = renderPractitionerId(practitionerData);
+      const helperRes = functions.generatePractitionerId(practitionerData);
+
+      expect(templateRes).toBeDefined();
+      expect(helperRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+      expect(typeof templateRes.Id).toBe("string");
+    });
+
+    it("should generate consistent UUIDs for same name data when falling back", () => {
+      const practitionerData = {
+        id: [
+          {
+            root: "2.16.840.1.113883.19.5",
+          },
+        ],
+        assignedPerson: {
+          name: {
+            given: ["Consistent"],
+            family: "Name",
+          },
+        },
+        addr: {
+          city: "SomeCity",
+        },
+        telecom: [
+          {
+            value: "tel:+1-555-999-9999",
+          },
+        ],
+      };
+
+      const templateRes1 = renderPractitionerId(practitionerData);
+      const templateRes2 = renderPractitionerId(practitionerData);
+      const helperRes1 = functions.generatePractitionerId(practitionerData);
+      const helperRes2 = functions.generatePractitionerId(practitionerData);
+
+      expect(templateRes1.Id).toBe(templateRes2.Id);
+      expect(helperRes1).toBe(helperRes2);
+      expect(templateRes1.Id).toBe(helperRes1);
+    });
+  });
+
+  describe("Edge cases and error handling", () => {
+    it("should handle empty practitioner object", () => {
+      const practitionerData = {};
+
+      const templateRes = renderPractitionerId(practitionerData);
+      const helperRes = functions.generatePractitionerId(practitionerData);
+
+      expect(templateRes).toBeUndefined();
+      expect(helperRes).toBeUndefined();
+    });
+
+    it("should handle null practitioner", () => {
+      const practitionerData = null;
+
+      const templateRes = renderPractitionerId(practitionerData);
+      const helperRes = functions.generatePractitionerId(practitionerData);
+
+      expect(templateRes).toBeUndefined();
+      expect(helperRes).toBeUndefined();
+    });
+
+    it("should handle undefined practitioner", () => {
+      const practitionerData = undefined;
+
+      const templateRes = renderPractitionerId(practitionerData);
+      const helperRes = functions.generatePractitionerId(practitionerData);
+
+      expect(templateRes).toBeUndefined();
+      expect(helperRes).toBeUndefined();
+    });
+
+    it("should handle assignedPerson without name", () => {
+      const practitionerData = {
+        assignedPerson: {},
+      };
+
+      const templateRes = renderPractitionerId(practitionerData);
+      const helperRes = functions.generatePractitionerId(practitionerData);
+
+      expect(templateRes).toBeUndefined();
+      expect(helperRes).toBeUndefined();
+    });
+  });
+
+  describe("Priority handling", () => {
+    it("should prioritize root/extension over assignedPerson when both exist", () => {
+      const practitionerData = {
+        id: [
+          {
+            root: "2.16.840.1.113883.19.5",
+            extension: "priority-test",
+          },
+        ],
+        assignedPerson: {
+          name: {
+            given: ["Should"],
+            family: "BeIgnored",
+          },
+        },
+      };
+
+      const templateRes = renderPractitionerId(practitionerData);
+      const helperRes = functions.generatePractitionerId(practitionerData);
+
+      expect(templateRes).toBeDefined();
+      expect(helperRes).toBeDefined();
+      expect(templateRes.Id).toBe(helperRes);
+
+      const nameBasedData = {
+        assignedPerson: {
+          name: {
+            given: ["Should"],
+            family: "BeIgnored",
+          },
+        },
+      };
+      const nameBasedResult = functions.generatePractitionerId(nameBasedData);
+      expect(templateRes.Id).not.toBe(nameBasedResult);
+      expect(nameBasedResult).toBeUndefined();
+    });
+  });
+
+  describe("Template structure validation", () => {
+    it("should handle template compilation without errors", () => {
+      expect(() => {
+        const templatePath = path.join(
+          __dirname,
+          "../../../templates/cda/Utils/GeneratePractitionerId.hbs"
+        );
+        const templateContent = fs.readFileSync(templatePath, "utf8");
+        handlebarsInstance.compile(templateContent);
+      }).not.toThrow();
+    });
+  });
+});

--- a/packages/fhir-converter/src/lib/handlebars-converter/__tests__/period.test.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/__tests__/period.test.js
@@ -1,0 +1,246 @@
+const fs = require("fs");
+const path = require("path");
+const Handlebars = require("handlebars");
+const helpers = require("../handlebars-helpers").external;
+const functions = require("../handlebars-helpers").internal;
+
+describe("Period.hbs template vs buildPeriod helper tests", function () {
+  let handlebarsInstance;
+  let periodTemplate;
+
+  beforeAll(() => {
+    handlebarsInstance = Handlebars.create();
+
+    helpers.forEach(helper => {
+      handlebarsInstance.registerHelper(helper.name, helper.func);
+    });
+
+    const templatePath = path.join(__dirname, "../../../templates/cda/DataType/Period.hbs");
+    const templateContent = fs.readFileSync(templatePath, "utf8");
+    periodTemplate = handlebarsInstance.compile(templateContent);
+  });
+
+  const renderPeriod = periodData => {
+    const result = periodTemplate({ period: periodData });
+    // Clean up the templateRes by removing trailing comma and parsing JSON
+    const cleanResult = result.replace(/,\s*}/g, "}").replace(/,\s*$/, "");
+    return JSON.parse(cleanResult);
+  };
+
+  describe("Valid period with both low and high dates (start <= end)", () => {
+    it("should render both start and end dates when low <= high", () => {
+      const periodData = {
+        low: { value: "20240101" },
+        high: { value: "20240131" },
+      };
+
+      const templateRes = renderPeriod(periodData);
+      const helperRes = functions.buildPeriod(periodData);
+
+      expect(templateRes).toEqual(helperRes);
+      expect(templateRes.start).toBe("2024-01-01T00:00:00.000Z");
+      expect(templateRes.end).toBe("2024-01-31T00:00:00.000Z");
+    });
+
+    it("should render both start and end dates when low equals high", () => {
+      const periodData = {
+        low: { value: "20240115" },
+        high: { value: "20240115" },
+      };
+
+      const templateRes = renderPeriod(periodData);
+      const helperRes = functions.buildPeriod(periodData);
+
+      expect(templateRes).toEqual(helperRes);
+      expect(templateRes.start).toBe("2024-01-15T00:00:00.000Z");
+      expect(templateRes.end).toBe("2024-01-15T00:00:00.000Z");
+    });
+
+    it("should handle datetime values with time components", () => {
+      const periodData = {
+        low: { value: "20240101120000" },
+        high: { value: "20240101180000" },
+      };
+
+      const templateRes = renderPeriod(periodData);
+      const helperRes = functions.buildPeriod(periodData);
+
+      expect(templateRes).toEqual(helperRes);
+      expect(templateRes.start).toBe("2024-01-01T12:00:00.000Z");
+      expect(templateRes.end).toBe("2024-01-01T18:00:00.000Z");
+    });
+  });
+
+  describe("Invalid period with low > high", () => {
+    it("should render only start date when low > high", () => {
+      const periodData = {
+        low: { value: "20240131" },
+        high: { value: "20240101" },
+      };
+
+      const templateRes = renderPeriod(periodData);
+      const helperRes = functions.buildPeriod(periodData);
+
+      expect(templateRes).toEqual(helperRes);
+      expect(templateRes.start).toBe("2024-01-31T00:00:00.000Z");
+    });
+  });
+
+  describe("Period with only low date", () => {
+    it("should render only start date when only low is provided", () => {
+      const periodData = {
+        low: { value: "20240115" },
+      };
+
+      const templateRes = renderPeriod(periodData);
+      const helperRes = functions.buildPeriod(periodData);
+
+      expect(templateRes).toEqual(helperRes);
+      expect(templateRes).not.toHaveProperty("end");
+      expect(templateRes.start).toBe("2024-01-15T00:00:00.000Z");
+    });
+  });
+
+  describe("Period with only high date", () => {
+    it("should render only end date when only high is provided", () => {
+      const periodData = {
+        high: { value: "20240131" },
+      };
+
+      const templateRes = renderPeriod(periodData);
+      const helperRes = functions.buildPeriod(periodData);
+
+      expect(templateRes).toEqual(helperRes);
+      expect(templateRes).not.toHaveProperty("start");
+      expect(templateRes.end).toBe("2024-01-31T00:00:00.000Z");
+    });
+  });
+
+  describe("Period with only value (fallback case)", () => {
+    it("should render start date from period.value when no low/high", () => {
+      const periodData = {
+        value: "20240115",
+      };
+
+      const templateRes = renderPeriod(periodData);
+      const helperRes = functions.buildPeriod(periodData);
+
+      expect(templateRes).toEqual(helperRes);
+      expect(templateRes).not.toHaveProperty("end");
+      expect(templateRes.start).toBe("2024-01-15T00:00:00.000Z");
+    });
+  });
+
+  describe("Edge cases and error handling", () => {
+    it("should handle empty period object", () => {
+      const periodData = {};
+
+      const templateRes = renderPeriod(periodData);
+
+      expect(templateRes).not.toHaveProperty("end");
+      expect(templateRes).toHaveProperty("start");
+      expect(templateRes.start).toBe("");
+    });
+
+    it("should handle null period", () => {
+      const periodData = null;
+
+      const templateRes = renderPeriod(periodData);
+      const helperRes = functions.buildPeriod(periodData);
+
+      expect(templateRes).toEqual(helperRes);
+      expect(templateRes).toHaveProperty("start");
+      expect(templateRes.start).toBe("");
+    });
+
+    it("should handle invalid date formats gracefully", () => {
+      const periodData = {
+        low: { value: "invalid-date" },
+        high: { value: "20240131" },
+      };
+
+      const templateRes = renderPeriod(periodData);
+      const helperRes = functions.buildPeriod(periodData);
+
+      expect(templateRes).toEqual(helperRes);
+      expect(templateRes).not.toHaveProperty("end");
+      expect(templateRes).toHaveProperty("start");
+      expect(templateRes.start).toBe("");
+    });
+
+    it("should handle dates before 1900", () => {
+      const periodData = {
+        low: { value: "18991231" },
+        high: { value: "20240131" },
+      };
+
+      const templateRes = renderPeriod(periodData);
+      const helperRes = functions.buildPeriod(periodData);
+
+      expect(templateRes).toEqual(helperRes);
+      expect(templateRes).toHaveProperty("start");
+      expect(templateRes).not.toHaveProperty("end");
+      expect(templateRes.start).toBe("");
+    });
+  });
+
+  describe("Integration with helper functions", () => {
+    it("should use formatAsDateTime helper correctly", () => {
+      const periodData = {
+        low: { value: "20240101120000" },
+        high: { value: "20240101180000" },
+      };
+
+      // Test the helper function directly
+      const formattedLow = functions.getDateTime("20240101120000");
+      const formattedHigh = functions.getDateTime("20240101180000");
+
+      expect(formattedLow).toBe("2024-01-01T12:00:00.000Z");
+      expect(formattedHigh).toBe("2024-01-01T18:00:00.000Z");
+
+      const templateRes = renderPeriod(periodData);
+      const helperRes = functions.buildPeriod(periodData);
+
+      expect(templateRes).toEqual(helperRes);
+      expect(templateRes.start).toBe(formattedLow);
+      expect(templateRes.end).toBe(formattedHigh);
+    });
+
+    it("should use startDateLteEndDate helper correctly", () => {
+      // Test the helper function directly
+      const validPeriod = functions.startDateLteEndDate("20240101", "20240131");
+      const invalidPeriod = functions.startDateLteEndDate("20240131", "20240101");
+      const equalDates = functions.startDateLteEndDate("20240115", "20240115");
+
+      expect(validPeriod).toBe(true);
+      expect(invalidPeriod).toBe(false);
+      expect(equalDates).toBe(true);
+    });
+  });
+
+  describe("Template structure validation", () => {
+    it("should produce valid JSON structure", () => {
+      const periodData = {
+        low: { value: "20240101" },
+        high: { value: "20240131" },
+      };
+
+      const templateRes = renderPeriod(periodData);
+
+      // Verify the structure is valid JSON
+      expect(() => JSON.stringify(templateRes)).not.toThrow();
+
+      // Verify it has the expected properties
+      expect(typeof templateRes).toBe("object");
+      expect(templateRes).not.toBeNull();
+    });
+
+    it("should handle template compilation without errors", () => {
+      expect(() => {
+        const templatePath = path.join(__dirname, "../../../templates/cda/DataType/Period.hbs");
+        const templateContent = fs.readFileSync(templatePath, "utf8");
+        handlebarsInstance.compile(templateContent);
+      }).not.toThrow();
+    });
+  });
+});

--- a/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
@@ -385,12 +385,20 @@ var buildPeriod = function (period) {
   return result;
 };
 
+/**
+ * Returns a valid CarePlan.activity.status value from a status code.
+ *
+ * not-started | scheduled | in-progress | on-hold | completed | cancelled | stopped | unknown | entered-in-error
+ * @param {string} statusCode - The status code to validate.
+ * @returns {string} - Returns the status code if it is valid, otherwise undefined.
+ */
 var getCarePlanActivityStatus = function (statusCode) {
-  if (!statusCode) return undefined;
+  if (!statusCode) return "unknown";
   if (validCarePlanActivityStatusCodes.includes(statusCode.trim().toLowerCase())) {
     return statusCode;
   }
-  return undefined;
+
+  return "unknown";
 };
 
 // convert the dateString to date string with hyphens

--- a/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
@@ -1866,7 +1866,6 @@ module.exports.external = [
       const performer = encounter.performer?.assignedEntity;
       if (performer) {
         const performerId = generatePractitionerId(performer);
-
         detail.performer = [
           {
             reference: `Practitioner/${performerId}`,

--- a/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
@@ -264,8 +264,8 @@ var buildCoding = function (code, canBeUnknown = false) {
     display: code.displayName
       ? parseReferenceData(code.displayName)
       : canBeUnknown
-      ? "unknown"
-      : undefined,
+        ? "unknown"
+        : undefined,
     version: code.codeSystemVersion,
     system: getSystemUrl(code.codeSystem, canBeUnknown),
   };

--- a/packages/fhir-converter/src/templates/cda/DataType/CodeableConcept.hbs
+++ b/packages/fhir-converter/src/templates/cda/DataType/CodeableConcept.hbs
@@ -24,6 +24,7 @@
   //     CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.  
   // -------------------------------------------------------------------------------------------------
 --}}
+{{!-- @warning - If you are updating this, please also update the buildCoding helper function in the handlebars-helpers.js file. --}}
 {
 	{{#if code.originalText}}
 		"text":"{{{parseReferenceData code.originalText._ }}}",

--- a/packages/fhir-converter/src/templates/cda/DataType/Narrative.hbs
+++ b/packages/fhir-converter/src/templates/cda/DataType/Narrative.hbs
@@ -1,0 +1,4 @@
+{        
+  "status": "generated",
+  "div": "{{{parseReferenceData narrative}}}"
+}

--- a/packages/fhir-converter/src/templates/cda/DataType/Narrative.hbs
+++ b/packages/fhir-converter/src/templates/cda/DataType/Narrative.hbs
@@ -1,4 +1,0 @@
-{        
-  "status": "generated",
-  "div": "{{{parseReferenceData narrative}}}"
-}

--- a/packages/fhir-converter/src/templates/cda/DataType/Period.hbs
+++ b/packages/fhir-converter/src/templates/cda/DataType/Period.hbs
@@ -24,6 +24,7 @@
   //     CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.  
   // -------------------------------------------------------------------------------------------------
 --}}
+{{!-- @warning - If you are updating this, please also update the buildPeriod function in the handlebars-helpers.js file. --}}
 {
     {{#if (and (and period.low period.high) (startDateLteEndDate period.low.value period.high.value) )}}
         "start":"{{formatAsDateTime period.low.value}}",

--- a/packages/fhir-converter/src/templates/cda/Resources/CarePlan.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/CarePlan.hbs
@@ -14,7 +14,7 @@
         {{/if}}
 
         "status":{{>ValueSet/CarePlanStatus.hbs code=encounter.statusCode.code}},
-        "intent":{{>ValueSet/CarePlanIntent.hbs code=encounter.statusCode.intent}},
+        "intent":{{>ValueSet/CarePlanIntent.hbs code="plan"}},
 
         {{#if encounter.code.originalText._}}
             "description": "{{encounter.code.originalText._}}",

--- a/packages/fhir-converter/src/templates/cda/Resources/CarePlan.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/CarePlan.hbs
@@ -40,6 +40,6 @@
     },
     "request":{
         "method":"PUT",
-        "url":"Encounter/{{ID}}",
+        "url":"CarePlan/{{ID}}",
     },
 },

--- a/packages/fhir-converter/src/templates/cda/Resources/CarePlan.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/CarePlan.hbs
@@ -1,0 +1,45 @@
+{
+    "fullUrl": "urn:uuid:{{ID}}",
+    "resource": {
+        "resourceType": "CarePlan",
+        "id":"{{ID}}",
+        "identifier":
+        [
+        	{{#each (toArray encounter.id)}}
+        		{{>DataType/Identifier.hbs id=this}},
+            {{/each}}
+        ],
+        {{#if encounter.text}}
+            "text": {{>DataType/Narrative.hbs narrative=encounter.text._b64}},
+        {{/if}}
+
+        "status":{{>ValueSet/CarePlanStatus.hbs code=encounter.statusCode.code}},
+        "intent":{{>ValueSet/CarePlanIntent.hbs code=encounter.statusCode.intent}},
+
+        {{#if encounter.code.originalText._}}
+            "description": "{{encounter.code.originalText._}}",
+        {{/if}}
+
+        "category":[
+            {{>DataType/CodeableConcept.hbs code=encounter.categoryCode}}
+        ],
+
+        "period": {{>DataType/Period.hbs period=encounter.effectiveTime}},
+
+        {{#if encounter.author.time.low.value}}
+            "created": "{{formatAsDateTime encounter.author.time.low.value}}",
+        {{else if encounter.author.time.value}}
+            "created": "{{formatAsDateTime encounter.author.time.value}}",
+        {{/if}}
+
+        {{#with (getActivityFromTreatmentPlanEncounter encounter) as |activity|}}
+            {{#if activity}}    
+                "activity":{{{activity}}},
+            {{/if}}
+        {{/with}}
+    },
+    "request":{
+        "method":"PUT",
+        "url":"Encounter/{{ID}}",
+    },
+},

--- a/packages/fhir-converter/src/templates/cda/Resources/CarePlan.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/CarePlan.hbs
@@ -9,9 +9,6 @@
         		{{>DataType/Identifier.hbs id=this}},
             {{/each}}
         ],
-        {{#if encounter.text}}
-            "text": {{>DataType/Narrative.hbs narrative=encounter.text._b64}},
-        {{/if}}
 
         "status":{{>ValueSet/CarePlanStatus.hbs code=encounter.statusCode.code}},
         "intent":{{>ValueSet/CarePlanIntent.hbs code="plan"}},

--- a/packages/fhir-converter/src/templates/cda/Sections/CarePlan.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/CarePlan.hbs
@@ -1,0 +1,33 @@
+{{#if (contains (toString (toJsonString msg)) '2.16.840.1.113883.10.20.22.2.10')}}
+    {{#with (getFirstCdaSectionsByTemplateId msg '2.16.840.1.113883.10.20.22.2.10')}}
+        {{#each (toArray 2_16_840_1_113883_10_20_22_2_10.entry) as |careplanEntry|}}
+            {{#if careplanEntry.encounter}}
+                {{>Resources/CarePlan.hbs encounter=careplanEntry.encounter performer=careplanEntry.encounter.performer.assignedEntity ID=(generateUUID (toJsonString careplanEntry))}},
+                {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                    {{>References/CarePlan/subject.hbs ID=(generateUUID (toJsonString careplanEntry)) REF=(concat 'Patient/' patientId.Id)}},
+                {{/with}}
+            {{/if}}
+
+            {{#if careplanEntry.encounter.author.assignedAuthor.representedOrganization}}
+                {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=careplanEntry.encounter.author.assignedAuthor.representedOrganization) as |orgId|}}
+                    {{>Resources/Organization.hbs org=careplanEntry.encounter.author.assignedAuthor ID=orgId.Id}},
+                    {{>References/CarePlan/author.hbs ID=(generateUUID (toJsonString careplanEntry)) REF=(concat 'Organization/' orgId.Id)}},
+                {{/with}}
+            {{/if}}
+
+            {{#if careplanEntry.encounter.performer.assignedEntity}}
+                {{#with (generatePractitionerId careplanEntry.encounter.performer.assignedEntity) as |practitionerId|}}
+                    {{>Resources/Practitioner.hbs practitioner=careplanEntry.encounter.performer.assignedEntity ID=practitionerId.Id}},
+                    {{!-- Reference to the Practitioner is generated at the time of CarePlan resource generation --}}
+                {{/with}}
+            {{/if}}
+            
+            {{#if careplanEntry.encounter.participant.participantRole}}
+                {{#with (generateLocationId careplanEntry.encounter.participant.participantRole) as |locationId|}}
+                    {{>Resources/Location.hbs location=careplanEntry.encounter.participant.participantRole playingEntity=careplanEntry.encounter.participant.participantRole.playingEntity ID=locationId}},
+                    {{!-- Reference to the Location is generated at the time of CarePlan resource generation --}}
+                {{/with}}
+            {{/if}}
+        {{/each}}
+    {{/with}}
+{{/if}}

--- a/packages/fhir-converter/src/templates/cda/Sections/CarePlan.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/CarePlan.hbs
@@ -6,27 +6,28 @@
                 {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
                     {{>References/CarePlan/subject.hbs ID=(generateUUID (toJsonString careplanEntry)) REF=(concat 'Patient/' patientId.Id)}},
                 {{/with}}
-            {{/if}}
-
-            {{#if careplanEntry.encounter.author.assignedAuthor.representedOrganization}}
-                {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=careplanEntry.encounter.author.assignedAuthor.representedOrganization) as |orgId|}}
-                    {{>Resources/Organization.hbs org=careplanEntry.encounter.author.assignedAuthor ID=orgId.Id}},
-                    {{>References/CarePlan/author.hbs ID=(generateUUID (toJsonString careplanEntry)) REF=(concat 'Organization/' orgId.Id)}},
-                {{/with}}
-            {{/if}}
-
-            {{#if careplanEntry.encounter.performer.assignedEntity}}
-                {{#with (generatePractitionerId careplanEntry.encounter.performer.assignedEntity) as |practitionerId|}}
-                    {{>Resources/Practitioner.hbs practitioner=careplanEntry.encounter.performer.assignedEntity ID=practitionerId}},
-                    {{!-- Reference to the Practitioner is generated at the time of CarePlan resource generation --}}
-                {{/with}}
-            {{/if}}
             
-            {{#if careplanEntry.encounter.participant.participantRole}}
-                {{#with (generateLocationId careplanEntry.encounter.participant.participantRole) as |locationId|}}
-                    {{>Resources/Location.hbs location=careplanEntry.encounter.participant.participantRole playingEntity=careplanEntry.encounter.participant.participantRole.playingEntity ID=locationId}},
-                    {{!-- Reference to the Location is generated at the time of CarePlan resource generation --}}
-                {{/with}}
+                {{#if careplanEntry.encounter.author.assignedAuthor.representedOrganization}}
+                    {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=careplanEntry.encounter.author.assignedAuthor.representedOrganization) as |orgId|}}
+                        {{>Resources/Organization.hbs org=careplanEntry.encounter.author.assignedAuthor ID=orgId.Id}},
+                        {{>References/CarePlan/author.hbs ID=(generateUUID (toJsonString careplanEntry)) REF=(concat 'Organization/' orgId.Id)}},
+                    {{/with}}
+                {{/if}}
+
+                {{#if careplanEntry.encounter.performer.assignedEntity}}
+                    {{#with (generatePractitionerId careplanEntry.encounter.performer.assignedEntity) as |practitionerId|}}
+                        {{>Resources/Practitioner.hbs practitioner=careplanEntry.encounter.performer.assignedEntity ID=practitionerId}},
+                        {{!-- Reference to the Practitioner is generated at the time of CarePlan resource generation --}}
+                    {{/with}}
+                {{/if}}
+                
+                {{#if careplanEntry.encounter.participant.participantRole}}
+                    {{#with (generateLocationId careplanEntry.encounter.participant.participantRole) as |locationId|}}
+                        {{>Resources/Location.hbs location=careplanEntry.encounter.participant.participantRole playingEntity=careplanEntry.encounter.participant.participantRole.playingEntity ID=locationId}},
+                        {{!-- Reference to the Location is generated at the time of CarePlan resource generation --}}
+                    {{/with}}
+                {{/if}}
+                
             {{/if}}
         {{/each}}
     {{/with}}

--- a/packages/fhir-converter/src/templates/cda/Sections/CarePlan.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/CarePlan.hbs
@@ -17,7 +17,7 @@
 
             {{#if careplanEntry.encounter.performer.assignedEntity}}
                 {{#with (generatePractitionerId careplanEntry.encounter.performer.assignedEntity) as |practitionerId|}}
-                    {{>Resources/Practitioner.hbs practitioner=careplanEntry.encounter.performer.assignedEntity ID=practitionerId.Id}},
+                    {{>Resources/Practitioner.hbs practitioner=careplanEntry.encounter.performer.assignedEntity ID=practitionerId}},
                     {{!-- Reference to the Practitioner is generated at the time of CarePlan resource generation --}}
                 {{/with}}
             {{/if}}

--- a/packages/fhir-converter/src/templates/cda/Utils/GenerateLocationId.hbs
+++ b/packages/fhir-converter/src/templates/cda/Utils/GenerateLocationId.hbs
@@ -24,11 +24,17 @@
   //     CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.  
   // -------------------------------------------------------------------------------------------------
 --}}
-{{!-- ID composed of code, addr, name --}}
+
+{{!-- @deprecated - Use the generateLocationId from the helpers file instead --}}
+{{!-- TODO: Migrate away from using this anywhere in the Converter. --}}
+{{!-- @warning - If you are updating this, please also update the generateLocationId function in the handlebars-helpers.js file --}}
 {
+    {{!-- ID composed of code, addr, name --}}
     {{#if location.location.addr}}
         "Id": "{{generateUUID (concatDefined location.location.addr location.location.name location.code)}}"
     {{else if location.addr}}
         "Id": "{{generateUUID (concatDefined location.addr location.playingEntity.name location.code)}}"
+    {{else if location.playingEntity.name}}
+        "Id": "{{generateUUID location.playingEntity.name}}"
     {{/if}}
 }

--- a/packages/fhir-converter/src/templates/cda/Utils/GenerateLocationId.hbs
+++ b/packages/fhir-converter/src/templates/cda/Utils/GenerateLocationId.hbs
@@ -25,8 +25,6 @@
   // -------------------------------------------------------------------------------------------------
 --}}
 
-{{!-- @deprecated - Use the generateLocationId from the helpers file instead --}}
-{{!-- TODO: Migrate away from using this anywhere in the Converter. --}}
 {{!-- @warning - If you are updating this, please also update the generateLocationId function in the handlebars-helpers.js file --}}
 {
     {{!-- ID composed of code, addr, name --}}

--- a/packages/fhir-converter/src/templates/cda/Utils/GeneratePractitionerId.hbs
+++ b/packages/fhir-converter/src/templates/cda/Utils/GeneratePractitionerId.hbs
@@ -28,6 +28,7 @@
 {{!-- @deprecated - Use the generatePractitionerId from the helpers file instead --}}
 {{!-- TODO: Migrate away from using this anywhere in the Converter. --}}
 {{!-- @warning - If you are updating this, please also update the generatePractitionerId function in the handlebars-helpers.js file --}}
+{{!-- TODO ENG-640: Fix the logic. If the external ID isn't present, we should still generate a UUID from the name, addr, and telecom --}}
 {{#with (elementAt (toArray obj.id) 0) as |FirstId|}}
     {{!-- Id composed of root and extension if they both exist, else name addr telecom --}}
     {

--- a/packages/fhir-converter/src/templates/cda/Utils/GeneratePractitionerId.hbs
+++ b/packages/fhir-converter/src/templates/cda/Utils/GeneratePractitionerId.hbs
@@ -24,8 +24,12 @@
   //     CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.  
   // -------------------------------------------------------------------------------------------------
 --}}
-{{!-- Id composed of root and extension if they both exist, else name addr telecom --}}
+
+{{!-- @deprecated - Use the generatePractitionerId from the helpers file instead --}}
+{{!-- TODO: Migrate away from using this anywhere in the Converter. --}}
+{{!-- @warning - If you are updating this, please also update the generatePractitionerId function in the handlebars-helpers.js file --}}
 {{#with (elementAt (toArray obj.id) 0) as |FirstId|}}
+    {{!-- Id composed of root and extension if they both exist, else name addr telecom --}}
     {
         "Id":
             {{#if (and FirstId.root FirstId.extension)}}

--- a/packages/fhir-converter/src/templates/cda/ValueSet/CarePlanIntent.hbs
+++ b/packages/fhir-converter/src/templates/cda/ValueSet/CarePlanIntent.hbs
@@ -1,0 +1,18 @@
+{{!-- 
+  // The list of possible values for the intent element in a CarePlan resource.
+  // See https://hl7.org/fhir/R4/careplan.html for reference.
+ --}}
+ {{!-- proposal | plan | order | option --}}
+{{#with (toLower code) as |normalizedCode|}}
+	{{#if (eq normalizedCode 'proposal')}}
+		"proposal"
+	{{else if (eq normalizedCode 'plan')}}
+		"plan"
+	{{else if (eq normalizedCode 'order')}}
+		"order"
+	{{else if (eq normalizedCode 'option')}}
+		"option"
+	{{else}}
+		"plan"
+	{{/if}}
+{{/with}}

--- a/packages/fhir-converter/src/templates/cda/ValueSet/CarePlanStatus.hbs
+++ b/packages/fhir-converter/src/templates/cda/ValueSet/CarePlanStatus.hbs
@@ -1,0 +1,21 @@
+{{!-- 
+  // The list of possible values for the status element in a CarePlan resource.
+  // See https://hl7.org/fhir/R4/careplan.html for reference.
+ --}}
+{{#with (toLower code) as |normalizedCode|}}
+	{{#if (eq normalizedCode 'draft')}}
+		"draft"
+	{{else if (eq normalizedCode 'active')}}
+		"active"
+	{{else if (eq normalizedCode 'on-hold')}}
+		"on-hold"
+	{{else if (eq normalizedCode 'revoked')}}
+		"revoked"
+	{{else if (eq normalizedCode 'completed')}}
+		"completed"
+	{{else if (eq normalizedCode 'entered-in-error')}}
+		"entered-in-error"
+	{{else}}
+		"unknown"
+	{{/if}}
+{{/with}}

--- a/packages/fhir-converter/src/templates/cda/ValueSet/NarrativeStatus.hbs
+++ b/packages/fhir-converter/src/templates/cda/ValueSet/NarrativeStatus.hbs
@@ -1,0 +1,11 @@
+{{!-- 
+  // The list of possible values for the status element in a CarePlan resource.
+  // See https://hl7.org/fhir/R4/careplan.html for reference.
+ --}}
+{{#with (toLower code) as |normalizedCode|}}
+	{{#if (eq normalizedCode 'generated')}}
+		"generated"
+	{{else}}
+		"additional"
+	{{/if}}
+{{/with}}

--- a/packages/fhir-converter/src/templates/cda/ccd.hbs
+++ b/packages/fhir-converter/src/templates/cda/ccd.hbs
@@ -38,6 +38,8 @@
 
       {{>Sections/Encounters.hbs}},
 
+      {{>Sections/CarePlan.hbs}},
+
       {{>Sections/Family_history.hbs}},
 
       {{>Sections/Functional_Status.hbs}},


### PR DESCRIPTION
Part of ENG-419

Issues:

- https://linear.app/metriport/issue/ENG-419

### Description
- Plan of Treatment section converted
  - encounter-based only for v0 - [context](https://metriport.slack.com/archives/C06CQC7GQG3/p1752129443914039?thread_ts=1752126634.007549&cid=C06CQC7GQG3)
- CarePlan resource built using .hbs templates
- CarePlan.activity field built thru the .js helpers
  - New function in helpers - `getActivityFromTreatmentPlanEncounter`  
- Some existing helper functions from `.hbs` files replicated onto the helpers
  - `GeneratePractitionerId.hbs`
  - `GenerateLocationId.hbs`
  - `Period.hbs`
  - `CodeableConcept.hbs`
  - `Coding.hbs`
- Added deduplication logic for CarePlan

### Testing
- Local
  - [x] Converting a bunch of docs and confirming payloads are good
    - i.e. the CarePlan resources contain the expected fields with the correct information 
  - [x] Running old vs new practitioner ID generation to make sure the methods are identical
  - [x] Running old vs new location ID generation to make sure the methods are identical
  - [x] Run FHIR test suite to ensure that more docs don't start to fail the conversion
    - checked the number of resources from the tests, and the changes are as expected - now we have CarePlans, and we have more Location, Practitioner, Organization resources (see img below)
  - [x] Created consolidated bundles for a handful of patients and checked that the resulting deduplicated CarePlans look good 
  - [ ] Validate FHIR output
<img width="1064" height="410" alt="Screenshot 2025-07-11 at 1 25 54 AM" src="https://github.com/user-attachments/assets/84bfd83e-8d29-4abb-bff7-3c10df20c7c5" />

- Staging
  - [ ] TBD
- Production
  - [ ] TBD

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for FHIR CarePlan resource extraction, deduplication, and reference management.
  * Introduced new Handlebars templates for CarePlan resources, intent, status, and narrative status.
  * CarePlan resources are now generated from CDA input and included in CCD bundles.

* **Bug Fixes**
  * Improved reference replacement logic for CarePlan-specific fields.

* **Tests**
  * Added comprehensive test suites for practitioner/location ID and period template helpers to ensure correct and consistent output.

* **Chores**
  * Added comments and warnings to templates to ensure synchronization with helper functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->