### PR TITLE
ENG-652 Don't delete orgs at CQ, just mark them as inactive

### DIFF
--- a/packages/api/src/external/carequality/command/cq-organization/__tests__/carequality-fhir-mock.ts
+++ b/packages/api/src/external/carequality/command/cq-organization/__tests__/carequality-fhir-mock.ts
@@ -40,11 +40,17 @@ export class CarequalityManagementApiFhirMock extends CarequalityManagementApiFh
     }
   }
 
-  override async deleteOrganization(oid: string): Promise<void> {
+  override async deleteOrganization(oid: string): Promise<OrganizationWithId>;
+  override async deleteOrganization(org: OrganizationWithId): Promise<OrganizationWithId>;
+  override async deleteOrganization(
+    oidOrOrg: string | OrganizationWithId
+  ): Promise<OrganizationWithId> {
     if (getApiMode() === APIMode.production) {
       throw new Error("deleteOrganization cannot be run in production");
-    } else {
-      return super.deleteOrganization(oid);
     }
+    if (typeof oidOrOrg === "string") {
+      return super.deleteOrganization(oidOrOrg);
+    }
+    return super.deleteOrganization(oidOrOrg);
   }
 }

--- a/packages/api/src/external/carequality/command/cq-organization/__tests__/carequality-fhir.test.e2e.ts
+++ b/packages/api/src/external/carequality/command/cq-organization/__tests__/carequality-fhir.test.e2e.ts
@@ -214,19 +214,27 @@ describe("CarequalityManagementApiFhir", () => {
       it.skip("deleteOrganization", () => {});
       return;
     } else {
-      it("deletes the organization", async () => {
+      it("soft-deletes the organization", async () => {
         const oid = getOid();
         const orgBeforeDelete = await api.getOrganization(oid);
         expect(orgBeforeDelete).toBeDefined();
-        await api.deleteOrganization(oid);
-        const orgAfterDelete = await api.getOrganization(oid);
-        expect(orgAfterDelete).toBeUndefined();
+        if (!orgBeforeDelete) throw new Error("programming error");
+        expect(orgBeforeDelete.active).toBe(true);
+
+        const orgAfterDelete = await api.deleteOrganization(oid);
+        expect(orgAfterDelete).toBeDefined();
+        if (!orgAfterDelete) throw new Error("programming error");
+        expect(orgAfterDelete.active).toBe(false);
+
+        const orgAfterGet = await api.getOrganization(oid);
+        expect(orgAfterGet).toBeDefined();
+        if (!orgAfterGet) throw new Error("programming error");
+        expect(orgAfterGet.active).toBe(false);
       });
 
-      it("does not throw when deleting a non-existent organization", async () => {
+      it("throws when deleting a non-existent organization", async () => {
         const oid = makeOid();
-        await api.deleteOrganization(oid);
-        expect(true).toBeTruthy();
+        await expect(api.deleteOrganization(oid)).rejects.toThrow();
       });
     }
   });

--- a/packages/api/src/external/fhir/document/index.ts
+++ b/packages/api/src/external/fhir/document/index.ts
@@ -23,7 +23,7 @@ import {
   GenderCodes,
   HumanName as CWHumanName,
 } from "@metriport/commonwell-sdk";
-import { Gender } from "@metriport/commonwell-sdk/src/models/demographics";
+import { Gender } from "@metriport/commonwell-sdk/models/demographics";
 import { joinName, Patient, splitName } from "@metriport/core/domain/patient";
 import { cwExtension } from "@metriport/core/external/commonwell/extension";
 import { toFHIRSubject } from "@metriport/core/external/fhir/patient/conversion";
@@ -79,11 +79,11 @@ export function getBestDateFromCWDocRef(content: DocumentContent): string {
 }
 
 // TODO: Move to external/commonwell
-export const cwToFHIR = (
+export function cwToFHIR(
   docId: string,
   doc: CWDocumentWithMetriportData,
   patient: Pick<Patient, "id">
-): DocumentReferenceWithId => {
+): DocumentReferenceWithId {
   const content = doc.content;
   const baseAttachment = {
     contentType: doc.metriport.fileContentType,
@@ -139,7 +139,7 @@ export const cwToFHIR = (
     extension: [cwExtension],
     context: content.context,
   });
-};
+}
 
 export function getFHIRDocRef(
   patientId: string,

--- a/packages/carequality-sdk/src/client/carequality-fhir.ts
+++ b/packages/carequality-sdk/src/client/carequality-fhir.ts
@@ -116,13 +116,6 @@ export class CarequalityManagementApiFhir implements CarequalityManagementApi {
     return this.api.put(url, data, { headers: this.buildHeaders(headers) });
   }
 
-  private async sendDeleteRequest(
-    url: string,
-    headers?: Record<string, string>
-  ): Promise<AxiosResponse> {
-    return this.api.delete(url, { headers: this.buildHeaders(headers) });
-  }
-
   private isNotFoundError(error: AxiosError): boolean {
     if (error.response && [404, 410].includes(error.response?.status)) return true;
     return false;
@@ -186,8 +179,31 @@ export class CarequalityManagementApiFhir implements CarequalityManagementApi {
     return resp.data;
   }
 
-  async deleteOrganization(oid: string): Promise<void> {
-    const url = `${CarequalityManagementApiFhir.ORG_ENDPOINT}/${oid}`;
-    await this.sendDeleteRequest(url);
+  /**
+   * Marks an organization as inactive in the Carequality directory.
+   * The API doesn't support DELETE, so we need to send an update to disable it.
+   * The API doesn't support PATCH operations, so we need to load the Org and then update it.
+   * @param oid the OID of the organization to delete
+   * @returns the organization with the active flag set to false
+   */
+  async deleteOrganization(oid: string): Promise<OrganizationWithId>;
+  /**
+   * Marks an organization as inactive in the Carequality directory.
+   * The API doesn't support DELETE, so we need to send an update to disable it.
+   * The API doesn't support PATCH operations, so issue a PUT instead.
+   * @param org the organization to delete
+   * @returns the organization with the active flag set to false
+   */
+  async deleteOrganization(org: OrganizationWithId): Promise<OrganizationWithId>;
+  async deleteOrganization(oidOrOrg: string | OrganizationWithId): Promise<OrganizationWithId> {
+    if (typeof oidOrOrg === "string") {
+      const org = await this.getOrganization(oidOrOrg);
+      if (!org) throw new Error(`Organization with OID ${oidOrOrg} not found`);
+      org.active = false;
+      return this.updateOrganization(org);
+    }
+    const org: OrganizationWithId = oidOrOrg;
+    org.active = false;
+    return this.updateOrganization(org);
   }
 }

--- a/packages/carequality-sdk/src/client/carequality.ts
+++ b/packages/carequality-sdk/src/client/carequality.ts
@@ -58,9 +58,15 @@ export interface CarequalityManagementApi {
   updateOrganization(org: OrganizationWithId): Promise<OrganizationWithId>;
 
   /**
-   * Removes an organization from the Carequality directory.
+   * Deactivates an organization in the Carequality directory.
    *
    * @param oid the OID of the organization to delete
    */
-  deleteOrganization(oid: string): Promise<void>;
+  deleteOrganization(oid: string): Promise<OrganizationWithId>;
+  /**
+   * Deactivates an organization in the Carequality directory.
+   *
+   * @param org the organization to delete
+   */
+  deleteOrganization(org: OrganizationWithId): Promise<OrganizationWithId>;
 }


### PR DESCRIPTION
### Dependencies

none

### Description

Don't delete orgs at CQ, just mark them as inactive.

### Testing

- Local
  - [x] `carequality-fhir.test.e2e.ts` runs successfully
- Staging
  - [ ] E2E tests are successful
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Publish NPM package
- [ ] Merge this
