### PR TITLE
ENG-615: Fixes the array typecasts that were breaking queries

### DIFF
--- a/packages/api/src/command/medical/patient/settings/hie-subscriptions.ts
+++ b/packages/api/src/command/medical/patient/settings/hie-subscriptions.ts
@@ -137,7 +137,7 @@ async function _addHieSubscriptionToPatients({
         ),
         updated_at = NOW()
     WHERE cx_id = :cxId::uuid 
-      AND patient_id = ANY(:patientIds::text[])
+      AND patient_id in (:patientIds)
       AND NOT (subscriptions->'adt' @> to_jsonb(:hieName::text))
   `;
 
@@ -181,7 +181,7 @@ async function _removeHieSubscriptionsFromPatients({
         ),
         updated_at = NOW()
     WHERE cx_id = :cxId::uuid 
-      AND patient_id = ANY(:patientIds::text[])
+      AND patient_id in (:patientIds)
       AND subscriptions->'adt' @> to_jsonb(:hieName::text)
   `;
 


### PR DESCRIPTION
### Dependencies

None

### Description

Fixes prod - sql query typecasts to array were failing. These started failing once we switching from binding args to using replacements.

### Testing

- Local
  - [x] Run post + delete, as well update patient endpoints. Make sure they all run fine
- Staging
  - [ ] Run post + delete, as well update patient endpoints. Make sure they all run fine
- Production
  - [ ] Run post + delete, as well update patient endpoints. Make sure they all run fine

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of patient ID lists when updating HIE subscriptions in patient settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->