### PR TITLE
fix(api): filter cq orgs by xcpd url

### DIFF
--- a/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
+++ b/packages/api/src/external/carequality/command/cq-directory/search-cq-directory.ts
@@ -126,15 +126,15 @@ export function toBasicOrgAttributes(org: CQDirectoryEntry): CQOrgBasicDetails {
 }
 
 export function filterCQOrgsToSearch(orgs: CQOrgBasicDetails[]): CQOrgBasicDetails[] {
-  const uniqueOrgsById = new Map<string, CQOrgBasicDetails>();
+  const uniqueOrgsByUrlXcpd = new Map<string, CQOrgBasicDetails>();
   for (const org of orgs) {
-    if (org.active && hasValidXcpdLink(org)) {
-      if (!uniqueOrgsById.has(org.id)) {
-        uniqueOrgsById.set(org.id, org);
+    if (org.active && org.urlXCPD && hasValidXcpdLink(org)) {
+      if (!uniqueOrgsByUrlXcpd.has(org.urlXCPD)) {
+        uniqueOrgsByUrlXcpd.set(org.urlXCPD, org);
       }
     }
   }
-  return Array.from(uniqueOrgsById.values());
+  return Array.from(uniqueOrgsByUrlXcpd.values());
 }
 
 /**


### PR DESCRIPTION
Part of ENG-669

Issues:

- https://linear.app/metriport/issue/ENG-669

### Description
- For CQ XCPD requests, instead of filtering by ID (which imo should be unique anyway, but not 100% sure), we will be filtering by url xcpd to ensure that we don't send multiple requests to the same gateway within the same pd event

### Testing

- Local
  - [x] See if the new filtering decreases the number of gateways we query (~14k down to ~2.6k)

### Release Plan

- [ ] Merge this
