### PR TITLE
feat(fhir-converter): CarePlan from treatment plan observations

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Sections/CarePlan.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/CarePlan.hbs
@@ -28,6 +28,32 @@
                     {{/with}}
                 {{/if}}
                 
+            {{else if careplanEntry.observation}}
+                {{>Resources/CarePlan.hbs encounter=careplanEntry.observation ID=(generateUUID (toJsonString careplanEntry))}},
+                {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                    {{>References/CarePlan/subject.hbs ID=(generateUUID (toJsonString careplanEntry)) REF=(concat 'Patient/' patientId.Id)}},
+                {{/with}}
+            
+                {{#if careplanEntry.observation.author.assignedAuthor.representedOrganization}}
+                    {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=careplanEntry.observation.author.assignedAuthor.representedOrganization) as |orgId|}}
+                        {{>Resources/Organization.hbs org=careplanEntry.observation.author.assignedAuthor ID=orgId.Id}},
+                        {{>References/CarePlan/author.hbs ID=(generateUUID (toJsonString careplanEntry)) REF=(concat 'Organization/' orgId.Id)}},
+                    {{/with}}
+                {{/if}}
+
+                {{#if careplanEntry.observation.performer.assignedEntity}}
+                    {{#with (generatePractitionerId careplanEntry.observation.performer.assignedEntity) as |practitionerId|}}
+                        {{>Resources/Practitioner.hbs practitioner=careplanEntry.observation.performer.assignedEntity ID=practitionerId}},
+                        {{!-- Reference to the Practitioner is generated at the time of CarePlan resource generation --}}
+                    {{/with}}
+                {{/if}}
+                
+                {{#if careplanEntry.observation.participant.participantRole}}
+                    {{#with (generateLocationId careplanEntry.observation.participant.participantRole) as |locationId|}}
+                        {{>Resources/Location.hbs location=careplanEntry.observation.participant.participantRole playingEntity=careplanEntry.observation.participant.participantRole.playingEntity ID=locationId}},
+                        {{!-- Reference to the Location is generated at the time of CarePlan resource generation --}}
+                    {{/with}}
+                {{/if}}
             {{/if}}
         {{/each}}
     {{/with}}


### PR DESCRIPTION
Part of ENG-419

Issues:

- https://linear.app/metriport/issue/ENG-419

### Description
- Added support for Treatment of Plan observation entries 

### Testing

- Local
  - [x] Run on individual files and verify outputs
  - [x] Run in bulk and make sure nothing breaks
  - [x] Counts are as expected

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CarePlan template to support entries containing observations, including rendering related organization, practitioner, and location information when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->