### PR TITLE
ENG-550: Update vpn tunnel workflows to properly use internal feature branch 

### DIFF
--- a/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
+++ b/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
@@ -90,6 +90,10 @@ jobs:
           npm ci --ignore-scripts --no-fund
         working-directory: "metriport/"
 
+      - name: Build fhir converter dependencies
+        run: npm install --only=production --no-fund --no-optional --no-audit
+        working-directory: "metriport/packages/fhir-converter"
+
       - name: Lambdas build shared layer
         run: npm run prep-deploy
         working-directory: "metriport/packages/lambdas/"

--- a/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
+++ b/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
@@ -118,7 +118,7 @@ jobs:
           npm ci --ignore-scripts --no-fund
         working-directory: "metriport/"
 
-      # TODO: 
+      # TODO: This shouldn't be needed as a dependency, but it is.
       - name: Build fhir converter dependencies
         run: npm install --only=production --no-fund --no-optional --no-audit
         working-directory: "metriport/packages/fhir-converter"

--- a/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
+++ b/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
@@ -79,6 +79,34 @@ jobs:
           sparse-checkout: |
             config-oss/api-infra
 
+      # checkout the internal repo to get configs - feature branch when "branching to staging"
+      - name: Determine which internal branch to checkout
+        env:
+          GITHUB_TOKEN: ${{ secrets.SERVICE_PAT }}
+        run: |
+          set +e # don't stop on failure
+          gh api /repos/metriport/metriport-internal/branches/${{ github.ref_name }} --silent
+          RESULT=$?
+          if [ $RESULT -eq 0 ]; then
+            INTERNAL_BRANCH=${{ github.ref }}
+          else
+            INTERNAL_BRANCH=develop
+          fi
+          echo "Internal branch for checkout: $INTERNAL_BRANCH"
+          echo "INTERNAL_BRANCH=$INTERNAL_BRANCH" >> $GITHUB_ENV
+
+      - name: Checkout internal feature branch
+        uses: actions/checkout@v3
+        if: ${{ inputs.is_branch_to_staging == true }}
+        with:
+          repository: metriport/metriport-internal
+          ref: ${{ env.INTERNAL_BRANCH }}
+          token: ${{ secrets.SERVICE_PAT }} # secret token from user 'metriport-service'
+          path: metriport-internal
+          sparse-checkout: |
+            config-oss/api-infra
+
+
       - name: Log Git Ref
         run: |
           echo "Git ref: $(git rev-parse HEAD)"
@@ -90,6 +118,7 @@ jobs:
           npm ci --ignore-scripts --no-fund
         working-directory: "metriport/"
 
+      # TODO: 
       - name: Build fhir converter dependencies
         run: npm install --only=production --no-fund --no-optional --no-audit
         working-directory: "metriport/packages/fhir-converter"

--- a/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
+++ b/.github/workflows/_deploy-hl7-vpn-tunnel-cdk.yml
@@ -97,7 +97,6 @@ jobs:
 
       - name: Checkout internal feature branch
         uses: actions/checkout@v3
-        if: ${{ inputs.is_branch_to_staging == true }}
         with:
           repository: metriport/metriport-internal
           ref: ${{ env.INTERNAL_BRANCH }}

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -198,6 +198,9 @@ export function createRosterRowInput(
   const assigningAuthorityIdentifier = METRIPORT_ASSIGNING_AUTHORITY_IDENTIFIER;
   const lineOfBusiness = "COMMERCIAL";
   const emptyString = "";
+  const address1SingleLine =
+    addresses[0]?.addressLine1 +
+    (addresses[0]?.addressLine2 ? " " + addresses[0]?.addressLine2 : "");
   const { firstName, middleInitial } = getFirstNameAndMiddleInitial(data.firstName);
 
   return {
@@ -213,6 +216,7 @@ export function createRosterRowInput(
     genderAtBirth: data.genderAtBirth,
     address1AddressLine1: addresses[0]?.addressLine1,
     address1AddressLine2: addresses[0]?.addressLine2,
+    address1SingleLine,
     address1City: addresses[0]?.city,
     address1State: addresses[0]?.state,
     address1Zip: addresses[0]?.zip,

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -28,6 +28,7 @@ export type RosterRowData = {
   email: string | undefined;
   address1AddressLine1: string | undefined;
   address1AddressLine2: string | undefined;
+  address1SingleLine: string | undefined;
   address1City: string | undefined;
   address1State: string | undefined;
   address1Zip: string | undefined;


### PR DESCRIPTION
### Dependencies

Downstream: https://github.com/metriport/metriport-internal/pull/3107

### Description

- Adds a new usable property for roster generation for new partner HIE
- Adds matching behavior as branch-to-staging: gh workflow uses the same named internal branch when it can be found.
  - Basically just copied from branch-to-staging workflow

### Testing

Used the new functionality in the workflow already and it works properly

### Release Plan

- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new single-line address field to roster data, combining the first and second address lines for easier viewing and export.

* **Chores**
  * Updated deployment workflow to conditionally check out feature branches and install production-only dependencies for improved deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->