### PR TITLE
ENG-602 FhirToCsv lambda calls the transform one directly

### DIFF
--- a/packages/core/src/command/analytics-platform/api/start-fhir-to-csv-transform.ts
+++ b/packages/core/src/command/analytics-platform/api/start-fhir-to-csv-transform.ts
@@ -10,6 +10,7 @@ export type StartFhirToCsvTransformParams = {
   inputBundle?: string;
 };
 
+// TODO remove this
 /**
  * Sends a request to the API to start the fhir to csv transform.
  *

--- a/packages/core/src/command/analytics-platform/fhir-to-csv/command/fhir-to-csv/fhir-to-csv-direct.ts
+++ b/packages/core/src/command/analytics-platform/fhir-to-csv/command/fhir-to-csv/fhir-to-csv-direct.ts
@@ -1,5 +1,5 @@
 import { sleep } from "@metriport/shared";
-import { startFhirToCsvTransformThroughApi } from "../../../api/start-fhir-to-csv-transform";
+import { startFhirToCsvTransform } from "../fhir-to-csv-transform";
 import { FhirToCsvHandler, ProcessFhirToCsvRequest } from "./fhir-to-csv";
 
 export class FhirToCsvDirect implements FhirToCsvHandler {
@@ -11,7 +11,7 @@ export class FhirToCsvDirect implements FhirToCsvHandler {
     patientId,
     inputBundle,
   }: ProcessFhirToCsvRequest): Promise<void> {
-    await startFhirToCsvTransformThroughApi({
+    await startFhirToCsvTransform({
       cxId,
       jobId,
       patientId,

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -513,7 +513,6 @@ export class APIStack extends Stack {
         vpc: this.vpc,
         lambdaLayers,
         medicalDocumentsBucket,
-        secrets,
       });
     }
 

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1,11 +1,11 @@
 import {
   Aspects,
+  aws_wafv2 as wafv2,
   CfnOutput,
   Duration,
   RemovalPolicy,
   Stack,
   StackProps,
-  aws_wafv2 as wafv2,
 } from "aws-cdk-lib";
 import * as apig from "aws-cdk-lib/aws-apigateway";
 import { BackupResource } from "aws-cdk-lib/aws-backup";
@@ -513,6 +513,7 @@ export class APIStack extends Stack {
         vpc: this.vpc,
         lambdaLayers,
         medicalDocumentsBucket,
+        secrets,
       });
     }
 

--- a/packages/lambdas/src/analytics-platform/fhir-to-csv.ts
+++ b/packages/lambdas/src/analytics-platform/fhir-to-csv.ts
@@ -1,3 +1,4 @@
+import { getSecret } from "@aws-lambda-powertools/parameters/secrets";
 import { FhirToCsvDirect } from "@metriport/core/command/analytics-platform/fhir-to-csv/command/fhir-to-csv/fhir-to-csv-direct";
 import { SQSEvent } from "aws-lambda";
 import { fhirToCsvSchema } from "../shared/analytics-platform";
@@ -12,6 +13,7 @@ capture.init();
 
 // Automatically set by AWS
 const lambdaName = getEnvOrFail("AWS_LAMBDA_FUNCTION_NAME");
+const secretName = getEnvOrFail("SNOWFLAKE_CREDS_SECRET_NAME");
 
 export const handler = capture.wrapHandler(async (event: SQSEvent) => {
   capture.setExtra({ event, context: lambdaName });
@@ -24,6 +26,13 @@ export const handler = capture.wrapHandler(async (event: SQSEvent) => {
 
   const log = prefixedLog(`jobId ${jobId}, cxId ${cxId}, patientId ${patientId}`);
   log(`Parsed: ${JSON.stringify(parsedBody)}`);
+
+  const creds = (await getSecret(secretName)) as string;
+  if (!creds) {
+    throw new Error(`Config error - secret ${secretName} is empty/could not be retrieved`);
+  }
+  // TODO read the env var name from a share place and update infra to use that too
+  process.env.SNOWFLAKE_CREDS = creds;
 
   const fhirToCsvHandler = new FhirToCsvDirect();
   await fhirToCsvHandler.processFhirToCsv(parsedBody);


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4215
- Downstream: none

### Description

FhirToCsv lambda calls the transform one directly - [context](https://metriport.slack.com/archives/C0616FCPAKZ/p1752973319397359?thread_ts=1752623015.505869&cid=C0616FCPAKZ)

### Testing

see upstream

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Securely retrieves Snowflake credentials from AWS Secrets Manager for analytics processing.
  * Adds environment variable support for secret names, improving configuration flexibility.

* **Chores**
  * Updates infrastructure configuration to pass and use secrets securely in analytics platform components.

* **Refactor**
  * Adjusts internal usage of transformation functions to streamline implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->