### PR TITLE
fix(api): fixing schemas for hl7 notifs

### DIFF
--- a/packages/api/src/routes/medical/schemas/tcm-encounter.ts
+++ b/packages/api/src/routes/medical/schemas/tcm-encounter.ts
@@ -19,9 +19,9 @@ export const tcmEncounterBaseSchema = z.strictObject({
     .datetime()
     .transform(val => buildDayjs(val).toDate())
     .nullish(),
-  clinicalInformation: z.record(z.unknown()).optional().default({}),
-  freetextNote: z.string().optional(),
-  dischargeSummaryPath: z.string().optional(),
+  clinicalInformation: z.record(z.unknown()).nullish().default({}),
+  freetextNote: z.string().nullish(),
+  dischargeSummaryPath: z.string().nullish(),
 });
 
 export const tcmEncounterCreateSchema = tcmEncounterBaseSchema.extend({

--- a/packages/shared/src/domain/patient/patient-monitoring/discharge-requery.ts
+++ b/packages/shared/src/domain/patient/patient-monitoring/discharge-requery.ts
@@ -24,7 +24,7 @@ export const dischargeRequeryRuntimeDataSchema = z
     downloadCount: z.number().optional(),
     convertCount: z.number().optional(),
   })
-  .optional();
+  .nullish();
 
 export type DischargeRequeryJobRuntimeData = z.infer<typeof dischargeRequeryRuntimeDataSchema>;
 


### PR DESCRIPTION
Part of ENG-697

Issues:

- https://linear.app/metriport/issue/ENG-697

### Description
- DischargeRequery job creation schema fixed to avoid breakage on null `runtimeData`
- Added logs to Tcm Encounter upsert 
- Updated Tcm Encounter schemas to be slightly less stringent

### Testing

- Local
  - [x] Make sure the DischargeRequery creation stops breaking
- Staging
  - [ ] Try to send a couple of ADTs and see if
    - [ ] TCM Encounter row is added
    - [ ] DischargeRequery job is created
- Production
  - [ ] Monitor the alert

### Release Plan
- [ ] Merge this
