### PR TITLE
ENG-661: Support vpnless integrations for new + upcoming integrations

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/__tests__/hl7v2-roster-generator.test.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/__tests__/hl7v2-roster-generator.test.ts
@@ -34,7 +34,7 @@ describe("AdtRosterGenerator", () => {
     EMAIL: "email",
     SSN: "ssn",
     "DRIVERS LICENSE": "driversLicense",
-    "AUTHORIZING PARTICIPANT FACILITY CODE": "authorizingParticipantFacilityCode",
+    "AUTHORIZING PARTICIPANT FACILITY CODE": "cxShortcode",
     "ASSIGNING AUTHORITY IDENTIFIER": "assigningAuthorityIdentifier",
   };
 

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -194,6 +194,7 @@ export function createRosterRowInput(
   const rosterGenerationDate = buildDayjs(new Date()).format("YYYY-MM-DD");
   const dob = data.dob;
   const dobNoDelimiter = dob.replace(/[-]/g, "");
+  const dobMonthDayYear = buildDayjs(dob).format("MM/DD/YYYY");
   const cxShortcode = org.shortcode;
   const authorizingParticipantMrn = p.externalId || createUuidFromText(scrambledId);
   const assigningAuthorityIdentifier = METRIPORT_ASSIGNING_AUTHORITY_IDENTIFIER;
@@ -214,6 +215,7 @@ export function createRosterRowInput(
     middleName: middleInitial,
     dob,
     dobNoDelimiter,
+    dobMonthDayYear,
     genderAtBirth: data.genderAtBirth,
     genderOtherAsUnknown: genderOtherAsUnknown(data.genderAtBirth),
     address1AddressLine1: addresses[0]?.addressLine1,

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -1,7 +1,6 @@
 import {
   executeWithNetworkRetries,
   GenderAtBirth,
-  genderOtherAsUnknown,
   InternalOrganizationDTO,
   internalOrganizationDTOSchema,
   MetriportError,

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -193,7 +193,7 @@ export function createRosterRowInput(
   const rosterGenerationDate = buildDayjs(new Date()).format("YYYY-MM-DD");
   const dob = data.dob;
   const dobNoDelimiter = dob.replace(/[-]/g, "");
-  const authorizingParticipantFacilityCode = org.shortcode;
+  const cxShortcode = org.shortcode;
   const authorizingParticipantMrn = p.externalId || createUuidFromText(scrambledId);
   const assigningAuthorityIdentifier = METRIPORT_ASSIGNING_AUTHORITY_IDENTIFIER;
   const lineOfBusiness = "COMMERCIAL";
@@ -223,7 +223,7 @@ export function createRosterRowInput(
     insuranceId: undefined,
     insuranceCompanyId: undefined,
     insuranceCompanyName: undefined,
-    authorizingParticipantFacilityCode,
+    cxShortcode,
     authorizingParticipantMrn,
     assigningAuthorityIdentifier,
     ssn,

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -1,9 +1,12 @@
 import {
   executeWithNetworkRetries,
+  GenderAtBirth,
   genderOtherAsUnknown,
   InternalOrganizationDTO,
   internalOrganizationDTOSchema,
   MetriportError,
+  otherGender,
+  unknownGender,
 } from "@metriport/shared";
 import { buildDayjs } from "@metriport/shared/common/date";
 import { createUuidFromText } from "@metriport/shared/common/uuid";
@@ -179,6 +182,11 @@ type RosterRowKey = keyof RosterRowData;
 function isRosterRowKey(key: string, obj: RosterRowData): key is RosterRowKey {
   return key in obj;
 }
+
+export function genderOtherAsUnknown(gender: GenderAtBirth): GenderAtBirth {
+  return gender === otherGender ? unknownGender : gender;
+}
+
 export function createRosterRowInput(
   p: Patient,
   org: { shortcode?: string | undefined },

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -1,5 +1,6 @@
 import {
   executeWithNetworkRetries,
+  genderOtherAsUnknown,
   InternalOrganizationDTO,
   internalOrganizationDTOSchema,
   MetriportError,
@@ -214,6 +215,7 @@ export function createRosterRowInput(
     dob,
     dobNoDelimiter,
     genderAtBirth: data.genderAtBirth,
+    genderOtherAsUnknown: genderOtherAsUnknown(data.genderAtBirth),
     address1AddressLine1: addresses[0]?.addressLine1,
     address1AddressLine2: addresses[0]?.addressLine2,
     address1SingleLine,

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -84,6 +84,6 @@ export type Hl7v2SubscriberApiResponse = {
  * @param config
  * @returns true if config is HieConfig, false if config is VpnlessHieConfig
  */
-export function isHieEnabledForVpn(config: HieConfig | VpnlessHieConfig): config is HieConfig {
+export function doesHieUseVpn(config: HieConfig | VpnlessHieConfig): config is HieConfig {
   return "gatewayPublicIp" in config && "internalCidrBlock" in config;
 }

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -84,6 +84,6 @@ export type Hl7v2SubscriberApiResponse = {
  * @param config
  * @returns true if config is HieConfig, false if config is VpnlessHieConfig
  */
-export function isHieConfig(config: HieConfig | VpnlessHieConfig): config is HieConfig {
+export function isHieEnabledForVpn(config: HieConfig | VpnlessHieConfig): config is HieConfig {
   return "gatewayPublicIp" in config && "internalCidrBlock" in config;
 }

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -21,6 +21,7 @@ export type RosterRowData = {
   dobNoDelimiter: string;
   middleName: string | undefined;
   genderAtBirth: string | undefined;
+  genderOtherAsUnknown: string | undefined;
   scrambledId: string;
   ssn: string | undefined;
   driversLicense: string | undefined;

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -19,6 +19,7 @@ export type RosterRowData = {
   lastName: string;
   dob: string;
   dobNoDelimiter: string;
+  dobMonthDayYear: string;
   middleName: string | undefined;
   genderAtBirth: string | undefined;
   genderOtherAsUnknown: string | undefined;

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -35,7 +35,7 @@ export type RosterRowData = {
   insuranceId: string | undefined;
   insuranceCompanyId: string | undefined;
   insuranceCompanyName: string | undefined;
-  authorizingParticipantFacilityCode: string | undefined;
+  cxShortcode: string | undefined;
   authorizingParticipantMrn: string | undefined;
   assigningAuthorityIdentifier: string | undefined;
   lineOfBusiness: string;
@@ -58,6 +58,8 @@ export type HieConfig = {
   mapping: HiePatientRosterMapping;
 };
 
+export type VpnlessHieConfig = Omit<HieConfig, "gatewayPublicIp" | "internalCidrBlock">;
+
 export type Hl7v2SubscriberParams = {
   hie: string;
   count?: number | undefined;
@@ -74,3 +76,12 @@ export type Hl7v2SubscriberApiResponse = {
     nextPage?: string;
   };
 };
+
+/**
+ * Type guard to check if config is HieConfig (not VpnlessHieConfig)
+ * @param config
+ * @returns true if config is HieConfig, false if config is VpnlessHieConfig
+ */
+export function isHieConfig(config: HieConfig | VpnlessHieConfig): config is HieConfig {
+  return "gatewayPublicIp" in config && "internalCidrBlock" in config;
+}

--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -1,4 +1,4 @@
-import { isHieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
+import { isHieEnabledForVpn } from "@metriport/core/command/hl7v2-subscriptions/types";
 import * as cdk from "aws-cdk-lib";
 import "source-map-support/register";
 import { EnvConfig } from "../config/env-config";
@@ -66,7 +66,7 @@ async function deploy(config: EnvConfig) {
 
     Object.values(config.hl7Notification.hieConfigs).forEach((hieConfig, index) => {
       // We only create VPN stacks for full HieConfig objects (not `VpnlessHieConfig`s)
-      if (!isHieConfig(hieConfig)) {
+      if (!isHieEnabledForVpn(hieConfig)) {
         return;
       }
 

--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -1,3 +1,4 @@
+import { isHieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
 import * as cdk from "aws-cdk-lib";
 import "source-map-support/register";
 import { EnvConfig } from "../config/env-config";
@@ -64,6 +65,11 @@ async function deploy(config: EnvConfig) {
     });
 
     Object.values(config.hl7Notification.hieConfigs).forEach((hieConfig, index) => {
+      // We only create VPN stacks for full HieConfig objects (not `VpnlessHieConfig`s)
+      if (!isHieConfig(hieConfig)) {
+        return;
+      }
+
       const vpnStack = new VpnStack(app, `VpnStack-${hieConfig.name}`, {
         hieConfig,
         index,

--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -1,4 +1,4 @@
-import { isHieEnabledForVpn } from "@metriport/core/command/hl7v2-subscriptions/types";
+import { doesHieUseVpn } from "@metriport/core/command/hl7v2-subscriptions/types";
 import * as cdk from "aws-cdk-lib";
 import "source-map-support/register";
 import { EnvConfig } from "../config/env-config";
@@ -66,7 +66,7 @@ async function deploy(config: EnvConfig) {
 
     Object.values(config.hl7Notification.hieConfigs).forEach((hieConfig, index) => {
       // We only create VPN stacks for full HieConfig objects (not `VpnlessHieConfig`s)
-      if (!isHieEnabledForVpn(hieConfig)) {
+      if (!doesHieUseVpn(hieConfig)) {
         return;
       }
 

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -199,7 +199,7 @@ export const config: EnvConfigNonSandbox = {
           CITY: "address1City",
           STATE: "address1State",
           ZIP: "address1Zip",
-          FACCODE: "authorizingParticipantFacilityCode",
+          FACCODE: "cxShortcode",
           ASSIGNERID: "assigningAuthorityIdentifier",
         },
       },

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -1,4 +1,4 @@
-import { HieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
+import { HieConfig, VpnlessHieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
 
 export interface Hl7NotificationConfig {
   secrets: {
@@ -24,7 +24,7 @@ export interface Hl7NotificationConfig {
   hl7v2RosterUploadLambda: {
     bucketName: string;
   };
-  hieConfigs: Record<string, HieConfig>;
+  hieConfigs: Record<string, HieConfig | VpnlessHieConfig>;
   // ENG-536 remove this once we automatically find the discharge summary
   dischargeNotificationSlackUrl: string;
 }

--- a/packages/infra/lib/shared/hie-config-dictionary.ts
+++ b/packages/infra/lib/shared/hie-config-dictionary.ts
@@ -1,8 +1,23 @@
-import { HieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
+import {
+  HieConfig,
+  isHieConfig,
+  VpnlessHieConfig,
+} from "@metriport/core/command/hl7v2-subscriptions/types";
 import { HieConfigDictionary } from "@metriport/core/external/hl7-notification/hie-config-dictionary";
 
-export const createHieConfigDictionary = (hieConfigs: Record<string, HieConfig>) => {
+/**
+ * Create a dictionary of metadata for HieConfigs, for use in identifying messages based on source tunnel.
+ * @param hieConfigs HieConfigs from the environment config
+ * @returns Dictionary of HieConfig objects
+ */
+export const createHieConfigDictionary = (
+  hieConfigs: Record<string, HieConfig | VpnlessHieConfig>
+) => {
   return Object.values(hieConfigs).reduce((acc, item) => {
+    // Skip VpnlessHieConfig objects - no VPN means no ability to identify messages
+    if (!isHieConfig(item)) {
+      return acc;
+    }
     acc[item.name] = {
       cidrBlock: item.internalCidrBlock,
       timezone: item.timezone,

--- a/packages/infra/lib/shared/hie-config-dictionary.ts
+++ b/packages/infra/lib/shared/hie-config-dictionary.ts
@@ -1,6 +1,6 @@
 import {
   HieConfig,
-  isHieConfig,
+  isHieEnabledForVpn,
   VpnlessHieConfig,
 } from "@metriport/core/command/hl7v2-subscriptions/types";
 import { HieConfigDictionary } from "@metriport/core/external/hl7-notification/hie-config-dictionary";
@@ -15,7 +15,7 @@ export const createHieConfigDictionary = (
 ) => {
   return Object.values(hieConfigs).reduce((acc, item) => {
     // Skip VpnlessHieConfig objects - no VPN means no ability to identify messages
-    if (!isHieConfig(item)) {
+    if (!isHieEnabledForVpn(item)) {
       return acc;
     }
     acc[item.name] = {

--- a/packages/infra/lib/shared/hie-config-dictionary.ts
+++ b/packages/infra/lib/shared/hie-config-dictionary.ts
@@ -14,7 +14,6 @@ export const createHieConfigDictionary = (
   hieConfigs: Record<string, HieConfig | VpnlessHieConfig>
 ) => {
   return Object.values(hieConfigs).reduce((acc, item) => {
-    // Skip VpnlessHieConfig objects - no VPN means no ability to identify messages
     if (!isHieEnabledForVpn(item)) {
       return acc;
     }

--- a/packages/infra/lib/shared/hie-config-dictionary.ts
+++ b/packages/infra/lib/shared/hie-config-dictionary.ts
@@ -1,6 +1,6 @@
 import {
   HieConfig,
-  isHieEnabledForVpn,
+  doesHieUseVpn,
   VpnlessHieConfig,
 } from "@metriport/core/command/hl7v2-subscriptions/types";
 import { HieConfigDictionary } from "@metriport/core/external/hl7-notification/hie-config-dictionary";
@@ -14,7 +14,7 @@ export const createHieConfigDictionary = (
   hieConfigs: Record<string, HieConfig | VpnlessHieConfig>
 ) => {
   return Object.values(hieConfigs).reduce((acc, item) => {
-    if (!isHieEnabledForVpn(item)) {
+    if (!doesHieUseVpn(item)) {
       return acc;
     }
     acc[item.name] = {

--- a/packages/shared/src/domain/gender.ts
+++ b/packages/shared/src/domain/gender.ts
@@ -11,6 +11,10 @@ export type GenderAtBirth =
   | typeof otherGender
   | typeof unknownGender;
 
+export function genderOtherAsUnknown(gender: GenderAtBirth): GenderAtBirth {
+  return gender === otherGender ? unknownGender : gender;
+}
+
 export function normalizeGenderSafe(gender: string): GenderAtBirth | undefined {
   const lowerGender = gender.toLowerCase().trim();
   if (lowerGender === "male" || lowerGender === "m") {

--- a/packages/shared/src/domain/gender.ts
+++ b/packages/shared/src/domain/gender.ts
@@ -11,10 +11,6 @@ export type GenderAtBirth =
   | typeof otherGender
   | typeof unknownGender;
 
-export function genderOtherAsUnknown(gender: GenderAtBirth): GenderAtBirth {
-  return gender === otherGender ? unknownGender : gender;
-}
-
 export function normalizeGenderSafe(gender: string): GenderAtBirth | undefined {
   const lowerGender = gender.toLowerCase().trim();
   if (lowerGender === "male" || lowerGender === "m") {


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/3112

### Description

Adds support for Vpnless Hie Configs for some of our upcoming integrations with HIEs that don't fit into the current "MLLP over VPN" based paradigm.

### Testing

- Local
  - [x] Branch to staging with new configs already on develop, ensure 
- Staging
  - [ ] Ensure there is no VPN tunnel created on staging
- Production
  - [ ] Ensure there is no VPN tunnel created on production

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new configuration type that omits VPN-related fields, allowing more flexible HIE configuration.
  * Included a formatted date of birth and enhanced gender handling in roster data outputs.

* **Bug Fixes**
  * Improved filtering to ensure VPN resources are only created for configurations that support VPN.

* **Refactor**
  * Renamed certain fields in configuration and data outputs for clarity and consistency.

* **Tests**
  * Updated test mappings to reflect changes in field names and data structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->