### PR TITLE
PATCH RELEASE ENG-701 Init progress for all HIEs upon DQ

### DIFF
--- a/packages/api/src/command/medical/document/document-query.ts
+++ b/packages/api/src/command/medical/document/document-query.ts
@@ -26,7 +26,7 @@ import { resetDocQueryProgress } from "../../../external/hie/reset-doc-query-pro
 import { PatientModel } from "../../../models/medical/patient";
 import { executeOnDBTx } from "../../../models/transaction-wrapper";
 import { getPatientOrFail } from "../patient/get-patient";
-import { storeQueryInit } from "../patient/query-init";
+import { InitDocumentQueryCmd, storeQueryInit } from "../patient/query-init";
 import { areDocumentsProcessing } from "./document-status";
 
 export function isProgressEqual(a?: Progress, b?: Progress): boolean {
@@ -81,7 +81,14 @@ export async function queryDocumentsAcrossHIEs({
   ]);
 
   const isQueryCarequality = carequalityEnabled || forceCarequality;
-  const isQueryCommonwell = commonwellEnabled || forceCommonwell;
+  /**
+   * It's likely safe to remove the check for `cqManagingOrgName` based on the usage of this function.
+   * But because it touches a core flow and we don't have time to review/test it now, leaving as is.
+   * The expected behavior is that we never pass `cqManagingOrgName`, so it should be null/undefined every
+   * time this function is called - otherwise we can miss the opportunity to query CW for docs.
+   * @see https://metriport.slack.com/archives/C04DMKE9DME/p1745685924702559
+   */
+  const isQueryCommonwell = (commonwellEnabled || forceCommonwell) && !cqManagingOrgName;
 
   if (!isQueryCarequality && !isQueryCommonwell) {
     log("No HIE networks enabled, skipping DQ for Commonwell and Carequality");
@@ -115,15 +122,31 @@ export async function queryDocumentsAcrossHIEs({
 
   const startedAt = new Date();
 
+  const initialDocumentQueryProgress: Pick<InitDocumentQueryCmd, "documentQueryProgress"> = {
+    documentQueryProgress: {
+      requestId,
+      startedAt,
+      triggerConsolidated,
+      download: { status: "processing" },
+    },
+  };
+
   const updatedPatient = await storeQueryInit({
     id: patient.id,
     cxId: patient.cxId,
     cmd: {
-      documentQueryProgress: {
-        requestId,
-        startedAt,
-        triggerConsolidated,
-        download: { status: "processing" },
+      ...initialDocumentQueryProgress,
+      externalData: {
+        ...(isQueryCommonwell
+          ? {
+              [MedicalDataSource.COMMONWELL]: initialDocumentQueryProgress,
+            }
+          : {}),
+        ...(isQueryCarequality
+          ? {
+              [MedicalDataSource.CAREQUALITY]: initialDocumentQueryProgress,
+            }
+          : {}),
       },
       cxDocumentRequestMetadata,
     },
@@ -142,26 +165,22 @@ export async function queryDocumentsAcrossHIEs({
 
   const isForceRedownloadEnabled =
     forceDownload ?? (await isXmlRedownloadFeatureFlagEnabledForCx(cxId));
-  /**
-   * This is likely safe to remove based on the usage of this function with the `cqManagingOrgName` param.
-   * But because it touches a core flow and we don't have time to review/test it now, leaving as is.
-   * The expected behavior is that we never pass `cqManagingOrgName`, so it should be null/undefined every
-   * time this function is called - otherwise we can miss the opportunity to query CW for docs.
-   * @see https://metriport.slack.com/archives/C04DMKE9DME/p1745685924702559
-   */
-  if (!cqManagingOrgName) {
-    if (isQueryCommonwell) {
-      getDocumentsFromCW({
-        patient: updatedPatient,
-        facilityId,
-        forceDownload: isForceRedownloadEnabled,
-        forceQuery,
-        forcePatientDiscovery,
-        requestId,
-        getOrgIdExcludeList: getCqOrgIdsToDenyOnCw,
-      }).catch(emptyFunction);
-      triggeredDocumentQuery = true;
-    }
+  if (isQueryCommonwell) {
+    getDocumentsFromCW({
+      patient: updatedPatient,
+      facilityId,
+      forceDownload: isForceRedownloadEnabled,
+      forceQuery,
+      forcePatientDiscovery,
+      requestId,
+      getOrgIdExcludeList: getCqOrgIdsToDenyOnCw,
+    }).catch(emptyFunction);
+    triggeredDocumentQuery = true;
+  } else {
+    await resetDocQueryProgress({
+      source: MedicalDataSource.COMMONWELL,
+      patient: updatedPatient,
+    });
   }
 
   if (isQueryCarequality) {
@@ -174,6 +193,11 @@ export async function queryDocumentsAcrossHIEs({
       forcePatientDiscovery,
     }).catch(emptyFunction);
     triggeredDocumentQuery = true;
+  } else {
+    await resetDocQueryProgress({
+      source: MedicalDataSource.CAREQUALITY,
+      patient: updatedPatient,
+    });
   }
 
   if (triggeredDocumentQuery) {

--- a/packages/api/src/command/medical/patient/__tests__/store-query-cmd.ts
+++ b/packages/api/src/command/medical/patient/__tests__/store-query-cmd.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { ConsolidatedQuery } from "@metriport/api-sdk";
+import { ConsolidatedQuery, MedicalDataSource } from "@metriport/api-sdk";
 import { DocumentQueryProgress } from "@metriport/core/domain/document-query";
 import { makePatientData } from "@metriport/core/domain/__tests__/patient";
 import * as uuidv7_file from "@metriport/core/util/uuid-v7";
@@ -9,19 +9,27 @@ import { makeProgress } from "../../../../domain/medical/__tests__/document-quer
 import { WebhookRequestCreate } from "../../../../domain/webhook";
 import { makePatientModel } from "../../../../models/medical/__tests__/patient";
 import { WebhookRequest } from "../../../../models/webhook-request";
-import { StoreQueryParams } from "../query-init";
+import { InitDocumentQueryCmd, StoreQueryParams } from "../query-init";
 
 export const requestId = uuidv7_file.uuidv4();
 export const patient = { id: uuidv7_file.uuidv7(), cxId: uuidv7_file.uuidv7() };
+
+export const initialDocumentQueryProgress: Pick<InitDocumentQueryCmd, "documentQueryProgress"> = {
+  documentQueryProgress: {
+    requestId,
+    startedAt: new Date(),
+    download: makeProgress(),
+  },
+};
 
 export const dqParams: StoreQueryParams = {
   id: patient.id,
   cxId: patient.cxId,
   cmd: {
-    documentQueryProgress: {
-      requestId,
-      startedAt: new Date(),
-      download: makeProgress(),
+    ...initialDocumentQueryProgress,
+    externalData: {
+      [MedicalDataSource.COMMONWELL]: initialDocumentQueryProgress,
+      [MedicalDataSource.CAREQUALITY]: initialDocumentQueryProgress,
     },
   },
 };

--- a/packages/api/src/command/medical/patient/query-init.ts
+++ b/packages/api/src/command/medical/patient/query-init.ts
@@ -1,6 +1,6 @@
 import { ConsolidatedQuery } from "@metriport/api-sdk";
 import { DocumentQueryProgress } from "@metriport/core/domain/document-query";
-import { Patient } from "@metriport/core/domain/patient";
+import { Patient, PatientExternalData } from "@metriport/core/domain/patient";
 import { PatientModel } from "../../../models/medical/patient";
 import { executeOnDBTx } from "../../../models/transaction-wrapper";
 import { getPatientModelOrFail } from "./get-patient";
@@ -12,11 +12,14 @@ export type InitConsolidatedQueryCmd = {
   patientDiscovery?: never;
 };
 
+export type InitDocumentQueryProgress = Required<
+  Pick<DocumentQueryProgress, "download" | "requestId" | "startedAt">
+> &
+  Pick<DocumentQueryProgress, "triggerConsolidated">;
+
 export type InitDocumentQueryCmd = {
-  documentQueryProgress: Required<
-    Pick<DocumentQueryProgress, "download" | "requestId" | "startedAt">
-  > &
-    Pick<DocumentQueryProgress, "triggerConsolidated">;
+  documentQueryProgress: InitDocumentQueryProgress;
+  externalData: PatientExternalData;
   cxDocumentRequestMetadata?: unknown;
   consolidatedQueries?: never;
   patientDiscovery?: never;


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-701

### Dependencies

none

### Description

Init progress for all HIEs upon DQ.

### Testing

- Local
  - [x] E2E tests
- Staging
  - none
- Sandbox
  - none
- Production
  - [ ] Trigger DQ for affected pt
  - [ ] Monitor for 5 DQs

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
