### PR TITLE
ENG-660: New hie integration

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -187,7 +187,7 @@ export function genderOtherAsUnknown(gender: GenderAtBirth): GenderAtBirth {
   return gender === otherGender ? unknownGender : gender;
 }
 
-export function genderEnumerated(gender: GenderAtBirth) {
+export function genderOneTwoAndNine(gender: GenderAtBirth) {
   return {
     M: "1",
     F: "2",
@@ -243,7 +243,7 @@ export function createRosterRowInput(
     dobMonthDayYear,
     genderAtBirth: data.genderAtBirth,
     genderOtherAsUnknown: genderOtherAsUnknown(data.genderAtBirth),
-    genderEnumerated: genderEnumerated(data.genderAtBirth),
+    genderOneTwoAndNine: genderOneTwoAndNine(data.genderAtBirth),
     address1AddressLine1: a1?.addressLine1,
     address1AddressLine2: a1?.addressLine2,
     address1SingleLine,

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -187,6 +187,15 @@ export function genderOtherAsUnknown(gender: GenderAtBirth): GenderAtBirth {
   return gender === otherGender ? unknownGender : gender;
 }
 
+export function genderEnumerated(gender: GenderAtBirth) {
+  return {
+    M: "1",
+    F: "2",
+    O: "9",
+    U: "9",
+  }[gender];
+}
+
 export function createRosterRowInput(
   p: Patient,
   org: { shortcode?: string | undefined },
@@ -234,6 +243,7 @@ export function createRosterRowInput(
     dobMonthDayYear,
     genderAtBirth: data.genderAtBirth,
     genderOtherAsUnknown: genderOtherAsUnknown(data.genderAtBirth),
+    genderEnumerated: genderEnumerated(data.genderAtBirth),
     address1AddressLine1: a1?.addressLine1,
     address1AddressLine2: a1?.addressLine2,
     address1SingleLine,

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -35,7 +35,7 @@ const HL7V2_SUBSCRIBERS_ENDPOINT = `internal/patient/hl7v2-subscribers`;
 const GET_ORGANIZATION_ENDPOINT = `internal/organization`;
 const NUMBER_OF_PATIENTS_PER_PAGE = 500;
 const NUMBER_OF_ATTEMPTS = 3;
-const DEFAULT_ZIP_PLUS_4_EXT = "+0000";
+const DEFAULT_ZIP_PLUS_4_EXT = "-0000";
 const BASE_DELAY = dayjs.duration({ seconds: 1 });
 
 export class Hl7v2RosterGenerator {
@@ -208,10 +208,11 @@ export function createRosterRowInput(
   const assigningAuthorityIdentifier = METRIPORT_ASSIGNING_AUTHORITY_IDENTIFIER;
   const lineOfBusiness = "COMMERCIAL";
   const emptyString = "";
-  const address1SingleLine =
-    addresses[0]?.addressLine1 +
-    (addresses[0]?.addressLine2 ? " " + addresses[0]?.addressLine2 : "");
-  const address1ZipPlus4 = addresses[0]?.zip + DEFAULT_ZIP_PLUS_4_EXT;
+  const a1 = addresses[0];
+  const address1SingleLine = a1?.addressLine1
+    ? a1.addressLine1 + (a1.addressLine2 ? " " + a1.addressLine2 : "")
+    : undefined;
+  const address1ZipPlus4 = a1?.zip ? a1.zip + DEFAULT_ZIP_PLUS_4_EXT : undefined;
   const { firstName, middleInitial } = getFirstNameAndMiddleInitial(data.firstName);
   const dateTwoMonthsInFutureNoDelimiter = buildDayjs(new Date())
     .add(2, "month")
@@ -233,12 +234,12 @@ export function createRosterRowInput(
     dobMonthDayYear,
     genderAtBirth: data.genderAtBirth,
     genderOtherAsUnknown: genderOtherAsUnknown(data.genderAtBirth),
-    address1AddressLine1: addresses[0]?.addressLine1,
-    address1AddressLine2: addresses[0]?.addressLine2,
+    address1AddressLine1: a1?.addressLine1,
+    address1AddressLine2: a1?.addressLine2,
     address1SingleLine,
-    address1City: addresses[0]?.city,
-    address1State: addresses[0]?.state,
-    address1Zip: addresses[0]?.zip,
+    address1City: a1?.city,
+    address1State: a1?.state,
+    address1Zip: a1?.zip,
     address1ZipPlus4,
     insuranceId: undefined,
     insuranceCompanyId: undefined,

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -23,7 +23,7 @@ export type RosterRowData = {
   middleName: string | undefined;
   genderAtBirth: string | undefined;
   genderOtherAsUnknown: string | undefined;
-  genderEnumerated: string | undefined;
+  genderOneTwoAndNine: string | undefined;
   scrambledId: string;
   patientExternalId: string | undefined;
   ssn: string | undefined;

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -23,6 +23,7 @@ export type RosterRowData = {
   middleName: string | undefined;
   genderAtBirth: string | undefined;
   genderOtherAsUnknown: string | undefined;
+  genderEnumerated: string | undefined;
   scrambledId: string;
   patientExternalId: string | undefined;
   ssn: string | undefined;

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -24,6 +24,7 @@ export type RosterRowData = {
   genderAtBirth: string | undefined;
   genderOtherAsUnknown: string | undefined;
   scrambledId: string;
+  patientExternalId: string | undefined;
   ssn: string | undefined;
   driversLicense: string | undefined;
   phone: string | undefined;
@@ -34,6 +35,7 @@ export type RosterRowData = {
   address1City: string | undefined;
   address1State: string | undefined;
   address1Zip: string | undefined;
+  address1ZipPlus4: string | undefined;
   insuranceId: string | undefined;
   insuranceCompanyId: string | undefined;
   insuranceCompanyName: string | undefined;
@@ -41,6 +43,8 @@ export type RosterRowData = {
   authorizingParticipantMrn: string | undefined;
   assigningAuthorityIdentifier: string | undefined;
   lineOfBusiness: string;
+  dateTwoMonthsInFutureNoDelimiter: string;
+  dateMid2025NoDelimiter: string;
   emptyString: string;
 };
 


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/3114

### Description

Adds new fields to roster row payload to support our newest hie integration

### Testing

- Local
  - None  
- Staging
  - [ ] Ensure there is no VPN tunnel created on staging
- Production
  - [ ] Ensure there is no VPN tunnel created on production

We'll also do a roster generation and have them spotcheck it for us.

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added new fields to roster data, including an external patient identifier, an extended ZIP code, enumerated gender values, and two date fields representing future dates in a specific format.

* **Documentation**
  * Improved comments clarifying the format of date fields in roster data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->