### PR TITLE
fix(api): dont error if adt wh is disabled and settings missing

### DIFF
--- a/packages/api/src/command/medical/patient/hl7-fhir-webhook.ts
+++ b/packages/api/src/command/medical/patient/hl7-fhir-webhook.ts
@@ -59,7 +59,8 @@ export async function processHl7FhirBundleWebhook({
     );
 
     if (!settings || !isHl7NotificationWhFlagEnabled) {
-      log(`WH FF disabled. Not sending it...`);
+      const msg = !settings ? "Settings not found" : "WH FF disabled";
+      log(`${msg}. Not sending it...`);
       await createWebhookRequest({
         cxId,
         type: webhookType,

--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -165,7 +165,7 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
       durationSeconds: SIGNED_URL_DURATION_SECONDS,
     });
 
-    log(`Sending HL7 notification to API...`);
+    log(`Calling Hl7 notification callback endpoint in API...`);
     await executeWithNetworkRetries(
       async () =>
         await axios.post(internalHl7RouteUrl, undefined, {


### PR DESCRIPTION
Part of ENG-724

Issues:

- https://linear.app/metriport/issue/ENG-724

### Description

- moved the logic around on the hl7 notifications API endpoint logic to avoid erroring when the WH FF is disabled AND CX settings are missing

### Testing
- N/A, imo

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved HL7 notification webhook processing with earlier feature flag checks and optimized data handling.
* **Chores**
  * Enhanced logging and streamlined workflow when the HL7 notification webhook feature is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->