### PR TITLE
PATCH RELEASE All or none on new DQ/Consolidated init flow

### DIFF
--- a/packages/core/src/command/feature-flags/domain-ffs.ts
+++ b/packages/core/src/command/feature-flags/domain-ffs.ts
@@ -281,19 +281,25 @@ export async function isXmlRedownloadFeatureFlagEnabledForCx(cxId: string): Prom
 }
 
 /**
- * TODO ENG-701 Remove this asap
- * @deprecated
+ * @deprecated TODO ENG-701 Remove this asap
  */
-export async function getCxsWithNewDqAndConsolidatedInitialState(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsWithNewDqAndConsolidatedInitialState");
-}
+// export async function getCxsWithNewDqAndConsolidatedInitialState(): Promise<string[]> {
+//   return getCxsWithFeatureFlagEnabled("cxsWithNewDqAndConsolidatedInitialState");
+// }
 /**
- * TODO ENG-701 Remove this asap
- * @deprecated
+ * Returns true for every customer if the FF is enabled. Last step before removing the FF.
+ * @deprecated TODO ENG-701 Remove this asap
  */
 export async function isNewDqAndConsolidatedInitialStateEnabledForCx(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   cxId: string
 ): Promise<boolean> {
-  const enabledCxs = await getCxsWithNewDqAndConsolidatedInitialState();
-  return enabledCxs.some(i => i === cxId);
+  try {
+    const featureFlag = await getFeatureFlagValueStringArray(
+      "cxsWithNewDqAndConsolidatedInitialState"
+    );
+    return featureFlag && featureFlag.enabled;
+  } catch (error) {
+    return false;
+  }
 }


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-701

### Dependencies

none

### Description

This makes the FF for the new DQ/Consolidated init flow to be either ON or OFF for all customers at one, not on a per cx basis. This is the last step before removing the code.

### Testing

- [x] Run E2E tests locally

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated feature flag logic to treat the flag as enabled for all customers if the flag itself is enabled, regardless of customer ID.
  * Deprecated and disabled a previously used function related to customer-specific feature flag checks.

* **Documentation**
  * Updated comments to clarify the new global behavior of the feature flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->