### PR TITLE
fix(core): remove bad chars from contributed conditions

### DIFF
--- a/packages/core/src/external/ehr/job/bundle/contribute-bundles/ehr-contribute-resource-diff-bundles-direct.ts
+++ b/packages/core/src/external/ehr/job/bundle/contribute-bundles/ehr-contribute-resource-diff-bundles-direct.ts
@@ -263,7 +263,7 @@ function prepareEhrOnlyResourcesForContribution(
     if (!oldResourceId) continue;
     dangerouslyAdjustPatientReference(resource, metriportPatientId);
     dangerouslyAdjustExtensions(resource, oldResourceId, ehr);
-    dangeouslyNormalizeResource(resource);
+    dangerouslyNormalizeResource(resource);
   }
   return preparedEhrOnlyResources;
 }
@@ -285,7 +285,7 @@ function dangerouslyAdjustExtensions(resource: any, predecessorId: string, ehr: 
   resource.extension = [...(resource.extension ?? []), predecessorExtension, dataSourceExtension];
 }
 
-function dangeouslyNormalizeResource(resource: Resource) {
+function dangerouslyNormalizeResource(resource: Resource) {
   if (isCondition(resource)) {
     if (resource.note) {
       resource.note.forEach(note => {

--- a/packages/core/src/external/ehr/job/bundle/contribute-bundles/ehr-contribute-resource-diff-bundles-direct.ts
+++ b/packages/core/src/external/ehr/job/bundle/contribute-bundles/ehr-contribute-resource-diff-bundles-direct.ts
@@ -31,6 +31,9 @@ const parallelRequests = 2;
 const minJitter = dayjs.duration(0, "seconds");
 const maxJitter = dayjs.duration(5, "seconds");
 
+const INVISIBLE_WIDE_SPACE = "\u2003";
+const EN_DASH = "\u2013";
+
 export class EhrContributeResourceDiffBundlesDirect
   implements EhrContributeResourceDiffBundlesHandler
 {
@@ -287,7 +290,9 @@ function dangeouslyNormalizeResource(resource: Resource) {
     if (resource.note) {
       resource.note.forEach(note => {
         if (note.text) {
-          note.text = note.text.replace(/\u2003/g, " ").replace(/\u2013/g, "-");
+          note.text = note.text
+            .replace(new RegExp(INVISIBLE_WIDE_SPACE, "g"), " ")
+            .replace(new RegExp(EN_DASH, "g"), "-");
         }
       });
     }


### PR DESCRIPTION
Part of ENG-725

Issues:

- https://linear.app/metriport/issue/ENG-725

### Description
- Contributed Conditions often have some bad chars that fail validation. Now, we'll be removing those.

### Testing

- Local
  - [x] Test locally to make sure this works, and the invalid resources will now pass validation
- Production
  - [ ] Monitor in prod

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic normalization of note texts in certain resources, improving consistency by replacing specific Unicode characters with standard spaces and hyphens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->