### PR TITLE
PATCH RELEASE fix codeable concept builder

### DIFF
--- a/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
@@ -341,7 +341,7 @@ var buildCodeableConcept = function (code, canBeUnknown = false) {
 
   const codeableConcept = {
     text,
-    coding: buildCoding(code, canBeUnknown),
+    coding: [buildCoding(code, canBeUnknown)],
   };
 
   return codeableConcept;


### PR DESCRIPTION
Part of ENG-732

Issues:

- https://linear.app/metriport/issue/ENG-732

### Description
- New helper for building `CodeableConcept`, that's only currently used in `CarePlan.activity` was missing the array wrapper. Adding it here. 

### Testing
- Local
  - [x] Convert the file that caused a problematic resource and make the sure the error is fixed

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the structure of the coding property to be an array, ensuring compatibility with standard FHIR CodeableConcept formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->