### PR TITLE
PATCH RELEASE Re-convert endpoint to not call delete consolidated

### DIFF
--- a/packages/api/src/command/medical/document/document-reconvert.ts
+++ b/packages/api/src/command/medical/document/document-reconvert.ts
@@ -186,7 +186,7 @@ async function reConvertByPatient({
 
   const [documents, patient] = await Promise.all([getDocs(), disableWHAndGetPatient()]);
 
-  log(`Starting reconversion for ${patient.id}, who has ${documents.length} documents...`);
+  log(`Starting reconversion for ${documents.length} documents...`);
   await reConvertDocumentsInternal({
     patient,
     documents,

--- a/packages/api/src/command/medical/document/document-reconvert.ts
+++ b/packages/api/src/command/medical/document/document-reconvert.ts
@@ -19,7 +19,6 @@ import { convertCDAToFHIR } from "../../../external/fhir-converter/converter";
 import { countResources } from "../../../external/fhir/patient/count-resources";
 import { Config } from "../../../shared/config";
 import { getDocRefMappings } from "../docref-mapping/get-docref-mapping";
-import { deleteConsolidated as deleteConsolidatedOnFHIRServer } from "../patient/consolidated-delete";
 import { getPatientOrFail } from "../patient/get-patient";
 import { setDisableDocumentRequestWHFlag } from "../patient/webhook";
 import { docRefContentToFileFunction, SimplerFile } from "./document-query-storage-info";
@@ -187,15 +186,7 @@ async function reConvertByPatient({
 
   const [documents, patient] = await Promise.all([getDocs(), disableWHAndGetPatient()]);
 
-  log(`Deleting consolidated data...`);
-  const docIds = documents.map(d => d.docRef.id);
-  await deleteConsolidatedOnFHIRServer({
-    patient,
-    resources: resourcesToDelete,
-    docIds,
-    dryRun,
-  });
-
+  log(`Starting reconversion for ${patient.id}, who has ${documents.length} documents...`);
   await reConvertDocumentsInternal({
     patient,
     documents,

--- a/packages/api/src/command/medical/patient/consolidated-delete.ts
+++ b/packages/api/src/command/medical/patient/consolidated-delete.ts
@@ -156,6 +156,13 @@ async function deleteChunk(
     if (issuesFlattened.length > 0) {
       const msg = `Gracefully failed to delete FHIR resources`;
       log(`${msg} - ${JSON.stringify(issuesFlattened)}`);
+      capture.error(msg, {
+        extra: {
+          context: `deleteConsolidated.graceful-fail`,
+          patientId: patientId,
+          issues: issuesFlattened,
+        },
+      });
     }
   } catch (error) {
     const detailMsg =

--- a/packages/api/src/command/medical/patient/consolidated-delete.ts
+++ b/packages/api/src/command/medical/patient/consolidated-delete.ts
@@ -156,13 +156,6 @@ async function deleteChunk(
     if (issuesFlattened.length > 0) {
       const msg = `Gracefully failed to delete FHIR resources`;
       log(`${msg} - ${JSON.stringify(issuesFlattened)}`);
-      capture.error(msg, {
-        extra: {
-          context: `deleteConsolidated.graceful-fail`,
-          patientId: patientId,
-          issues: issuesFlattened,
-        },
-      });
     }
   } catch (error) {
     const detailMsg =


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-734

### Description
- remove a call from the internal `re-convert` route to the `deleteConsolidatedOnFHIRServer` since we no longer store consolidated on there

### Testing

- N/A

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during batch deletion of patient data by logging issues instead of capturing them as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->