### PR TITLE
feat(fix): added warning label for case sensitive column headers

### DIFF
--- a/docs/medical-api/api-reference/patient/bulk-create-patient.mdx
+++ b/docs/medical-api/api-reference/patient/bulk-create-patient.mdx
@@ -37,7 +37,7 @@ We support up to 10 addresses, 10 email addresses, and 10 phone numbers. In orde
 just index each column with `-N` at the end of the column name, where `N` is the index (1-10).
 
 <Warning> 
-  Column headers are **case sensitive**. Be sure to match them _exactly_ as shown in the example file; otherwise the row may be marked as invalid. 
+  Column headers are **case sensitive**. Be sure to match them _exactly_ as shown in the example file; otherwise the whole file may be marked as invalid. 
 </Warning>
 
 <Expandable title="CSV columns">


### PR DESCRIPTION

Issues:

- https://linear.app/metriport/issue/ENG-745

### Dependencies

- Upstream: None
- Downstream: None

### Description
Added warning label for case sensitive column headers.

### Testing
Ran mintlify locally

<img width="692" height="556" alt="Screenshot 2025-07-28 at 2 36 37 PM" src="https://github.com/user-attachments/assets/7e80ec83-6c7a-44f6-bd29-015ec1befcc7" />

- Local
  - [x] mintlify dev
- Production
  - [x] Check that it exists in production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a warning highlighting that CSV column headers are case sensitive and must match the example file exactly to prevent invalid rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->