### PR TITLE
feat(api): added update secondary mapping endpoint

### DIFF
--- a/packages/api/src/routes/internal/index.ts
+++ b/packages/api/src/routes/internal/index.ts
@@ -341,6 +341,15 @@ router.post(
   })
 );
 
+/**
+ * PATCH /internal/cx-mapping/update-secondary-mappings
+ *
+ * Update secondary mapping in a cx mapping
+ *
+ * @param req.query.cxId - The cutomer's ID.
+ * @param req.query.id - The cx mapping ID.
+ * @param req.query.source - the mapping source
+ */
 router.patch(
   "/cx-mapping/update-secondary-mappings",
   requestLogger,

--- a/packages/api/src/routes/internal/index.ts
+++ b/packages/api/src/routes/internal/index.ts
@@ -30,7 +30,11 @@ import {
   revokeMapiAccess,
 } from "../../command/medical/mapi-access";
 import { getOrganizationOrFail } from "../../command/medical/organization/get-organization";
-import { isCxMappingSource, secondaryMappingsSchemaMap } from "../../domain/cx-mapping";
+import {
+  CxMappingSource,
+  isCxMappingSource,
+  secondaryMappingsSchemaMap,
+} from "../../domain/cx-mapping";
 import { isFacilityMappingSource } from "../../domain/facility-mapping";
 import { initCQOrgIncludeList } from "../../external/commonwell/organization";
 import { subscribeToAllWebhooks as subscribeToElationWebhooks } from "../../external/ehr/elation/command/subscribe-to-webhook";
@@ -342,39 +346,33 @@ router.post(
 );
 
 /**
- * PATCH /internal/cx-mapping/update-secondary-mappings
+ * POST /internal/cx-mapping/update-secondary-mappings
  *
  * Update secondary mapping in a cx mapping
  *
- * @param req.query.cxId - The cutomer's ID.
+ * @param req.query.cxId - The customer's ID.
  * @param req.query.id - The cx mapping ID.
- * @param req.query.source - the mapping source
+ * @param req.query.source - the mapping source.
+ *
+ * @return status 200 with the newly updated CxMapping object.
  */
-router.patch(
+router.post(
   "/cx-mapping/update-secondary-mappings",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
     const id = getFrom("query").orFail("id", req);
     const source = getFromQueryOrFail("source", req);
-    if (!isCxMappingSource(source)) {
-      throw new BadRequestError(`Invalid source for cx mapping`, undefined, { source });
-    }
-    const secondaryMappingsSchema = secondaryMappingsSchemaMap[source];
+    const secondaryMappingsSchema = secondaryMappingsSchemaMap[source as CxMappingSource];
     const secondaryMappings = secondaryMappingsSchema
       ? secondaryMappingsSchema.parse(req.body)
       : null;
-    if (!secondaryMappings) {
-      throw new BadRequestError(`Invalid secondaryMappings for cx mapping`, undefined, {
-        secondaryMappings,
-      });
-    }
-    await setSecondaryMappingsOnCxMappingById({
+    const newCxMapping = await setSecondaryMappingsOnCxMappingById({
       cxId,
       id,
       secondaryMappings,
     });
-    return res.sendStatus(httpStatus.OK);
+    return res.status(httpStatus.OK).json(newCxMapping);
   })
 );
 

--- a/packages/api/src/routes/internal/index.ts
+++ b/packages/api/src/routes/internal/index.ts
@@ -9,6 +9,7 @@ import {
   findOrCreateCxMapping,
   getCxMappingsByCustomer,
   setExternalIdOnCxMappingById,
+  setSecondaryMappingsOnCxMappingById,
 } from "../../command/mapping/cx";
 import {
   deleteFacilityMapping,
@@ -340,10 +341,40 @@ router.post(
   })
 );
 
+router.patch(
+  "/cx-mapping/update-secondary-mappings",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").orFail();
+    const id = getFrom("query").orFail("id", req);
+    const source = getFromQueryOrFail("source", req);
+    if (!isCxMappingSource(source)) {
+      throw new BadRequestError(`Invalid source for cx mapping`, undefined, { source });
+    }
+    const secondaryMappingsSchema = secondaryMappingsSchemaMap[source];
+    console.log(secondaryMappingsSchema);
+    console.log(req.body);
+    const secondaryMappings = secondaryMappingsSchema
+      ? secondaryMappingsSchema.parse(req.body)
+      : null;
+    if (!secondaryMappings) {
+      throw new BadRequestError(`Invalid secondaryMappings for cx mapping`, undefined, {
+        secondaryMappings,
+      });
+    }
+    await setSecondaryMappingsOnCxMappingById({
+      cxId,
+      id,
+      secondaryMappings,
+    });
+    return res.sendStatus(httpStatus.OK);
+  })
+);
+
 /**
  * GET /internal/cx-mapping
  *
- * Get cx mappings for customer
+ * Get cx mappings for customer3
  *
  * @param req.query.cxId - The cutomer's ID.
  * @param req.query.source - Optional mapping source

--- a/packages/api/src/routes/internal/index.ts
+++ b/packages/api/src/routes/internal/index.ts
@@ -346,45 +346,6 @@ router.post(
 );
 
 /**
- * POST /internal/cx-mapping/update-secondary-mappings
- *
- * Update secondary mapping in a cx mapping.
- *
- * @param req.query.cxId - The customer's ID.
- * @param req.query.id - The cx mapping ID.
- * @param req.query.source - the mapping source.
- *
- * @return status 200 with the newly updated CxMapping object.
- */
-router.post(
-  "/cx-mapping/update-secondary-mappings",
-  requestLogger,
-  asyncHandler(async (req: Request, res: Response) => {
-    const cxId = getUUIDFrom("query", req, "cxId").orFail();
-    const id = getFrom("query").orFail("id", req);
-    const source = getFromQueryOrFail("source", req);
-    const secondaryMappingsSchema = secondaryMappingsSchemaMap[source as CxMappingSource];
-    const secondaryMappings = secondaryMappingsSchema
-      ? secondaryMappingsSchema.parse(req.body)
-      : null;
-    if (!secondaryMappings) {
-      throw new BadRequestError(`Invalid secondaryMappings for cx mapping`, undefined, {
-        cxId,
-        id,
-        source,
-        secondaryMappings,
-      });
-    }
-    const newCxMapping = await setSecondaryMappingsOnCxMappingById({
-      cxId,
-      id,
-      secondaryMappings,
-    });
-    return res.status(httpStatus.OK).json(newCxMapping);
-  })
-);
-
-/**
  * GET /internal/cx-mapping
  *
  * Get cx mappings for customer.
@@ -451,6 +412,45 @@ router.delete(
       id,
     });
     return res.sendStatus(httpStatus.NO_CONTENT);
+  })
+);
+
+/**
+ * PUT /internal/cx-mapping/update-secondary-mapping
+ *
+ * Update secondary mapping in a cx mapping.
+ *
+ * @param req.query.cxId - The customer's ID.
+ * @param req.query.id - The cx mapping ID.
+ * @param req.query.source - the mapping source.
+ *
+ * @return status 200 with the newly updated CxMapping object.
+ */
+router.put(
+  "/cx-mapping/:id/update-secondary-mapping",
+  requestLogger,
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getUUIDFrom("query", req, "cxId").orFail();
+    const id = getFrom("query").orFail("id", req);
+    const source = getFromQueryOrFail("source", req);
+    const secondaryMappingsSchema = secondaryMappingsSchemaMap[source as CxMappingSource];
+    const secondaryMappings = secondaryMappingsSchema
+      ? secondaryMappingsSchema.parse(req.body)
+      : undefined;
+    if (!secondaryMappings) {
+      throw new BadRequestError(`Invalid secondaryMappings for cx mapping`, undefined, {
+        cxId,
+        id,
+        source,
+        secondaryMappings,
+      });
+    }
+    const newCxMapping = await setSecondaryMappingsOnCxMappingById({
+      cxId,
+      id,
+      secondaryMappings,
+    });
+    return res.status(httpStatus.OK).json(newCxMapping);
   })
 );
 

--- a/packages/api/src/routes/internal/index.ts
+++ b/packages/api/src/routes/internal/index.ts
@@ -348,7 +348,7 @@ router.post(
 /**
  * POST /internal/cx-mapping/update-secondary-mappings
  *
- * Update secondary mapping in a cx mapping
+ * Update secondary mapping in a cx mapping.
  *
  * @param req.query.cxId - The customer's ID.
  * @param req.query.id - The cx mapping ID.
@@ -367,6 +367,14 @@ router.post(
     const secondaryMappings = secondaryMappingsSchema
       ? secondaryMappingsSchema.parse(req.body)
       : null;
+    if (!secondaryMappings) {
+      throw new BadRequestError(`Invalid secondaryMappings for cx mapping`, undefined, {
+        cxId,
+        id,
+        source,
+        secondaryMappings,
+      });
+    }
     const newCxMapping = await setSecondaryMappingsOnCxMappingById({
       cxId,
       id,

--- a/packages/api/src/routes/internal/index.ts
+++ b/packages/api/src/routes/internal/index.ts
@@ -416,12 +416,12 @@ router.delete(
 );
 
 /**
- * PUT /internal/cx-mapping/update-secondary-mapping
+ * PUT /internal/cx-mapping/:id/update-secondary-mapping
  *
  * Update secondary mapping in a cx mapping.
  *
  * @param req.query.cxId - The customer's ID.
- * @param req.query.id - The cx mapping ID.
+ * @param req.parmas.id - The cx mapping ID.
  * @param req.query.source - the mapping source.
  *
  * @return status 200 with the newly updated CxMapping object.
@@ -431,7 +431,7 @@ router.put(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
-    const id = getFrom("query").orFail("id", req);
+    const id = getFrom("params").orFail("id", req);
     const source = getFromQueryOrFail("source", req);
     const secondaryMappingsSchema = secondaryMappingsSchemaMap[source as CxMappingSource];
     const secondaryMappings = secondaryMappingsSchema
@@ -450,7 +450,7 @@ router.put(
       id,
       secondaryMappings,
     });
-    return res.status(httpStatus.OK).json(newCxMapping);
+    return res.status(httpStatus.OK).json({ cxMapping: newCxMapping });
   })
 );
 

--- a/packages/api/src/routes/internal/index.ts
+++ b/packages/api/src/routes/internal/index.ts
@@ -416,7 +416,7 @@ router.delete(
 );
 
 /**
- * PUT /internal/cx-mapping/:id/update-secondary-mapping
+ * PUT /internal/cx-mapping/:id/secondary-mapping
  *
  * Update secondary mapping in a cx mapping.
  *
@@ -427,7 +427,7 @@ router.delete(
  * @return status 200 with the newly updated CxMapping object.
  */
 router.put(
-  "/cx-mapping/:id/update-secondary-mapping",
+  "/cx-mapping/:id/secondary-mapping",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();

--- a/packages/api/src/routes/internal/index.ts
+++ b/packages/api/src/routes/internal/index.ts
@@ -361,8 +361,6 @@ router.patch(
       throw new BadRequestError(`Invalid source for cx mapping`, undefined, { source });
     }
     const secondaryMappingsSchema = secondaryMappingsSchemaMap[source];
-    console.log(secondaryMappingsSchema);
-    console.log(req.body);
     const secondaryMappings = secondaryMappingsSchema
       ? secondaryMappingsSchema.parse(req.body)
       : null;
@@ -383,7 +381,7 @@ router.patch(
 /**
  * GET /internal/cx-mapping
  *
- * Get cx mappings for customer3
+ * Get cx mappings for customer.
  *
  * @param req.query.cxId - The cutomer's ID.
  * @param req.query.source - Optional mapping source


### PR DESCRIPTION
metriport/metriport-internal#1040

Issues:

- https://linear.app/metriport/issue/ENG-729

### Dependencies

- Upstream: None
- Downstream: None

### Description
Added a PATCH endpoint to update secondary mapping in cx mapping.

### Testing
- Local
  - [x] Send PATCH api request to internal/cx-mapping/update-secondary-mappings using postman
  - [x] Ensure secondary mappings value changed in cx mapping table
  - [x] Ensure invalid Source throws error
  - [x] Ensure invalid secondary mappings throws error
- Staging
  - [ ] Send PATCH api request to internal/cx-mapping/update-secondary-mappings using postman
  - [ ] Ensure secondary mappings value changed in cx mapping table
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to update secondary mappings for specific items through a new internal API endpoint, with validation to ensure accurate updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->