### PR TITLE
ENG-575: Improve debuggability of ADT utcification error

### DIFF
--- a/packages/core/src/command/hl7-notification/s3.ts
+++ b/packages/core/src/command/hl7-notification/s3.ts
@@ -1,0 +1,36 @@
+import { Logger } from "../../util/log";
+import { buildDayjs, ISO_DATE_TIME } from "@metriport/shared/common/date";
+import { S3Utils } from "../../external/aws/s3";
+import { Config } from "../../util/config";
+import { createUnparseableHl7MessagePhiFileKey } from "../hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
+
+export async function persistHl7Phi({
+  patientId,
+  stringMessage,
+  logger,
+}: {
+  patientId: string;
+  stringMessage: string;
+  logger: Logger;
+}) {
+  const { log } = logger;
+  const bucketName = Config.getHl7IncomingMessageBucketName();
+  const s3Utils = new S3Utils(Config.getAWSRegion());
+
+  const keyParams = {
+    rawPtIdentifier: patientId,
+    rawTimestamp: buildDayjs().format(ISO_DATE_TIME),
+    messageCode: "UNK",
+    triggerEvent: "UNK",
+  };
+
+  const phiFileKey = createUnparseableHl7MessagePhiFileKey(keyParams);
+
+  log(`Uploading PHI to S3 with key: ${phiFileKey}`);
+  await s3Utils.uploadFile({
+    bucket: bucketName,
+    key: phiFileKey,
+    file: Buffer.from(stringMessage),
+    contentType: "text/plain",
+  });
+}

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
@@ -197,3 +197,17 @@ export function createUnparseableHl7MessageErrorMessageFileKey({
 }) {
   return `parse-failure/${rawTimestamp}_${rawPtIdentifier}_${messageCode}_${triggerEvent}_${nanoid()}_error.txt`;
 }
+
+export function createUnparseableHl7MessagePhiFileKey({
+  rawPtIdentifier,
+  rawTimestamp,
+  messageCode,
+  triggerEvent,
+}: {
+  rawPtIdentifier: string;
+  rawTimestamp: string;
+  messageCode: string;
+  triggerEvent: string;
+}) {
+  return `parse-failure/phi/${rawTimestamp}_${rawPtIdentifier}_${messageCode}_${triggerEvent}_${nanoid()}_phi.txt`;
+}

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
@@ -209,5 +209,5 @@ export function createUnparseableHl7MessagePhiFileKey({
   messageCode: string;
   triggerEvent: string;
 }) {
-  return `parse-failure/phi/${rawTimestamp}_${rawPtIdentifier}_${messageCode}_${triggerEvent}_${nanoid()}_phi.txt`;
+  return `phi/${rawTimestamp}_${rawPtIdentifier}_${messageCode}_${triggerEvent}_${nanoid()}_phi.txt`;
 }

--- a/packages/core/src/external/hl7-notification/__tests__/datetime.test.ts
+++ b/packages/core/src/external/hl7-notification/__tests__/datetime.test.ts
@@ -1,6 +1,10 @@
 import { handleTimezoneOffset, utcifyHl7Message } from "../datetime";
 import { makeHl7Message } from "./make-hl7-message";
 
+jest.mock("../../../command/hl7-notification/s3", () => ({
+  persistHl7Phi: jest.fn(),
+}));
+
 /**
  * Test fixture to suppress console logs during test execution
  */

--- a/packages/core/src/external/hl7-notification/datetime.ts
+++ b/packages/core/src/external/hl7-notification/datetime.ts
@@ -4,6 +4,7 @@ import { buildDayjs, buildDayjsTz } from "@metriport/shared/common/date";
 import { flow } from "lodash";
 import { capture, out } from "../../util";
 import { getOptionalValueFromMessage } from "../../command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
+import { persistHl7Phi } from "../../command/hl7-notification/s3";
 
 const MSH_DATETIME_OF_MESSAGE_INDEX = 7;
 const EVN_RECORDED_DATETIME_INDEX = 2;
@@ -72,6 +73,18 @@ function utcifyHl7Components(
         ? component
         : buildDayjsTz(component, timezone).format("YYYYMMDDHHmmss");
     } catch (e) {
+      const logMessage = `Full segment: ${segment.toString()}
+      \nField @ ${fieldIndex} has value ${segment.getField(fieldIndex)?.toString()}
+      \nField @ ${fieldIndex - 1} has value ${segment.getField(fieldIndex - 1)?.toString()}
+      \nField @ ${fieldIndex + 1} has value ${segment.getField(fieldIndex + 1)?.toString()}
+      \nFull message: ${message.segments.map(s => s.toString()).join("\n")}`;
+
+      persistHl7Phi({
+        patientId: getOptionalValueFromMessage(message, "PID", 3, 1) ?? "unknown-patient",
+        stringMessage: logMessage,
+        logger: out("utcifyHl7Components"),
+      });
+
       const msg = `Error UTCifying component in segment ${segmentName}`;
       log(`${msg}, error - ${errorToString(e)}`);
       capture.error(msg, {


### PR DESCRIPTION
### Dependencies

None

### Description

This is the fixed version of [this patch](https://github.com/metriport/metriport/pull/4247).

This has 2 updates:
1. The import path here has been fixed to be correct.
```
import { buildDayjs, ISO_DATE_TIME } from "@metriport/shared/common/date";
```

2. During tests we mock out the persistHl7Phi call that requires configs + does IO to S3
```
jest.mock("../../../command/hl7-notification/s3", () => ({
  persistHl7Phi: jest.fn(),
}));
```

### Testing

- Local
  - [x] Verify that we get the failure data to show in S3
- Staging
  - [ ] Verify that we get the failure data to show in S3
- Production
  - [ ] Verify that we get the failure data to show in S3


### Release Plan

- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to persist HL7 Protected Health Information (PHI) messages to an external storage location for enhanced diagnostics.
  * Introduced a new method for generating unique file keys for unparseable HL7 PHI messages.

* **Bug Fixes**
  * Improved error handling by saving detailed diagnostic information when errors occur during HL7 datetime conversion.

* **Tests**
  * Updated tests to mock the new PHI persistence functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->