### PR TITLE
feat(api): added if statement to delete primary org

### DIFF
--- a/packages/api/src/external/carequality/command/cq-organization/__tests__/carequality-fhir.test.e2e.ts
+++ b/packages/api/src/external/carequality/command/cq-organization/__tests__/carequality-fhir.test.e2e.ts
@@ -93,7 +93,6 @@ describe("CarequalityManagementApiFhir", () => {
   afterAll(async () => {
     if (primaryOrg) {
       try {
-        console.log("Deleting primary org");
         await api.deleteOrganization(primaryOrg.id);
       } catch (error) {
         console.error(`Failed to delete primary org (${primaryOrg.id})`, error);
@@ -101,7 +100,6 @@ describe("CarequalityManagementApiFhir", () => {
     }
     if (secondaryOrg) {
       try {
-        console.log("Deleting secondary org");
         await api.deleteOrganization(secondaryOrg.id);
       } catch (error) {
         console.error(`Failed to delete secondary org (${secondaryOrg.id})`, error);
@@ -109,7 +107,6 @@ describe("CarequalityManagementApiFhir", () => {
     }
     if (unrelatedOidOrg) {
       try {
-        console.log("Deleting unrelated org");
         await api.deleteOrganization(unrelatedOidOrg.id);
       } catch (error) {
         console.error(`Failed to delete unrelated OID org (${unrelatedOidOrg.id})`, error);


### PR DESCRIPTION
metriport/metriport-internal#1040

Issues:

- https://linear.app/metriport/issue/ENG-730

### Dependencies

- Upstream: None
- Downstream: None

### Description

Fixed a bug where orgs made from e2e tests wouldn't get deleted/disabled.
Fixed by adding if statement because primary org was never deleted.

### Testing

- Local
  - [x] Ran e2e tests locally to make sure all orgs are deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cleanup process in tests to ensure all organizations are properly deleted, with enhanced logging for deletion attempts and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->