### PR TITLE
ENG-779 Make consolidated search stricter

### DIFF
--- a/packages/core/src/external/opensearch/lexical/__tests__/query.test.ts
+++ b/packages/core/src/external/opensearch/lexical/__tests__/query.test.ts
@@ -6,11 +6,11 @@ describe("query", () => {
       const fuziness = getFuzziness(undefined);
       expect(fuziness).toBe("AUTO");
     });
-    it("returns 0 when query is less than 3 chars", async () => {
+    it("returns 0 when query is 3 chars or less", async () => {
       const fuziness = getFuzziness("CDA");
       expect(fuziness).toBe("0");
     });
-    it("returns 1 when query is more than 3 chars", async () => {
+    it("returns 1 when query is 4 chars or more", async () => {
       const fuziness = getFuzziness("CDAS");
       expect(fuziness).toBe("1");
     });

--- a/packages/core/src/external/opensearch/lexical/__tests__/query.test.ts
+++ b/packages/core/src/external/opensearch/lexical/__tests__/query.test.ts
@@ -1,0 +1,18 @@
+import { getFuzziness } from "../query";
+
+describe("query", () => {
+  describe("getFuzziness", () => {
+    it("returns AUTO when query is undefined  ", async () => {
+      const fuziness = getFuzziness(undefined);
+      expect(fuziness).toBe("AUTO");
+    });
+    it("returns 0 when query is less than 3 chars", async () => {
+      const fuziness = getFuzziness("CDA");
+      expect(fuziness).toBe("0");
+    });
+    it("returns 1 when query is more than 3 chars", async () => {
+      const fuziness = getFuzziness("CDAS");
+      expect(fuziness).toBe("1");
+    });
+  });
+});

--- a/packages/core/src/external/opensearch/lexical/query.ts
+++ b/packages/core/src/external/opensearch/lexical/query.ts
@@ -41,7 +41,7 @@ export function createLexicalSearchQuery({ query, cxId, patientId }: LexicalSear
                       match: {
                         [contentFieldName]: {
                           query: actualQuery,
-                          fuzziness: "AUTO",
+                          ...getFuzzySettings(actualQuery),
                         },
                       },
                     },
@@ -103,4 +103,30 @@ export function createQueryHasData({
       bool: { must: getPatientFilters(cxId, patientId) },
     },
   };
+}
+
+/**
+ * @see https://docs.opensearch.org/latest/query-dsl/full-text/match/#fuzziness
+ */
+export function getFuzzySettings(query: string | undefined): {
+  fuzziness: string;
+  fuzzy_transpositions: boolean;
+} {
+  return {
+    fuzziness: getFuzziness(query),
+    /**
+     * Whether to allow transpositions/character swaps.
+     * - false: uses Levenshtein distance (calculated by counting the number of insertions,
+     *   deletions, and substitutions required to transform one string into the other)
+     * - true: uses Damerau–Levenshtein distance (same as above, but transpositions/swaps are
+     *   counted as single edits)
+     */
+    fuzzy_transpositions: false,
+  };
+}
+
+export function getFuzziness(query: string | undefined) {
+  if (!query) return "AUTO";
+  if (query.length < 4) return "0";
+  return "1";
 }

--- a/packages/core/src/external/opensearch/lexical/query.ts
+++ b/packages/core/src/external/opensearch/lexical/query.ts
@@ -121,7 +121,7 @@ export function getFuzzySettings(query: string | undefined): {
      * - true: uses Damerau–Levenshtein distance (same as above, but transpositions/swaps are
      *   counted as single edits)
      */
-    fuzzy_transpositions: false,
+    fuzzy_transpositions: true,
   };
 }
 


### PR DESCRIPTION
### Dependencies

none

### Description

Make consolidated search stricter:
- no transpositions allowed for fuzzy calculation
- words with 3 chars or less use exact matching
- words with 4 chars or more accept a single "edit" (for distance calculation)

### Testing

- Local
  - [x] Unit testing
  - [x] Test these changes directly on OS
- Staging
  - [ ] Searching for word with 3 chars needs to be exact
  - [ ] Searching for word with 4 chars accepts single edit
  - [ ] Char swapping counts as 2 edits
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved search functionality with dynamic fuzzy matching that adapts to the length of your search query for more relevant results.

* **Tests**
  * Added tests to ensure fuzzy search behavior works correctly for different query lengths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->