### PR TITLE
ENG-258: Stop mixing encounter reason in with diagnosis codes

### DIFF
--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -241,13 +241,7 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
                 system: coding.system ?? "",
               })) ?? [],
           });
-        }
-      }
-    }
-
-    if (bundle.entry) {
-      for (const entry of bundle.entry) {
-        if (entry.resource?.resourceType === "Encounter") {
+        } else if (entry.resource?.resourceType === "Encounter") {
           clinicalInformation.encounterReason = entry.resource.reasonCode ?? [];
         }
       }

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/condition.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/condition.ts
@@ -1,7 +1,6 @@
 import { Hl7Message, Hl7Segment } from "@medplum/core";
 import { CodeableConcept, Condition, EncounterDiagnosis } from "@medplum/fhirtypes";
 import { createUuidFromText } from "@metriport/shared/common/uuid";
-import _ from "lodash";
 import {
   buildConditionReference,
   buildPatientReference,
@@ -32,11 +31,9 @@ export function getConditionsAndReferences(
   adt: Hl7Message,
   patientId: string
 ): ConditionsAndReferences {
-  const encReason = getEncounterReason(adt, patientId);
   const diagnoses = getAllDiagnoses(adt, patientId);
 
-  const combinedDiagnoses = _.concat(encReason?.condition ?? [], diagnoses);
-  const uniqueConditions = deduplicateConditions(combinedDiagnoses, false).combinedResources;
+  const uniqueConditions = deduplicateConditions(diagnoses, false).combinedResources;
   const conditionReferences = uniqueConditions.map(condition =>
     buildConditionReference({ resource: condition })
   );


### PR DESCRIPTION
### Dependencies

- Upstream: None
- Downstream: None

### Description

We're mixing encounter reason in with diagnosis codes, 

### Testing

- Local
  - [ ] Run ADT with an encounter reason through conversion, see no Condition in output with the encounter reason
- Staging
  - [ ] Run ADT with an encounter reason through conversion, see no Condition in output with the encounter reason
- Production
  - [ ] Check monitor for samples 



### Release Plan

- [ ] Merge this
- [ ] ??? Reconvert many old ADTs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated condition handling to exclude encounter reason conditions from deduplication and references, focusing only on diagnoses.  
* **New Features**
  * Enhanced clinical information extraction to include both conditions and encounter reasons for improved data representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->