### PR TITLE
feat(utils): added script to preview a bundle

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -39,7 +39,7 @@
     "npi": "ts-node src/facility/make-npi",
     "fhir-demo": "ts-node src/fhir-sdk-demo.ts",
     "test-typing": "ts-node src/test-typing.ts",
-    "preview": "ts-node src/preview-consolidated.ts"
+    "preview-consolidated": "ts-node src/preview-consolidated.ts"
   },
   "keywords": [],
   "author": "",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -38,7 +38,8 @@
     "load-test": "artillery run ./src/terminology/load-test.yml",
     "npi": "ts-node src/facility/make-npi",
     "fhir-demo": "ts-node src/fhir-sdk-demo.ts",
-    "test-typing": "ts-node src/test-typing.ts"
+    "test-typing": "ts-node src/test-typing.ts",
+    "preview": "ts-node src/preview-consolidated.ts"
   },
   "keywords": [],
   "author": "",

--- a/packages/utils/src/preview-consolidated.ts
+++ b/packages/utils/src/preview-consolidated.ts
@@ -49,4 +49,6 @@ program
     await main(cxId, ptId);
   });
 
+program.parse(process.argv);
+
 export default program;

--- a/packages/utils/src/preview-consolidated.ts
+++ b/packages/utils/src/preview-consolidated.ts
@@ -6,7 +6,12 @@ import { getEnvVarOrFail, MetriportError } from "../../shared/dist";
 import { Command } from "commander";
 import { openPreviewUrl } from "./surescripts/shared";
 
-async function main(cxId: string, ptId: string) {
+type PreviewParams = {
+  cxId: string;
+  ptId: string;
+};
+
+async function main({ cxId, ptId }: PreviewParams) {
   const S3Utils = getS3UtilsInstance();
   const trimmedCxId = cxId.trim();
   const trimmedPtId = ptId.trim();
@@ -42,14 +47,12 @@ const program = new Command();
 
 program
   .name("preview-consolidated")
-  .option("--cx-id <cxId>", "The customer ID")
-  .option("--pt-id <ptId>", "The patient ID")
+  .requiredOption("--cx-id <cxId>", "The customer ID")
+  .requiredOption("--pt-id <ptId>", "The patient ID")
   .description("Previews a patients consolidated bundle")
   .showHelpAfterError()
   .version("1.0.0")
-  .action(async function ({ cxId, ptId }) {
-    await main(cxId, ptId);
-  });
+  .action(main);
 
 program.parse(process.argv);
 

--- a/packages/utils/src/preview-consolidated.ts
+++ b/packages/utils/src/preview-consolidated.ts
@@ -1,16 +1,30 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
 import { getS3UtilsInstance } from "@metriport/core/external/ehr/bundle/bundle-shared";
 import { exec } from "child_process";
+import { getEnvVarOrFail, MetriportError } from "@metriport/shared";
 
 async function main(cxId: string, ptId: string) {
   const S3Utils = getS3UtilsInstance();
   const fileName = `${cxId}/${ptId}/${cxId}_${ptId}_CONSOLIDATED_DATA.json`;
-  const durationSeconds = 1 * 60 * 60; //1 hour
-  const bucketName = "metriport-medical-documents";
+  const durationSeconds = getEnvVarOrFail("DURATION_SECONDS");
+  const bucketName = getEnvVarOrFail("MEDICAL_BUCKET_NAME");
+
+  const existsFile = await S3Utils.fileExists(bucketName, fileName);
+
+  if (!existsFile) {
+    throw new MetriportError(
+      `Could not find file. Make sure your cxId and ptId are correct.`,
+      undefined,
+      { cxId, ptId }
+    );
+  }
 
   const presignedUrl = await S3Utils.getSignedUrl({
     bucketName,
     fileName,
-    durationSeconds,
+    durationSeconds: Number(durationSeconds),
   });
 
   const encoded = encodeURIComponent(presignedUrl);

--- a/packages/utils/src/preview-consolidated.ts
+++ b/packages/utils/src/preview-consolidated.ts
@@ -4,6 +4,7 @@ dotenv.config();
 import { getS3UtilsInstance } from "@metriport/core/external/ehr/bundle/bundle-shared";
 import { getEnvVarOrFail, MetriportError } from "../../shared/dist";
 import { Command } from "commander";
+import { openPreviewUrl } from "./surescripts/shared";
 
 async function main(cxId: string, ptId: string) {
   const S3Utils = getS3UtilsInstance();
@@ -34,11 +35,7 @@ async function main(cxId: string, ptId: string) {
     durationSeconds,
   });
 
-  const encoded = encodeURIComponent(presignedUrl);
-
-  const url = `https://preview.metriport.com?url=${encoded}`;
-
-  console.log(`Open this url: ${url}`);
+  openPreviewUrl(presignedUrl);
 }
 
 const program = new Command();

--- a/packages/utils/src/preview-consolidated.ts
+++ b/packages/utils/src/preview-consolidated.ts
@@ -10,8 +10,13 @@ async function main(cxId: string, ptId: string) {
   const trimmedCxId = cxId.trim();
   const trimmedPtId = ptId.trim();
   const fileName = `${trimmedCxId}/${trimmedPtId}/${trimmedCxId}_${trimmedPtId}_CONSOLIDATED_DATA.json`;
-  const durationSeconds = getEnvVarOrFail("DURATION_SECONDS");
+  const durationSecondsString = getEnvVarOrFail("DURATION_SECONDS");
   const bucketName = getEnvVarOrFail("MEDICAL_BUCKET_NAME");
+  const durationSeconds = Number(durationSecondsString);
+
+  if (isNaN(durationSeconds)) {
+    throw new MetriportError(`Your DURATION_SECONDS is NaN.`, undefined, { durationSeconds });
+  }
 
   const fileExists = await S3Utils.fileExists(bucketName, fileName);
 
@@ -26,7 +31,7 @@ async function main(cxId: string, ptId: string) {
   const presignedUrl = await S3Utils.getSignedUrl({
     bucketName,
     fileName,
-    durationSeconds: Number(durationSeconds),
+    durationSeconds,
   });
 
   const encoded = encodeURIComponent(presignedUrl);

--- a/packages/utils/src/preview-consolidated.ts
+++ b/packages/utils/src/preview-consolidated.ts
@@ -2,22 +2,24 @@ import * as dotenv from "dotenv";
 dotenv.config();
 // keep that ^ on top
 import { getS3UtilsInstance } from "@metriport/core/external/ehr/bundle/bundle-shared";
-import { exec } from "child_process";
-import { getEnvVarOrFail, MetriportError } from "@metriport/shared";
+import { getEnvVarOrFail, MetriportError } from "../../shared/dist";
+import { Command } from "commander";
 
 async function main(cxId: string, ptId: string) {
   const S3Utils = getS3UtilsInstance();
-  const fileName = `${cxId}/${ptId}/${cxId}_${ptId}_CONSOLIDATED_DATA.json`;
+  const trimmedCxId = cxId.trim();
+  const trimmedPtId = ptId.trim();
+  const fileName = `${trimmedCxId}/${trimmedPtId}/${trimmedCxId}_${trimmedPtId}_CONSOLIDATED_DATA.json`;
   const durationSeconds = getEnvVarOrFail("DURATION_SECONDS");
   const bucketName = getEnvVarOrFail("MEDICAL_BUCKET_NAME");
 
-  const existsFile = await S3Utils.fileExists(bucketName, fileName);
+  const fileExists = await S3Utils.fileExists(bucketName, fileName);
 
-  if (!existsFile) {
+  if (!fileExists) {
     throw new MetriportError(
-      `Could not find file. Make sure your cxId and ptId are correct.`,
+      `File does not exist. Make sure your cxId and ptId are correct.`,
       undefined,
-      { cxId, ptId }
+      { cxId, ptId, bucketName, durationSeconds }
     );
   }
 
@@ -31,13 +33,20 @@ async function main(cxId: string, ptId: string) {
 
   const url = `https://preview.metriport.com?url=${encoded}`;
 
-  exec(`open -a "Google Chrome" "${url}"`);
+  console.log(`Open this url: ${url}`);
 }
 
-const args = process.argv.slice(2);
-const [cxId, ptId] = args;
+const program = new Command();
 
-main(cxId, ptId).catch(error => {
-  console.error("Error: ", error);
-  process.exit(1);
-});
+program
+  .name("preview-consolidated")
+  .option("--cx-id <cxId>", "The customer ID")
+  .option("--pt-id <ptId>", "The patient ID")
+  .description("Previews a patients consolidated bundle")
+  .showHelpAfterError()
+  .version("1.0.0")
+  .action(async function ({ cxId, ptId }) {
+    await main(cxId, ptId);
+  });
+
+export default program;

--- a/packages/utils/src/preview-consolidated.ts
+++ b/packages/utils/src/preview-consolidated.ts
@@ -1,0 +1,29 @@
+import { getS3UtilsInstance } from "@metriport/core/external/ehr/bundle/bundle-shared";
+import { exec } from "child_process";
+
+async function main(cxId: string, ptId: string) {
+  const S3Utils = getS3UtilsInstance();
+  const fileName = `${cxId}/${ptId}/${cxId}_${ptId}_CONSOLIDATED_DATA.json`;
+  const durationSeconds = 1 * 60 * 60; //1 hour
+  const bucketName = "metriport-medical-documents";
+
+  const presignedUrl = await S3Utils.getSignedUrl({
+    bucketName,
+    fileName,
+    durationSeconds,
+  });
+
+  const encoded = encodeURIComponent(presignedUrl);
+
+  const url = `https://preview.metriport.com?url=${encoded}`;
+
+  exec(`open -a "Google Chrome" "${url}"`);
+}
+
+const args = process.argv.slice(2);
+const [cxId, ptId] = args;
+
+main(cxId, ptId).catch(error => {
+  console.error("Error: ", error);
+  process.exit(1);
+});


### PR DESCRIPTION
refs. metriport/metriport#1440
Issues:

- https://linear.app/metriport/issue/ENG-542

### Dependencies

- Upstream: None
- Downstream: None

### Description

Added a script to preview a consolidated bundle of a patient given the customer id and patient id.

ran by doing
ts-node path/preview-consolidated.ts --cx-id [cxId] --pt-id [ptId]

Automatically opens a tab to preview the consolidated bundle

[Link to relevant notion](https://www.notion.so/Using-the-preview-dash-240b51bb90408092a520ed53b4eefcff?d=240b51bb904080428168001c06bde71a&source=copy_link#240b51bb904080a18fabc4783c335c6c)


### Testing
- Local
  - [x] Ran script with real cxId ptId 
  - [x] Ran script with fake cxId ptId 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a command-line tool to generate a preview URL for a patient's consolidated data bundle.
  * Supports specifying customer and patient IDs to locate the data.
  * Provides clear error messages for missing information or invalid input.
  * Offers help and version information via the CLI.
  * Added a convenient script to run the preview URL generator directly from the command line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->