### PR TITLE
feat(ehr): response fixes

### DIFF
--- a/packages/api/src/external/ehr/healthie/shared.ts
+++ b/packages/api/src/external/ehr/healthie/shared.ts
@@ -39,7 +39,8 @@ export function createAddresses(patient: HealthiePatient): Address[] {
   const addresses = patient.locations.flatMap(address => {
     const addressLine1 = address.line1.trim();
     if (addressLine1 === "") return [];
-    const addressLine2 = address.line2.trim() !== "" ? address.line2.trim() : undefined;
+    const addressLine2 =
+      address.line2 && address.line2.trim() !== "" ? address.line2.trim() : undefined;
     const city = address.city.trim();
     if (city === "") return [];
     const country = normalizeCountrySafe(address.country) ?? normalizedCountryUsa;

--- a/packages/core/src/external/ehr/athenahealth/index.ts
+++ b/packages/core/src/external/ehr/athenahealth/index.ts
@@ -489,8 +489,9 @@ class AthenaHealthApi {
       });
     }
     const patientCustomFields = patientsCustomFields[0]?.customfields;
-    if (!patientCustomFields)
+    if (!patientCustomFields) {
       throw new NotFoundError("Patient not found", undefined, additionalInfo);
+    }
     return patientCustomFields;
   }
 

--- a/packages/shared/src/interface/external/ehr/athenahealth/patient.ts
+++ b/packages/shared/src/interface/external/ehr/athenahealth/patient.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const patientCustomFieldSchema = z.object({
   customfieldid: z.string(),
-  customfieldvalue: z.string(),
+  customfieldvalue: z.string().optional(),
   optionid: z.string().optional(),
 });
 export type PatientCustomField = z.infer<typeof patientCustomFieldSchema>;

--- a/packages/shared/src/interface/external/ehr/healthie/patient.ts
+++ b/packages/shared/src/interface/external/ehr/healthie/patient.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 const locationSchema = z.object({
   line1: z.string(),
-  line2: z.string(),
+  line2: z.string().nullable(),
   city: z.string(),
   state: z.string(),
   zip: z.string(),


### PR DESCRIPTION
Ref: ENG-437

Issues:

- https://linear.app/metriport/issue/ENG-437

### Description

- fix healthie null - address line 2
- fix athenahealth undefeind - custom fields value

### Testing

- Local
  - [ ] N/A
- Staging
  - [ ] TODO
- Sandbox
  - [ ] N/A
- Production
  - [ ] N/A

### Release Plan

- [ ] Merge this
