### PR TITLE
ENG-333: fix(infra): add quest secrets to main secrets stack

### DIFF
--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -92,6 +92,13 @@ export class SecretsStack extends Stack {
       }
     }
 
+    if (props.config.quest) {
+      for (const secretName of Object.values(props.config.quest.secrets)) {
+        const secret = makeSecret(secretName);
+        logSecretInfo(this, secret, secretName);
+      }
+    }
+
     if (!isSandbox(props.config)) {
       for (const secretName of Object.values(props.config.hl7Notification.secrets)) {
         const secret = makeSecret(secretName);


### PR DESCRIPTION
metriport/metriport-internal#3045

Issues:

- https://linear.app/metriport/issue/ENG-333

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4305
- Downstream: None

### Description

Fixes an infrastructure configuration issue that does not initialize the Quest secret in AWS Secrets Manager (required for a staging test of the upstream PR).

### Testing

See if the Quest password shows up in Secrets Manager.

- Staging
  - [ ] Check for presence of secret, and update value to correct one
  - [ ] Run an SFTP connect from Lambda to ensure everything is hooked up properly
- Production
  - [ ] Same as above, test SFTP connection to production Quest system

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically creates and logs information for secrets defined in the quest configuration, enhancing secret management for users with quest-related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->