### PR TITLE
ENG-810 Add subject reference to Encounters

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Header.hbs
+++ b/packages/fhir-converter/src/templates/cda/Header.hbs
@@ -39,6 +39,9 @@
     {{#if document.componentOf.encompassingEncounter}}
         {{!-- do we want to include this? Kinda a duplicate of more rich data later in encounter section --}}
         {{>Resources/Encounter.hbs encounter=document.componentOf.encompassingEncounter ID=@encompassingEncounterIds.newId}},
+        {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+            {{>References/Encounter/subject.hbs ID=@encompassingEncounterIds.newId REF=(concat 'Patient/' patientId.Id)}},
+        {{/with}}
         
         {{#if document.componentOf.encompassingEncounter.responsibleParty.assignedEntity}}
             {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=document.componentOf.encompassingEncounter.responsibleParty.assignedEntity) as |practitionerId|}}


### PR DESCRIPTION
Part of ENG-810

Signed-off-by: Ramil Garipov <ramil@metriport.com>

### Description

- XML `encompassingEncounter` was not getting the patient reference, so I added the mapping for it

### Testing

- Local
  - [x] Confirm the fix works for 3 different cases listed in the [initial thread](https://metriport.slack.com/archives/C094AJ8L0E8/p1754509413028479?thread_ts=1754422098.493109&cid=C094AJ8L0E8)
  - [x] Run the FHIR integration test
    - [x] No new erroring files
    - [x] Resource counts must remain the same 
<img width="944" height="475" alt="Screenshot 2025-08-06 at 2 36 51 PM" src="https://github.com/user-attachments/assets/c1f86a26-5cc5-4a26-8187-bc4a83b4fafb" />

- Staging 
  - [x] Convert a problematic doc on the staging converter and verify the output
- Production
  - [ ] Convert a problematic doc on the prod converter and verify the output

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit linking of Encounter resources to Patient references in generated documents, ensuring clearer associations between encounters and patients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->