### PR TITLE
fix(core): always replace the doc on s3 after dr

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xca/process/dr-response.ts
@@ -106,14 +106,12 @@ async function processDocumentReference({
     );
     const fileInfo = await s3Utils.getFileInfoFromS3(filePath, bucket);
 
-    if (!fileInfo.exists) {
-      await s3Utils.uploadFile({
-        bucket,
-        key: filePath,
-        file: decodedBytes,
-        contentType: mimeType,
-      });
-    }
+    await s3Utils.uploadFile({
+      bucket,
+      key: filePath,
+      file: decodedBytes,
+      contentType: mimeType,
+    });
 
     log(
       `Downloaded a document with mime type: ${mimeType} for patient: ${outboundRequest.patientId} and request: ${outboundRequest.id}`


### PR DESCRIPTION
Part of ENG-620

Issues:

- https://linear.app/metriport/issue/ENG-620

### Description
- The XML redownload FF decides whether a document needs to be re-queried from the networks. We find them on the networks, download, and then we don't replace the files on S3?? Why?
- I removed the check for whether the file already exists on s3, so we can just update it with the newer version. I don't see any drawback in doing that, but not 100% sure

### Testing
- Staging
  - [ ] Test with a CW connection
- Production
  - [ ] Rerun DQ on some of the affected patients and make sure the doc gets redownloaded

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Files are now always uploaded to S3, regardless of whether they already exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->