### PR TITLE
Eng 000 fix athena units

### DIFF
--- a/packages/core/src/external/ehr/unit-conversion.ts
+++ b/packages/core/src/external/ehr/unit-conversion.ts
@@ -198,7 +198,13 @@ function isMmHg(units: string): boolean {
 }
 
 function isBpm(units: string): boolean {
-  return units === "bpm" || units === "/min" || units === "beats/min" || units === "per minute";
+  return (
+    units === "bpm" ||
+    units === "/min" ||
+    units === "beats/min" ||
+    units === "per minute" ||
+    units === "br/min"
+  );
 }
 
 function isPercent(units: string): boolean {


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-000

### Description
- We're getting a lot of errors for conversion units being `br/min` for respiratory rate on Athena. Let's start handling them.

### Testing
- N/A, imo

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
