### PR TITLE
chore(release): publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28896,12 +28896,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "17.2.1-alpha.0",
+      "version": "17.2.1-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.9.19-alpha.0",
-        "@metriport/shared": "^0.24.8-alpha.0",
+        "@metriport/commonwell-sdk": "^5.9.20-alpha.0",
+        "@metriport/shared": "^0.24.9-alpha.0",
         "axios": "^1.8.2",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28968,11 +28968,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.18.19-alpha.0",
+      "version": "1.18.20-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.19.19-alpha.0",
-        "@metriport/shared": "^0.24.8-alpha.0"
+        "@metriport/ihe-gateway-sdk": "^0.19.20-alpha.0",
+        "@metriport/shared": "^0.24.9-alpha.0"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -29004,10 +29004,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.26.21-alpha.0",
+      "version": "1.26.22-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.9.19-alpha.0",
+        "@metriport/commonwell-sdk": "^5.9.20-alpha.0",
         "axios": "^1.8.2",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -29046,10 +29046,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.24.21-alpha.0",
+      "version": "1.24.22-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.9.19-alpha.0",
+        "@metriport/commonwell-sdk": "^5.9.20-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -29081,10 +29081,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.9.19-alpha.0",
+      "version": "5.9.20-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.24.8-alpha.0",
+        "@metriport/shared": "^0.24.9-alpha.0",
         "axios": "^1.8.2",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -29625,10 +29625,10 @@
     "packages/fhir-sdk/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.19.19-alpha.0",
+      "version": "0.19.20-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.24.8-alpha.0",
+        "@metriport/shared": "^0.24.9-alpha.0",
         "axios": "^1.8.2",
         "zod": "^3.22.1"
       }
@@ -29896,7 +29896,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.24.8-alpha.0",
+      "version": "0.24.9-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28896,12 +28896,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "17.2.0",
+      "version": "17.2.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.9.18",
-        "@metriport/shared": "^0.24.7",
+        "@metriport/commonwell-sdk": "^5.9.19-alpha.0",
+        "@metriport/shared": "^0.24.8-alpha.0",
         "axios": "^1.8.2",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28968,11 +28968,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.18.18",
+      "version": "1.18.19-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.19.18",
-        "@metriport/shared": "^0.24.7"
+        "@metriport/ihe-gateway-sdk": "^0.19.19-alpha.0",
+        "@metriport/shared": "^0.24.8-alpha.0"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -29004,10 +29004,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.26.20",
+      "version": "1.26.21-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.9.18",
+        "@metriport/commonwell-sdk": "^5.9.19-alpha.0",
         "axios": "^1.8.2",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -29046,10 +29046,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.24.20",
+      "version": "1.24.21-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.9.18",
+        "@metriport/commonwell-sdk": "^5.9.19-alpha.0",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -29081,10 +29081,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.9.18",
+      "version": "5.9.19-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.24.7",
+        "@metriport/shared": "^0.24.8-alpha.0",
         "axios": "^1.8.2",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -29625,10 +29625,10 @@
     "packages/fhir-sdk/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.19.18",
+      "version": "0.19.19-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.24.7",
+        "@metriport/shared": "^0.24.8-alpha.0",
         "axios": "^1.8.2",
         "zod": "^3.22.1"
       }
@@ -29896,7 +29896,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.24.7",
+      "version": "0.24.8-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28811,7 +28811,7 @@
       }
     },
     "packages/api": {
-      "version": "1.27.16",
+      "version": "1.27.17",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.800.0",
@@ -28896,12 +28896,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "17.2.0-17.3.0.0",
+      "version": "17.2.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.9.17",
-        "@metriport/shared": "^0.24.6",
+        "@metriport/commonwell-sdk": "^5.9.18",
+        "@metriport/shared": "^0.24.7",
         "axios": "^1.8.2",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28968,11 +28968,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.19.17",
-        "@metriport/shared": "^0.24.6"
+        "@metriport/ihe-gateway-sdk": "^0.19.18",
+        "@metriport/shared": "^0.24.7"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -28980,7 +28980,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -29004,10 +29004,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.26.19",
+      "version": "1.26.20",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.9.17",
+        "@metriport/commonwell-sdk": "^5.9.18",
         "axios": "^1.8.2",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -29046,10 +29046,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.24.19",
+      "version": "1.24.20",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.9.17",
+        "@metriport/commonwell-sdk": "^5.9.18",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -29081,10 +29081,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.9.17",
+      "version": "5.9.18",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.24.6",
+        "@metriport/shared": "^0.24.7",
         "axios": "^1.8.2",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -29132,7 +29132,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.24.15",
+      "version": "1.24.16",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -29485,7 +29485,7 @@
     "packages/core/packages/shared": {},
     "packages/eslint-rules": {
       "name": "@metriport/eslint-plugin-eslint-rules",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/rule-tester": "^6.0.0",
@@ -29501,7 +29501,7 @@
     },
     "packages/fhir-sdk": {
       "name": "@metriport/fhir-sdk",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.2.10",
@@ -29625,17 +29625,17 @@
     "packages/fhir-sdk/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.19.17",
+      "version": "0.19.18",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.24.6",
+        "@metriport/shared": "^0.24.7",
         "axios": "^1.8.2",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.22.15",
+      "version": "1.22.16",
       "dependencies": {
         "@metriport/core": "file:packages/core",
         "@metriport/shared": "file:packages/shared",
@@ -29698,7 +29698,7 @@
     "packages/infra/packages/core": {},
     "packages/infra/packages/shared": {},
     "packages/mllp-server": {
-      "version": "0.3.15",
+      "version": "0.3.16",
       "license": "ISC",
       "dependencies": {
         "@medplum/core": "^3.2.33",
@@ -29896,7 +29896,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.24.6",
+      "version": "0.24.7",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -29949,7 +29949,7 @@
       "dev": true
     },
     "packages/utils": {
-      "version": "1.25.15",
+      "version": "1.25.16",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.800.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28811,7 +28811,7 @@
       }
     },
     "packages/api": {
-      "version": "1.27.17",
+      "version": "1.27.18",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.800.0",
@@ -28896,12 +28896,12 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "17.2.1-alpha.1",
+      "version": "17.2.1",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/commonwell-sdk": "^5.9.20-alpha.0",
-        "@metriport/shared": "^0.24.9-alpha.0",
+        "@metriport/commonwell-sdk": "^5.9.20",
+        "@metriport/shared": "^0.24.9",
         "axios": "^1.8.2",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28968,11 +28968,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.18.20-alpha.0",
+      "version": "1.18.20",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.19.20-alpha.0",
-        "@metriport/shared": "^0.24.9-alpha.0"
+        "@metriport/ihe-gateway-sdk": "^0.19.20",
+        "@metriport/shared": "^0.24.9"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -28980,7 +28980,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -29004,10 +29004,10 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "1.26.22-alpha.0",
+      "version": "1.26.22",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.9.20-alpha.0",
+        "@metriport/commonwell-sdk": "^5.9.20",
         "axios": "^1.8.2",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -29046,10 +29046,10 @@
     },
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.24.22-alpha.0",
+      "version": "1.24.22",
       "license": "MIT",
       "dependencies": {
-        "@metriport/commonwell-sdk": "^5.9.20-alpha.0",
+        "@metriport/commonwell-sdk": "^5.9.20",
         "commander": "^9.5.0"
       },
       "bin": {
@@ -29081,10 +29081,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "5.9.20-alpha.0",
+      "version": "5.9.20",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.24.9-alpha.0",
+        "@metriport/shared": "^0.24.9",
         "axios": "^1.8.2",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -29132,7 +29132,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.24.16",
+      "version": "1.24.17",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -29485,7 +29485,7 @@
     "packages/core/packages/shared": {},
     "packages/eslint-rules": {
       "name": "@metriport/eslint-plugin-eslint-rules",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/rule-tester": "^6.0.0",
@@ -29501,7 +29501,7 @@
     },
     "packages/fhir-sdk": {
       "name": "@metriport/fhir-sdk",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.2.10",
@@ -29625,17 +29625,17 @@
     "packages/fhir-sdk/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.19.20-alpha.0",
+      "version": "0.19.20",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.24.9-alpha.0",
+        "@metriport/shared": "^0.24.9",
         "axios": "^1.8.2",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.22.16",
+      "version": "1.22.17",
       "dependencies": {
         "@metriport/core": "file:packages/core",
         "@metriport/shared": "file:packages/shared",
@@ -29698,7 +29698,7 @@
     "packages/infra/packages/core": {},
     "packages/infra/packages/shared": {},
     "packages/mllp-server": {
-      "version": "0.3.16",
+      "version": "0.3.17",
       "license": "ISC",
       "dependencies": {
         "@medplum/core": "^3.2.33",
@@ -29896,7 +29896,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.24.9-alpha.0",
+      "version": "0.24.9",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -29949,7 +29949,7 @@
       "dev": true
     },
     "packages/utils": {
-      "version": "1.25.16",
+      "version": "1.25.17",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.800.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "17.2.0",
+  "version": "17.2.1-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.9.18",
-    "@metriport/shared": "^0.24.7",
+    "@metriport/commonwell-sdk": "^5.9.19-alpha.0",
+    "@metriport/shared": "^0.24.8-alpha.0",
     "axios": "^1.8.2",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "17.2.0-17.3.0.0",
+  "version": "17.2.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.9.17",
-    "@metriport/shared": "^0.24.6",
+    "@metriport/commonwell-sdk": "^5.9.18",
+    "@metriport/shared": "^0.24.7",
     "axios": "^1.8.2",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "17.2.1-alpha.1",
+  "version": "17.2.1",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.9.20-alpha.0",
-    "@metriport/shared": "^0.24.9-alpha.0",
+    "@metriport/commonwell-sdk": "^5.9.20",
+    "@metriport/shared": "^0.24.9",
     "axios": "^1.8.2",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "17.2.1-alpha.0",
+  "version": "17.2.1-alpha.1",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/commonwell-sdk": "^5.9.19-alpha.0",
-    "@metriport/shared": "^0.24.8-alpha.0",
+    "@metriport/commonwell-sdk": "^5.9.20-alpha.0",
+    "@metriport/shared": "^0.24.9-alpha.0",
     "axios": "^1.8.2",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -77,6 +77,5 @@
     "ts-essentials": "^9.3.1",
     "ts-jest": "29.1.1",
     "typescript": "^4.9.5"
-  },
-  "gitHead": "98570bd9fa0651ba364d76092c52f9618f94a80b"
+  }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.27.17",
+  "version": "1.27.18",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.27.16",
+  "version": "1.27.17",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.18.18",
+  "version": "1.18.19-alpha.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.19.18",
-    "@metriport/shared": "^0.24.7"
+    "@metriport/ihe-gateway-sdk": "^0.19.19-alpha.0",
+    "@metriport/shared": "^0.24.8-alpha.0"
   }
 }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.18.20-alpha.0",
+  "version": "1.18.20",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.19.20-alpha.0",
-    "@metriport/shared": "^0.24.9-alpha.0"
+    "@metriport/ihe-gateway-sdk": "^0.19.20",
+    "@metriport/shared": "^0.24.9"
   }
 }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.18.19-alpha.0",
+  "version": "1.18.20-alpha.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.19.19-alpha.0",
-    "@metriport/shared": "^0.24.8-alpha.0"
+    "@metriport/ihe-gateway-sdk": "^0.19.20-alpha.0",
+    "@metriport/shared": "^0.24.9-alpha.0"
   }
 }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.19.17",
-    "@metriport/shared": "^0.24.6"
+    "@metriport/ihe-gateway-sdk": "^0.19.18",
+    "@metriport/shared": "^0.24.7"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.26.20",
+  "version": "1.26.21-alpha.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.9.18",
+    "@metriport/commonwell-sdk": "^5.9.19-alpha.0",
     "axios": "^1.8.2",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.26.21-alpha.0",
+  "version": "1.26.22-alpha.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.9.19-alpha.0",
+    "@metriport/commonwell-sdk": "^5.9.20-alpha.0",
     "axios": "^1.8.2",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.26.22-alpha.0",
+  "version": "1.26.22",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.9.20-alpha.0",
+    "@metriport/commonwell-sdk": "^5.9.20",
     "axios": "^1.8.2",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "1.26.19",
+  "version": "1.26.20",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -42,7 +42,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.9.17",
+    "@metriport/commonwell-sdk": "^5.9.18",
     "axios": "^1.8.2",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.24.19",
+  "version": "1.24.20",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.9.17",
+    "@metriport/commonwell-sdk": "^5.9.18",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.24.21-alpha.0",
+  "version": "1.24.22-alpha.0",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.9.19-alpha.0",
+    "@metriport/commonwell-sdk": "^5.9.20-alpha.0",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.24.20",
+  "version": "1.24.21-alpha.0",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.9.18",
+    "@metriport/commonwell-sdk": "^5.9.19-alpha.0",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.24.22-alpha.0",
+  "version": "1.24.22",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/commonwell-sdk": "^5.9.20-alpha.0",
+    "@metriport/commonwell-sdk": "^5.9.20",
     "commander": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.9.19-alpha.0",
+  "version": "5.9.20-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.24.8-alpha.0",
+    "@metriport/shared": "^0.24.9-alpha.0",
     "axios": "^1.8.2",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.9.17",
+  "version": "5.9.18",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.24.6",
+    "@metriport/shared": "^0.24.7",
     "axios": "^1.8.2",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.9.18",
+  "version": "5.9.19-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.24.7",
+    "@metriport/shared": "^0.24.8-alpha.0",
     "axios": "^1.8.2",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "5.9.20-alpha.0",
+  "version": "5.9.20",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.24.9-alpha.0",
+    "@metriport/shared": "^0.24.9",
     "axios": "^1.8.2",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.24.15",
+  "version": "1.24.16",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.24.16",
+  "version": "1.24.17",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/eslint-rules/package.json
+++ b/packages/eslint-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/eslint-plugin-eslint-rules",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Custom ESLint rules for Metriport's monorepo",
   "main": "index.js",
   "keywords": [

--- a/packages/eslint-rules/package.json
+++ b/packages/eslint-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/eslint-plugin-eslint-rules",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Custom ESLint rules for Metriport's monorepo",
   "main": "index.js",
   "keywords": [

--- a/packages/fhir-sdk/package.json
+++ b/packages/fhir-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/fhir-sdk",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "description": "FHIR Bundle SDK for parsing, querying, and manipulating FHIR bundles with reference resolution",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/fhir-sdk/package.json
+++ b/packages/fhir-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/fhir-sdk",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "description": "FHIR Bundle SDK for parsing, querying, and manipulating FHIR bundles with reference resolution",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.19.20-alpha.0",
+  "version": "0.19.20",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.24.9-alpha.0",
+    "@metriport/shared": "^0.24.9",
     "axios": "^1.8.2",
     "zod": "^3.22.1"
   }

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.19.17",
+  "version": "0.19.18",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.24.6",
+    "@metriport/shared": "^0.24.7",
     "axios": "^1.8.2",
     "zod": "^3.22.1"
   }

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.19.19-alpha.0",
+  "version": "0.19.20-alpha.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.24.8-alpha.0",
+    "@metriport/shared": "^0.24.9-alpha.0",
     "axios": "^1.8.2",
     "zod": "^3.22.1"
   }

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.19.18",
+  "version": "0.19.19-alpha.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.24.7",
+    "@metriport/shared": "^0.24.8-alpha.0",
     "axios": "^1.8.2",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.22.15",
+  "version": "1.22.16",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.22.16",
+  "version": "1.22.17",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mllp-server",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "MLLP server that reads HL7 messages off of a raw tcp connection",
   "main": "app.js",
   "private": true,

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mllp-server",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "MLLP server that reads HL7 messages off of a raw tcp connection",
   "main": "app.js",
   "private": true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.24.8-alpha.0",
+  "version": "0.24.9-alpha.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.24.7",
+  "version": "0.24.8-alpha.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.24.9-alpha.0",
+  "version": "0.24.9",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.25.15",
+  "version": "1.25.16",
   "description": "",
   "private": true,
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.25.16",
+  "version": "1.25.17",
   "description": "",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Ref: #000

 - api@1.27.17
 - @metriport/api-sdk@17.2.0
 - @metriport/carequality-cert-runner@1.18.18
 - @metriport/carequality-sdk@1.7.2
 - @metriport/commonwell-cert-runner@1.26.20
 - @metriport/commonwell-jwt-maker@1.24.20
 - @metriport/commonwell-sdk@5.9.18
 - @metriport/core@1.24.16
 - @metriport/eslint-plugin-eslint-rules@1.0.8
 - @metriport/fhir-sdk@1.0.7
 - @metriport/ihe-gateway-sdk@0.19.18
 - infrastructure@1.22.16
 - mllp-server@0.3.16
 - @metriport/shared@0.24.7
 - utils@1.25.16

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-000

### Description
- Republishing the packages due to latest version having a botched name - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1754674869828289)

### Testing
- N/A

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package versions across multiple packages.
  * Bumped dependency versions for several internal packages to ensure compatibility and latest improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->