### PR TITLE
ENG-750: Update GET /tcm/viewer to return a patient's facility ids

### DIFF
--- a/packages/api/src/command/medical/tcm-encounter/get-tcm-encounters.ts
+++ b/packages/api/src/command/medical/tcm-encounter/get-tcm-encounters.ts
@@ -13,11 +13,13 @@ const DEFAULT_FILTER_DATE = new Date("2020-01-01T00:00:00.000Z");
 export interface TcmEncounterQueryData extends TcmEncounterModel {
   dataValues: TcmEncounterModel["dataValues"] & {
     patient_data: PatientModel["dataValues"]["data"];
+    patient_facility_ids: PatientModel["dataValues"]["facilityIds"];
   };
 }
 
 export type TcmEncounterResult = TcmEncounterModel["dataValues"] & {
   patientData: PatientModel["dataValues"]["data"];
+  patientFacilityIds: PatientModel["dataValues"]["facilityIds"];
 };
 
 export async function getTcmEncounters({
@@ -42,7 +44,7 @@ export async function getTcmEncounters({
    * ⚠️ Always change this query and the count query together.
    */
   const queryString = `
-      SELECT tcm_encounter.*, patient.data as patient_data
+      SELECT tcm_encounter.*, patient.data as patient_data, patient.facility_ids as patient_facility_ids
       FROM ${tcmEncounterTable} tcm_encounter
       INNER JOIN ${patientTable} patient 
       ON tcm_encounter.patient_id = patient.id
@@ -69,8 +71,9 @@ export async function getTcmEncounters({
   })) as TcmEncounterQueryData[];
 
   const encounters = rawEncounters.map(e => ({
-    ...omit(e.dataValues, "patient_data"),
+    ...omit(e.dataValues, ["patient_data", "patient_facility_ids"]),
     patientData: e.dataValues.patient_data,
+    patientFacilityIds: e.dataValues.patient_facility_ids,
   }));
 
   return sortForPagination(encounters, pagination);

--- a/packages/api/src/routes/medical/dtos/tcm-encounter-dto.ts
+++ b/packages/api/src/routes/medical/dtos/tcm-encounter-dto.ts
@@ -5,6 +5,7 @@ export type TcmEncounterDTO = Omit<TcmEncounterResult, "patientData"> & {
   patientDateOfBirth: string;
   patientPhoneNumbers: string[];
   patientStates: string[];
+  patientFacilityIds: string[];
 };
 
 export function dtoFromTcmEncounter(queryResult: TcmEncounterResult): TcmEncounterDTO {
@@ -18,5 +19,6 @@ export function dtoFromTcmEncounter(queryResult: TcmEncounterResult): TcmEncount
       patientData.contact?.flatMap(contact => (contact.phone ? [contact.phone] : [])) ?? [],
     patientStates:
       patientData.address?.flatMap(address => (address.state ? [address.state] : [])) ?? [],
+    patientFacilityIds: encounterData.patientFacilityIds ?? [],
   };
 }


### PR DESCRIPTION
### Dependencies

- Downstream: https://github.com/metriport/metriport-internal/pull/3151

### Description

This exposes the patient's facility id(s) to the TCM viewer so that facility filtering can be done. See downstream for a quick gif.

### Testing

- Local
  - [x] Test against cases in TCM Viewer (downstream)
- Staging
  - [ ] Test against cases in TCM Viewer (downstream)
- Production
  - [ ] Test against cases in TCM Viewer (downstream)

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Patient facility IDs are now included in TCM encounter data, allowing users to view associated facility information for each patient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->