### PR TITLE
ENG-827 CCDA cleanup prior to FHIR conversion

### DIFF
--- a/packages/core/src/domain/conversion/__tests__/cleanup.test.ts
+++ b/packages/core/src/domain/conversion/__tests__/cleanup.test.ts
@@ -1,9 +1,10 @@
 import fs from "fs";
 import path from "path";
 import {
+  GREATER_THAN,
   LESS_THAN,
   cleanUpTranslationCode,
-  replaceLessThanChar,
+  replaceXmlTagChars,
   xmlTranslationCodeRegex,
 } from "../cleanup";
 
@@ -31,32 +32,64 @@ describe("cleanUpTranslationCode", () => {
   });
 });
 
-describe("replaceLessThanChar", () => {
+describe("replaceXmlTagChars", () => {
   test("should replace '<' with spaces around it", () => {
-    expect(replaceLessThanChar("A < B")).toBe(`A ${LESS_THAN} B`);
+    expect(replaceXmlTagChars(createTestCase("A < B"))).toBe(createTestCase(`A ${LESS_THAN} B`));
   });
 
   test("should replace '<' before a digit", () => {
-    expect(replaceLessThanChar("A < 5")).toBe(`A ${LESS_THAN} 5`);
+    expect(replaceXmlTagChars(createTestCase("A < 5"))).toBe(createTestCase(`A ${LESS_THAN} 5`));
   });
 
   test("should replace '<' without a space before it", () => {
-    expect(replaceLessThanChar("A<5")).toBe(`A ${LESS_THAN} 5`);
+    expect(replaceXmlTagChars(createTestCase("A<5"))).toBe(createTestCase(`A${LESS_THAN}5`));
   });
 
   test("should replace '<' with a space after it", () => {
-    expect(replaceLessThanChar("A< 5")).toBe(`A ${LESS_THAN} 5`);
-  });
-
-  test("should not replace '<' before a letter", () => {
-    expect(replaceLessThanChar("A<B")).toBe("A<B");
+    expect(replaceXmlTagChars(createTestCase("A< 5"))).toBe(createTestCase(`A${LESS_THAN} 5`));
   });
 
   test("should not change text with no '<'", () => {
-    expect(replaceLessThanChar("No changes needed")).toBe("No changes needed");
+    expect(replaceXmlTagChars(createTestCase("No changes needed"))).toBe(
+      createTestCase("No changes needed")
+    );
   });
 
   test("should not replace '<' if it's part of an HTML tag", () => {
-    expect(replaceLessThanChar("<div>")).toBe("<div>");
+    expect(replaceXmlTagChars(createTestCase("<div>"))).toBe(createTestCase("<div>"));
+  });
+
+  test("should replace '>' with spaces around it", () => {
+    expect(replaceXmlTagChars(createTestCase("A > B"))).toBe(createTestCase(`A ${GREATER_THAN} B`));
+  });
+
+  test("should replace '>' before a digit", () => {
+    expect(replaceXmlTagChars(createTestCase("A > 5"))).toBe(createTestCase(`A ${GREATER_THAN} 5`));
+  });
+
+  test("should replace '>' without a space before it", () => {
+    expect(replaceXmlTagChars(createTestCase("A>5"))).toBe(createTestCase(`A${GREATER_THAN}5`));
+  });
+
+  test("should replace '>' with a space after it", () => {
+    expect(replaceXmlTagChars(createTestCase("A> 5"))).toBe(createTestCase(`A${GREATER_THAN} 5`));
+  });
+
+  test("should not change text with no '>'", () => {
+    expect(replaceXmlTagChars(createTestCase("No changes needed here"))).toBe(
+      createTestCase("No changes needed here")
+    );
+  });
+
+  test("should not replace '>' if it's part of an HTML tag", () => {
+    expect(replaceXmlTagChars(createTestCase("<div>"))).toBe(createTestCase("<div>"));
+  });
+
+  test("expectedly does not handle both '<' and '>' in the same text", () => {
+    expect(replaceXmlTagChars(createTestCase("A < B > C"))).toBe(createTestCase(`A < B > C`));
   });
 });
+
+function createTestCase(str: string): string {
+  return `<ClinicalDocument>${str}</ClinicalDocument>`;
+}

--- a/packages/core/src/domain/conversion/cleanup.ts
+++ b/packages/core/src/domain/conversion/cleanup.ts
@@ -1,6 +1,7 @@
 export const xmlTranslationCodeRegex = /(<translation[^>]*\scode=")([^"]*?)(")/g;
 
 export const LESS_THAN = "&lt;";
+export const GREATER_THAN = "&gt;";
 const AMPERSAND = "&amp;";
 
 export function cleanUpPayload(payloadRaw: string): string {


### PR DESCRIPTION
Part of ENG-827

Signed-off-by: Ramil Garipov <ramil@metriport.com>

### Description
- Replace `<` and `>` with `&lt;` and `&gt;`, respectively, when they appear in a place that's not an XML tag

### Testing

- Local
  - [x] Run the FHIR test suite with this included in the flow
    - [x] All files convert
    - [x] Resource counts are unaffected
    - [x] The new function is super quick (most documents take 0 or 1ms to cleanup)
- Staging
  - [ ] Re-convert docs for an existing patient
- Production
  - [ ] Rerun FHIR Converter DLQ
  - [ ] Monitor prod FHIR Converter queue

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of special characters in XML content, ensuring that less-than (“<”) and greater-than (“>”) characters are replaced with safe placeholders when appropriate.

* **Bug Fixes**
  * Enhanced character replacement logic to avoid altering characters inside HTML tags.

* **Tests**
  * Expanded and updated test coverage to verify correct replacement of both “<” and “>” characters in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->