### PR TITLE
ENG-828: Increase max page size

### DIFF
--- a/packages/api/src/routes/__tests__/pagination.test.ts
+++ b/packages/api/src/routes/__tests__/pagination.test.ts
@@ -69,7 +69,7 @@ describe("Pagination", () => {
       });
 
       it("accepts count equal to limit", async () => {
-        const req = { query: { count: "2500" }, baseUrl };
+        const req = { query: { count: "500" }, baseUrl };
         await paginated({
           request: req as any,
           additionalQueryParams: undefined,
@@ -77,7 +77,7 @@ describe("Pagination", () => {
           getTotalCount,
         });
         // One extra since we ask for one more to determine if there is a next page
-        expect(getItems).toHaveBeenNthCalledWith(1, { count: 2501 });
+        expect(getItems).toHaveBeenNthCalledWith(1, { count: 501 });
       });
 
       it("fails if count is lower than 0", async () => {
@@ -93,7 +93,7 @@ describe("Pagination", () => {
       });
 
       it("fails if count is higher than limit", async () => {
-        const req = { query: { count: "2501" }, baseUrl };
+        const req = { query: { count: "501" }, baseUrl };
         await expect(() =>
           paginated({
             request: req as any,
@@ -101,7 +101,7 @@ describe("Pagination", () => {
             getItems,
             getTotalCount,
           })
-        ).rejects.toThrow("Count has to be less than or equal to 2500");
+        ).rejects.toThrow("Count has to be less than or equal to 500");
       });
       it("rejects invalid count parameter", async () => {
         const req = { query: { count: "invalid" }, baseUrl };
@@ -152,9 +152,7 @@ describe("Pagination", () => {
 
     describe("logic", () => {
       it("returns empty array when no items exist", async () => {
-        async function emptyGetItems() {
-          return [];
-        }
+        const emptyGetItems = async () => [];
         const req = { query: {}, baseUrl };
         const result = await paginated({
           request: req as any,
@@ -170,9 +168,7 @@ describe("Pagination", () => {
 
       it("returns single item when only one exists", async () => {
         const id = faker.string.uuid();
-        async function singleItemGetItems() {
-          return [{ id, name: "Item 1" }];
-        }
+        const singleItemGetItems = async () => [{ id, name: "Item 1" }];
         const req = { query: {}, baseUrl };
         const result = await paginated({
           request: req as any,
@@ -327,12 +323,11 @@ describe("Pagination", () => {
       });
 
       it("defaults to 50 items per page", async () => {
-        async function moreItemsThanDefaultCount() {
-          return Array.from({ length: defaultItemsPerPage + 10 }, (_, i) => ({
+        const moreItemsThanDefaultCount = async () =>
+          Array.from({ length: defaultItemsPerPage + 10 }, (_, i) => ({
             id: i.toString(),
             name: `Item ${i}`,
           }));
-        }
         const req = { query: {}, baseUrl };
         const result = await paginated({
           request: req as any,
@@ -345,12 +340,11 @@ describe("Pagination", () => {
       });
 
       it("returns first page when no pagination params provided", async () => {
-        async function hundredPlusItems() {
-          return Array.from({ length: defaultItemsPerPage + 10 }, (_, i) => ({
+        const hundredPlusItems = async () =>
+          Array.from({ length: defaultItemsPerPage + 10 }, (_, i) => ({
             id: (++i).toString(),
             name: `Item ${i}`,
           }));
-        }
         const req = { query: {}, baseUrl };
         const result = await paginated({
           request: req as any,

--- a/packages/api/src/routes/__tests__/pagination.test.ts
+++ b/packages/api/src/routes/__tests__/pagination.test.ts
@@ -69,7 +69,7 @@ describe("Pagination", () => {
       });
 
       it("accepts count equal to limit", async () => {
-        const req = { query: { count: "500" }, baseUrl };
+        const req = { query: { count: "2500" }, baseUrl };
         await paginated({
           request: req as any,
           additionalQueryParams: undefined,
@@ -77,7 +77,7 @@ describe("Pagination", () => {
           getTotalCount,
         });
         // One extra since we ask for one more to determine if there is a next page
-        expect(getItems).toHaveBeenNthCalledWith(1, { count: 501 });
+        expect(getItems).toHaveBeenNthCalledWith(1, { count: 2501 });
       });
 
       it("fails if count is lower than 0", async () => {
@@ -93,7 +93,7 @@ describe("Pagination", () => {
       });
 
       it("fails if count is higher than limit", async () => {
-        const req = { query: { count: "501" }, baseUrl };
+        const req = { query: { count: "2501" }, baseUrl };
         await expect(() =>
           paginated({
             request: req as any,
@@ -101,7 +101,7 @@ describe("Pagination", () => {
             getItems,
             getTotalCount,
           })
-        ).rejects.toThrow("Count has to be less than or equal to 500");
+        ).rejects.toThrow("Count has to be less than or equal to 2500");
       });
       it("rejects invalid count parameter", async () => {
         const req = { query: { count: "invalid" }, baseUrl };
@@ -152,7 +152,9 @@ describe("Pagination", () => {
 
     describe("logic", () => {
       it("returns empty array when no items exist", async () => {
-        const emptyGetItems = async () => [];
+        async function emptyGetItems() {
+          return [];
+        }
         const req = { query: {}, baseUrl };
         const result = await paginated({
           request: req as any,
@@ -168,7 +170,9 @@ describe("Pagination", () => {
 
       it("returns single item when only one exists", async () => {
         const id = faker.string.uuid();
-        const singleItemGetItems = async () => [{ id, name: "Item 1" }];
+        async function singleItemGetItems() {
+          return [{ id, name: "Item 1" }];
+        }
         const req = { query: {}, baseUrl };
         const result = await paginated({
           request: req as any,
@@ -323,11 +327,12 @@ describe("Pagination", () => {
       });
 
       it("defaults to 50 items per page", async () => {
-        const moreItemsThanDefaultCount = async () =>
-          Array.from({ length: defaultItemsPerPage + 10 }, (_, i) => ({
+        async function moreItemsThanDefaultCount() {
+          return Array.from({ length: defaultItemsPerPage + 10 }, (_, i) => ({
             id: i.toString(),
             name: `Item ${i}`,
           }));
+        }
         const req = { query: {}, baseUrl };
         const result = await paginated({
           request: req as any,
@@ -340,11 +345,12 @@ describe("Pagination", () => {
       });
 
       it("returns first page when no pagination params provided", async () => {
-        const hundredPlusItems = async () =>
-          Array.from({ length: defaultItemsPerPage + 10 }, (_, i) => ({
+        async function hundredPlusItems() {
+          return Array.from({ length: defaultItemsPerPage + 10 }, (_, i) => ({
             id: (++i).toString(),
             name: `Item ${i}`,
           }));
+        }
         const req = { query: {}, baseUrl };
         const result = await paginated({
           request: req as any,

--- a/packages/api/src/routes/medical/network-entry.ts
+++ b/packages/api/src/routes/medical/network-entry.ts
@@ -1,8 +1,8 @@
-import { PaginatedResponse } from "@metriport/shared";
+import { createQueryMetaSchema, PaginatedResponse } from "@metriport/shared";
 import { Request, Response } from "express";
-import { z } from "zod";
 import Router from "express-promise-router";
 import status from "http-status";
+import { z } from "zod";
 
 import { Pagination } from "../../command/pagination";
 import {
@@ -10,7 +10,7 @@ import {
   getHieDirectoryEntriesByFilterCount,
 } from "../../external/hie/command/get-hie-directory-entries";
 import { requestLogger } from "../helpers/request-logger";
-import { paginated, queryMetaSchema } from "../pagination";
+import { paginated } from "../pagination";
 import { asyncHandler } from "../util";
 import { dtoFromHieDirectoryEntry, NetworkEntryDTO } from "./dtos/network-entry-dto";
 
@@ -18,7 +18,7 @@ export const networkEntryGetSchema = z
   .object({
     filter: z.string().optional(),
   })
-  .and(queryMetaSchema);
+  .and(createQueryMetaSchema());
 
 const router = Router();
 

--- a/packages/api/src/routes/medical/patient-root.ts
+++ b/packages/api/src/routes/medical/patient-root.ts
@@ -20,6 +20,7 @@ import {
   matchPatient,
 } from "../../command/medical/patient/get-patient";
 import { createPatientImportJob } from "../../command/medical/patient/patient-import/create";
+import { createSampleTcmEncounters } from "../../command/medical/tcm-encounter/create-sample-tcm-encounter";
 import { Pagination } from "../../command/pagination";
 import { getSandboxPatientLimitForCx } from "../../domain/medical/get-patient-limit";
 import { isPatientMappingSource, PatientMappingSource } from "../../domain/patient-mapping";
@@ -38,7 +39,6 @@ import {
 import { fromCreateResponseToDto, PatientImportDto } from "./dtos/patient-import";
 import { dtoFromModel, PatientDTO } from "./dtos/patientDTO";
 import { schemaCreateToPatientData, schemaDemographicsToPatientData } from "./schemas/patient";
-import { createSampleTcmEncounters } from "../../command/medical/tcm-encounter/create-sample-tcm-encounter";
 
 dayjs.extend(duration);
 

--- a/packages/api/src/routes/medical/schemas/tcm-encounter.ts
+++ b/packages/api/src/routes/medical/schemas/tcm-encounter.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
-import { queryMetaSchema } from "../../pagination";
 import { buildDayjs } from "@metriport/shared/common/date";
+import { createQueryMetaSchema } from "@metriport/shared";
 
+const tcmEncounterMaxPageSize = 2500;
 const stringOrNullSchema = z.union([z.string(), z.undefined(), z.null()]);
 
 export const tcmEncounterBaseSchema = z.strictObject({
@@ -51,7 +52,7 @@ const tcmEncounterQuerySchema = z
   .object({
     after: z.string().datetime().optional(),
   })
-  .and(queryMetaSchema);
+  .and(createQueryMetaSchema(tcmEncounterMaxPageSize));
 
 export const tcmEncounterListQuerySchema = tcmEncounterQuerySchema;
 export type TcmEncounterListQuery = z.infer<typeof tcmEncounterListQuerySchema>;

--- a/packages/api/src/routes/medical/tcm-encounter.ts
+++ b/packages/api/src/routes/medical/tcm-encounter.ts
@@ -70,6 +70,7 @@ router.get(
       getTotalCount: async () => {
         return await getTcmEncountersCount({ cxId, after: query.after });
       },
+      maxItemsPerPage: 2500,
     });
 
     return res.status(httpStatus.OK).json({

--- a/packages/api/src/routes/pagination.ts
+++ b/packages/api/src/routes/pagination.ts
@@ -12,7 +12,7 @@ import {
 } from "../command/pagination";
 
 export const defaultItemsPerPage = 50;
-export const maxItemsPerPage = 5000;
+export const maxItemsPerPage = 2500;
 
 /**
  * @deprecated Use queryMetaSchema from shared/src/domain/pagination instead

--- a/packages/api/src/routes/pagination.ts
+++ b/packages/api/src/routes/pagination.ts
@@ -12,7 +12,7 @@ import {
 } from "../command/pagination";
 
 export const defaultItemsPerPage = 50;
-export const maxItemsPerPage = 500;
+export const maxItemsPerPage = 5000;
 
 /**
  * @deprecated Use queryMetaSchema from shared/src/domain/pagination instead

--- a/packages/api/src/routes/pagination.ts
+++ b/packages/api/src/routes/pagination.ts
@@ -12,7 +12,7 @@ import {
 } from "../command/pagination";
 
 export const defaultItemsPerPage = 50;
-export const maxItemsPerPage = 5000;
+export const maxItemsPerPage = 500;
 
 /**
  * @deprecated Use queryMetaSchema from shared/src/domain/pagination instead

--- a/packages/api/src/routes/pagination.ts
+++ b/packages/api/src/routes/pagination.ts
@@ -9,11 +9,11 @@ import {
   PaginationToItem,
 } from "../command/pagination";
 
-export const defaultItemsPerPage = 50;
+const defaultItemsPerPage = 50;
 
 // TODO 483 remove this once pagination is fully rolled out
-export function isPaginated(req: Request, maxItemsPerPage = defaultItemsPerPage): boolean {
-  const meta = createQueryMetaSchema(maxItemsPerPage).parse(req.query);
+export function isPaginated(req: Request): boolean {
+  const meta = createQueryMetaSchema().parse(req.query);
   return Object.keys(meta).length > 0;
 }
 

--- a/packages/api/src/routes/pagination.ts
+++ b/packages/api/src/routes/pagination.ts
@@ -1,5 +1,10 @@
 import { Config } from "@metriport/core/util/config";
-import { createQueryMetaSchema, PaginatedResponse, ResponseMeta } from "@metriport/shared";
+import {
+  createQueryMetaSchema,
+  defaultItemsPerPage,
+  PaginatedResponse,
+  ResponseMeta,
+} from "@metriport/shared";
 import { Request } from "express";
 import {
   getPaginationItems,
@@ -8,8 +13,6 @@ import {
   PaginationItem,
   PaginationToItem,
 } from "../command/pagination";
-
-const defaultItemsPerPage = 50;
 
 // TODO 483 remove this once pagination is fully rolled out
 export function isPaginated(req: Request): boolean {

--- a/packages/api/src/routes/pagination.ts
+++ b/packages/api/src/routes/pagination.ts
@@ -12,7 +12,7 @@ import {
 } from "../command/pagination";
 
 export const defaultItemsPerPage = 50;
-export const maxItemsPerPage = 2500;
+export const maxItemsPerPage = 5000;
 
 /**
  * @deprecated Use queryMetaSchema from shared/src/domain/pagination instead

--- a/packages/api/src/routes/pagination.ts
+++ b/packages/api/src/routes/pagination.ts
@@ -17,7 +17,7 @@ export function isPaginated(req: Request): boolean {
   return Object.keys(meta).length > 0;
 }
 
-export function getRequestMeta(req: Request, maxItemsPerPage = 500): Pagination {
+export function getRequestMeta(req: Request, maxItemsPerPage: number): Pagination {
   const parsed = createQueryMetaSchema(maxItemsPerPage).parse(req.query);
   return {
     ...parsed,

--- a/packages/core/src/domain/patient-settings.ts
+++ b/packages/core/src/domain/patient-settings.ts
@@ -3,11 +3,11 @@ import {
   adtSubscriptionRequestSchema,
   BulkPatientSettingsRequest,
   bulkPatientSettingsRequestSchema,
+  createQueryMetaSchema,
   PatientSettingsRequest,
   patientSettingsRequestSchema,
   QuestMonitoringRequest,
   questMonitoringRequestSchema,
-  queryMetaSchema,
 } from "@metriport/shared";
 import { z } from "zod";
 import {
@@ -44,7 +44,7 @@ export const hl7v2SubscribersQuerySchema = z
   .object({
     hieName: z.string(),
   })
-  .and(queryMetaSchema);
+  .and(createQueryMetaSchema());
 
 export function parsePatientSettingsRequest(data: unknown): PatientSettingsRequest {
   try {

--- a/packages/shared/src/domain/pagination.ts
+++ b/packages/shared/src/domain/pagination.ts
@@ -4,30 +4,33 @@ import { numericValueSchema } from "../common/zod";
 export const defaultItemsPerPage = 50;
 export const maxItemsPerPage = 500;
 
-export const queryMetaSchema = z.intersection(
-  z.union(
-    [
-      z.object({
-        fromItem: z.string().optional(),
-        toItem: z.never().optional(),
-      }),
-      z.object({
-        fromItem: z.never().optional(),
-        toItem: z.string().optional(),
-      }),
-    ],
-    { errorMap: () => ({ message: "Either fromItem or toItem can be provided, but not both" }) }
-  ),
-  z.object({
-    count: numericValueSchema
-      .refine(count => count >= 0, {
-        message: `Count has to be greater than or equal to 0`,
-      })
-      .refine(count => count <= maxItemsPerPage, {
-        message: `Count has to be less than or equal to ${maxItemsPerPage}`,
-      })
-      .optional(),
-  })
-);
+export function createQueryMetaSchema(maxItems: number = maxItemsPerPage) {
+  return z.intersection(
+    z.union(
+      [
+        z.object({
+          fromItem: z.string().optional(),
+          toItem: z.never().optional(),
+        }),
+        z.object({
+          fromItem: z.never().optional(),
+          toItem: z.string().optional(),
+        }),
+      ],
+      { errorMap: () => ({ message: "Either fromItem or toItem can be provided, but not both" }) }
+    ),
+    z.object({
+      count: numericValueSchema
+        .refine(count => count >= 0, {
+          message: `Count has to be greater than or equal to 0`,
+        })
+        .refine(count => count <= maxItems, {
+          message: `Count has to be less than or equal to ${maxItems}`,
+        })
+        .optional(),
+    })
+  );
+}
 
+const queryMetaSchema = createQueryMetaSchema();
 export type HttpMeta = z.infer<typeof queryMetaSchema>;


### PR DESCRIPTION
### Dependencies

- Downstream: https://github.com/metriport/metriport-internal/pull/3155

### Description

Update max page size constant from 500 -> 2500 so that tables that are light on data but have lots of rows can have their data paginated more efficiently.

### Testing

Trivial, see downstream

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-endpoint pagination limits are now configurable at call time.
  * TCM Encounter listing supports up to 2,500 items per page.

* **Refactor**
  * Unified pagination validation around a shared schema factory for consistency.
  * Removed legacy pagination artifacts and minor import reorganization; public pagination surface simplified.

* **Bug Fixes**
  * Pagination fallback behavior and defaults preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->