### PR TITLE
fix(core): update diagreport dedupe logic and tests

### DIFF
--- a/packages/core/src/fhir-deduplication/__tests__/group-same-diag-reports.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/group-same-diag-reports.test.ts
@@ -1,7 +1,10 @@
 import { faker } from "@faker-js/faker";
-import { DiagnosticReport, Practitioner, Reference } from "@medplum/fhirtypes";
+import { DiagnosticReport } from "@medplum/fhirtypes";
 import {
+  a1cPanelConceptLoinc,
   makeDiagnosticReport,
+  metabolicPanelConceptLoinc,
+  metabolicPanelConceptOther,
   presentedFormExample,
   resultExample,
 } from "../../fhir-to-cda/cda-templates/components/__tests__/make-diagnostic-report";
@@ -12,18 +15,8 @@ let diagReportId: string;
 let diagReportId2: string;
 let diagReport: DiagnosticReport;
 let diagReport2: DiagnosticReport;
-let practId: string;
-let practId2: string;
-let practRef: Reference<Practitioner>;
-let practRef2: Reference<Practitioner>;
 
 beforeEach(() => {
-  practId = faker.string.uuid();
-  practId2 = faker.string.uuid();
-
-  practRef = { reference: `Practitioner/${practId}` };
-  practRef2 = { reference: `Practitioner/${practId2}` };
-
   diagReportId = faker.string.uuid();
   diagReportId2 = faker.string.uuid();
   diagReport = makeDiagnosticReport({ id: diagReportId });
@@ -66,63 +59,7 @@ describe("groupSameDiagnosticReports", () => {
     expect(diagReportsMap.size).toBe(1);
   });
 
-  it("groups diagReports with the same effectiveDateTime and performer ref", () => {
-    diagReport.effectiveDateTime = dateTime.start;
-    diagReport2.effectiveDateTime = dateTime.start;
-    diagReport.performer = [practRef];
-    diagReport2.performer = [practRef];
-
-    diagReport.result = resultExample;
-    diagReport2.presentedForm = presentedFormExample;
-
-    const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
-    expect(diagReportsMap.size).toBe(1);
-  });
-
-  it("does not group diagReports with the same effectiveDateTime, if one of them has a performer and the other one does not", () => {
-    diagReport.effectiveDateTime = dateTime.start;
-    diagReport2.effectiveDateTime = dateTime.start;
-    diagReport.performer = [practRef];
-    diagReport2.performer = [];
-
-    diagReport.result = resultExample;
-    diagReport2.presentedForm = presentedFormExample;
-
-    const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
-    expect(diagReportsMap.size).toBe(2);
-
-    const diagReportIds = Array.from(diagReportsMap.values()).map(d => d.id);
-    expect(diagReportIds).toEqual(expect.arrayContaining([diagReport.id, diagReport2.id]));
-  });
-
-  it("groups diagReports with the same effectiveDateTime if neither has a practitioner reference", () => {
-    diagReport.effectiveDateTime = dateTime.start;
-    diagReport2.effectiveDateTime = dateTime.start;
-
-    diagReport.result = resultExample;
-    diagReport2.presentedForm = presentedFormExample;
-
-    const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
-    expect(diagReportsMap.size).toBe(1);
-  });
-
-  it("does not group diagReports with different performer refs", () => {
-    diagReport.effectiveDateTime = dateTime.start;
-    diagReport2.effectiveDateTime = dateTime.start;
-    diagReport.performer = [practRef];
-    diagReport2.performer = [practRef2];
-
-    diagReport.result = resultExample;
-    diagReport2.presentedForm = presentedFormExample;
-
-    const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
-    expect(diagReportsMap.size).toBe(2);
-
-    const diagReportIds = Array.from(diagReportsMap.values()).map(d => d.id);
-    expect(diagReportIds).toEqual(expect.arrayContaining([diagReport.id, diagReport2.id]));
-  });
-
-  it("does not group duplicate diagReports if effectiveDateTime is not present", () => {
+  it("groups duplicate diagReports even if effectiveDateTime is not present", () => {
     diagReport.presentedForm = presentedFormExample;
     diagReport2.presentedForm = presentedFormExample;
 
@@ -145,15 +82,12 @@ describe("groupSameDiagnosticReports", () => {
 
   it("discards diagReport if result and presented form are not present", () => {
     diagReport.effectiveDateTime = dateTime.start;
-    diagReport.performer = [practRef];
 
     const { diagReportsMap } = groupSameDiagnosticReports([diagReport]);
     expect(diagReportsMap.size).toBe(0);
   });
 
   it("keeps diagReport if result is present and presentedForm is not - without a date", () => {
-    diagReport.performer = [practRef];
-
     diagReport.result = resultExample;
 
     const { diagReportsMap } = groupSameDiagnosticReports([diagReport]);
@@ -166,8 +100,6 @@ describe("groupSameDiagnosticReports", () => {
 
   it("keeps diagReport if result is present and presentedForm is not", () => {
     diagReport.effectiveDateTime = dateTime.start;
-    diagReport.performer = [practRef];
-
     diagReport.result = resultExample;
 
     const { diagReportsMap } = groupSameDiagnosticReports([diagReport]);
@@ -180,8 +112,6 @@ describe("groupSameDiagnosticReports", () => {
 
   it("keeps diagReport if presentedForm is present and result is not", () => {
     diagReport.effectiveDateTime = dateTime.start;
-    diagReport.performer = [practRef];
-
     diagReport.presentedForm = presentedFormExample;
 
     const { diagReportsMap } = groupSameDiagnosticReports([diagReport]);
@@ -192,13 +122,11 @@ describe("groupSameDiagnosticReports", () => {
     expect(dedupedDiagReport.result).toBeFalsy();
   });
 
-  it("discards codes that don't come from loinc", () => {
+  it("keeps all codes including non-LOINC ones", () => {
     diagReport.effectiveDateTime = dateTime.start;
     diagReport2.effectiveDateTime = dateTime.start;
     diagReport.presentedForm = presentedFormExample;
     diagReport2.presentedForm = presentedFormExample;
-    diagReport.performer = [practRef];
-    diagReport2.performer = [practRef];
 
     diagReport.code = {
       coding: [
@@ -224,13 +152,92 @@ describe("groupSameDiagnosticReports", () => {
     expect(diagReportsMap.size).toBe(1);
     const masterReport = diagReportsMap.values().next().value as DiagnosticReport;
 
-    expect(masterReport.code?.coding?.length).toBe(2);
+    expect(masterReport.code?.coding?.length).toBe(3);
     expect(masterReport.code?.coding).toEqual(
-      expect.not.arrayContaining([
+      expect.arrayContaining([
         expect.objectContaining({
-          system: expect.stringContaining("urn:oid:1.2.840.114350.1.72.727879.69848980"),
+          system: "http://loinc.org",
+          code: "34109-9",
+        }),
+        expect.objectContaining({
+          system: "http://loinc.org",
+          code: "11506-3",
+        }),
+        expect.objectContaining({
+          system: "urn:oid:1.2.840.114350.1.72.727879.69848980",
+          code: "1",
         }),
       ])
     );
+  });
+
+  it("groups lab panel reports with same LOINC codes and datetime", () => {
+    diagReport.effectiveDateTime = dateTime.start;
+    diagReport2.effectiveDateTime = dateTime.start;
+
+    diagReport.code = a1cPanelConceptLoinc;
+    diagReport2.code = a1cPanelConceptLoinc;
+
+    diagReport.result = resultExample;
+    diagReport2.presentedForm = presentedFormExample;
+
+    const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
+    expect(diagReportsMap.size).toBe(1);
+  });
+
+  it("does not group lab panel reports with same identifiers if the dates are different", () => {
+    diagReport.effectiveDateTime = dateTime.start;
+    diagReport2.effectiveDateTime = dateTime2.start;
+
+    diagReport.code = a1cPanelConceptLoinc;
+    diagReport2.code = a1cPanelConceptLoinc;
+
+    diagReport.result = resultExample;
+    diagReport2.presentedForm = presentedFormExample;
+
+    const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
+    expect(diagReportsMap.size).toBe(2);
+  });
+
+  it("groups lab panel reports with same display text even if codes differ", () => {
+    diagReport.effectiveDateTime = dateTime.start;
+    diagReport2.effectiveDateTime = dateTime.start;
+
+    diagReport.code = metabolicPanelConceptLoinc;
+    diagReport2.code = metabolicPanelConceptOther;
+
+    diagReport.result = resultExample;
+    diagReport2.presentedForm = presentedFormExample;
+
+    const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
+    expect(diagReportsMap.size).toBe(1);
+  });
+
+  it("does not group lab panel reports with different LOINC codes even with same datetime", () => {
+    diagReport.effectiveDateTime = dateTime.start;
+    diagReport2.effectiveDateTime = dateTime.start;
+
+    diagReport.code = metabolicPanelConceptLoinc;
+    diagReport2.code = a1cPanelConceptLoinc;
+
+    diagReport.result = resultExample;
+    diagReport2.presentedForm = presentedFormExample;
+
+    const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
+    expect(diagReportsMap.size).toBe(2);
+  });
+
+  it("groups lab panel reports with same codes but different datetime using date bit logic", () => {
+    diagReport.effectiveDateTime = dateTime.start;
+    // diagReport2 has no datetime
+
+    diagReport.code = metabolicPanelConceptLoinc;
+    diagReport2.code = metabolicPanelConceptOther;
+
+    diagReport.result = resultExample;
+    diagReport2.presentedForm = presentedFormExample;
+
+    const { diagReportsMap } = groupSameDiagnosticReports([diagReport, diagReport2]);
+    expect(diagReportsMap.size).toBe(1);
   });
 });

--- a/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
+++ b/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
@@ -148,7 +148,9 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
       // the report will dedup against ones that might or might not have the date
       getterKeys.push(...createKeysFromObjectArrayAndBits(identifiers, [0]));
       getterKeys.push(...createKeysFromObjectArrayAndBits(identifiers, [1]));
+    }
 
+    if (diagReport.id) {
       const idKey = JSON.stringify({ id: diagReport.id });
       setterKeys.push(idKey);
       getterKeys.push(idKey);

--- a/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
+++ b/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
@@ -114,7 +114,7 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
         const { code, display, system } = c;
         const normalizedSystem = system?.toLowerCase().replace("urn:oid:", "").trim();
 
-        if (code) {
+        if (code && normalizedSystem) {
           identifiers.push({ key: `${code.toLowerCase().trim()}|${normalizedSystem}` });
         }
 

--- a/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
+++ b/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
@@ -113,7 +113,10 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
 
         const { code, display, system } = c;
         const normalizedSystem = system?.toLowerCase().replace("urn:oid:", "").trim();
-        identifiers.push({ key: `${code?.toLowerCase().trim()}|${normalizedSystem}` });
+
+        if (code) {
+          identifiers.push({ key: `${code.toLowerCase().trim()}|${normalizedSystem}` });
+        }
 
         if (display && !isUselessDisplay(display)) {
           identifiers.push({ key: display.toLowerCase().trim() });
@@ -150,9 +153,6 @@ export function groupSameDiagnosticReports(diagReports: DiagnosticReport[]): {
       setterKeys.push(idKey);
       getterKeys.push(idKey);
     }
-
-    console.log("setterKeys", setterKeys);
-    console.log("getterKeys", getterKeys);
 
     if (setterKeys.length > 0) {
       fillL1L2Maps({

--- a/packages/core/src/fhir-to-cda/cda-templates/components/__tests__/make-diagnostic-report.ts
+++ b/packages/core/src/fhir-to-cda/cda-templates/components/__tests__/make-diagnostic-report.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import { CodeableConcept, Coding, DiagnosticReport } from "@medplum/fhirtypes";
 import { makeSubjectReference } from "./shared";
 
+// TODO ENG-835: Put these in a more general place, so it's available for testing other flows as well.
 export function makeDiagnosticReport(
   params: Partial<DiagnosticReport> = {},
   patientId?: string
@@ -47,3 +48,36 @@ export function makeDiagnosticReportCategory(
     coding: [coding],
   };
 }
+
+export const a1cPanelConceptLoinc = {
+  text: "HEMOGLOBIN A1C/HEMOGLOBIN.TOTAL IN BLOOD",
+  coding: [
+    {
+      code: "4548-4",
+      display: "HEMOGLOBIN A1C/HEMOGLOBIN.TOTAL IN BLOOD",
+      system: "http://loinc.org",
+    },
+  ],
+};
+
+export const metabolicPanelConceptLoinc = {
+  text: "Comprehensive metabolic 2000 panel - Serum or Plasma",
+  coding: [
+    {
+      code: "24323-8",
+      display: "Comprehensive metabolic 2000 panel - Serum or Plasma",
+      system: "http://loinc.org",
+    },
+  ],
+};
+
+export const metabolicPanelConceptOther = {
+  text: "Comprehensive metabolic 2000 panel - Serum or Plasma",
+  coding: [
+    {
+      code: "1234",
+      display: "Comprehensive metabolic 2000 panel - Serum or Plasma",
+      system: "http://terminology.hl7.org/ValueSet/v3-Unknown",
+    },
+  ],
+};


### PR DESCRIPTION
Part of ENG-603


Issues:

- https://linear.app/metriport/issue/ENG-603

### Description
- Reworked DiagnosticReport dedupe logic to consider the following:
  - code value
  - display
  - text
  - datetime bits
- Updated the tests

### Testing

- Local
  - [x] Reprocess a patient with messy lab panels and verify the results
  - [x] Unit tests
- Staging
  - [ ] Reprocess an existing patient's payload
- Production
  - [ ] Reprocess a patient with messy lab panels and verify the results

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved deduplication for lab-panel diagnostic reports that groups by standardized panel identifiers (LOINC-focused), plus preserved non-standard codes in consolidated reports.
  - Added test coverage for various lab-panel grouping scenarios (same/missing/different dates, matching displays).

- Bug Fixes
  - More reliable handling when report dates are missing or differ, preventing incorrect merges.
  - Prevents grouping of reports with different standardized codes even if timestamps match.
  - More stable detection of identical result sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->