### PR TITLE
feat(ehr): sollis contribute ehr summaries + remove bad encounters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28820,6 +28820,7 @@
         "@metriport/carequality-sdk": "file:packages/carequality-sdk",
         "@metriport/commonwell-sdk": "file:packages/commonwell-sdk",
         "@metriport/core": "file:packages/core",
+        "@metriport/fhir-sdk": "file:packages/fhir-sdk",
         "@metriport/ihe-gateway-sdk": "file:packages/ihe-gateway-sdk",
         "@metriport/shared": "file:packages/shared",
         "@opensearch-project/opensearch": "^2.3.1",
@@ -28944,6 +28945,10 @@
       "resolved": "packages/api/packages/eslint-rules",
       "link": true
     },
+    "packages/api/node_modules/@metriport/fhir-sdk": {
+      "resolved": "packages/api/packages/fhir-sdk",
+      "link": true
+    },
     "packages/api/node_modules/@metriport/ihe-gateway-sdk": {
       "resolved": "packages/api/packages/ihe-gateway-sdk",
       "link": true
@@ -28964,8 +28969,12 @@
     "packages/api/packages/eslint-rules": {
       "dev": true
     },
+    "packages/api/packages/fhir-sdk": {},
     "packages/api/packages/ihe-gateway-sdk": {},
     "packages/api/packages/shared": {},
+    "packages/api/packge/fhir-sdk": {
+      "extraneous": true
+    },
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
       "version": "1.18.17",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,6 +33,7 @@
     "@metriport/carequality-sdk": "file:packages/carequality-sdk",
     "@metriport/commonwell-sdk": "file:packages/commonwell-sdk",
     "@metriport/core": "file:packages/core",
+    "@metriport/fhir-sdk": "file:packages/fhir-sdk",
     "@metriport/ihe-gateway-sdk": "file:packages/ihe-gateway-sdk",
     "@metriport/shared": "file:packages/shared",
     "@opensearch-project/opensearch": "^2.3.1",

--- a/packages/api/src/command/medical/document/get-upload-url-and-create-doc-ref.ts
+++ b/packages/api/src/command/medical/document/get-upload-url-and-create-doc-ref.ts
@@ -1,0 +1,54 @@
+import { UploadDocumentResult } from "@metriport/api-sdk";
+import { createDocumentFilePath } from "@metriport/core/domain/document/filename";
+import { uuidv7 } from "@metriport/core/util/uuid-v7";
+import { composeDocumentReference } from "../../../external/fhir/document/draft-update-document-reference";
+import { upsertDocumentToFHIRServer } from "../../../external/fhir/document/save-document-reference";
+import { Config } from "../../../shared/config";
+import { getOrganizationOrFail } from "../organization/get-organization";
+import {} from "../patient/update-hie-opt-out";
+
+const region = Config.getAWSRegion();
+const s3Utils = new S3Utils(region);
+
+import { DocumentReference } from "@medplum/fhirtypes";
+import { S3Utils } from "@metriport/core/external/aws/s3";
+
+export async function getUploadUrlAndCreateDocRef({
+  cxId,
+  patientId,
+  inputDocRef,
+}: {
+  cxId: string;
+  patientId: string;
+  inputDocRef: DocumentReference;
+}): Promise<UploadDocumentResult> {
+  const docRefId = uuidv7();
+  const s3FileName = createDocumentFilePath(cxId, patientId, docRefId);
+  const organization = await getOrganizationOrFail({ cxId });
+
+  const docRef = composeDocumentReference({
+    inputDocRef,
+    organization,
+    patientId,
+    docRefId,
+    s3Key: s3FileName,
+    s3BucketName: Config.getMedicalDocumentsUploadBucketName(),
+  });
+
+  async function upsertOnFHIRServer() {
+    // Make a temporary DocumentReference on the FHIR server.
+    console.log("Creating a temporary DocumentReference on the FHIR server with ID:", docRef.id);
+    await upsertDocumentToFHIRServer(cxId, docRef);
+  }
+
+  async function getPresignedUrl() {
+    return s3Utils.getPresignedUploadUrl({
+      bucket: Config.getMedicalDocumentsUploadBucketName(),
+      key: s3FileName,
+    });
+  }
+
+  const [, url] = await Promise.all([upsertOnFHIRServer(), getPresignedUrl()]);
+
+  return { documentReferenceId: docRefId, uploadUrl: url };
+}

--- a/packages/api/src/external/ehr/shared/command/bundle/contribute-resource-diff-bundle.ts
+++ b/packages/api/src/external/ehr/shared/command/bundle/contribute-resource-diff-bundle.ts
@@ -1,14 +1,26 @@
+import { Bundle, BundleEntry, Encounter, Extension, Resource } from "@medplum/fhirtypes";
 import { isAthenaCustomFieldsEnabledForCx } from "@metriport/core/command/feature-flags/domain-ffs";
+import { encounterAppointmentExtensionUrl } from "@metriport/core/external/ehr/athenahealth";
 import { BundleType } from "@metriport/core/external/ehr/bundle/bundle-shared";
 import {
   fetchBundle,
   FetchBundleParams,
 } from "@metriport/core/external/ehr/bundle/command/fetch-bundle";
+import { fetchDocument } from "@metriport/core/external/ehr/document/command/fetch-document";
+import { DocumentType } from "@metriport/core/external/ehr/document/document-shared";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { uuidv7 } from "@metriport/core/util/uuid-v7";
+import { FhirBundleSdk } from "@metriport/fhir-sdk";
+import { MetriportError } from "@metriport/shared/dist/error/metriport-error";
+import { athenaSecondaryMappingsSchema } from "@metriport/shared/interface/external/ehr/athenahealth/cx-mapping";
 import { EhrSources } from "@metriport/shared/interface/external/ehr/source";
+import axios from "axios";
+import { getCxMappingOrFail } from "../../../../../command/mapping/cx";
 import { getPatientMappingOrFail } from "../../../../../command/mapping/patient";
+import { getUploadUrlAndCreateDocRef } from "../../../../../command/medical/document/get-upload-url-and-create-doc-ref";
 import { handleDataContribution } from "../../../../../command/medical/patient/data-contribution/handle-data-contributions";
 import { getPatientOrFail } from "../../../../../command/medical/patient/get-patient";
+import { getAthenaPracticeIdFromPatientId } from "../../../athenahealth/shared";
 import { ContributeBundleParams } from "../../utils/bundle/types";
 
 /**
@@ -47,7 +59,33 @@ export async function contributeResourceDiffBundle({
     fetchBundle(fetchParams),
   ]);
   if (!bundle?.bundle.entry || bundle.bundle.entry.length < 1) return;
-  if (await isAthenaCustomFieldsEnabledForCx(cxId)) return;
+  if (await isAthenaCustomFieldsEnabledForCx(cxId)) {
+    const athenaPracticeId = getAthenaPracticeIdFromPatientId(patientMapping.externalId);
+    const cxMappingLookupParams = { externalId: athenaPracticeId, source: EhrSources.athena };
+    const cxMapping = await getCxMappingOrFail(cxMappingLookupParams);
+    if (!cxMapping.secondaryMappings) {
+      throw new MetriportError("Athena secondary mappings not found", undefined, {
+        externalId: athenaPracticeId,
+        source: EhrSources.athena,
+      });
+    }
+    const secondaryMappings = athenaSecondaryMappingsSchema.parse(cxMapping.secondaryMappings);
+    if (secondaryMappings.contributionEncounterAppointmentTypesBlacklist) {
+      dangerouslyRemoveEncounterEntriesWithBlacklistedAppointmentType({
+        bundle: bundle.bundle,
+        blacklistedAppointmentTypes:
+          secondaryMappings.contributionEncounterAppointmentTypesBlacklist,
+      });
+    }
+    if (secondaryMappings.contributionEncounterSummariesEnabled) {
+      await uploadEncounterSummaries({
+        bundle: bundle.bundle,
+        cxId,
+        metriportPatientId,
+        ehrPatientId,
+      });
+    }
+  }
   if (ehr === EhrSources.healthie) return;
   await handleDataContribution({
     requestId: uuidv7(),
@@ -59,4 +97,154 @@ export async function contributeResourceDiffBundle({
       entry: bundle.bundle.entry,
     },
   });
+}
+
+/**
+ * Removes Encounter entries from the bundle whose appointment types are blacklisted or who do not
+ * have the appointment type extension.
+ *
+ * This function mutates the provided bundle by filtering out Encounter resources that have
+ * appointment types present in the blacklist. It also removes any resources referenced by
+ * those Encounters.
+ *
+ * @param params - The parameters for the function.
+ * @param params.bundle - The FHIR Bundle to mutate.
+ * @param params.blacklistedAppointmentTypes - The list of appointment types to exclude.
+ */
+async function dangerouslyRemoveEncounterEntriesWithBlacklistedAppointmentType({
+  bundle,
+  blacklistedAppointmentTypes,
+}: {
+  bundle: Bundle;
+  blacklistedAppointmentTypes: string[];
+}): Promise<void> {
+  if (!bundle.entry) return;
+  const bundleSdk = await FhirBundleSdk.create(bundle);
+  const encounters = bundleSdk.getEncounters();
+  const encountersToRemove = encounters.filter((encounter: Encounter) => {
+    if (!encounter.extension) return true;
+    const appointmentTypeExtension = encounter.extension.find(
+      (ext: Extension) => ext.url === encounterAppointmentExtensionUrl
+    );
+    if (!appointmentTypeExtension) return true;
+    return blacklistedAppointmentTypes.includes(appointmentTypeExtension.valueString as string);
+  });
+  const encounterReferences = encountersToRemove.map(encounter => `Encounter/${encounter.id}`);
+  const resourcesToRemove = new Set<string>();
+  for (const encounter of encountersToRemove) {
+    if (!encounter.id) continue;
+    resourcesToRemove.add(encounter.id);
+  }
+  for (const entry of bundle.entry) {
+    if (!entry.resource) continue;
+    if (!entry.resource.id) continue;
+    if (doesResourceReferToEncounter(entry.resource, encounterReferences)) {
+      resourcesToRemove.add(entry.resource.id);
+    }
+  }
+  bundle.entry = bundle.entry.filter((entry: BundleEntry<Resource>) => {
+    if (!entry.resource) return true;
+    if (!entry.resource.id) return true;
+    return !resourcesToRemove.has(entry.resource.id);
+  });
+}
+
+/**
+ * Returns a set of resource IDs referenced by the given FHIR resource.
+ *
+ * This function traverses the resource object and collects all values of properties named "reference"
+ * that are strings in the format "ResourceType/id", extracting the "id" part.
+ *
+ * @param resource - The FHIR resource from which to extract referenced IDs.
+ * @returns A set containing the referenced resource IDs.
+ */
+function doesResourceReferToEncounter(resource: Resource, encounterReferences: string[]): boolean {
+  if ("encounter" in resource) {
+    const encounter = resource.encounter;
+    if (!encounter || !encounter.reference) return false;
+    return encounterReferences.includes(encounter.reference);
+  }
+  return false;
+}
+
+/**
+ * Uploads encounter summaries to the FHIR server.
+ *
+ * This function fetches encounter summaries for each encounter in the bundle and uploads them to the FHIR server.
+ *
+ * @param bundle - The FHIR bundle containing the encounters.
+ * @param cxId - The CX ID of the patient.
+ * @param metriportPatientId - The Metriport patient ID.
+ * @param ehrPatientId - The EHR patient ID.
+ */
+async function uploadEncounterSummaries({
+  bundle,
+  cxId,
+  metriportPatientId,
+  ehrPatientId,
+}: {
+  bundle: Bundle;
+  cxId: string;
+  metriportPatientId: string;
+  ehrPatientId: string;
+}): Promise<void> {
+  if (!bundle.entry) return;
+  const encounterSummaries: { encounter: Encounter; summary: string }[] = [];
+  for (const entry of bundle.entry) {
+    if (!entry.resource) continue;
+    if (!entry.resource?.id || entry.resource?.resourceType !== "Encounter") continue;
+    const summary = await fetchDocument({
+      ehr: EhrSources.athena,
+      cxId,
+      metriportPatientId,
+      ehrPatientId,
+      documentType: DocumentType.HTML,
+      resourceType: "Encounter",
+      resourceId: entry.resource.id,
+    });
+    if (!summary) continue;
+    encounterSummaries.push({ encounter: entry.resource, summary: summary.file });
+  }
+  await executeAsynchronously(
+    encounterSummaries,
+    async encounterSummary => {
+      const { uploadUrl } = await getUploadUrlAndCreateDocRef({
+        cxId,
+        patientId: metriportPatientId,
+        inputDocRef: {
+          resourceType: "DocumentReference",
+          status: "current",
+          docStatus: "final",
+          description: "Encounter summary",
+          type: {
+            text: "Summarization of encounter note Narrative",
+            coding: [
+              {
+                code: "67781-5",
+                system: "http://loinc.org",
+                display: "Summarization of encounter note Narrative",
+              },
+            ],
+          },
+          context: {
+            period: {
+              start: encounterSummary.encounter.period?.start,
+              end: encounterSummary.encounter.period?.end,
+            },
+            facilityType: {
+              text: encounterSummary.encounter.location?.[0]?.location?.display,
+            },
+          },
+        },
+      });
+      axios.post(uploadUrl, encounterSummary.summary, {
+        headers: {
+          "Content-Type": "text/html",
+        },
+      });
+    },
+    {
+      numberOfParallelExecutions: 1,
+    }
+  );
 }

--- a/packages/core/src/external/ehr/athenahealth/command/get-bundle-by-resource-type.ts
+++ b/packages/core/src/external/ehr/athenahealth/command/get-bundle-by-resource-type.ts
@@ -1,4 +1,7 @@
 import { Bundle } from "@medplum/fhirtypes";
+import { athenaSecondaryMappingsSchema } from "@metriport/shared/interface/external/ehr/athenahealth/cx-mapping";
+import { EhrSources } from "@metriport/shared/interface/external/ehr/source";
+import { getSecondaryMappings } from "../../api/get-secondary-mappings";
 import { GetBundleByResourceTypeClientRequest } from "../../command/get-bundle-by-resource-type";
 import { createAthenaHealthClient } from "../shared";
 
@@ -19,12 +22,23 @@ export async function getBundleByResourceType(
     practiceId,
     ...(tokenId && { tokenId }),
   });
+  const mappings = await getSecondaryMappings({
+    ehr: EhrSources.athena,
+    practiceId,
+    schema: athenaSecondaryMappingsSchema,
+  });
   const bundle = await client.getBundleByResourceType({
     cxId,
     metriportPatientId,
     athenaPatientId: ehrPatientId,
     resourceType,
     useCachedBundle,
+    ...(mappings?.contributionEncounterAppointmentTypesBlacklist && {
+      attachAppointmentType: true,
+    }),
+    ...(mappings?.contributionEncounterSummariesEnabled && {
+      fetchEncounterSummary: true,
+    }),
   });
   return bundle;
 }

--- a/packages/core/src/external/ehr/document/command/create-or-replace-document.ts
+++ b/packages/core/src/external/ehr/document/command/create-or-replace-document.ts
@@ -50,8 +50,9 @@ export async function createOrReplaceDocument({
   );
   const s3Utils = getS3UtilsInstance();
   const createKeyAndExtension = createKeyAndExtensionMap[documentType];
-  if (!createKeyAndExtension)
+  if (!createKeyAndExtension) {
     throw new BadRequestError("Invalid document type", undefined, { documentType });
+  }
   const key = createKeyAndExtension.key({
     ehr,
     cxId,

--- a/packages/shared/src/interface/external/ehr/athenahealth/cx-mapping.ts
+++ b/packages/shared/src/interface/external/ehr/athenahealth/cx-mapping.ts
@@ -7,6 +7,8 @@ export const athenaSecondaryMappingsSchema = z
     webhookAppointmentDisabled: z.boolean().optional(),
     backgroundAppointmentsDisabled: z.boolean().optional(),
     appointmentTypesFilter: z.string().array().optional(),
+    contributionEncounterAppointmentTypesBlacklist: z.string().array().optional(),
+    contributionEncounterSummariesEnabled: z.boolean().optional(),
   })
   .merge(writeBackFiltersSchema);
 export type AthenaSecondaryMappings = z.infer<typeof athenaSecondaryMappingsSchema>;


### PR DESCRIPTION
Ref: ENG-634

Issues:

- https://linear.app/metriport/issue/ENG-634

### Description

- only capture account type ID and save encounter summaries if required
- only save encounter summary if one is not already saved
- when contributing, remove encounters and resources that reference the encounter if needed
- when contribution, try to upload the encounter summary if requested

### Testing

- Local
  - [ ] conditionals for summaries / appointment type ID work
  - [ ] removing bad encounters creates clean bundle
  - [ ] encounter summary docs are uploaded correctly
- Staging
  - [ ] conditionals for summaries / appointment type ID work
  - [ ] removing bad encounters creates clean bundle
  - [ ] encounter summary docs are uploaded correctly
- Sandbox
  - [ ] N/A
- Production
  - [ ] conditionals for summaries / appointment type ID work
  - [ ] removing bad encounters creates clean bundle
  - [ ] encounter summary docs are uploaded correctly

### Release Plan

- [ ] Merge this
