### PR TITLE
PATCH ENG-751: fix zod validation failure

### DIFF
--- a/packages/api/src/routes/medical/schemas/tcm-encounter.ts
+++ b/packages/api/src/routes/medical/schemas/tcm-encounter.ts
@@ -30,14 +30,14 @@ export const tcmEncounterBaseSchema = z.strictObject({
 export const tcmEncounterCreateSchema = tcmEncounterBaseSchema.extend({
   cxId: z.string().uuid(),
   id: z.string().uuid().optional(),
-  outreachStatus: z.enum(outreachStatuses),
+  outreachStatus: z.enum(outreachStatuses).optional(),
 });
 export type TcmEncounterCreate = z.infer<typeof tcmEncounterCreateSchema>;
 
 export const tcmEncounterUpsertSchema = tcmEncounterBaseSchema.extend({
   id: z.string().uuid(),
   cxId: z.string().uuid(),
-  outreachStatus: z.enum(outreachStatuses),
+  outreachStatus: z.enum(outreachStatuses).optional(),
 });
 export type TcmEncounterUpsert = z.infer<typeof tcmEncounterUpsertSchema>;
 


### PR DESCRIPTION
metriport/metriport-internal#1040

Ref: ENG-751
Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

Issues:

- https://linear.app/metriport/issue/ENG-751

### Dependencies

None

### Description

Fixes TCM encounter rows not being created in prod

### Testing

- Local
  - [x] Verify that without code change, error is thrown when status is not specified.
  - [x] Verify that with code change, error is NOT thrown when status is not specified.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Create and upsert TCM encounter endpoints now accept requests without an outreach status; this field is now optional.
  - Reduces validation errors when the status is not yet determined and streamlines data submission workflows.
  - Backward compatible: requests that include the field continue to work, with no changes to response payloads or other fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->