### PR TITLE
ENG-333: fix(core): Quest environment variables failing in sandbox

### DIFF
--- a/packages/core/src/external/quest/client.ts
+++ b/packages/core/src/external/quest/client.ts
@@ -18,10 +18,11 @@ export class QuestSftpClient extends SftpClient {
     this.incomingDirectory = config.incomingDirectory ?? Config.getQuestSftpIncomingDirectory();
 
     const replicaBucketName = config.replicaBucket ?? Config.getQuestReplicaBucketName();
+    const replicaBucketRegion = config.replicaBucketRegion ?? Config.getAWSRegion();
     if (replicaBucketName) {
       this.initializeS3Replica({
         bucketName: replicaBucketName,
-        region: config.replicaBucketRegion ?? Config.getAWSRegion(),
+        region: replicaBucketRegion,
       });
     }
   }

--- a/packages/core/src/external/quest/client.ts
+++ b/packages/core/src/external/quest/client.ts
@@ -16,10 +16,14 @@ export class QuestSftpClient extends SftpClient {
     });
     this.outgoingDirectory = config.outgoingDirectory ?? Config.getQuestSftpOutgoingDirectory();
     this.incomingDirectory = config.incomingDirectory ?? Config.getQuestSftpIncomingDirectory();
-    this.initializeS3Replica({
-      bucketName: config.replicaBucket ?? Config.getQuestReplicaBucketName(),
-      region: config.replicaBucketRegion ?? Config.getAWSRegion(),
-    });
+
+    const replicaBucketName = config.replicaBucket ?? Config.getQuestReplicaBucketName();
+    if (replicaBucketName) {
+      this.initializeS3Replica({
+        bucketName: replicaBucketName,
+        region: config.replicaBucketRegion ?? Config.getAWSRegion(),
+      });
+    }
   }
 
   async writeToQuest(fileName: string, fileContent: Buffer): Promise<void> {

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -325,11 +325,11 @@ export class Config {
   static getQuestConversionLambdaName(): string {
     return getEnvVarOrFail("QUEST_CONVERT_RESPONSE_LAMBDA_NAME");
   }
-  static getQuestReplicaBucketName(): string {
-    return getEnvVarOrFail("QUEST_REPLICA_BUCKET_NAME");
+  static getQuestReplicaBucketName(): string | undefined {
+    return getEnvVar("QUEST_REPLICA_BUCKET_NAME");
   }
-  static getLabConversionBucketName(): string {
-    return getEnvVarOrFail("LAB_CONVERSION_BUCKET_NAME");
+  static getLabConversionBucketName(): string | undefined {
+    return getEnvVar("LAB_CONVERSION_BUCKET_NAME");
   }
 
   static getAthenaHealthEnv(): string | undefined {


### PR DESCRIPTION
metriport/metriport-internal#3045

Issues:

- https://linear.app/metriport/issue/ENG-333

### Dependencies

- Upstream: None
- Downstream: None

### Description

Fixes the environment variables for Quest so they do not throw an error in the sandbox (where there isn't a `quest` config). There is already an `undefined` check at the only call site which uses this (`external/quest/command/get-bundle.ts`):

```typescript
const bucketName = Config.getLabConversionBucketName();
  if (!bucketName) {
    log(`No lab conversion bucket name found, skipping`);
    return undefined;
}
```

### Testing

- Local
  - [x] `getBundle` does not fail from environment variable error
- Sandbox
  - [ ] can rebuild consolidated bundles

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents hard failures when certain environment configurations are missing, allowing the app to start and operate gracefully in more environments.
  * Improves error handling by treating select configuration values as optional, reducing unexpected crashes and improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->