### PR TITLE
fix(core): changed name of roster generated file to follow proper naming convention

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -170,9 +170,11 @@ export class Hl7v2RosterGenerator {
   }
 
   private createFileKeyHl7v2Roster(hieName: string): string {
-    const todaysDate = buildDayjs(new Date()).toISOString().split("T")[0];
-    const fileName = `Metriport_${hieName}_Patient_Enrollment_${todaysDate}`;
-    return `${todaysDate}/${fileName}.${CSV_FILE_EXTENSION}`;
+    const todaysDate = buildDayjs(new Date());
+    const folderDate = todaysDate.format("YYYY-MM-DD");
+    const fileDate = todaysDate.format("YYYYMMDD");
+    const fileName = `Metriport_${hieName}_Patient_Enrollment_${fileDate}`;
+    return `${folderDate}/${fileName}.${CSV_FILE_EXTENSION}`;
   }
 }
 

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -171,7 +171,8 @@ export class Hl7v2RosterGenerator {
 
   private createFileKeyHl7v2Roster(hieName: string): string {
     const todaysDate = buildDayjs(new Date()).toISOString().split("T")[0];
-    return `${todaysDate}/${hieName}.${CSV_FILE_EXTENSION}`;
+    const fileName = `Metriport_${hieName}_Patient_Enrollment_${todaysDate}`;
+    return `${todaysDate}/${fileName}.${CSV_FILE_EXTENSION}`;
   }
 }
 

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -39,6 +39,8 @@ const NUMBER_OF_PATIENTS_PER_PAGE = 500;
 const NUMBER_OF_ATTEMPTS = 3;
 const DEFAULT_ZIP_PLUS_4_EXT = "-0000";
 const BASE_DELAY = dayjs.duration({ seconds: 1 });
+const FOLDER_DATE_FORMAT = "YYYY-MM-DD";
+const FILE_DATE_FORMAT = "YYYYMMDD";
 
 export class Hl7v2RosterGenerator {
   private readonly s3Utils: S3Utils;
@@ -170,9 +172,9 @@ export class Hl7v2RosterGenerator {
   }
 
   private createFileKeyHl7v2Roster(hieName: string): string {
-    const todaysDate = buildDayjs(new Date());
-    const folderDate = todaysDate.format("YYYY-MM-DD");
-    const fileDate = todaysDate.format("YYYYMMDD");
+    const todaysDate = buildDayjs();
+    const folderDate = todaysDate.format(FOLDER_DATE_FORMAT);
+    const fileDate = todaysDate.format(FILE_DATE_FORMAT);
     const fileName = `Metriport_${hieName}_Patient_Enrollment_${fileDate}`;
     return `${folderDate}/${fileName}.${CSV_FILE_EXTENSION}`;
   }


### PR DESCRIPTION
Part of ENG-830

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-830

### Dependencies

- Upstream: None
- Downstream: None

### Description
Changed the generated roster csv file name from just the HIE name to follow this format: 
Metriport_{hieName}_Patient_Enrollment_{YYYYMMDD}.csv

### Testing
- Local
  - [x] Ran script with HIE name MyTestHIE. Made sure file: 2025-08-12/Metriport_MyTestHIE_Patient_Enrollment_20250812.csv was created in S3
  - [x] Ran script with a non existent HIE name (Test). Made sure no file was created and original file wasn't edited.
 
https://github.com/user-attachments/assets/0887d307-6a28-4775-9cbe-05ba56a3eb79

- Staging (deleted folder before doing staging tests)
  - [x] Ran script with HIE name MyTestHIE. Made sure file: 2025-08-12/Metriport_MyTestHIE_Patient_Enrollment_20250812.csv was created in S3
  - [x] Ran script with a non existent HIE name (Test). Made sure no file was created and original file wasn't edited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized directory structure and filename convention for HL7v2 roster exports: files are now organized in date-based folders and use a consistent date-stamped filename.
  * CSV extension remains unchanged.
  * Note: integrations or automations that rely on previous paths/filenames may need updating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->