### PR TITLE
fix(core): fixing lengthy doc ids on metadata xmls

### DIFF
--- a/packages/core/src/shareback/metadata/create-metadata-xml.ts
+++ b/packages/core/src/shareback/metadata/create-metadata-xml.ts
@@ -55,7 +55,7 @@ export function createExtrinsicObjectXml({
   title?: string | undefined;
   mimeType: string;
 }) {
-  const shortDocumentId = extractFileId(documentUniqueId);
+  const shortDocumentId = buildShortDocId(documentUniqueId);
   const documentUUID = uuidv7();
   const classCodeNode = classCode?.coding?.[0]?.code || DEFAULT_CLASS_CODE_NODE;
   const practiceSettingCodeNode =
@@ -72,6 +72,7 @@ export function createExtrinsicObjectXml({
     organization?.identifier?.find(identifier =>
       identifier.value?.startsWith(METRIPORT_HOME_COMMUNITY_ID_NO_PREFIX)
     )?.value || METRIPORT_HOME_COMMUNITY_ID_NO_PREFIX;
+  const htmlSafeTitle = title ? encodeToHtml(title) : DEFAULT_CLASS_CODE_DISPLAY;
 
   const stableDocumentId = "urn:uuid:7edca82f-054d-47f2-a032-9b2a5b5186c1";
 
@@ -137,7 +138,7 @@ export function createExtrinsicObjectXml({
         </ValueList>
       </Slot>
       <Name>
-        <LocalizedString charset="UTF-8" value="${title ?? DEFAULT_CLASS_CODE_DISPLAY}"/>
+        <LocalizedString charset="UTF-8" value="${htmlSafeTitle}"/>
       </Name>
     </Classification>
     
@@ -159,7 +160,7 @@ export function createExtrinsicObjectXml({
         </ValueList>
       </Slot>
       <Name>
-        <LocalizedString charset="UTF-8" value="${title ?? DEFAULT_CLASS_CODE_DISPLAY}"/>
+        <LocalizedString charset="UTF-8" value="${htmlSafeTitle}"/>
       </Name>
     </Classification>
     
@@ -192,7 +193,7 @@ export function createExtrinsicObjectXml({
         </ValueList>
       </Slot>
       <Name>
-        <LocalizedString charset="UTF-8" value="${title ?? DEFAULT_CLASS_CODE_DISPLAY}"/>
+        <LocalizedString charset="UTF-8" value="${htmlSafeTitle}"/>
       </Name>
     </Classification>
     
@@ -213,6 +214,6 @@ export function createExtrinsicObjectXml({
   return metadataXml;
 }
 
-function extractFileId(documentUniqueId: string): string {
+function buildShortDocId(documentUniqueId: string): string {
   return documentUniqueId.split("/").pop() ?? documentUniqueId;
 }

--- a/packages/core/src/shareback/metadata/create-metadata-xml.ts
+++ b/packages/core/src/shareback/metadata/create-metadata-xml.ts
@@ -55,6 +55,7 @@ export function createExtrinsicObjectXml({
   title?: string | undefined;
   mimeType: string;
 }) {
+  const shortDocumentId = extractFileId(documentUniqueId);
   const documentUUID = uuidv7();
   const classCodeNode = classCode?.coding?.[0]?.code || DEFAULT_CLASS_CODE_NODE;
   const practiceSettingCodeNode =
@@ -136,7 +137,7 @@ export function createExtrinsicObjectXml({
         </ValueList>
       </Slot>
       <Name>
-        <LocalizedString charset="UTF-8" value="${DEFAULT_CLASS_CODE_DISPLAY}"/>
+        <LocalizedString charset="UTF-8" value="${title ?? DEFAULT_CLASS_CODE_DISPLAY}"/>
       </Name>
     </Classification>
     
@@ -158,7 +159,7 @@ export function createExtrinsicObjectXml({
         </ValueList>
       </Slot>
       <Name>
-        <LocalizedString charset="UTF-8" value="${DEFAULT_CLASS_CODE_DISPLAY}"/>
+        <LocalizedString charset="UTF-8" value="${title ?? DEFAULT_CLASS_CODE_DISPLAY}"/>
       </Name>
     </Classification>
     
@@ -191,7 +192,7 @@ export function createExtrinsicObjectXml({
         </ValueList>
       </Slot>
       <Name>
-        <LocalizedString charset="UTF-8" value="${DEFAULT_CLASS_CODE_DISPLAY}"/>
+        <LocalizedString charset="UTF-8" value="${title ?? DEFAULT_CLASS_CODE_DISPLAY}"/>
       </Name>
     </Classification>
     
@@ -202,7 +203,7 @@ export function createExtrinsicObjectXml({
     </ExternalIdentifier>
     
     <ExternalIdentifier id="${uuidv7()}" identificationScheme="${XDSDocumentEntryUniqueId}" objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier" registryObject="${documentUUID}" value="${createDocumentUniqueId(
-    documentUniqueId
+    shortDocumentId
   )}">
       <Name>
         <LocalizedString charset="UTF-8" value="XDSDocumentEntry.uniqueId"/>
@@ -210,4 +211,8 @@ export function createExtrinsicObjectXml({
     </ExternalIdentifier>
   </ExtrinsicObject>`;
   return metadataXml;
+}
+
+function extractFileId(documentUniqueId: string): string {
+  return documentUniqueId.split("/").pop() ?? documentUniqueId;
 }


### PR DESCRIPTION
Part of ENG-854

Issues:

- https://linear.app/metriport/issue/ENG-854

### Description
- Updated the metadata XML file builder:
  - Use a shorter doc id (`cxId_ptId_docId`, instead of using the entire file path)
  - Use the title specified in the DocRef instead of always defaulting to CCD
- Updated the inbound DR request processor to re-build the full filepath to the docs on S3

### Testing
- Branch to Staging
  - [x] Upload a document for a patient
    - [x] Confirm the metadata has the updated doc id as expected
  - [x] Run DQ #1
    - [x] Successfully download the docs
    - [x] Check the dq responses
    - [x] Check the dr responses
- Staging
  - [ ] Upload a document for a patient
    - [ ] Confirm the metadata has the updated doc id as expected
  - [ ] Run DQ 1 (for newly-uploaded doc)
    - [ ] Successfully download the docs
    - [ ] Check the dq responses
    - [ ] Check the dr responses
  - [ ] Run DQ 2 (for old-formatted doc)
    - [ ] Successfully download the docs
    - [ ] Check the dq responses
    - [ ] Check the dr responses
- Production
  - [ ] Check that the inbound works as expected

Check each PR.

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced document reference generation that builds correct download URLs using reconstructed file paths.
  * Added support for documents stored under derived paths, improving retrieval across varied storage keys.
  * Metadata now uses an optional title to override default classification displays.
  * Metadata unique IDs now incorporate a shortened document ID for cleaner references.

* Bug Fixes
  * Improved reliability of document downloads by resolving lookup failures when IDs lacked full paths.
  * Enhanced error reporting for easier troubleshooting during document retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->