### PR TITLE
Eng 381 create endpoint to setup a new cx in canvas

### DIFF
--- a/packages/api/src/routes/internal/ehr/canvas/setup.ts
+++ b/packages/api/src/routes/internal/ehr/canvas/setup.ts
@@ -1,31 +1,97 @@
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import httpStatus from "http-status";
+import z from "zod";
 import { updateCustomerBillingToPointToParent } from "../../../../command/internal-server/update-customer";
+import { findOrCreateFacilityMapping } from "../../../../command/mapping/facility";
 import { requestLogger } from "../../../helpers/request-logger";
 import { getUUIDFrom } from "../../../schemas/uuid";
-import { asyncHandler, getFromQueryOrFail } from "../../../util";
+import { asyncHandler, getFromQuery, getFromQueryOrFail } from "../../../util";
+import { findOrCreateCxMapping } from "../../../../command/mapping/cx";
+import { saveJwtToken } from "../../../../external/ehr/shared/utils/jwt-token";
+import {
+  canvasDashSource,
+  canvasWebhookSource,
+} from "@metriport/shared/interface/external/ehr/canvas/jwt-token";
+import ForbiddenError from "../../../../errors/forbidden";
 
 const router = Router();
+
+const setupCanvasSchema = z.object({
+  dashToken: z.object({
+    token: z.string(),
+    exp: z.number(),
+  }),
+  webhookToken: z.object({
+    token: z.string(),
+    exp: z.number(),
+  }),
+});
 
 /**
  * POST /internal/ehr/canvas/setup
  *
- * Updates customer billing to point to parent organization
- * @param req.query.parentName - The parent customer's name
+ * Setup a new cx in Canvas
  * @param req.query.childCxId - The child customer's ID
+ * @param req.query.facilityId - The facility ID
+ * @param req.query.externalId - The external ID
+ * @param req.query.state - The state of the facility
+ * @param req.body - The JWT token data
  * @returns 200 OK
  */
 router.post(
   "/",
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
-    const parentName = getFromQueryOrFail("parentName", req);
     const childCxId = getUUIDFrom("query", req, "childCxId").orFail();
+    const facilityId = getUUIDFrom("query", req, "facilityId").orFail();
+    const externalId = getFromQueryOrFail("externalId", req);
+    const state = getFromQuery("state", req);
 
-    await updateCustomerBillingToPointToParent({ parentName, childCxId });
+    const token = setupCanvasSchema.parse(req.body).dashToken;
+    const webhookToken = setupCanvasSchema.parse(req.body).webhookToken;
 
-    // ALEXEY TODO: the rest of the setup here...
+    if (token.token === "" || webhookToken.token === "") throw new ForbiddenError();
+
+    await updateCustomerBillingToPointToParent({ parentName: canvasDashSource, childCxId });
+
+    const externalIdWithState = state ? `${externalId}-${state}` : externalId;
+
+    await findOrCreateFacilityMapping({
+      cxId: childCxId,
+      facilityId: facilityId,
+      externalId: externalIdWithState,
+      source: canvasDashSource,
+    });
+
+    await findOrCreateCxMapping({
+      cxId: childCxId,
+      source: canvasDashSource,
+      externalId: externalId,
+      secondaryMappings: null,
+    });
+
+    await Promise.all([
+      saveJwtToken({
+        token: token.token,
+        source: canvasDashSource,
+        exp: token.exp,
+        data: {
+          source: canvasDashSource,
+          practiceId: externalId,
+        },
+      }),
+      saveJwtToken({
+        token: webhookToken.token,
+        source: canvasWebhookSource,
+        exp: webhookToken.exp,
+        data: {
+          cxId: childCxId,
+          source: canvasWebhookSource,
+          practiceId: externalId,
+        },
+      }),
+    ]);
 
     return res.sendStatus(httpStatus.OK);
   })

--- a/packages/api/src/routes/internal/ehr/canvas/setup.ts
+++ b/packages/api/src/routes/internal/ehr/canvas/setup.ts
@@ -33,8 +33,7 @@ function getDefaultExpiration(): number {
  * @param req.query.facilityId - The facility ID
  * @param req.query.externalId - The external ID
  * @param req.query.state - The state of the facility
- * @param req.body - The JWT token data
- * @returns 200 OK
+ * @returns 200 OK with the dash and webhook tokens
  */
 router.post(
   "/",

--- a/packages/api/src/routes/internal/jwt-token/canvas.ts
+++ b/packages/api/src/routes/internal/jwt-token/canvas.ts
@@ -30,7 +30,7 @@ router.get(
   })
 );
 
-const createJwtSchema = z.object({
+export const createcCanvasJwtSchema = z.object({
   exp: z.number(),
   data: canvasDashJwtTokenDataSchema,
 });
@@ -43,7 +43,7 @@ router.post(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const token = getAuthorizationToken(req);
-    const data = createJwtSchema.parse(req.body);
+    const data = createcCanvasJwtSchema.parse(req.body);
     await saveJwtToken({
       token,
       source: canvasDashSource,
@@ -69,7 +69,7 @@ router.get(
   })
 );
 
-const createWebhookJwtSchema = z.object({
+export const createcCanvasWebhookJwtSchema = z.object({
   exp: z.number(),
   data: canvasWebhookJwtTokenDataSchema,
 });
@@ -82,7 +82,7 @@ router.post(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const token = getAuthorizationToken(req);
-    const data = createWebhookJwtSchema.parse(req.body);
+    const data = createcCanvasWebhookJwtSchema.parse(req.body);
     await saveJwtToken({
       token,
       source: canvasWebhookSource,

--- a/packages/api/src/routes/internal/jwt-token/canvas.ts
+++ b/packages/api/src/routes/internal/jwt-token/canvas.ts
@@ -30,7 +30,7 @@ router.get(
   })
 );
 
-export const createcCanvasJwtSchema = z.object({
+const createJwtSchema = z.object({
   exp: z.number(),
   data: canvasDashJwtTokenDataSchema,
 });
@@ -43,7 +43,7 @@ router.post(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const token = getAuthorizationToken(req);
-    const data = createcCanvasJwtSchema.parse(req.body);
+    const data = createJwtSchema.parse(req.body);
     await saveJwtToken({
       token,
       source: canvasDashSource,
@@ -69,7 +69,7 @@ router.get(
   })
 );
 
-export const createcCanvasWebhookJwtSchema = z.object({
+const createWebhookJwtSchema = z.object({
   exp: z.number(),
   data: canvasWebhookJwtTokenDataSchema,
 });
@@ -82,7 +82,7 @@ router.post(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const token = getAuthorizationToken(req);
-    const data = createcCanvasWebhookJwtSchema.parse(req.body);
+    const data = createWebhookJwtSchema.parse(req.body);
     await saveJwtToken({
       token,
       source: canvasWebhookSource,


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-381

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4367
- Downstream: none

### Description

Endpoint to setup a new cx in Canvas

### Testing



- Local
  - [x] run locally the full flow and get 200
  - [x] return 2 tokens to the caller
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] update engineering documentation
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-step POST setup to provision a Canvas integration for a child account.
  * Automatically creates required facility and account mappings.
  * Generates, returns, and securely persists dashboard and webhook authentication tokens with long-lived expiry.
  * Billing now links the child account to the Canvas parent; tenant flag defaults to tenant behavior when omitted.

* **Documentation**
  * Endpoint docs updated: facilityId and externalId required; optional tenant flag; responses include returned tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->