### PR TITLE
ENG-000: Disallow param reassignment in eslint rules

### DIFF
--- a/packages/eslint-rules/index.js
+++ b/packages/eslint-rules/index.js
@@ -8,6 +8,7 @@ module.exports = {
       rules: {
         '@metriport/eslint-rules/no-named-arrow-functions': 'warn',
         '@metriport/eslint-rules/require-script-docstring': 'warn',
+        'no-param-reassign': 'warn',
       },
     },
     all: {

--- a/packages/eslint-rules/package.json
+++ b/packages/eslint-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/eslint-plugin-eslint-rules",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Custom ESLint rules for Metriport's monorepo",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
### Dependencies

None

### Description

Enabling another pre-existing eslint rule that we should probably enforce

<img width="764" height="486" alt="image" src="https://github.com/user-attachments/assets/21a4ae89-b796-4b1a-a2a6-9b94dd2c2157" />

### Testing

- Local
  - [x] See photo

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Recommended ESLint config now warns on parameter reassignment, helping catch unintended mutations in function parameters. Existing recommended rules remain unchanged.
- Chores
  - Bumped eslint-rules package version to 1.0.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->