### PR TITLE
ENG-861: Fix duplicate condition ids in conversion bundles

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/encounter.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/encounter.ts
@@ -11,7 +11,7 @@ import { DEFAULT_ENCOUNTER_CLASS, adtToFhirEncounterClassMap, isAdtPatientClass 
 import { getParticipantsFromAdt } from "./practitioner";
 import { createEncounterId, getEncounterPeriod, getPatientClassCode } from "./utils";
 
-export function mapEncounterAndRelatedResources(adt: Hl7Message, patientId: string): Resource[] {
+export function convertAdtToFhirResources(adt: Hl7Message, patientId: string): Resource[] {
   const msgType = getHl7MessageTypeOrFail(adt);
   const encounterId = createEncounterId(adt, patientId);
   const encounterReason = getEncounterReason({ adt, patientId, encounterId });

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
@@ -5,7 +5,7 @@ import { elapsedTimeFromNow } from "@metriport/shared/common/date";
 import { BundleWithEntry, buildBundleFromResources } from "../../../external/fhir/bundle/bundle";
 import { buildDocIdFhirExtension } from "../../../external/fhir/shared/extensions/doc-id-extension";
 import { capture, out } from "../../../util";
-import { mapEncounterAndRelatedResources } from "./adt/encounter";
+import { convertAdtToFhirResources } from "./adt/encounter";
 import { getHl7MessageTypeOrFail } from "./msh";
 
 export type Hl7ToFhirParams = {
@@ -31,7 +31,7 @@ export function convertHl7v2MessageToFhir({
   const { messageCode } = getHl7MessageTypeOrFail(message);
 
   if (messageCode === "ADT") {
-    const resources = mapEncounterAndRelatedResources(message, patientId);
+    const resources = convertAdtToFhirResources(message, patientId);
     const bundle = buildBundleFromResources({ type: "collection", resources });
     const duration = elapsedTimeFromNow(startedAt);
 

--- a/packages/utils/src/hl7v2-notifications/merge-adt-bundles.ts
+++ b/packages/utils/src/hl7v2-notifications/merge-adt-bundles.ts
@@ -1,0 +1,76 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
+// keep that ^ on top
+import { dangerouslyDeduplicateFhir } from "@metriport/core/fhir-deduplication/deduplicate-fhir";
+import { getFileContents, makeDir } from "@metriport/core/util/fs";
+import { elapsedTimeFromNow } from "@metriport/shared/common/date";
+import dayjs from "dayjs";
+
+import { FhirBundleSdk } from "@metriport/fhir-sdk";
+import { cloneDeep } from "lodash";
+import { writeFileSync } from "fs";
+
+/**
+ * Folder with consolidated files/bundles. If the files need to be combined into a bundle
+ * set createBundle, existingPatientId, and auth stuff.
+ *
+ * WARNING: this will overwrite the *_deduped.json files!!!
+ */
+const ptId = "";
+const cxId = "";
+const pathToData = "/Users/lucasdellabella/Documents/PHI";
+const adtBundle1Path = `${pathToData}/admit.hl7.json`;
+const adtBundle2Path = `${pathToData}/discharge.hl7.json`;
+
+/**
+ * Read FHIR bundles from 'samplesFolderPath' and deduplicates the resources inside those bundles.
+ *
+ * Stores the output in:
+ * - the source folder, with the same name and the suffix '_deduped.json'
+ * - a the './runs/' folder, with the same name and the suffix '_deduped.json'
+ *
+ * WARNING: it will override the *_deduped.json files from the source folder!!!
+ */
+async function main() {
+  const timestamp = dayjs().toISOString();
+  const logsFolderName = `runs/merge-adt-bundles/${timestamp}`;
+
+  makeDir(logsFolderName);
+
+  const startedAt = new Date();
+  console.log("Starting deduplication at ", startedAt);
+
+  const adtBundle1 = await FhirBundleSdk.create(JSON.parse(getFileContents(adtBundle1Path)));
+  const adtBundle2 = await FhirBundleSdk.create(JSON.parse(getFileContents(adtBundle2Path)));
+
+  const joinedBundle = await adtBundle1.concatEntries(adtBundle2);
+
+  const initialSize = joinedBundle.total;
+
+  const resultBundle = cloneDeep(joinedBundle.toObject());
+  dangerouslyDeduplicateFhir(resultBundle, cxId, ptId);
+
+  const { baseOnly: joinedBundleOnly, parameterOnly: resultBundleOnly } = await joinedBundle.diff(
+    resultBundle
+  );
+
+  console.log("joinedBundleOnly", JSON.stringify(joinedBundleOnly.toObject(), null, 2));
+  console.log("resultBundleOnly", JSON.stringify(resultBundleOnly.toObject(), null, 2));
+  console.log("all entries", JSON.stringify(joinedBundle.entry, null, 2));
+
+  console.log(
+    `Went from ${initialSize} to ${resultBundle.entry?.length} resources in ${elapsedTimeFromNow(
+      startedAt
+    )} ms.`
+  );
+
+  const lastSlash = adtBundle1Path.lastIndexOf("/");
+  const fileName = adtBundle1Path.slice(lastSlash + 1).split(".json")[0];
+  const fileNameWithExtension = `${fileName}_merged.json`;
+
+  const output = JSON.stringify(resultBundle);
+  writeFileSync(`${logsFolderName}/${fileNameWithExtension}`, output);
+}
+
+main();

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/clean-duplicate-condition-ids.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/clean-duplicate-condition-ids.ts
@@ -29,7 +29,7 @@ import { reprocessAdtConversionBundles } from "./common";
 const prefixes: string[] = [];
 
 async function main() {
-  await reprocessAdtConversionBundles(prefixes, cleanDuplicateConditionIds);
+  await reprocessAdtConversionBundles(prefixes, cleanDuplicateConditionIds, false);
 }
 
 async function cleanDuplicateConditionIds(

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/clean-duplicate-condition-ids.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/clean-duplicate-condition-ids.ts
@@ -1,0 +1,69 @@
+/* eslint-disable no-useless-escape */
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+
+import { FhirBundleSdk } from "@metriport/fhir-sdk";
+import { createUuidFromText } from "@metriport/shared/common/uuid";
+import _ from "lodash";
+import { reprocessAdtConversionBundles } from "./common";
+
+/**
+ * Removes encounter reason codings from ADT conversion bundles stored in S3.
+ *
+ * This script pulls down every conversion bundle from s3, and removes any conditions that have identical codings to encounter reason codes.
+ * It then uploads the cleaned bundles back to s3.
+ *
+ * Steps:
+ * 1. Ensure your .env file has the required AWS and bucket configuration (HL7_CONVERSION_BUCKET_NAME)
+ * 2. Update the prefixes array on line 18 with the customer IDs to process
+ * 3. Run the script:
+ *    npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/remove-encounter-reason-codings.ts
+ *
+ * Usage:
+ * Run with: npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/remove-encounter-reason-codings.ts
+ *
+ * Note: This script modifies data in S3. Ensure you have backups if needed.
+ */
+
+const prefixes: string[] = [];
+
+async function main() {
+  await reprocessAdtConversionBundles(prefixes, cleanDuplicateConditionIds);
+}
+
+async function cleanDuplicateConditionIds(
+  bundle: FhirBundleSdk,
+  log: (message: string) => void
+): Promise<FhirBundleSdk> {
+  const encounter = _(bundle.getEncounters()).first();
+  if (encounter === undefined) {
+    log("Encounter missing - critical, skipping");
+    return bundle;
+  }
+
+  // Create old + new uuid pairings
+  const conditionIds = _(bundle.getConditions())
+    .map(c => {
+      if (c.id === undefined) {
+        log("Condition id missing - critical, skipping");
+        return;
+      }
+      return {
+        oldId: c.id,
+        newId: createUuidFromText(`${encounter.id}-${JSON.stringify(c.code)}`),
+      };
+    })
+    .compact()
+    .value();
+
+  // Replace all old ids with new ids
+  const bundleAsString = JSON.stringify(bundle.toObject());
+  const cleanedBundleString = conditionIds.reduce((acc, { oldId, newId }) => {
+    return acc.replaceAll(oldId, newId);
+  }, bundleAsString);
+
+  return await FhirBundleSdk.create(JSON.parse(cleanedBundleString));
+}
+
+main();

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/common.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/common.ts
@@ -1,0 +1,69 @@
+/* eslint-disable no-useless-escape */
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+
+import { S3Utils } from "@metriport/core/external/aws/s3";
+import { Config } from "@metriport/core/util/config";
+import { out } from "@metriport/core/util/log";
+import { FhirBundleSdk } from "@metriport/fhir-sdk";
+import { parseFhirBundle } from "@metriport/shared/medical/fhir/bundle";
+
+const bucketName = Config.getHl7ConversionBucketName();
+
+/**
+ * Re-processes ADT conversion bundles stored in S3.
+ *
+ * @param prefixes - The prefixes of the bundles to re-process.
+ * @param handler - The handler function that will be called to transform each bundle.
+ */
+export async function reprocessAdtConversionBundles(
+  prefixes: string[],
+  handler: (bundle: FhirBundleSdk, log: (message: string) => void) => Promise<FhirBundleSdk>
+) {
+  if (bucketName === undefined) {
+    throw new Error(
+      "Failed to find environment variable from `Config.getHl7ConversionBucketName()`"
+    );
+  }
+
+  const s3Utils = new S3Utils(Config.getAWSRegion());
+  const promises = prefixes.map(async prefix => {
+    const { log } = out(prefix);
+    const results = await s3Utils.listObjects(bucketName, prefix);
+    log(`Found ${results.length} objects for prefix: ${prefix}`);
+    let processedCount = 0;
+    const fileProcessingPromises = results.map(async result => {
+      log(`Processing object: ${result.Key}`);
+      if (result.Key === undefined) {
+        log("Key is undefined - and it shouldn't be");
+        return;
+      }
+      const fileBuffer = await s3Utils.downloadFile({ bucket: bucketName, key: result.Key });
+      const rawBuffer = fileBuffer.toString();
+      const bundleObject = parseFhirBundle(rawBuffer);
+      if (!bundleObject) {
+        log("Bundle is undefined - and it shouldn't be");
+        return;
+      }
+
+      const bundle = await FhirBundleSdk.create(bundleObject);
+      const cleanedBundle = await handler(bundle, log);
+
+      // Overwrite old bundle
+      await s3Utils.uploadFile({
+        bucket: bucketName,
+        key: result.Key,
+        file: Buffer.from(JSON.stringify(cleanedBundle.toObject())),
+        contentType: "application/json",
+      });
+      processedCount++;
+      log(`Processed ${processedCount} objects`);
+    });
+
+    await Promise.all(fileProcessingPromises);
+  });
+
+  await Promise.all(promises);
+  console.log("Done");
+}

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/find-duplicate-resource-ids-within-a-bundle.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/find-duplicate-resource-ids-within-a-bundle.ts
@@ -1,0 +1,64 @@
+/* eslint-disable no-useless-escape */
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+
+import { FhirBundleSdk } from "@metriport/fhir-sdk";
+import _ from "lodash";
+import { reprocessAdtConversionBundles } from "./common";
+
+/**
+ * Finds duplicate resource IDs within ADT conversion bundles stored in S3.
+ *
+ * This script pulls down every conversion bundle from S3 and checks for duplicate resource IDs within each bundle.
+ * It logs when duplicates are found but does not modify the bundles.
+ *
+ * Steps:
+ * 1. Ensure your .env file has the required AWS and bucket configuration (HL7_CONVERSION_BUCKET_NAME)
+ * 2. Update the prefixes array on line 29 with the customer IDs to process
+ * 3. Run the script:
+ *    npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/find-duplicate-resource-ids-within-a-bundle.ts
+ *
+ * Usage:
+ * Run with: npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/find-duplicate-resource-ids-within-a-bundle.ts
+ *
+ * Note: This script only reads data from S3 and logs findings. It does not modify any data.
+ */
+
+// You can use an empty string to run on all bundles
+const prefixes: string[] = [];
+
+async function main() {
+  await reprocessAdtConversionBundles(prefixes, cleanDuplicateConditionIds, true);
+}
+
+async function cleanDuplicateConditionIds(
+  bundle: FhirBundleSdk,
+  log: (message: string) => void
+): Promise<FhirBundleSdk> {
+  const observationIds = _(bundle.getConditions())
+    .map(e => e.id)
+    .compact()
+    .value();
+
+  const observationDuplicates = _.uniq(observationIds).length !== observationIds.length;
+
+  if (observationDuplicates) {
+    log("Condition duplicates found");
+  }
+
+  const encounterIds = _(bundle.getEncounters())
+    .map(e => e.id)
+    .compact()
+    .value();
+
+  const encounterDuplicates = _.uniq(encounterIds).length !== encounterIds.length;
+
+  if (encounterDuplicates) {
+    log("Encounter duplicates found");
+  }
+
+  return bundle;
+}
+
+main();


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4392

### Description

Updates all the condition uuids to ensure they're based on the hash of the encounter id as well as the coding contents, guaranteeing that between different encounters, the coding resource ids are different.

### Testing

- Local
  - [x] Verify that Condition conversions look the same before + after these changes
- Staging
  - [x] Verify that script changes only the necessary condition ids.
- Production
  - ⚠️  Verify that there are no bundles in production which internally have duplicate resource ids - there shouldn't be, as anything that would would have been deduplicated.
     - This test led to discovering that there were duplicate encounter ids, and the corresponding upstream PR.  
     - Once we run the upstrea, this will be fixed.

Changes only the necessary ids, + changes them properly (each is unique, etc)
<img width="1287" height="1302" alt="image" src="https://github.com/user-attachments/assets/a41d1ea0-0178-4692-bfb9-7ddd5aba04de" />

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ADT-to-FHIR conversion now emits Encounter plus separate Condition resources; diagnoses link to those Conditions.
  * Condition IDs are generated per-encounter for stable, encounter-scoped identifiers.
* **Bug Fixes**
  * Deduplicates Conditions derived from diagnoses and improves encounter reason mapping.
* **Chores**
  * Added utilities to scan, clean, and reprocess bundles to detect and fix duplicate Condition IDs.
  * Added a tool to merge and deduplicate two ADT bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->