### PR TITLE
PATCH RELEASE .ENG-753 Update thread pool

### DIFF
--- a/packages/data-transformation/fhir-to-csv/main.py
+++ b/packages/data-transformation/fhir-to-csv/main.py
@@ -83,7 +83,7 @@ def transform_and_upload_data(
     output_bucket_and_file_keys_and_table_names = []
     output_file_prefix = create_output_file_prefix(dwh, transform_name, cx_id, patient_id, job_id)
     
-    with ThreadPoolExecutor(max_workers=10) as executor:
+    with ThreadPoolExecutor(max_workers=3) as executor:
         future_to_file = {}
         for file in local_output_files:
             output_file_key = f"{output_file_prefix}/{file.replace('/', '_')}"


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-753

### Dependencies

- Upstream: _[this PR points to another PR or depends on its release]_
- Downstream: _[PRs that depend on this one, either point to this or can only be released after this one is released]_

### Description

Update thread pool on Data Transformer from 10 to 3 - [context](https://metriport.slack.com/archives/C04DBBJSKGB/p1755307676966249?thread_ts=1755306196.770939&cid=C04DBBJSKGB)

### Testing

none

### Release Plan

- :warning: Points to `master`
- [ ] Merge this
- [ ] Manually trigger CICD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted file-upload parallelism to limit simultaneous uploads from 10 to 3.

* **Impact**
  * Smoother, more consistent performance during large CSV upload operations.
  * Reduced peak resource usage on client and server during uploads.
  * Upload batches may take slightly longer to complete due to lower concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->