### PR TITLE
ENG-861: ADT backfill fast-follows

### DIFF
--- a/packages/core/src/external/fhir/bundle/utils.ts
+++ b/packages/core/src/external/fhir/bundle/utils.ts
@@ -3,7 +3,7 @@ import { FhirBundleSdk } from "@metriport/fhir-sdk";
 import { MetriportError } from "@metriport/shared";
 import _, { cloneDeep } from "lodash";
 import { dangerouslyDeduplicateFhir } from "../../../fhir-deduplication/deduplicate-fhir";
-import { groupSameEncountersDateOnly } from "../../../fhir-deduplication/resources/encounter";
+import { groupSameEncountersDatetimeOnly } from "../../../fhir-deduplication/resources/encounter";
 import { normalizeFhir } from "../normalization/normalize-fhir";
 import { isEncounter } from "../shared";
 import { buildBundle, buildBundleEntry, RequiredBundleType } from "./bundle";
@@ -41,7 +41,7 @@ export function mergeBundles({
  * our core deduplication logic. This is only used for ADT encounters.
  *
  * ⚠️ NOTE: This function relies on the assumption that all resource ids in the bundle
- * are stable, because we do not use the refReplacementMap from `groupSameEncountersDateOnly`.
+ * are stable, because we do not use the refReplacementMap from `groupSameEncountersDatetimeOnly`.
  * If resource ids are not stable, and there are references pointing to an encounter, the
  * references will not be updated and will be left broken.
  */
@@ -51,7 +51,7 @@ export function dedupeAdtEncounters(existing: Bundle<Resource>): Bundle<Resource
     .partition(isEncounter)
     .value();
 
-  const { encountersMap: dedupedEncountersMap } = groupSameEncountersDateOnly(encounters);
+  const { encountersMap: dedupedEncountersMap } = groupSameEncountersDatetimeOnly(encounters);
 
   const encounterBundleEntries = [...dedupedEncountersMap.values()].map(buildBundleEntry);
   const nonEncounterBundleEntries = _(nonEncounters).compact().map(buildBundleEntry).value();

--- a/packages/core/src/external/fhir/bundle/utils.ts
+++ b/packages/core/src/external/fhir/bundle/utils.ts
@@ -44,6 +44,8 @@ export function mergeBundles({
  * are stable, because we do not use the refReplacementMap from `groupSameEncountersDatetimeOnly`.
  * If resource ids are not stable, and there are references pointing to an encounter, the
  * references will not be updated and will be left broken.
+ *
+ * TODO: Fix this ^, ticket at ENG-876
  */
 export function dedupeAdtEncounters(existing: Bundle<Resource>): Bundle<Resource> {
   const [encounters, nonEncounters] = _(existing.entry)

--- a/packages/core/src/fhir-deduplication/__tests__/shared.test.ts
+++ b/packages/core/src/fhir-deduplication/__tests__/shared.test.ts
@@ -2,175 +2,177 @@
 import { Encounter } from "@medplum/fhirtypes";
 import { deepMerge, pickMostSevereClass, dangerouslyAssignMostSevereClass } from "../shared";
 
-describe("deepMerge", () => {
-  it("keeps the target 'display' value when source is 'unknown'", () => {
-    const target = {
-      class: {
-        system: "http://www.ama-assn.org/go/cpt",
-        code: "99214",
-        display: "OFFICE O/P EST MOD 30-39 MIN",
-      },
-    };
-    const source = {
-      class: {
-        system: "http://www.ama-assn.org/go/cpt",
-        code: "99214",
-        display: "unknown",
-      },
-    };
-    const result = deepMerge(target, source, true);
-    expect(result.class.display).toEqual("OFFICE O/P EST MOD 30-39 MIN");
+describe("fhir-deduplication > shared > ", () => {
+  describe("deepMerge", () => {
+    it("keeps the target 'display' value when source is 'unknown'", () => {
+      const target = {
+        class: {
+          system: "http://www.ama-assn.org/go/cpt",
+          code: "99214",
+          display: "OFFICE O/P EST MOD 30-39 MIN",
+        },
+      };
+      const source = {
+        class: {
+          system: "http://www.ama-assn.org/go/cpt",
+          code: "99214",
+          display: "unknown",
+        },
+      };
+      const result = deepMerge(target, source, true);
+      expect(result.class.display).toEqual("OFFICE O/P EST MOD 30-39 MIN");
+    });
+
+    it("uses the source 'display' value when it's not 'unknown'", () => {
+      const target = {
+        class: {
+          system: "http://www.ama-assn.org/go/cpt",
+          code: "99214",
+          display: "unknown",
+        },
+      };
+      const source = {
+        class: {
+          system: "http://www.ama-assn.org/go/cpt",
+          code: "99214",
+          display: "OFFICE O/P EST MOD 30-39 MIN",
+        },
+      };
+      const result = deepMerge(target, source, true);
+      expect(result.class.display).toEqual("OFFICE O/P EST MOD 30-39 MIN");
+    });
   });
 
-  it("uses the source 'display' value when it's not 'unknown'", () => {
-    const target = {
-      class: {
-        system: "http://www.ama-assn.org/go/cpt",
-        code: "99214",
-        display: "unknown",
-      },
-    };
-    const source = {
-      class: {
-        system: "http://www.ama-assn.org/go/cpt",
-        code: "99214",
-        display: "OFFICE O/P EST MOD 30-39 MIN",
-      },
-    };
-    const result = deepMerge(target, source, true);
-    expect(result.class.display).toEqual("OFFICE O/P EST MOD 30-39 MIN");
-  });
-});
+  describe("pickMostSevereClass", () => {
+    it("returns the more severe class when both have correct case", () => {
+      const class1 = { code: "AMB" as const };
+      const class2 = { code: "ACUTE" as const };
+      const result = pickMostSevereClass(class1, class2);
+      expect(result).toEqual(class2); // ACUTE is more severe than AMB
+    });
 
-describe("pickMostSevereClass", () => {
-  it("returns the more severe class when both have correct case", () => {
-    const class1 = { code: "AMB" as const };
-    const class2 = { code: "ACUTE" as const };
-    const result = pickMostSevereClass(class1, class2);
-    expect(result).toEqual(class2); // ACUTE is more severe than AMB
-  });
+    it("normalizes capitalization and picks the more severe class", () => {
+      const class1 = { code: "amb" } as any; // lowercase - type assertion needed for test
+      const class2 = { code: "ACUTE" as const };
+      const result = pickMostSevereClass(class1, class2);
+      expect(result).toEqual(class2); // ACUTE is more severe than AMB
+    });
 
-  it("normalizes capitalization and picks the more severe class", () => {
-    const class1 = { code: "amb" } as any; // lowercase - type assertion needed for test
-    const class2 = { code: "ACUTE" as const };
-    const result = pickMostSevereClass(class1, class2);
-    expect(result).toEqual(class2); // ACUTE is more severe than AMB
-  });
+    it("normalizes mixed case and picks correctly", () => {
+      const class1 = { code: "Acute" } as any; // mixed case - type assertion needed for test
+      const class2 = { code: "imp" } as any; // lowercase - type assertion needed for test
+      const result = pickMostSevereClass(class1, class2);
+      expect(result).toEqual(class1); // ACUTE is more severe than IMP
+    });
 
-  it("normalizes mixed case and picks correctly", () => {
-    const class1 = { code: "Acute" } as any; // mixed case - type assertion needed for test
-    const class2 = { code: "imp" } as any; // lowercase - type assertion needed for test
-    const result = pickMostSevereClass(class1, class2);
-    expect(result).toEqual(class1); // ACUTE is more severe than IMP
+    it("returns undefined when both classes are undefined", () => {
+      const result = pickMostSevereClass(undefined, undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when both classes have no code", () => {
+      const class1 = {} as any;
+      const class2 = {} as any;
+      const result = pickMostSevereClass(class1, class2);
+      expect(result).toBeUndefined();
+    });
   });
 
-  it("returns undefined when both classes are undefined", () => {
-    const result = pickMostSevereClass(undefined, undefined);
-    expect(result).toBeUndefined();
-  });
+  describe("dangerouslyAssignMostSevereClass", () => {
+    const HL7_ACT_URL = "http://terminology.hl7.org/CodeSystem/v3-ActCode";
 
-  it("returns undefined when both classes have no code", () => {
-    const class1 = {} as any;
-    const class2 = {} as any;
-    const result = pickMostSevereClass(class1, class2);
-    expect(result).toBeUndefined();
-  });
-});
+    it("assigns the most severe class to both encounters when both have valid ActCoding", () => {
+      const existing: Encounter = {
+        resourceType: "Encounter",
+        status: "finished",
+        class: {
+          system: HL7_ACT_URL,
+          code: "AMB", // Ambulatory - less severe
+          display: "Ambulatory",
+        },
+      };
 
-describe("dangerouslyAssignMostSevereClass", () => {
-  const HL7_ACT_URL = "http://terminology.hl7.org/CodeSystem/v3-ActCode";
+      const target: Encounter = {
+        resourceType: "Encounter",
+        status: "finished",
+        class: {
+          system: HL7_ACT_URL,
+          code: "ACUTE", // Acute - more severe
+          display: "Acute",
+        },
+      };
 
-  it("assigns the most severe class to both encounters when both have valid ActCoding", () => {
-    const existing: Encounter = {
-      resourceType: "Encounter",
-      status: "finished",
-      class: {
-        system: HL7_ACT_URL,
-        code: "AMB", // Ambulatory - less severe
-        display: "Ambulatory",
-      },
-    };
+      dangerouslyAssignMostSevereClass(existing, target);
 
-    const target: Encounter = {
-      resourceType: "Encounter",
-      status: "finished",
-      class: {
-        system: HL7_ACT_URL,
-        code: "ACUTE", // Acute - more severe
-        display: "Acute",
-      },
-    };
+      // Both should now have the more severe "ACUTE" class
+      expect(existing.class?.code).toBe("ACUTE");
+      expect(existing.class?.display).toBe("Acute");
+      expect(target.class?.code).toBe("ACUTE");
+      expect(target.class?.display).toBe("Acute");
+    });
 
-    dangerouslyAssignMostSevereClass(existing, target);
+    it("does not modify encounters when one has invalid ActCoding system", () => {
+      const existing: Encounter = {
+        resourceType: "Encounter",
+        status: "finished",
+        class: {
+          system: "http://invalid-system.org", // Invalid system
+          code: "AMB",
+          display: "Ambulatory",
+        },
+      };
 
-    // Both should now have the more severe "ACUTE" class
-    expect(existing.class?.code).toBe("ACUTE");
-    expect(existing.class?.display).toBe("Acute");
-    expect(target.class?.code).toBe("ACUTE");
-    expect(target.class?.display).toBe("Acute");
-  });
+      const target: Encounter = {
+        resourceType: "Encounter",
+        status: "finished",
+        class: {
+          system: HL7_ACT_URL,
+          code: "ACUTE",
+          display: "Acute",
+        },
+      };
 
-  it("does not modify encounters when one has invalid ActCoding system", () => {
-    const existing: Encounter = {
-      resourceType: "Encounter",
-      status: "finished",
-      class: {
-        system: "http://invalid-system.org", // Invalid system
-        code: "AMB",
-        display: "Ambulatory",
-      },
-    };
+      const originalExistingCode = existing.class?.code;
+      const originalTargetCode = target.class?.code;
 
-    const target: Encounter = {
-      resourceType: "Encounter",
-      status: "finished",
-      class: {
-        system: HL7_ACT_URL,
-        code: "ACUTE",
-        display: "Acute",
-      },
-    };
+      dangerouslyAssignMostSevereClass(existing, target);
 
-    const originalExistingCode = existing.class?.code;
-    const originalTargetCode = target.class?.code;
+      // Both should remain unchanged
+      expect(existing.class?.code).toBe(originalExistingCode);
+      expect(target.class?.code).toBe(originalTargetCode);
+    });
 
-    dangerouslyAssignMostSevereClass(existing, target);
+    it("does not modify encounters when most severe class has no code", () => {
+      const existing: Encounter = {
+        resourceType: "Encounter",
+        status: "finished",
+        class: {
+          system: HL7_ACT_URL,
+          // No code property - this will make pickMostSevereClass return undefined
+          display: "Some display",
+        },
+      };
 
-    // Both should remain unchanged
-    expect(existing.class?.code).toBe(originalExistingCode);
-    expect(target.class?.code).toBe(originalTargetCode);
-  });
+      const target: Encounter = {
+        resourceType: "Encounter",
+        status: "finished",
+        class: {
+          system: HL7_ACT_URL,
+          // No code property - this will make pickMostSevereClass return undefined
+          display: "Another display",
+        },
+      };
 
-  it("does not modify encounters when most severe class has no code", () => {
-    const existing: Encounter = {
-      resourceType: "Encounter",
-      status: "finished",
-      class: {
-        system: HL7_ACT_URL,
-        // No code property - this will make pickMostSevereClass return undefined
-        display: "Some display",
-      },
-    };
+      const originalExistingDisplay = existing.class?.display;
+      const originalTargetDisplay = target.class?.display;
 
-    const target: Encounter = {
-      resourceType: "Encounter",
-      status: "finished",
-      class: {
-        system: HL7_ACT_URL,
-        // No code property - this will make pickMostSevereClass return undefined
-        display: "Another display",
-      },
-    };
+      dangerouslyAssignMostSevereClass(existing, target);
 
-    const originalExistingDisplay = existing.class?.display;
-    const originalTargetDisplay = target.class?.display;
-
-    dangerouslyAssignMostSevereClass(existing, target);
-
-    // Both should remain unchanged since pickMostSevereClass returns undefined
-    expect(existing.class?.display).toBe(originalExistingDisplay);
-    expect(target.class?.display).toBe(originalTargetDisplay);
-    expect(existing.class?.code).toBeUndefined();
-    expect(target.class?.code).toBeUndefined();
+      // Both should remain unchanged since pickMostSevereClass returns undefined
+      expect(existing.class?.display).toBe(originalExistingDisplay);
+      expect(target.class?.display).toBe(originalTargetDisplay);
+      expect(existing.class?.code).toBeUndefined();
+      expect(target.class?.code).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
+++ b/packages/core/src/fhir-deduplication/resources/diagnostic-report.ts
@@ -2,7 +2,7 @@ import { DiagnosticReport } from "@medplum/fhirtypes";
 import { createUuidFromText } from "@metriport/shared/common/uuid";
 import {
   DeduplicationResult,
-  assignMostDescriptiveStatus,
+  dangerouslyAssignMostDescriptiveStatus,
   combineResources,
   createKeysFromObjectArray,
   createKeysFromObjectArrayAndBits,
@@ -41,7 +41,7 @@ const statusRanking: Record<DiagnosticReportStatus, number> = {
 };
 
 function preprocessStatus(existing: DiagnosticReport, target: DiagnosticReport) {
-  return assignMostDescriptiveStatus(statusRanking, existing, target);
+  return dangerouslyAssignMostDescriptiveStatus(statusRanking, existing, target);
 }
 
 export function deduplicateDiagReports(

--- a/packages/core/src/fhir-deduplication/resources/encounter.ts
+++ b/packages/core/src/fhir-deduplication/resources/encounter.ts
@@ -126,7 +126,7 @@ export function groupSameEncounters(encounters: Encounter[]): {
   };
 }
 
-export function groupSameEncountersDateOnly(encounters: Encounter[]): {
+export function groupSameEncountersDatetimeOnly(encounters: Encounter[]): {
   encountersMap: Map<string, Encounter>;
   refReplacementMap: Map<string, string>;
   danglingReferences: Set<string>;

--- a/packages/core/src/fhir-deduplication/resources/encounter.ts
+++ b/packages/core/src/fhir-deduplication/resources/encounter.ts
@@ -1,8 +1,8 @@
 import { Encounter } from "@medplum/fhirtypes";
 import {
   DeduplicationResult,
-  assignMostDescriptiveStatus,
-  assignMostSevereClass,
+  dangerouslyAssignMostDescriptiveStatus,
+  dangerouslyAssignMostSevereClass,
   combineResources,
   createKeysFromObjectArray,
   createRef,
@@ -37,11 +37,11 @@ export const statusRanking: Record<EncounterStatus, number> = {
 };
 
 function preprocessStatus(existing: Encounter, target: Encounter) {
-  return assignMostDescriptiveStatus(statusRanking, existing, target);
+  return dangerouslyAssignMostDescriptiveStatus(statusRanking, existing, target);
 }
 
 function preprocessClass(existing: Encounter, target: Encounter) {
-  return assignMostSevereClass(existing, target);
+  return dangerouslyAssignMostSevereClass(existing, target);
 }
 
 export function deduplicateEncounters(encounters: Encounter[]): DeduplicationResult<Encounter> {

--- a/packages/core/src/fhir-deduplication/resources/immunization.ts
+++ b/packages/core/src/fhir-deduplication/resources/immunization.ts
@@ -2,7 +2,7 @@ import { CodeableConcept, Immunization } from "@medplum/fhirtypes";
 import { CVX_CODE, CVX_OID, NDC_CODE, NDC_OID } from "../../util/constants";
 import {
   DeduplicationResult,
-  assignMostDescriptiveStatus,
+  dangerouslyAssignMostDescriptiveStatus,
   combineResources,
   createKeysFromObjectArray,
   createKeysFromObjectArrayAndBits,
@@ -25,7 +25,7 @@ export const statusRanking: Record<ImmunizationStatus, number> = {
 };
 
 function preprocessStatus(existing: Immunization, target: Immunization) {
-  return assignMostDescriptiveStatus(statusRanking, existing, target);
+  return dangerouslyAssignMostDescriptiveStatus(statusRanking, existing, target);
 }
 
 export function deduplicateImmunizations(

--- a/packages/core/src/fhir-deduplication/resources/medication-administration.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication-administration.ts
@@ -1,7 +1,7 @@
 import { MedicationAdministration } from "@medplum/fhirtypes";
 import {
   DeduplicationResult,
-  assignMostDescriptiveStatus,
+  dangerouslyAssignMostDescriptiveStatus,
   combineResources,
   createRef,
   deduplicateWithinMap,
@@ -30,7 +30,7 @@ const statusRanking: Record<MedicationAdministrationStatus, number> = {
 };
 
 function preprocessStatus(existing: MedicationAdministration, target: MedicationAdministration) {
-  return assignMostDescriptiveStatus(statusRanking, existing, target);
+  return dangerouslyAssignMostDescriptiveStatus(statusRanking, existing, target);
 }
 
 export function deduplicateMedAdmins(

--- a/packages/core/src/fhir-deduplication/resources/medication-dispense.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication-dispense.ts
@@ -1,7 +1,7 @@
 import { MedicationDispense } from "@medplum/fhirtypes";
 import {
   DeduplicationResult,
-  assignMostDescriptiveStatus,
+  dangerouslyAssignMostDescriptiveStatus,
   combineResources,
   createRef,
   deduplicateWithinMap,
@@ -34,7 +34,7 @@ const statusRanking: Record<MedicationDispenseStatus, number> = {
 };
 
 function preprocessStatus(existing: MedicationDispense, target: MedicationDispense) {
-  return assignMostDescriptiveStatus(statusRanking, existing, target);
+  return dangerouslyAssignMostDescriptiveStatus(statusRanking, existing, target);
 }
 
 export function deduplicateMedDispenses(

--- a/packages/core/src/fhir-deduplication/resources/medication-request.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication-request.ts
@@ -1,7 +1,7 @@
 import { MedicationRequest } from "@medplum/fhirtypes";
 import {
   DeduplicationResult,
-  assignMostDescriptiveStatus,
+  dangerouslyAssignMostDescriptiveStatus,
   combineResources,
   createRef,
   deduplicateWithinMap,
@@ -32,7 +32,7 @@ const statusRanking: Record<MedicationRequestStatus, number> = {
 };
 
 function preprocessStatus(existing: MedicationRequest, target: MedicationRequest) {
-  return assignMostDescriptiveStatus(statusRanking, existing, target);
+  return dangerouslyAssignMostDescriptiveStatus(statusRanking, existing, target);
 }
 
 export function deduplicateMedRequests(

--- a/packages/core/src/fhir-deduplication/resources/medication-statement.ts
+++ b/packages/core/src/fhir-deduplication/resources/medication-statement.ts
@@ -1,7 +1,7 @@
 import { MedicationStatement } from "@medplum/fhirtypes";
 import {
   DeduplicationResult,
-  assignMostDescriptiveStatus,
+  dangerouslyAssignMostDescriptiveStatus,
   combineResources,
   createRef,
   deduplicateWithinMap,
@@ -33,7 +33,7 @@ export const statusRanking: Record<MedicationStatementStatus, number> = {
 };
 
 function preprocessStatus(existing: MedicationStatement, target: MedicationStatement) {
-  return assignMostDescriptiveStatus(statusRanking, existing, target);
+  return dangerouslyAssignMostDescriptiveStatus(statusRanking, existing, target);
 }
 
 export function deduplicateMedStatements(

--- a/packages/core/src/fhir-deduplication/resources/observation-shared.ts
+++ b/packages/core/src/fhir-deduplication/resources/observation-shared.ts
@@ -11,7 +11,7 @@ import {
   isUnknownCoding,
   fetchCodingCodeOrDisplayOrSystem,
   fetchCodeableConceptText,
-  assignMostDescriptiveStatus,
+  dangerouslyAssignMostDescriptiveStatus,
 } from "../shared";
 
 export const observationStatus = [
@@ -39,7 +39,7 @@ export const statusRanking: Record<ObservationStatus, number> = {
 };
 
 export function preprocessStatus(existing: Observation, target: Observation) {
-  return assignMostDescriptiveStatus(statusRanking, existing, target);
+  return dangerouslyAssignMostDescriptiveStatus(statusRanking, existing, target);
 }
 
 export function extractCodes(concept: CodeableConcept | undefined): {

--- a/packages/core/src/fhir-deduplication/resources/procedure.ts
+++ b/packages/core/src/fhir-deduplication/resources/procedure.ts
@@ -9,7 +9,7 @@ import {
 } from "../../util/constants";
 import {
   DeduplicationResult,
-  assignMostDescriptiveStatus,
+  dangerouslyAssignMostDescriptiveStatus,
   combineResources,
   createKeysFromObjectArray,
   createKeysFromObjectArrayAndBits,
@@ -46,7 +46,7 @@ export const statusRanking: Record<ProcedureStatus, number> = {
 };
 
 function preprocessStatus(existing: Procedure, target: Procedure) {
-  return assignMostDescriptiveStatus(statusRanking, existing, target);
+  return dangerouslyAssignMostDescriptiveStatus(statusRanking, existing, target);
 }
 
 export function deduplicateProcedures(procedures: Procedure[]): DeduplicationResult<Procedure> {

--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -379,20 +379,29 @@ const classRanking = [
 type EncounterClassCode = (typeof classRanking)[number];
 type EncounterClassCoding = Coding & { code?: EncounterClassCode };
 
+/**
+ * Returns the rank of the class code in the classRanking array.
+ * The lower the rank, the more severe the class.
+ * @param c - The class coding to rank.
+ * @returns The rank of the class code in the classRanking array.
+ */
+function classRank(c: EncounterClassCoding | undefined) {
+  if (!c?.code) return Number.POSITIVE_INFINITY;
+  const idx = classRanking.indexOf(c.code.toUpperCase() as EncounterClassCode);
+  return idx === -1 ? Number.POSITIVE_INFINITY : idx;
+}
+
 export function pickMostSevereClass(
   class1: EncounterClassCoding | undefined,
   class2: EncounterClassCoding | undefined
 ): EncounterClassCoding | undefined {
-  if (class1 && class2 && class1.code && class2.code) {
-    const class1Rank = classRanking.indexOf(class1.code.toUpperCase() as EncounterClassCode);
-    const class2Rank = classRanking.indexOf(class2.code.toUpperCase() as EncounterClassCode);
-    return class1Rank < class2Rank ? class1 : class2;
+  if (class1 && class2) {
+    return classRank(class1) <= classRank(class2) ? class1 : class2;
   } else if (class1 && class1.code) {
     return class1;
   } else if (class2 && class2.code) {
     return class2;
   }
-
   return undefined;
 }
 

--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -535,7 +535,7 @@ export function fetchCodeableConceptText(concept: CodeableConcept): string | und
   }
 }
 
-export function assignMostDescriptiveStatus<T extends Resource & { status?: string }>(
+export function dangerouslyAssignMostDescriptiveStatus<T extends Resource & { status?: string }>(
   statusRanking: Record<string, number>,
   existing: T,
   target: T
@@ -545,7 +545,7 @@ export function assignMostDescriptiveStatus<T extends Resource & { status?: stri
   target.status = status;
 }
 
-export function assignMostSevereClass(existing: Encounter, target: Encounter): void {
+export function dangerouslyAssignMostSevereClass(existing: Encounter, target: Encounter): void {
   if (!isActCoding(existing.class) || !isActCoding(target.class)) {
     return;
   }

--- a/packages/core/src/fhir-deduplication/shared.ts
+++ b/packages/core/src/fhir-deduplication/shared.ts
@@ -396,6 +396,12 @@ export function pickMostSevereClass(
   class2: EncounterClassCoding | undefined
 ): EncounterClassCoding | undefined {
   if (class1 && class2) {
+    if (
+      classRank(class1) === Number.POSITIVE_INFINITY &&
+      classRank(class2) === Number.POSITIVE_INFINITY
+    ) {
+      return undefined;
+    }
     return classRank(class1) <= classRank(class2) ? class1 : class2;
   } else if (class1 && class1.code) {
     return class1;

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/clean-duplicate-condition-ids.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/clean-duplicate-condition-ids.ts
@@ -27,7 +27,7 @@ import { reprocessAdtConversionBundles } from "./common";
  */
 
 const prefixes: string[] = [];
-const dryRun = false;
+const dryRun = true;
 
 async function main() {
   await reprocessAdtConversionBundles(prefixes, cleanDuplicateConditionIds, dryRun);

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/clean-duplicate-condition-ids.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/clean-duplicate-condition-ids.ts
@@ -26,7 +26,7 @@ import { reprocessAdtConversionBundles } from "./common";
  * Note: This script modifies data in S3. Ensure you have backups if needed.
  */
 
-const prefixes: string[] = [""];
+const prefixes: string[] = [];
 const dryRun = false;
 
 async function main() {

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/clean-duplicate-condition-ids.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/clean-duplicate-condition-ids.ts
@@ -26,10 +26,11 @@ import { reprocessAdtConversionBundles } from "./common";
  * Note: This script modifies data in S3. Ensure you have backups if needed.
  */
 
-const prefixes: string[] = [];
+const prefixes: string[] = [""];
+const dryRun = false;
 
 async function main() {
-  await reprocessAdtConversionBundles(prefixes, cleanDuplicateConditionIds, false);
+  await reprocessAdtConversionBundles(prefixes, cleanDuplicateConditionIds, dryRun);
 }
 
 async function cleanDuplicateConditionIds(

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/common.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/common.ts
@@ -9,7 +9,10 @@ import { out } from "@metriport/core/util/log";
 import { FhirBundleSdk } from "@metriport/fhir-sdk";
 import { parseFhirBundle } from "@metriport/shared/medical/fhir/bundle";
 import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
 import { sleep } from "@metriport/shared/common/sleep";
+
+dayjs.extend(duration);
 
 const bucketName = Config.getHl7ConversionBucketName();
 

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/common.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/common.ts
@@ -8,6 +8,8 @@ import { Config } from "@metriport/core/util/config";
 import { out } from "@metriport/core/util/log";
 import { FhirBundleSdk } from "@metriport/fhir-sdk";
 import { parseFhirBundle } from "@metriport/shared/medical/fhir/bundle";
+import dayjs from "dayjs";
+import { sleep } from "@metriport/shared/common/sleep";
 
 const bucketName = Config.getHl7ConversionBucketName();
 
@@ -35,7 +37,13 @@ export async function reprocessAdtConversionBundles(
 
   const s3Utils = new S3Utils(Config.getAWSRegion());
 
-  console.log(`Running in ${dryRun ? "dryRun" : "⚠️ write"} mode`);
+  if (!dryRun) {
+    console.log(`⚠️ Running in write mode`);
+    await displayWarningAndConfirmation(prefixes);
+  } else {
+    console.log(`Running in dryRun mode`);
+  }
+
   const promises = prefixes.map(async prefix => {
     const { log } = out(prefix);
     const results = await s3Utils.listObjects(bucketName, prefix);
@@ -79,4 +87,22 @@ export async function reprocessAdtConversionBundles(
 
   await Promise.all(promises);
   console.log("Done");
+}
+
+const confirmationTime = dayjs.duration(10, "seconds");
+
+async function displayWarningAndConfirmation(prefixes: string[]) {
+  console.log(``);
+  console.log(
+    `THIS IS SUPER DESTRUCTIVE!! IT WILL MODIFY ADT CONVERSION BUNDLES IN S3! ONLY CONTINUE IF YOU KNOW WHAT YOU ARE DOING!`
+  );
+  console.log(``);
+  console.log(
+    `Modifying ALL conversion bundles in ${bucketName} for prefixes: ${prefixes.join(
+      ", "
+    )} in ${confirmationTime.asSeconds()} seconds...`
+  );
+  await sleep(confirmationTime.asMilliseconds());
+  console.log(`ok, continuing...`);
+  await sleep(dayjs.duration(1, "seconds").asMilliseconds());
 }

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/deduplicate-existing-bundles.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/deduplicate-existing-bundles.ts
@@ -27,9 +27,10 @@ import { reprocessAdtConversionBundles } from "./common";
  */
 
 const prefixes: string[] = [];
+const dryRun = true;
 
 async function main() {
-  await reprocessAdtConversionBundles(prefixes, deduplicateExistingBundles, true);
+  await reprocessAdtConversionBundles(prefixes, deduplicateExistingBundles, dryRun);
 }
 
 async function deduplicateExistingBundles(

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/deduplicate-existing-bundles.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/deduplicate-existing-bundles.ts
@@ -9,19 +9,19 @@ import { FhirBundleSdk } from "@metriport/fhir-sdk";
 import { reprocessAdtConversionBundles } from "./common";
 
 /**
- * Removes encounter reason codings from ADT conversion bundles stored in S3.
+ * Deduplicates resources within existing ADT conversion bundles stored in S3.
  *
- * This script pulls down every conversion bundle from s3, and removes any conditions that have identical codings to encounter reason codes.
- * It then uploads the cleaned bundles back to s3.
+ * This script pulls down every conversion bundle from S3, deduplicates the resources within each bundle
+ * using the mergeAdtBundles function (by merging with an empty bundle), and uploads the cleaned bundles back to S3.
  *
  * Steps:
  * 1. Ensure your .env file has the required AWS and bucket configuration (HL7_CONVERSION_BUCKET_NAME)
- * 2. Update the prefixes array on line 18 with the customer IDs to process
+ * 2. Update the prefixes array on line 29 with the customer IDs to process
  * 3. Run the script:
- *    npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/remove-encounter-reason-codings.ts
+ *    npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/deduplicate-existing-bundles.ts
  *
  * Usage:
- * Run with: npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/remove-encounter-reason-codings.ts
+ * Run with: npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/deduplicate-existing-bundles.ts
  *
  * Note: This script modifies data in S3. Ensure you have backups if needed.
  */

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/find-adts-without-encounter-resource.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/find-adts-without-encounter-resource.ts
@@ -16,10 +16,10 @@ import { reprocessAdtConversionBundles } from "./common";
  * 1. Ensure your .env file has the required AWS and bucket configuration (HL7_CONVERSION_BUCKET_NAME)
  * 2. Update the prefixes array on line 29 with the customer IDs to process
  * 3. Run the script:
- *    npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/find-duplicate-resource-ids-within-a-bundle.ts
+ *    npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/find-adts-without-encounter-resource.ts
  *
  * Usage:
- * Run with: npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/find-duplicate-resource-ids-within-a-bundle.ts
+ * Run with: npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/find-adts-without-encounter-resource.ts
  *
  * Note: This script only reads data from S3 and logs findings. It does not modify any data.
  */
@@ -32,10 +32,17 @@ async function main() {
   await reprocessAdtConversionBundles(prefixes, findAdtsWithoutEncounterResource, dryRun);
 }
 
-async function findAdtsWithoutEncounterResource(
-  bundle: FhirBundleSdk
-  // log: (message: string) => void
-): Promise<FhirBundleSdk> {
+/**
+ * Handler function that identifies ADT bundles without encounter resources.
+ *
+ * @param bundle - The FHIR bundle to analyze
+ * @param log - Logger function that includes the S3 file path being processed in its context.
+ *              Use this to log messages that will be prefixed with the file being processed.
+ *              Example: log("No encounters found") will output "[s3-file-path] No encounters found"
+ * @param context - Contains customer ID (cxId) and patient ID (ptId) for the bundle
+ * @returns The original bundle unchanged
+ */
+async function findAdtsWithoutEncounterResource(bundle: FhirBundleSdk): Promise<FhirBundleSdk> {
   const encounters = bundle.getEncounters();
 
   if (encounters.length === 0) {


### PR DESCRIPTION
### Dependencies

None

### Description

Adds a bunch of fast-follow items mentioned on [this PR](https://github.com/metriport/metriport/pull/4398) and [this PR](https://github.com/metriport/metriport/pull/4398).

This includes:
- correct script docstrings
- fix an edgecase in a pickMostSevereClass + add unit tests
- rename some stuff

### Testing

- Adds unit tests for `dangerouslyAssignMostSevereClass`

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public ADT deduplication utility that performs datetime-aware encounter deduplication.
  - New script to locate ADT bundles lacking encounter resources.

- **Improvements**
  - More consistent status/class resolution across deduplication for multiple clinical resource types.

- **Documentation**
  - Updated usage instructions and commands for ADT bundle maintenance scripts.

- **Tests**
  - Expanded tests covering encounter class severity and edge cases.

- **Chores**
  - Introduced configurable dry-run and a confirmation pause for destructive maintenance scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->