### PR TITLE
ENG-200:  cw cert runner fixes

### DIFF
--- a/packages/commonwell-cert-runner/src/flows/org-management-initiator-only.ts
+++ b/packages/commonwell-cert-runner/src/flows/org-management-initiator-only.ts
@@ -48,9 +48,7 @@ export async function orgManagementInitiatorOnly(): Promise<void> {
     initiatorOnlyOrg.locations[0].city = faker.location.city();
     // console.log("Updated payload: " + JSON.stringify(initiatorOnlyOrg, null, 2));
 
-    if ("securityTokenKeyType" in initiatorOnlyOrg) {
-      initiatorOnlyOrg.securityTokenKeyType = "";
-    }
+    initiatorOnlyOrg.securityTokenKeyType = "";
     if ("authorizationInformation" in initiatorOnlyOrg) {
       delete initiatorOnlyOrg.authorizationInformation;
     }

--- a/packages/commonwell-sdk/src/models/organization.ts
+++ b/packages/commonwell-sdk/src/models/organization.ts
@@ -57,9 +57,7 @@ const organizationBaseSchema = z.object({
 });
 
 export const organizationSchemaWithNetworkInfo = organizationBaseSchema.extend({
-  securityTokenKeyType: z
-    .union([z.literal("JWT"), z.literal("BEARER"), z.literal("HOLDER-OF-KEY")])
-    .nullish(),
+  securityTokenKeyType: z.string().nullish(),
   networks: z.array(
     z.object({
       type: z.string(),
@@ -104,9 +102,7 @@ export const organizationSchemaWithNetworkInfo = organizationBaseSchema.extend({
 export type OrganizationWithNetworkInfo = z.infer<typeof organizationSchemaWithNetworkInfo>;
 
 export const organizationSchemaWithoutNetworkInfo = organizationSchemaWithNetworkInfo.omit({
-  securityTokenKeyType: true,
   networks: true,
-  gateways: true,
   authorizationInformation: true,
 });
 export type OrganizationWithoutNetworkInfo = z.infer<typeof organizationSchemaWithoutNetworkInfo>;


### PR DESCRIPTION
Part of ENG-200

Issues:

- https://linear.app/metriport/issue/ENG-200

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4427

### Description
- Gotta set gateways to `[]` for the initiator-only flow to work

### Testing

- Local
  - [x] Create/get/update a test initiator-only org on CW cert runner

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified initiator-only organization flow: create, fetch by returned ID, then update in a single path.
  * Removed dependency on pre-known organization IDs.

* **Bug Fixes**
  * More consistent handling of security token key type and authorization information to avoid null-related issues.
  * Standardized payload defaults (e.g., empty gateways list).

* **Chores**
  * Improved logs with clearer transaction and organization IDs.

* **New Features**
  * Organization data models now accept a broader set of token key types and include gateways where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->