### PR TITLE
RELEASE ENG-484: Surescripts updates and improvements

### DIFF
--- a/packages/core/src/external/sftp/replica/s3.ts
+++ b/packages/core/src/external/sftp/replica/s3.ts
@@ -2,8 +2,8 @@ import { S3Utils } from "../../aws/s3";
 import { SftpReplica } from "../types";
 
 export class S3Replica implements SftpReplica {
-  private readonly s3: S3Utils;
-  private readonly bucketName: string;
+  protected readonly s3: S3Utils;
+  protected readonly bucketName: string;
 
   constructor({ bucketName, region }: { bucketName: string; region: string }) {
     this.s3 = new S3Utils(region);

--- a/packages/core/src/external/surescripts/codes.ts
+++ b/packages/core/src/external/surescripts/codes.ts
@@ -37,7 +37,23 @@ export const PLAN_CODE_NAME: Record<PlanCode, PlanCodeName> = {
   "06": "Workers' Compensation",
 };
 
-export const PAYMENT_CODES = ["01", "02", "03", "04", "05", "06", "07", "99"] as const;
+export const PAYMENT_CODES = [
+  "01",
+  "1",
+  "02",
+  "2",
+  "03",
+  "3",
+  "04",
+  "4",
+  "05",
+  "5",
+  "06",
+  "6",
+  "07",
+  "7",
+  "99",
+] as const;
 export const PAYMENT_CODE_NAMES = [
   "Private Pay",
   "Medicaid",
@@ -51,7 +67,14 @@ export const PAYMENT_CODE_NAMES = [
 export type PaymentCode = (typeof PAYMENT_CODES)[number];
 export type PaymentCodeName = (typeof PAYMENT_CODE_NAMES)[number];
 
-export const PAYMENT_CODE_NAME: Record<PaymentCode, PaymentCodeName> = {
+export function getPaymentCodeName(code: PaymentCode): PaymentCodeName {
+  if (code.length === 1 && code.match(/^[1-7]$/)) {
+    return getPaymentCodeName(("0" + code) as PaymentCode);
+  }
+  return PAYMENT_CODE_NAME[code] ?? "Other";
+}
+
+export const PAYMENT_CODE_NAME: Partial<Record<PaymentCode, PaymentCodeName>> = {
   "01": "Private Pay",
   "02": "Medicaid",
   "03": "Medicare",

--- a/packages/core/src/external/surescripts/fhir/bundle-entry.ts
+++ b/packages/core/src/external/surescripts/fhir/bundle-entry.ts
@@ -70,6 +70,7 @@ function getMedicationResources({
   const medicationRequest = getMedicationRequest({
     patient,
     prescriber,
+    pharmacy,
     medication,
     coverage,
     detail,

--- a/packages/core/src/external/surescripts/fhir/bundle.ts
+++ b/packages/core/src/external/surescripts/fhir/bundle.ts
@@ -1,13 +1,12 @@
 import { Bundle, Medication } from "@medplum/fhirtypes";
+import { NDC_URL } from "@metriport/shared/medical";
 import { buildBundle } from "../../fhir/bundle/bundle";
 import { ResponseDetail } from "../schema/response";
 import { IncomingData } from "../schema/shared";
 import { getAllBundleEntries } from "./bundle-entry";
-
 import { dangerouslyDeduplicateFhir } from "../../../fhir-deduplication/deduplicate-fhir";
 import { hydrateFhir } from "../../fhir/hydration/hydrate-fhir";
 import { crosswalkNdcToRxNorm } from "../../term-server";
-import { NDC_URL } from "../../../util/constants";
 
 export async function convertIncomingDataToFhirBundle(
   cxId: string,

--- a/packages/core/src/external/surescripts/fhir/condition.ts
+++ b/packages/core/src/external/surescripts/fhir/condition.ts
@@ -1,26 +1,65 @@
 import { uuidv7 } from "@metriport/shared/util/uuid-v7";
-import { Condition, Patient } from "@medplum/fhirtypes";
+import { ICD_10_URL } from "@metriport/shared/medical";
+import { CodeableConcept, Condition, Patient } from "@medplum/fhirtypes";
 import { ResponseDetail } from "../schema/response";
 import { getPatientReference } from "./patient";
 import { getSurescriptsDataSourceExtension } from "./shared";
-import { ICD_10_URL } from "../../../util/constants";
+import { CONDITION_CLINICAL_STATUS_URL, CONDITION_VERIFICATION_STATUS_URL } from "./constants";
 
 export function getCondition(patient: Patient, detail: ResponseDetail): Condition | undefined {
-  if (!detail.diagnosisICD10Code) return undefined;
   const subject = getPatientReference(patient);
+  const clinicalStatus = getClinicalStatus(detail);
+  const verificationStatus = getVerificationStatus(detail);
+  const code = getConditionCoding(detail);
+  if (!code) return undefined;
 
   return {
     resourceType: "Condition",
     id: uuidv7(),
     subject,
-    code: {
-      coding: [
-        {
-          system: ICD_10_URL,
-          code: detail.diagnosisICD10Code,
-        },
-      ],
-    },
+    code,
+    ...(clinicalStatus ? { clinicalStatus } : {}),
+    ...(verificationStatus ? { verificationStatus } : {}),
     extension: [getSurescriptsDataSourceExtension()],
   };
+}
+
+function getConditionCoding(detail: ResponseDetail): CodeableConcept | undefined {
+  if (!detail.diagnosisICD10Code) return undefined;
+  return {
+    coding: [
+      {
+        system: ICD_10_URL,
+        code: detail.diagnosisICD10Code,
+      },
+    ],
+  };
+}
+
+function getClinicalStatus(detail: ResponseDetail): Condition["clinicalStatus"] {
+  if (detail.diagnosisICD10Code?.startsWith("Z")) {
+    return {
+      coding: [
+        {
+          system: CONDITION_CLINICAL_STATUS_URL,
+          code: "active",
+        },
+      ],
+    };
+  }
+  return undefined;
+}
+
+function getVerificationStatus(detail: ResponseDetail): Condition["verificationStatus"] {
+  if (detail.diagnosisICD10Code?.startsWith("Z")) {
+    return {
+      coding: [
+        {
+          system: CONDITION_VERIFICATION_STATUS_URL,
+          code: "confirmed",
+        },
+      ],
+    };
+  }
+  return undefined;
 }

--- a/packages/core/src/external/surescripts/fhir/constants.ts
+++ b/packages/core/src/external/surescripts/fhir/constants.ts
@@ -18,3 +18,11 @@ export const DEA_SCHEDULE_SYSTEM =
 export const US_LICENSE_SYSTEM = "https://public.metriport.com/fhir/sid/us-license";
 export const MEDICATION_DISPENSE_FILL_NUMBER_EXTENSION =
   "http://hl7.org/fhir/StructureDefinition/medicationdispense-fillNumber";
+
+export const CONDITION_CLINICAL_STATUS_URL =
+  "http://terminology.hl7.org/CodeSystem/condition-clinical";
+export const CONDITION_VERIFICATION_STATUS_URL =
+  "http://terminology.hl7.org/CodeSystem/condition-ver-status";
+export const HL7_CODE_SYSTEM_URL = "http://terminology.hl7.org/CodeSystem/v2-0203";
+export const MEDICATION_REQUEST_CATEGORY_URL =
+  "http://terminology.hl7.org/CodeSystem/medicationrequest-category";

--- a/packages/core/src/external/surescripts/fhir/medication.ts
+++ b/packages/core/src/external/surescripts/fhir/medication.ts
@@ -7,13 +7,13 @@ import {
   MedicationBatch,
   Reference,
 } from "@medplum/fhirtypes";
-import { ResponseDetail } from "../schema/response";
 import { uuidv7 } from "@metriport/shared/util/uuid-v7";
 import { getDeaScheduleName } from "@metriport/shared/interface/external/surescripts/dea-schedule";
 import { getNcpdpName } from "@metriport/shared/interface/external/surescripts/ncpdp";
-import { DEA_SCHEDULE_URL, UNIT_OF_MEASURE_URL } from "./constants";
-import { NDC_URL, SNOMED_URL } from "../../../util/constants";
+import { ResponseDetail } from "../schema/response";
 import { getSurescriptsDataSourceExtension } from "./shared";
+import { DEA_SCHEDULE_URL, UNIT_OF_MEASURE_URL } from "./constants";
+import { NDC_URL, SNOMED_URL } from "@metriport/shared/medical";
 
 export function getMedication(detail: ResponseDetail): Medication {
   const code = getMedicationCodeableConcept(detail);

--- a/packages/core/src/external/surescripts/fhir/patient.ts
+++ b/packages/core/src/external/surescripts/fhir/patient.ts
@@ -57,8 +57,6 @@ function getPatientGender(detail: ResponseDetail): Patient["gender"] {
       return "female";
     case "U":
       return "unknown";
-    case "N":
-      return "other";
     default:
       return "unknown";
   }

--- a/packages/core/src/external/surescripts/file/file-generator.ts
+++ b/packages/core/src/external/surescripts/file/file-generator.ts
@@ -22,12 +22,12 @@ import { buildResponseFileNamePrefix } from "./file-names";
 // Latest Surescripts specification, but responses may be in 2.2 format
 const surescriptsVersion = "3.0";
 
-type SurescriptsGender = "M" | "F" | "N" | "U";
+type SurescriptsGender = "M" | "F" | "U";
 const makeGenderDemographics = genderMapperFromDomain<SurescriptsGender>(
   {
     M: "M",
     F: "F",
-    O: "N",
+    O: "U",
     U: "U",
   },
   "U"

--- a/packages/core/src/external/surescripts/replica.ts
+++ b/packages/core/src/external/surescripts/replica.ts
@@ -3,6 +3,7 @@ import { S3Replica } from "../sftp/replica/s3";
 import { SurescriptsFileIdentifier, SurescriptsSftpConfig } from "./types";
 import { buildRequestFileName, buildResponseFileNamePrefix } from "./file/file-names";
 import { decompressGzip } from "../sftp/compression";
+import { INCOMING_NAME } from "./constants";
 
 export class SurescriptsReplica extends S3Replica {
   constructor(config: Pick<SurescriptsSftpConfig, "replicaBucket" | "replicaBucketRegion"> = {}) {
@@ -15,7 +16,7 @@ export class SurescriptsReplica extends S3Replica {
   async getRawVerificationFile(transmissionId: string): Promise<Buffer | undefined> {
     const requestFileName = buildRequestFileName(transmissionId);
     const verificationFileNames = await this.listFileNamesWithPrefix(
-      "from_surescripts",
+      INCOMING_NAME,
       requestFileName
     );
     const verificationFile = verificationFileNames[0];
@@ -35,12 +36,37 @@ export class SurescriptsReplica extends S3Replica {
     populationId,
   }: SurescriptsFileIdentifier): Promise<Buffer | undefined> {
     const prefix = buildResponseFileNamePrefix(transmissionId, populationId);
-    const responseFileNames = await this.listFileNamesWithPrefix("from_surescripts", prefix);
+    const responseFileNames = await this.listFileNamesWithPrefix(INCOMING_NAME, prefix);
     const responseFile = responseFileNames[0];
     if (!responseFile) {
       return undefined;
     }
     const fileContent = await this.readFile(responseFile);
     return decompressGzip(fileContent);
+  }
+
+  async getRawResponseFileByKey(key: string): Promise<Buffer | undefined> {
+    const fileContent = await this.readFile(key);
+    return decompressGzip(fileContent);
+  }
+
+  async listResponseFiles(): Promise<
+    Array<{ key: string; transmissionId: string; patientId: string }>
+  > {
+    const responseFiles = await this.listFileNames(INCOMING_NAME);
+    const startIndex = INCOMING_NAME.length + 1;
+    return responseFiles
+      .filter(key => {
+        return key.charAt(startIndex + 10) === "_" && key.charAt(startIndex + 47) === "_";
+      })
+      .map(key => {
+        const transmissionId = key.substring(startIndex, startIndex + 10);
+        const patientId = key.substring(startIndex + 11, startIndex + 47);
+        return {
+          key,
+          transmissionId,
+          patientId,
+        };
+      });
   }
 }

--- a/packages/core/src/external/surescripts/schema/request.ts
+++ b/packages/core/src/external/surescripts/schema/request.ts
@@ -145,7 +145,7 @@ export const patientLoadDetailSchema = z.object({
     .min(8)
     .max(10)
     .regex(/^\d{4}-?\d{2}-?\d{2}$/),
-  genderAtBirth: z.enum(["M", "F", "N", "U"]), // n - non-binary, u - unknown
+  genderAtBirth: z.enum(["M", "F", "U"]), // u - unknown
   npiNumber: z.string(),
   endMonitoringDate: z.date().optional(),
   primaryPhone: z.string().optional(),
@@ -269,7 +269,7 @@ export const patientLoadDetailOrder: OutgoingFileRowSchema<PatientLoadDetail> = 
   {
     field: 15,
     key: "genderAtBirth",
-    toSurescripts: toSurescriptsEnum("genderAtBirth", ["M", "F", "N", "U"]),
+    toSurescripts: toSurescriptsEnum("genderAtBirth", ["M", "F", "U"]),
   },
   {
     field: 16,

--- a/packages/core/src/external/surescripts/schema/response.ts
+++ b/packages/core/src/external/surescripts/schema/response.ts
@@ -84,7 +84,7 @@ export const responseDetailSchema = z.object({
   patientLastName: z.string(),
   patientFirstName: z.string(),
   patientDOB: z.date(),
-  patientGender: z.enum(["M", "F", "N", "U"]),
+  patientGender: z.enum(["M", "F", "U"]),
   patientZipCode: z.string(),
   startDate: z.date(),
   endDate: z.date(),
@@ -225,7 +225,7 @@ export const responseDetailRow: IncomingFileRowSchema<ResponseDetail> = [
   {
     field: 12,
     key: "patientGender",
-    fromSurescripts: fromSurescriptsEnum(["M", "F", "N", "U"]),
+    fromSurescripts: fromSurescriptsEnum(["M", "F", "U"]),
   },
   {
     field: 13,

--- a/packages/core/src/external/surescripts/types.ts
+++ b/packages/core/src/external/surescripts/types.ts
@@ -3,7 +3,7 @@ import { Patient } from "@metriport/shared/domain/patient";
 import { FacilityData, OrganizationData } from "@metriport/shared/domain/customer";
 import { SftpConfig } from "../sftp/types";
 
-export type SurescriptsGender = "M" | "F" | "N" | "U";
+export type SurescriptsGender = "M" | "F" | "U";
 
 export enum SurescriptsEnvironment {
   Production = "P",

--- a/packages/utils/src/surescripts/convert-customer-response.ts
+++ b/packages/utils/src/surescripts/convert-customer-response.ts
@@ -5,10 +5,25 @@ dotenv.config();
 import { Command } from "commander";
 import { SurescriptsConvertPatientResponseHandlerDirect } from "@metriport/core/external/surescripts/command/convert-patient-response/convert-patient-response-direct";
 import { buildCsvPath, getTransmissionsFromCsv } from "./shared";
-import { buildLatestConversionBundleFileName } from "@metriport/core/external/surescripts/file/file-names";
 import { SurescriptsDataMapper } from "@metriport/core/external/surescripts/data-mapper";
-import { executeAsynchronously } from "@metriport/core/util";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
 
+/**
+ * Converts all patient responses for a customer transmission to FHIR bundles.
+ *
+ * Usage:
+ * npm run surescripts -- convert-customer-response \
+ *  --cx-id "acme-uuid-1234-sadsjksl" \
+ *  --facility-id "facility-uuid-7890-asdkjkds" \
+ *  --csv-data "acme-roster.csv"
+ *
+ * cx-id: The CX ID to perform reconversion.
+ * facility-id: The facility ID to perform reconversion.
+ * csv-data: A CSV file with two columns: "patient_id" and "transmission_id". This file can be automatically generated
+ * using the `generate-csv` command.
+ *
+ * @see generate-csv.ts for more details on how to generate a CSV of all patient IDs for batch reconversion.
+ */
 const program = new Command();
 
 interface ConvertCustomerResponseOptions {
@@ -52,39 +67,57 @@ program
       console.log(`Got ${transmissions.length} transmissions from ${startIndex} to ${endIndex}`);
     }
 
+    const conversionStart = Date.now();
     let convertedCount = 0;
     const handler = new SurescriptsConvertPatientResponseHandlerDirect();
-    for (const { patientId, transmissionId } of transmissions) {
-      console.log(`Converting patient ${patientId} with transmission ${transmissionId}`);
-      await handler.convertPatientResponse({
-        cxId,
-        facilityId,
-        transmissionId,
-        populationId: patientId,
-      });
-      console.log(`Key: ${buildLatestConversionBundleFileName(cxId, patientId)}`);
-      convertedCount++;
-      if (convertedCount % 100 === 0) {
-        console.log(`Converted ${convertedCount} patients`);
+    await executeAsynchronously(
+      transmissions,
+      async ({ patientId, transmissionId }) => {
+        console.log(`Converting patient ${patientId} with transmission ${transmissionId}`);
+        await handler.convertPatientResponse({
+          cxId,
+          facilityId,
+          transmissionId,
+          populationId: patientId,
+        });
+        convertedCount++;
+        if (convertedCount % 100 === 0) {
+          console.log(`Converted ${convertedCount} patients`);
+        }
+      },
+      {
+        numberOfParallelExecutions: 10,
+        keepExecutingOnError: true,
       }
-    }
-    console.log(`Converted ${convertedCount} patients`);
+    );
+    console.log(
+      `Converted ${convertedCount} patients in ${((Date.now() - conversionStart) / 1000).toFixed(
+        1
+      )} seconds`
+    );
 
     if (recreate) {
       console.log(`Recreating consolidated bundles for ${transmissions.length} patients`);
       const dataMapper = new SurescriptsDataMapper();
       let recreatedCount = 0;
-      await executeAsynchronously(transmissions, async ({ patientId }) => {
-        try {
-          const result = await dataMapper.recreateConsolidatedBundle(cxId, patientId);
-          console.log(
-            `Recreated consolidated bundle for ${patientId} with request ID ${result.requestId}`
-          );
-          recreatedCount++;
-        } catch (error) {
-          console.error(`Error recreating consolidated bundle for ${patientId}: ${error}`);
+      await executeAsynchronously(
+        transmissions,
+        async ({ patientId }) => {
+          try {
+            const result = await dataMapper.recreateConsolidatedBundle(cxId, patientId);
+            console.log(
+              `Recreated consolidated bundle for ${patientId} with request ID ${result.requestId}`
+            );
+            recreatedCount++;
+          } catch (error) {
+            console.error(`Error recreating consolidated bundle for ${patientId}: ${error}`);
+          }
+        },
+        {
+          numberOfParallelExecutions: 10,
+          keepExecutingOnError: true,
         }
-      });
+      );
       console.log(`Recreated ${recreatedCount} consolidated bundles`);
     }
   });

--- a/packages/utils/src/surescripts/generate-csv.ts
+++ b/packages/utils/src/surescripts/generate-csv.ts
@@ -1,0 +1,96 @@
+import { Command } from "commander";
+import { out } from "@metriport/core/util/log";
+import { SurescriptsDataMapper } from "@metriport/core/external/surescripts/data-mapper";
+import { SurescriptsReplica } from "@metriport/core/external/surescripts/replica";
+import { SurescriptsFileIdentifier } from "@metriport/core/external/surescripts/types";
+import { writeSurescriptsRunsFile } from "./shared";
+import { executeAsynchronously } from "@metriport/core/util/concurrency";
+
+/**
+ * For a given customer and facility, generates a CSV with all patients/population IDs that have had a
+ * corresponding Surescripts request. This CSV file can be used with the `convert-customer-response` command
+ * to fully reconvert all patients for a given customer, using the roster as an input. Note that the same patient ID
+ * may appear multiple times in the roster if they have had multiple Surescripts requests.
+ *
+ * Usage:
+ * npm run surescripts -- generate-csv --cx-name <cx-name> --cx-id <cx-id> --facility-id <facility-id>
+ *
+ * cx-name: A pneumonic customer name, used in file naming for the generated CSV roster.
+ * cx-id: The CX ID to gather patient IDs from.
+ * facility-id: The facility ID to limit patient IDs to (required since Surescripts is specific to a facility's NPI number).
+ *
+ * Example:
+ * npm run surescripts -- generate-csv --cx-name "acme" --cx-id "acme-uuid-1234-sadsjksl" --facility-id "facility-uuid-7890-asdkjkds"
+ *
+ * After generating this CSV, you can use the `convert-customer-response` command to fully reconvert all patients for a given customer, using the roster as an input.
+ *
+ * Usage:
+ * npm run surescripts -- convert-customer-response \
+ *  --cx-id "acme-uuid-1234-sadsjksl" \
+ *  --facility-id "facility-uuid-7890-asdkjkds" \
+ *  --csv-data "acme-roster.csv"
+ *
+ * @see convert-customer-response.ts for more details on the convert-customer-response command.
+ */
+const program = new Command();
+const replica = new SurescriptsReplica();
+const dataMapper = new SurescriptsDataMapper();
+
+program
+  .name("generate-csv")
+  .description("Generate a CSV of patient IDs and their Surescripts transmission IDs")
+  .requiredOption("--cx-name <cx-name>", "The customer name used in file naming")
+  .requiredOption("--cx-id <cx-id>", "The CX ID to gather patient IDs from")
+  .requiredOption("--facility-id <facility-id>", "The facility ID to limit patient IDs to")
+  .action(main);
+
+async function main({
+  cxId,
+  facilityId,
+  cxName,
+}: {
+  cxId: string;
+  facilityId: string;
+  cxName: string;
+}) {
+  const { log } = out(`ss.generate-csv - cx ${cxId}, facility ${facilityId}`);
+  const [patientIds, responses] = await Promise.all([
+    dataMapper.getPatientIdsForFacility({ cxId, facilityId }),
+    replica.listResponseFiles(),
+  ]);
+  const patientIdSet = new Set(patientIds);
+  log(`found ${patientIds.length} patient IDs`);
+  log(`found ${responses.length} response files`);
+
+  const identifiers: SurescriptsFileIdentifier[] = [];
+
+  await executeAsynchronously(
+    responses,
+    async response => {
+      if (patientIdSet.has(response.patientId)) {
+        identifiers.push({
+          transmissionId: response.transmissionId,
+          populationId: response.patientId,
+        });
+      }
+    },
+    {
+      numberOfParallelExecutions: 10,
+    }
+  );
+
+  // Make identifier ordering deterministic, so the CSV can be easily diffed against a future execution.
+  log(`found ${identifiers.length} identifiers`);
+  identifiers.sort((a, b) => a.transmissionId.localeCompare(b.transmissionId));
+
+  writeSurescriptsRunsFile(
+    cxName + "-roster.csv",
+    `"patient_id","transmission_id"\n` +
+      identifiers
+        .map(identifier => `"${identifier.populationId}","${identifier.transmissionId}"`)
+        .join("\n")
+  );
+  log(`wrote CSV to ${cxName}-roster.csv`);
+}
+
+export default program;

--- a/packages/utils/src/surescripts/index.ts
+++ b/packages/utils/src/surescripts/index.ts
@@ -19,8 +19,14 @@ import batchAnalysis from "./batch-analysis";
 import preview from "./preview";
 import findLargest from "./find-largest";
 import bundleVerification from "./bundle-verification";
+import generateCsv from "./generate-csv";
 
+/**
+ * This is the main command registry for the Surescripts CLI. You should add any new
+ * commands to this registry, and ensure that your command has a unique name.
+ */
 const program = new Command();
+
 program.addCommand(sftpAction);
 program.addCommand(sendPatientRequest);
 program.addCommand(sendBatchRequest);
@@ -37,4 +43,5 @@ program.addCommand(analyzeResponses);
 program.addCommand(preview);
 program.addCommand(findLargest);
 program.addCommand(bundleVerification);
+program.addCommand(generateCsv);
 program.parse();

--- a/packages/utils/src/surescripts/send-facility-request.ts
+++ b/packages/utils/src/surescripts/send-facility-request.ts
@@ -8,16 +8,22 @@ import { SurescriptsPatientRequestData } from "@metriport/core/external/surescri
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
 
 /**
- * This script is used to send a request to Surescripts to retrieve all patients for a particular customer and facility.
- * It must be run from within the corresponding VPC (staging or production), otherwise you will generate a valid request
- * file but it will not be received by Surescripts since only a very specific IP set is whitelisted for requests. See 1PW.
+ * Sends a request to Surescripts for all patients of the facility. Uses the client's
+ * batching method to send all patients in a single SFTP connection, which is what originally
+ * created the need for this command (to upload large rosters quickly).
  *
  * Usage:
- * npm run surescripts -- facility-request --cx-id <cx-id> --facility-id <facility-id> --csv-output <csv-output>
+ * npm run surescripts -- facility-request \
+ *  --cx-id <cx-id> \
+ * --facility-id <facility-id> \
+ * --csv-output <csv-output>
  *
- * The CSV output file will contain the transmission IDs and patient IDs for the requests that were sent. This output
- * file is required for running the corresponding script to retrieve the responses from Surescripts, which can vary in
- * duration based on their processing periods.
+ * cx-id: The CX ID of the requester
+ * facility-id: The facility ID of the requester
+ * csv-output: The file to write a CSV containing transmission IDs and patient IDs
+ *
+ * Note: The headers of the CSV file are "transmission_id","patient_id", which are used in scripts
+ * like `convert-customer-responses` to convert the responses from Surescripts into FHIR resources.
  */
 const program = new Command();
 

--- a/packages/utils/src/surescripts/sftp-action.ts
+++ b/packages/utils/src/surescripts/sftp-action.ts
@@ -4,6 +4,37 @@ import { SurescriptsSftpClient } from "@metriport/core/external/surescripts/clie
 import { SftpActionDirect } from "@metriport/core/external/sftp/command/sftp-action/sftp-action-direct";
 import { SftpAction } from "@metriport/core/external/sftp/command/sftp-action/sftp-action";
 
+/**
+ * Test an SFTP connection to Surescripts. Will only work if it is being run from a server
+ * within the VPC corresponding to the environment you are testing (production or staging).
+ *
+ * Usage:
+ * npm run surescripts -- sftp connect
+ *
+ * You can list all files on the remote SFTP server with:
+ *
+ * npm run surescripts -- sftp list /path/to/directory
+ *
+ * You can read a file from the remote SFTP server with:
+ *
+ * npm run surescripts -- sftp read /path/to/file
+ *
+ * You can write a file to the remote SFTP server with:
+ *
+ * npm run surescripts -- sftp write /path/to/local/file /path/to/remote/file
+ *
+ * Note that you can also write with GZIP compression enabled using the `--compress` flag.
+ *
+ * You can sync a directory in the SFTP server to an S3 bucket if the associated S3 client has
+ * been initialized with `initializeS3Replica`.
+ * @see @metriport/core/external/sftp/replica.ts for more details.
+ *
+ * npm run surescripts -- sftp sync /path/to/remote/directory
+ *
+ * You can check if a file exists in the SFTP server with:
+ *
+ * npm run surescripts -- sftp exists /path/to/remote/file
+ */
 const sftpAction = new Command();
 
 async function executeSftpAction<A extends SftpAction>(action: A) {


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-484

### Dependencies

- Upstream: None
- Downstream: None

### Description

- https://github.com/metriport/metriport/pull/4359

### Testing

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - MedicationRequest now includes pharmacy, identifiers (Rx reference), reason codes, and explicit intent/category.
  - Added a CLI command to generate a patient/transmission CSV and integrated it into the Surescripts CLI.
  - Surescripts replica can list response files and fetch a response by key; standardized incoming prefix.
- Bug Fixes
  - Broadened payment code support to accept single-digit codes with consistent name resolution.
  - Removed gender value “N”; now treated as unknown across schemas/outputs.
- Chores
  - Faster, more resilient batch conversion via parallel processing.
- Documentation
  - Expanded CLI docs for SFTP and facility request usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->