### PR TITLE
ENG-565: AWS Bedrock client for Anthropic models

### DIFF
--- a/packages/core/src/external/bedrock/__tests__/anthropic-agent.test.e2e.ts
+++ b/packages/core/src/external/bedrock/__tests__/anthropic-agent.test.e2e.ts
@@ -1,0 +1,178 @@
+import { z } from "zod";
+import { BadRequestError } from "@metriport/shared";
+import { AnthropicAgent } from "../agent/anthropic";
+import { AnthropicTool } from "../agent/anthropic/tool";
+import { AnthropicMessageThread } from "../model/anthropic/messages";
+import { getAssistantResponseText } from "../model/anthropic/response";
+import { AnthropicToolCall, AnthropicToolResult } from "../model/anthropic/tools";
+
+describe("Anthropic agent test", () => {
+  it("should be able to create an agent", async () => {
+    const agent = new AnthropicAgent({
+      version: "claude-sonnet-3.7",
+      systemPrompt:
+        "You are an automated test. Reply with YES if the user asks if you are working.",
+      region: "us-east-1",
+      temperature: 0,
+    });
+
+    const response = await agent.startConversation("Are you working?");
+    const firstMessage = getAssistantResponseText(response);
+    expect(firstMessage?.toLowerCase()).toContain("yes");
+  });
+
+  it("should be able to maintain a simple conversation", async () => {
+    const agent = new AnthropicAgent({
+      version: "claude-sonnet-3.7",
+      systemPrompt:
+        "You are an automated test. Any time you are asked if you are working, reply with YES.",
+      region: "us-east-1",
+      temperature: 0,
+    });
+
+    const response = await agent.startConversation("Are you working?");
+    const firstMessage = getAssistantResponseText(response);
+    expect(firstMessage?.toLowerCase()).toContain("yes");
+    expect(agent.shouldExecuteTools(response)).toBe(false);
+    await expect(agent.executeTools(response)).rejects.toThrow(BadRequestError);
+
+    agent.addUserMessage([
+      {
+        type: "text",
+        text: "Are you sure you are working?",
+      },
+    ]);
+    const nextResponse = await agent.continueConversation();
+    const nextMessage = getAssistantResponseText(nextResponse);
+    expect(nextMessage?.toLowerCase()).toContain("yes");
+  });
+
+  it("should be able to execute a tool", async () => {
+    const agent = new AnthropicAgent({
+      version: "claude-sonnet-3.7",
+      systemPrompt:
+        'Parse the sentence provided by the user into the input for the "parseSentence" tool.',
+      region: "us-east-1",
+      temperature: 0,
+      tools: [
+        new AnthropicTool({
+          name: "parseSentence",
+          description: "Parse the user's message",
+          inputSchema: z.object({ color: z.string(), animal: z.string() }),
+          outputSchema: z.object({ result: z.string() }),
+          handler: async input => {
+            return {
+              result: `Praise the ${input.color} ${input.animal}`,
+            };
+          },
+        }),
+      ],
+    });
+
+    const color = randomChoice(["red", "blue", "green"]);
+    const animal = randomChoice(["dog", "cat", "bird"]);
+    const response = await agent.startConversation(
+      `The ${color} ${animal} likes to write automated tests.`
+    );
+    expect(agent.shouldExecuteTools(response)).toBe(true);
+    expect(agent.hasTools()).toBe(true);
+
+    await agent.executeTools(response);
+    const conversation = await agent.getConversation();
+    const lastMessage = conversation[conversation.length - 1];
+    expect(lastMessage).toBeDefined();
+    expect(lastMessage?.role).toBe("user");
+    const toolResult = lastMessage?.content[0] as AnthropicToolResult;
+    expect(toolResult.type).toBe("tool_result");
+    expect(toolResult.content).toEqual(JSON.stringify({ result: `Praise the ${color} ${animal}` }));
+  });
+
+  it("should handle multiple tool calls with an error", async () => {
+    const agent = new AnthropicAgent({
+      version: "claude-sonnet-3.7",
+      systemPrompt: "You are an automated test that is not executed with the LLM.",
+      region: "us-east-1",
+      temperature: 0,
+      tools: [
+        new AnthropicTool({
+          name: "errorProducingTool",
+          description: "An error producing tool",
+          inputSchema: z.object({ input: z.string() }),
+          outputSchema: z.object({ result: z.string() }),
+          handler: async () => {
+            throw new Error("The error message");
+          },
+        }),
+      ],
+    });
+
+    const mockToolUseId = "bedrock_tool_1";
+    const mockToolUse: AnthropicToolCall = {
+      type: "tool_use",
+      name: "errorProducingTool",
+      id: mockToolUseId,
+      input: {
+        input: "The input",
+      },
+    };
+    const mockResponse: Awaited<ReturnType<typeof agent.continueConversation>> = {
+      id: "msg_bdrk_123",
+      type: "message",
+      model: "claude-sonnet-3.7",
+      role: "assistant",
+      content: [mockToolUse],
+      stop_reason: "tool_use",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 100,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    };
+
+    const mockConversation: AnthropicMessageThread<"claude-sonnet-3.7"> = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "An example message that called an error producing tool",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [mockToolUse],
+      },
+    ];
+
+    agent.setConversation(mockConversation);
+    expect(agent.shouldExecuteTools(mockResponse)).toBe(true);
+    await agent.executeTools(mockResponse);
+
+    const conversation = agent.getConversation();
+    expect(conversation).toEqual([
+      ...mockConversation,
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: mockToolUseId,
+            content: {
+              error: "The error message",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+function randomChoice<T>(choices: T[]): T {
+  const choice = choices[Math.floor(Math.random() * choices.length)];
+  if (!choice) {
+    throw new Error("Must be at least one choice");
+  }
+  return choice;
+}

--- a/packages/core/src/external/bedrock/__tests__/anthropic-tool.test.e2e.ts
+++ b/packages/core/src/external/bedrock/__tests__/anthropic-tool.test.e2e.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { AnthropicTool } from "../agent/anthropic/tool";
+
+describe("Anthropic tool test", () => {
+  it("should be able to create a tool", async () => {
+    const tool = new AnthropicTool({
+      name: "toUpperCase",
+      description: "Convert a string to uppercase",
+      inputSchema: z.object({
+        name: z.string(),
+      }),
+      outputSchema: z.object({
+        uppercased: z.string(),
+      }),
+      handler: async input => {
+        return {
+          uppercased: input.name.toUpperCase(),
+        };
+      },
+    });
+
+    expect(tool.getConfig()).toEqual({
+      type: "custom",
+      name: "toUpperCase",
+      description: "Convert a string to uppercase",
+      input_schema: {
+        $schema: "http://json-schema.org/draft-07/schema#",
+        additionalProperties: false,
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+          },
+        },
+        required: ["name"],
+      },
+    });
+
+    const result = await tool.execute({ name: "hello" });
+    expect(result.uppercased).toBe("HELLO");
+  });
+
+  it("should allow a tool with no output schema", async () => {
+    const tool = new AnthropicTool({
+      name: "toLowerCase",
+      description: "Convert a string to lowercase",
+      inputSchema: z.object({
+        name: z.string(),
+      }),
+      handler: async ({ name }) => {
+        return name.toLowerCase();
+      },
+    });
+
+    const result = await tool.execute({ name: "HELLO" });
+    expect(result).toBe("hello");
+  });
+});

--- a/packages/core/src/external/bedrock/__tests__/anthropic.test.e2e.ts
+++ b/packages/core/src/external/bedrock/__tests__/anthropic.test.e2e.ts
@@ -1,0 +1,201 @@
+import { z } from "zod";
+import { getAnthropicModelId } from "../model/anthropic/version";
+import { AnthropicAgent } from "../agent/anthropic";
+import { AnthropicTool } from "../agent/anthropic/tool";
+import { AnthropicResponse, getAssistantResponseText } from "../model/anthropic/response";
+import { AnthropicToolCall } from "../model/anthropic/tools";
+import { AnthropicMessageText, AnthropicMessageThread } from "../model/anthropic/messages";
+import { AnthropicModel } from "../model/anthropic";
+import zodToJsonSchema from "zod-to-json-schema";
+
+describe("Anthropic test", () => {
+  it("should get a correct model ID", () => {
+    expect(getAnthropicModelId("claude-sonnet-3.5")).toBe(
+      "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+    );
+    expect(getAnthropicModelId("claude-sonnet-3.7")).toBe(
+      "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+    );
+    expect(getAnthropicModelId("claude-sonnet-4")).toBe(
+      "us.anthropic.claude-sonnet-4-20250514-v1:0"
+    );
+  });
+
+  it("should instantiate with a correct model ID", () => {
+    expect(new AnthropicModel("claude-sonnet-3.5", "us-east-1")).toBeDefined();
+    expect(new AnthropicModel("claude-sonnet-3.7", "us-east-1")).toBeDefined();
+    expect(new AnthropicModel("claude-sonnet-4", "us-east-1")).toBeDefined();
+  });
+
+  it("should be able to invoke a model", async () => {
+    const model = new AnthropicModel("claude-sonnet-3.7", "us-east-1");
+    const response = await model.invokeModel({
+      system: "You are an automated test. Reply with YES to confirm that you are working.",
+      max_tokens: 100,
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Reply with YES to confirm that this works." }],
+        },
+      ],
+    });
+    expect(response.stop_reason).toBe("end_turn");
+    const responseContent = response.content[0] as AnthropicMessageText;
+    expect(responseContent.type).toBe("text");
+    expect(responseContent.text.toLowerCase()).toContain("yes");
+  });
+
+  it("should be able to invoke a model with a tool", async () => {
+    const model = new AnthropicModel("claude-sonnet-3.7", "us-east-1");
+    const response = await model.invokeModel({
+      system:
+        "You are an automated test. Execute the completeTest tool with the input { working: 'YES'} to complete your task.",
+      temperature: 0,
+      max_tokens: 100,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Execute the completeTest tool with the input { working: 'YES'} to complete your task.",
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          type: "custom",
+          name: "completeTest",
+          description: "Complete the test.",
+          input_schema: zodToJsonSchema(z.object({ working: z.string() })),
+        },
+      ],
+    });
+    expect(response.stop_reason).toBe("tool_use");
+    const toolCall = response.content[response.content.length - 1] as AnthropicToolCall;
+    expect(toolCall.type).toBe("tool_use");
+    expect(toolCall.name).toBe("completeTest");
+    expect(toolCall.input).toEqual({ working: "YES" });
+  });
+
+  it("should validate tool calls", async () => {
+    const getCapitalTool = new AnthropicTool<{ country: string }, { capital: string }>({
+      name: "get_capital",
+      description: "Get the capital of a given country.",
+      inputSchema: z.object({ country: z.string() }),
+      outputSchema: z.object({ capital: z.string() }),
+      handler: async input => {
+        if (input.country === "France") {
+          return { capital: "Paris" };
+        }
+        throw new Error("Country not found");
+      },
+    });
+
+    const agent = new AnthropicAgent({
+      region: "us-east-1",
+      temperature: 0,
+      version: "claude-sonnet-3.7",
+      systemPrompt: "You are a helpful assistant.",
+      tools: [getCapitalTool],
+    });
+    const mockToolCall: AnthropicToolCall = {
+      type: "tool_use",
+      id: "1",
+      name: "get_capital",
+      input: {
+        country: "France",
+      },
+    };
+    const mockConversation: AnthropicMessageThread<"claude-sonnet-3.7"> = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "What is the capital of France?" }],
+      },
+      {
+        role: "assistant",
+        content: [mockToolCall],
+      },
+    ];
+    agent.setConversation(mockConversation);
+
+    const mockResponse: AnthropicResponse<"claude-sonnet-3.7"> = {
+      id: "1",
+      type: "message",
+      model: "claude-sonnet-3.7",
+      role: "assistant",
+      content: [mockToolCall],
+      stop_reason: "tool_use",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    };
+    expect(agent.shouldExecuteTools(mockResponse)).toBe(true);
+    await agent.executeTools(mockResponse);
+    expect(agent.getConversation()).toEqual([
+      ...mockConversation,
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "1", content: JSON.stringify({ capital: "Paris" }) },
+        ],
+      },
+    ]);
+  });
+
+  it("should be able to parse assistant responses", () => {
+    const response: AnthropicResponse<"claude-sonnet-3.7"> = {
+      id: "1",
+      type: "message",
+      model: "claude-sonnet-3.7",
+      role: "assistant",
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      content: [
+        {
+          type: "text",
+          text: "The capital of France is Paris.",
+        },
+      ],
+    };
+
+    const text = getAssistantResponseText(response);
+    expect(text).toBe("The capital of France is Paris.");
+
+    const toolUseResponse: AnthropicResponse<"claude-sonnet-3.7"> = {
+      id: "1",
+      type: "message",
+      model: "claude-sonnet-3.7",
+      role: "assistant",
+      stop_reason: "tool_use",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      content: [
+        {
+          type: "tool_use",
+          id: "1",
+          name: "get_capital",
+          input: {
+            country: "France",
+          },
+        },
+      ],
+    };
+
+    const toolUseText = getAssistantResponseText(toolUseResponse);
+    expect(toolUseText).toBeUndefined();
+  });
+});

--- a/packages/core/src/external/bedrock/agent/anthropic.ts
+++ b/packages/core/src/external/bedrock/agent/anthropic.ts
@@ -1,0 +1,172 @@
+import { BadRequestError } from "@metriport/shared";
+import { AnthropicAgentConfig } from "./anthropic/types";
+import { AnthropicTool, buildToolExecutions } from "./anthropic/tool";
+import { AnthropicModel } from "../model/anthropic";
+import { AnthropicResponse } from "../model/anthropic/response";
+import { AnthropicUsage, buildInitialUsage, incrementUsage } from "../model/anthropic/usage";
+import { AnthropicModelVersion } from "../model/anthropic/version";
+import {
+  AnthropicAssistantContent,
+  AnthropicMessageThread,
+  AnthropicUserContent,
+} from "../model/anthropic/messages";
+import {
+  AnthropicToolResult,
+  buildToolResult,
+  buildToolResultError,
+  getToolCallsFromResponse,
+} from "../model/anthropic/tools";
+import { executeAsynchronously } from "../../../util";
+
+// Default parameters for Claude requests
+const DEFAULT_MAX_TOKENS = 1024;
+const DEFAULT_TEMPERATURE = 0;
+
+/**
+ * An agent creates AnthropicAgent instances to manage conversations, memory, and tool calls with the underlying Anthropic model.
+ */
+export class AnthropicAgent<V extends AnthropicModelVersion> {
+  private readonly model: AnthropicModel<V>;
+  private readonly config: AnthropicAgentConfig<V>;
+  private readonly tools?: AnthropicTool[] | undefined;
+  private usage: AnthropicUsage = buildInitialUsage();
+  private messages: AnthropicMessageThread<V> = [];
+
+  constructor(config: AnthropicAgentConfig<V>) {
+    this.model = new AnthropicModel<V>(config.version, config.region);
+    this.config = config;
+    this.tools = config.tools;
+  }
+
+  /**
+   * Adds a user message to the agent's conversation thread. This is usually the first step in starting
+   * a conversation with the agent.
+   * @param messageText - The text of the user message.
+   */
+  addUserMessage(content: AnthropicUserContent): void {
+    this.messages.push({
+      role: "user",
+      content,
+    });
+  }
+
+  addUserMessageText(text: string): void {
+    this.addUserMessage([{ type: "text", text }]);
+  }
+
+  /**
+   * Adds an assistant message to the agent's conversation thread.
+   * @param content - The content of the assistant message.
+   */
+  private addAssistantMessage(content: AnthropicAssistantContent<V>): void {
+    this.messages.push({
+      role: "assistant",
+      content,
+    });
+  }
+
+  /**
+   * Starts model invocation with the given user message. This is a more convenient method and most common pattern for
+   * starting a conversation with an Anthropic model.
+   * @param messageText - The text of the user message - usually, whatever follows the system prompt.
+   * @returns The response from the Anthropic model.
+   */
+  async startConversation(messageText: string): Promise<AnthropicResponse<V>> {
+    this.addUserMessage([
+      {
+        type: "text",
+        text: messageText,
+      },
+    ]);
+    return this.continueConversation();
+  }
+
+  /**
+   * Performs a single model invocation for this agent's conversation thread, and adds the response
+   * content onto the conversation thread.
+   * @returns The response from the Anthropic model.
+   */
+  async continueConversation(): Promise<AnthropicResponse<V>> {
+    // Invoke the underlying Claude Sonnet model
+    const response = await this.model.invokeModel({
+      system: this.config.systemPrompt,
+      messages: this.messages,
+      ...(this.tools && this.tools.length > 0
+        ? { tools: this.tools.map(tool => tool.getConfig()) }
+        : {}),
+      max_tokens: this.config.maxTokens ?? DEFAULT_MAX_TOKENS,
+      temperature: this.config.temperature ?? DEFAULT_TEMPERATURE,
+    });
+
+    // Update the internal state of the agent with the response
+    this.addAssistantMessage(response.content);
+    this.usage = incrementUsage(this.usage, response.usage);
+    return response;
+  }
+
+  /**
+   * After continuing a conversation, check the response object to see if the model has invoked any tools.
+   * @param response - The response from the model.
+   * @returns True if the model has invoked any tools.
+   */
+  shouldExecuteTools(response: AnthropicResponse<V>): boolean {
+    if (!this.tools || response.stop_reason !== "tool_use") return false;
+    return response.content.some(({ type }) => type === "tool_use");
+  }
+
+  /**
+   * If a model response contains tool calls, execute the tools and add the results to as a new user message
+   * on the agent's conversation thread.
+   * @param response - The response from the model.
+   */
+  async executeTools(response: AnthropicResponse<V>): Promise<void> {
+    const toolCalls = getToolCallsFromResponse(response);
+    if (!this.tools || response.stop_reason !== "tool_use" || toolCalls.length === 0) {
+      throw new BadRequestError("Not a valid tool call response");
+    }
+
+    const { toolExecutions, toolErrors } = buildToolExecutions(this.tools, toolCalls);
+    const toolResults: AnthropicToolResult[] = [];
+    await executeAsynchronously(toolExecutions, async ({ tool, toolCall, arg }) => {
+      try {
+        const result = await tool.execute(arg);
+        toolResults.push(buildToolResult(toolCall, result));
+      } catch (error) {
+        toolResults.push(buildToolResultError(toolCall, error));
+      }
+    });
+    toolResults.push(...toolErrors);
+    // Add the tool results to the conversation thread
+    this.addUserMessage(toolResults);
+  }
+
+  /**
+   * @returns True if the agent has tools configured.
+   */
+  hasTools(): boolean {
+    return !!this.tools;
+  }
+
+  /**
+   * Returns the conversation thread for this agent.
+   * @returns The history of messages between the user and assistant.
+   */
+  getConversation(): AnthropicMessageThread<V> {
+    return this.messages;
+  }
+
+  /**
+   * Sets the conversation thread for this agent. Used for testing agent methods.
+   * @param messages The history of messages between the user and assistant.
+   */
+  setConversation(messages: AnthropicMessageThread<V>): void {
+    this.messages = [...messages];
+  }
+
+  /**
+   * @returns The usage for this agent.
+   */
+  getUsage(): AnthropicUsage {
+    return this.usage;
+  }
+}

--- a/packages/core/src/external/bedrock/agent/anthropic/tool.ts
+++ b/packages/core/src/external/bedrock/agent/anthropic/tool.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { AnthropicToolConfig } from "../../model/anthropic/tools";
+
+/**
+ * Represents a tool that can be executed by an Anthropic agent.
+ * @param I - The type of the input to the tool.
+ * @param O - The type of the output from the tool.
+ */
+export class AnthropicTool<I = unknown, O = unknown> {
+  private name: string;
+  private description: string;
+  private inputSchema: z.ZodSchema;
+  private outputSchema: z.ZodSchema;
+  private handler: (input: I) => Promise<O>;
+
+  constructor({
+    name,
+    description,
+    inputSchema,
+    outputSchema,
+    handler,
+  }: Pick<AnthropicToolConfig, "name" | "description"> & {
+    inputSchema: z.ZodSchema<I>;
+    outputSchema?: z.ZodSchema<O>;
+    handler: (input: I) => Promise<O>;
+  }) {
+    this.name = name;
+    this.description = description;
+    this.inputSchema = inputSchema;
+    this.outputSchema = outputSchema ?? z.unknown();
+    this.handler = handler;
+  }
+
+  canExecute(input: I): boolean {
+    return this.inputSchema.safeParse(input).success;
+  }
+
+  async execute(input: I): Promise<O> {
+    const validatedInput = this.inputSchema.parse(input);
+    const result = await this.handler(validatedInput);
+    const validatedResult = this.outputSchema.parse(result);
+    return validatedResult;
+  }
+
+  getName() {
+    return this.name;
+  }
+
+  getConfig(): AnthropicToolConfig {
+    return {
+      type: "custom",
+      name: this.name,
+      description: this.description,
+      input_schema: zodToJsonSchema(this.inputSchema),
+    };
+  }
+}

--- a/packages/core/src/external/bedrock/agent/anthropic/types.ts
+++ b/packages/core/src/external/bedrock/agent/anthropic/types.ts
@@ -1,0 +1,24 @@
+import { BedrockRegion } from "../../client";
+import { AnthropicModelVersion } from "../../model/anthropic/version";
+import { AnthropicToolCall } from "../../model/anthropic/tools";
+import type { AnthropicTool } from "./tool";
+
+export interface AnthropicAgentConfig<V extends AnthropicModelVersion> {
+  region: BedrockRegion;
+  version: V;
+  systemPrompt: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tools?: AnthropicTool<any, any>[];
+  maxTokens?: number;
+  temperature?: number;
+}
+
+/** Represents the execution context of an Anthropic tool */
+export interface AnthropicToolExecution {
+  /** The tool instance being executed */
+  tool: AnthropicTool;
+  /** The tool call metadata from the model response */
+  toolCall: AnthropicToolCall;
+  /** The parsed input arguments for the tool */
+  arg: Record<string, unknown>;
+}

--- a/packages/core/src/external/bedrock/agent/client.ts
+++ b/packages/core/src/external/bedrock/agent/client.ts
@@ -1,0 +1,32 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+
+export type BedrockRegion = "us-east-1" | "us-east-2" | "us-west-2";
+
+/**
+ * A basic client for invoking Bedrock models. See the model/ directory for specialized clients.
+ */
+export class BedrockClient<I = unknown, O = unknown> {
+  private client: BedrockRuntimeClient;
+  private modelId: string;
+
+  constructor({ model, region }: { model: string; region: BedrockRegion }) {
+    this.client = new BedrockRuntimeClient({ region });
+    this.modelId = model;
+  }
+
+  /**
+   * Invokes a model with the given request body, and returns an unknown response body.
+   * The shape of the request and response bodies varies based on the model ID.
+   * @param body - The body of the request
+   * @returns The model response
+   */
+  async invokeModel(body: I): Promise<O> {
+    const command = new InvokeModelCommand({
+      modelId: this.modelId,
+      body: JSON.stringify(body),
+    });
+    const response = await this.client.send(command);
+    const responseBody = response.body?.transformToString();
+    return JSON.parse(responseBody) as O;
+  }
+}

--- a/packages/core/src/external/bedrock/client.ts
+++ b/packages/core/src/external/bedrock/client.ts
@@ -1,0 +1,32 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+
+export type BedrockRegion = "us-east-1" | "us-east-2" | "us-west-2";
+
+/**
+ * A basic client for invoking Bedrock models. See the model/ directory for specialized clients.
+ */
+export class BedrockClient<I = unknown, O = unknown> {
+  private client: BedrockRuntimeClient;
+  private modelId: string;
+
+  constructor({ model, region }: { model: string; region: BedrockRegion }) {
+    this.client = new BedrockRuntimeClient({ region });
+    this.modelId = model;
+  }
+
+  /**
+   * Invokes a model with the given request body, and returns an unknown response body.
+   * The shape of the request and response bodies varies based on the model ID.
+   * @param body - The body of the request
+   * @returns The model response
+   */
+  async invokeModel(body: I): Promise<O> {
+    const command = new InvokeModelCommand({
+      modelId: this.modelId,
+      body: JSON.stringify(body),
+    });
+    const response = await this.client.send(command);
+    const responseBody = response.body?.transformToString();
+    return JSON.parse(responseBody) as O;
+  }
+}

--- a/packages/core/src/external/bedrock/model/anthropic.ts
+++ b/packages/core/src/external/bedrock/model/anthropic.ts
@@ -1,0 +1,26 @@
+import { BedrockClient, BedrockRegion } from "../client";
+import { AnthropicModelVersion, getAnthropicModelId } from "./anthropic/version";
+import { AnthropicRequest } from "./anthropic/request";
+import { AnthropicResponse } from "./anthropic/response";
+
+export class AnthropicModel<V extends AnthropicModelVersion> extends BedrockClient<
+  AnthropicRequest<V>,
+  AnthropicResponse<V>
+> {
+  version: V;
+
+  constructor(version: V, region: BedrockRegion) {
+    super({
+      model: getAnthropicModelId(version),
+      region,
+    });
+    this.version = version;
+  }
+
+  override async invokeModel(input: AnthropicRequest<V>): Promise<AnthropicResponse<V>> {
+    return super.invokeModel({
+      anthropic_version: "bedrock-2023-05-31",
+      ...input,
+    });
+  }
+}

--- a/packages/core/src/external/bedrock/model/anthropic/messages.ts
+++ b/packages/core/src/external/bedrock/model/anthropic/messages.ts
@@ -1,0 +1,38 @@
+import { AnthropicModelVersion } from "./version";
+import { AnthropicToolCall, AnthropicToolResult } from "./tools";
+
+/** A thread of messages between the user and the LLM. */
+export type AnthropicMessageThread<V extends AnthropicModelVersion> = Array<
+  AnthropicUserMessage | AnthropicAssistantMessage<V>
+>;
+
+/** A user message to Anthropic can either be some text to the LLM, or the result from a tool call. */
+export interface AnthropicUserMessage {
+  role: "user";
+  content: AnthropicUserContent;
+}
+
+export type AnthropicUserContent = Array<AnthropicMessageText | AnthropicToolResult>;
+
+/** An assistant response may contain multiple content blocks with text and possibly one or more tool calls. */
+export interface AnthropicAssistantMessage<V extends AnthropicModelVersion> {
+  role: "assistant";
+  content: AnthropicAssistantContent<V>;
+}
+
+export type AnthropicAssistantContent<V extends AnthropicModelVersion> = Array<
+  AnthropicMessageText | AnthropicToolCall | (V extends "3.5" ? never : AnthropicThinking)
+>;
+
+/** A text message to/from the LLM. */
+export interface AnthropicMessageText {
+  type: "text";
+  text: string;
+}
+
+/** A thinking message from the LLM, only available for Sonnet 3.7+ models. */
+export interface AnthropicThinking {
+  type: "thinking";
+  text: string;
+  signature: string;
+}

--- a/packages/core/src/external/bedrock/model/anthropic/request.ts
+++ b/packages/core/src/external/bedrock/model/anthropic/request.ts
@@ -1,0 +1,53 @@
+import { AnthropicModelVersion } from "./version";
+import { AnthropicMessageThread } from "./messages";
+import { AnthropicToolConfig } from "./tools";
+
+/**
+ * An invocation request to a Bedrock LLM, serialized in the message body to InvokeModel.
+ * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-request-response.html
+ */
+export interface AnthropicRequest<V extends AnthropicModelVersion> {
+  // Required anthropic version.
+  anthropic_version?: "bedrock-2023-05-31";
+
+  // A system prompt is a way of providing context and instructions to Anthropic Claude, such as specifying a particular goal or role.
+  // https://docs.anthropic.com/en/docs/system-prompts
+  system: string;
+
+  // The maximum number of tokens to generate before stopping.
+  max_tokens: number;
+
+  // Array of conversation history with the model, including tool calls and results.
+  messages: AnthropicMessageThread<V>;
+
+  // Definitions of tools that the model may use.
+  tools?: Array<AnthropicToolConfig>;
+
+  // Specifies how the model should use the provided tools. The model can use a specific tool, any available tool, or decide by itself.
+  tool_choice?: {
+    type: string;
+    name: string;
+  };
+
+  // The temperature parameter to use for invocation.
+  temperature?: number;
+
+  // In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token
+  // in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. When adjusting
+  // sampling parameters, modify either temperature or top_p. Do not modify both at the same time.
+  top_p?: number;
+
+  // Only sample from the top K options for each subsequent token.
+  top_k?: number;
+
+  // The sequences that will stop the model from generating more tokens.
+  stop_sequences?: string[];
+
+  // Introduced in Claude 3.7
+  thinking?: V extends "claude-sonnet-3.5"
+    ? never
+    : {
+        type: "enabled";
+        budget_tokens: number;
+      };
+}

--- a/packages/core/src/external/bedrock/model/anthropic/response.ts
+++ b/packages/core/src/external/bedrock/model/anthropic/response.ts
@@ -1,0 +1,39 @@
+import { AnthropicModelVersion } from "./version";
+import { AnthropicAssistantContent, AnthropicMessageText } from "./messages";
+import { AnthropicUsage } from "./usage";
+
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-request-response.html
+export interface AnthropicResponse<V extends AnthropicModelVersion> {
+  // Unique ID that starts with "msg_bdrk_..."
+  id: string;
+  type: "message";
+  model: string;
+  role: "assistant";
+
+  // Messages, responses, and tool calls/results
+  content: AnthropicAssistantContent<V>;
+  stop_reason: "end_turn" | "tool_use" | "max_tokens";
+  stop_sequence?: string | null;
+  usage: AnthropicUsage;
+}
+
+export function getAssistantResponseText<V extends AnthropicModelVersion>(
+  response: AnthropicResponse<V>
+): string | undefined {
+  const textContent = response.content.filter(isTextContent);
+  if (textContent.length === 0) {
+    return undefined;
+  }
+  return concatenateAllTextContent(textContent);
+}
+
+function isTextContent<V extends AnthropicModelVersion>(
+  content: AnthropicAssistantContent<V>[number]
+): content is AnthropicMessageText {
+  return content.type === "text";
+}
+
+function concatenateAllTextContent(content: AnthropicMessageText[]): string {
+  const lines = content.map(content => content.text);
+  return lines.join("\n");
+}

--- a/packages/core/src/external/bedrock/model/anthropic/tools.ts
+++ b/packages/core/src/external/bedrock/model/anthropic/tools.ts
@@ -1,0 +1,63 @@
+import { AnthropicResponse } from "./response";
+import { AnthropicModelVersion } from "./version";
+
+/**
+ * A tool definition given to Anthropic. Note that there are additional costs associated with
+ * using tools, because a special prompt is automatically inserted into the system prompt. Do
+ * not waste additional tokens telling the LLM that there are tools available - it knows!
+ */
+export interface AnthropicToolConfig {
+  type: "custom";
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+/**
+ * Returned by the LLM as a request to invoke a tool.
+ */
+export interface AnthropicToolCall {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+/**
+ * Provided to the LLM in a user message to indicate the result of a tool call.
+ */
+export interface AnthropicToolResult {
+  type: "tool_result";
+  tool_use_id: string;
+  content?: unknown;
+}
+
+export function getToolCallsFromResponse<V extends AnthropicModelVersion>(
+  response: AnthropicResponse<V>
+): AnthropicToolCall[] {
+  return response.content.filter(({ type }) => type === "tool_use") as AnthropicToolCall[];
+}
+
+export function buildToolResult(
+  toolCall: AnthropicToolCall,
+  content: unknown
+): AnthropicToolResult {
+  return {
+    type: "tool_result",
+    tool_use_id: toolCall.id,
+    content: JSON.stringify(content ?? {}),
+  };
+}
+
+export function buildToolResultError(
+  toolCall: AnthropicToolCall,
+  error: unknown
+): AnthropicToolResult {
+  return {
+    type: "tool_result",
+    tool_use_id: toolCall.id,
+    content: {
+      error: error instanceof Error ? error.message : String(error),
+    },
+  };
+}

--- a/packages/core/src/external/bedrock/model/anthropic/usage.ts
+++ b/packages/core/src/external/bedrock/model/anthropic/usage.ts
@@ -1,0 +1,25 @@
+export interface AnthropicUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+}
+
+export function buildInitialUsage(): AnthropicUsage {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+  };
+}
+
+export function incrementUsage(usage: AnthropicUsage, increment: AnthropicUsage): AnthropicUsage {
+  return {
+    input_tokens: usage.input_tokens + increment.input_tokens,
+    output_tokens: usage.output_tokens + increment.output_tokens,
+    cache_read_input_tokens: usage.cache_read_input_tokens + increment.cache_read_input_tokens,
+    cache_creation_input_tokens:
+      usage.cache_creation_input_tokens + increment.cache_creation_input_tokens,
+  };
+}

--- a/packages/core/src/external/bedrock/model/anthropic/version.ts
+++ b/packages/core/src/external/bedrock/model/anthropic/version.ts
@@ -1,0 +1,11 @@
+export type AnthropicModelVersion = "claude-sonnet-3.5" | "claude-sonnet-3.7" | "claude-sonnet-4";
+
+const modelIdMapping: Record<AnthropicModelVersion, string> = {
+  "claude-sonnet-3.5": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+  "claude-sonnet-3.7": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+  "claude-sonnet-4": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+};
+
+export function getAnthropicModelId(version: AnthropicModelVersion): string {
+  return modelIdMapping[version];
+}

--- a/packages/utils/src/anthropic/agent-conversation.ts
+++ b/packages/utils/src/anthropic/agent-conversation.ts
@@ -1,0 +1,33 @@
+import { AnthropicAgent } from "@metriport/core/external/bedrock/agent/anthropic";
+import { logResponse, promptUser, startInteractive } from "./shared";
+
+/**
+ * Example of an Anthropic agent conversation. The agent maintains the conversation history, so
+ * you can continue the conversation by calling `continueConversation`.
+ */
+
+async function main() {
+  const agent = new AnthropicAgent({
+    version: "claude-sonnet-3.7",
+    region: "us-east-1",
+    systemPrompt: "You are a helpful assistant.",
+    maxTokens: 1024,
+    temperature: 0,
+  });
+
+  startInteractive();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // Get user input, and
+    const input = await promptUser();
+    if (input.toLowerCase() === "bye") {
+      process.exit(0);
+    }
+
+    agent.addUserMessageText(input);
+    const response = await agent.continueConversation();
+    logResponse(response);
+  }
+}
+
+main();

--- a/packages/utils/src/anthropic/agent-with-tools.ts
+++ b/packages/utils/src/anthropic/agent-with-tools.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import { AnthropicAgent } from "@metriport/core/external/bedrock/agent/anthropic";
+import { AnthropicTool } from "@metriport/core/external/bedrock/agent/anthropic/tool";
+import { logResponse, promptUser, startInteractive } from "./shared";
+
+/**
+ * Example of an Anthropic agent with tools. The agent first calls the `cityLocation` tool to get the location of a city,
+ * then calls the `weather` tool to get the weather at that location. The agent will continue to call tools until it has
+ * enough information to answer the user's question.
+ */
+async function main() {
+  const cityLocationTool = new AnthropicTool({
+    name: "cityLocation",
+    description: "Get the location of a city",
+    inputSchema: z.object({
+      city: z.string(),
+      state: z.string().optional(),
+    }),
+    outputSchema: z.object({ latitude: z.number(), longitude: z.number() }),
+    // The handler should usually be defined as a regular function declaration, and referenced by name in the tool setup
+    handler: async input => {
+      console.log(`Getting location of ${input.city} ${input.state ? `, ${input.state}` : ""}`);
+      return { latitude: 1.2345, longitude: 2.3456 };
+    },
+  });
+
+  const weatherTool = new AnthropicTool({
+    name: "weather",
+    description: "Get the weather of a city",
+    inputSchema: z.object({ latitude: z.number(), longitude: z.number() }),
+    outputSchema: z.object({ temperature: z.number() }),
+    handler: async input => {
+      console.log(`Getting weather for (${input.latitude}, ${input.longitude})`);
+      return {
+        temperature: 20 + Math.floor(Math.random() * 15),
+        units: "C",
+        humidity: Math.floor(Math.random() * 100),
+      };
+    },
+  });
+
+  const agent = new AnthropicAgent({
+    version: "claude-sonnet-3.7",
+    region: "us-east-1",
+    systemPrompt: `You are a helpful assistant that can get the location of a city (latitude and longitude), and the weather at a particular location.
+    Use the provided tools to answer the user's question. Try to infer the state from the city name if it is not provided.`,
+    maxTokens: 1024,
+    temperature: 0,
+    tools: [cityLocationTool, weatherTool],
+  });
+
+  startInteractive();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const input = await promptUser();
+    if (input.toLowerCase() === "bye") {
+      process.exit(0);
+    }
+    // Add the user message to the conversation history
+    agent.addUserMessageText(input);
+    let response = await agent.continueConversation();
+    while (agent.shouldExecuteTools(response)) {
+      await agent.executeTools(response);
+      response = await agent.continueConversation();
+    }
+    logResponse(response);
+  }
+}
+
+main();

--- a/packages/utils/src/anthropic/model-conversation.ts
+++ b/packages/utils/src/anthropic/model-conversation.ts
@@ -1,0 +1,47 @@
+import { AnthropicModel } from "@metriport/core/external/bedrock/model/anthropic";
+import { AnthropicMessageThread } from "@metriport/core/external/bedrock/model/anthropic/messages";
+import { promptUser, startInteractive } from "./shared";
+
+/**
+ * This is a simple example of using the Bedrock client to have a conversation with a model. You can
+ * change the system prompt to provide specific instructions on how the model should respond.
+ *
+ * @see agent-with-tools.ts for an example of how to use tools with an Anthropic model.
+ */
+
+async function main() {
+  const client = new AnthropicModel("claude-sonnet-3.7", "us-east-1");
+
+  // You can customize the system prompt to provide directions to the model.
+  const systemPrompt = `You are a helpful assistant.`;
+  const messages: AnthropicMessageThread<"claude-sonnet-3.7"> = [];
+
+  // Start a REPL until the user enters "bye".
+  startInteractive();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const input = await promptUser();
+    if (input.toLowerCase() === "bye") {
+      process.exit(0);
+    }
+
+    // Add the user message to the conversation history, then invoke the model with the full history.
+    messages.push({ role: "user", content: [{ type: "text", text: input }] });
+    const response = await client.invokeModel({
+      system: systemPrompt,
+      messages,
+      max_tokens: 100,
+    });
+
+    // Add the assistant response as a message in the conversation history.
+    messages.push({ role: "assistant", content: response.content });
+    for (const content of response.content) {
+      if (content.type === "text") {
+        process.stdout.write(content.text);
+        process.stdout.write("\n");
+      }
+    }
+  }
+}
+
+main();

--- a/packages/utils/src/anthropic/shared.ts
+++ b/packages/utils/src/anthropic/shared.ts
@@ -1,0 +1,43 @@
+import { AnthropicModelVersion } from "@metriport/core/external/bedrock/model/anthropic/version";
+import { AnthropicResponse } from "@metriport/core/external/bedrock/model/anthropic/response";
+
+export function startInteractive() {
+  process.stdin.setEncoding("utf8");
+}
+
+export function stopInteractiveOnGoodbye(input: string) {
+  if (input.toLowerCase() === "bye") {
+    process.stdout.write("Goodbye!\n");
+    process.exit(0);
+  }
+}
+
+/**
+ * @returns The user input on stdin
+ */
+export function promptUser(): Promise<string> {
+  return new Promise(resolve => {
+    process.stdout.write("> ");
+    function handleInput(data: string) {
+      process.stdin.removeListener("data", handleInput);
+      resolve(data.toString().trim());
+    }
+    process.stdin.on("data", handleInput);
+    process.stdin.on("end", () => {
+      process.stdin.removeListener("data", handleInput);
+    });
+  });
+}
+
+export function logResponse<V extends AnthropicModelVersion>(response: AnthropicResponse<V>) {
+  for (const content of response.content) {
+    if (content.type === "text") {
+      process.stdout.write(content.text);
+      process.stdout.write("\n");
+    } else if (content.type === "tool_use") {
+      process.stdout.write(`[TOOL CALL] [${content.name}]\n`);
+      process.stdout.write(JSON.stringify(content.input, null, 2));
+      process.stdout.write("\n");
+    }
+  }
+}


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-565

### Dependencies

- Upstream: None
- Downstream: None

### Description

Adds a low-level Anthropic API layer for starting LLM conversations, calling tools, and defining agents. There is a detailed user guide for any internal user that wants to integrate LLMs + tool calling into their workflows here:

https://www.notion.so/metriport/Bedrock-Agent-client-guide-229b51bb90408037ad12c22135bc1d62

The [original PR](https://github.com/metriport/metriport/pull/4307) was reviewed by none other than Dima himself.

<img width="301" height="148" alt="Screenshot 2025-08-18 at 17 20 26" src="https://github.com/user-attachments/assets/46ab6c81-1f6e-49ba-ab1e-32d58802cfaf" />

### Testing

Has 100% automated test coverage E2E - see the `__tests__` directory for LLM calls where the LLM is actually instructed that it is an automated test!

<img width="1690" height="193" alt="Screenshot 2025-08-04 at 19 59 41" src="https://github.com/user-attachments/assets/79141db7-e863-451b-84b6-14ae4629046d" />

- Local
  - [x] `cd core` and `npm run test:e2e`
  - [x] `cd utils` and `ts-node src/anthropic/agent-with-tools.ts`

<img width="638" height="267" alt="Screenshot 2025-08-06 at 18 47 04" src="https://github.com/user-attachments/assets/ee6244f1-4e78-4363-825d-82147042d747" />

  - [x]  `cd utils` and `ts-node src/anthropic/agent-conversation.ts`
  
<img width="626" height="199" alt="Screenshot 2025-08-04 at 20 04 14" src="https://github.com/user-attachments/assets/8dfa9468-f86e-40fd-a666-387627bdd4b9" />

👆 This really works!

### Release Plan

This is the first step of integrating AWS Comprehend Medical, by using an LLM to call the relevant API via tool calls (either the RxNorm or ICD-10 endpoint), then re-mapping the resulting JSON based on the context of the original text to accurate FHIR resources. 

A useful side-effect is that anyone can use this base typing for the Anthropic API to incorporate LLMs elsewhere in the application. 

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced Anthropic agent integration with conversation management, tool execution, and usage tracking.
  * Added support for defining, validating, and executing tools with typed input/output schemas in Anthropic conversations.
  * Enabled interactive command-line demos showcasing Anthropic agents with and without tools.
  * Provided utilities for managing Anthropic model versions, message threads, request/response formats, and token usage statistics.
  * Added new API endpoints and commands to manage Quest monitoring subscriptions for patients.
  * Integrated Quest monitoring features into patient settings and internal routes with pagination support.
  * Enhanced infrastructure stacks with new environment variables and S3 bucket support related to Quest and lab bundles.
  
* **Documentation**
  * Included example scripts and utilities demonstrating interactive Anthropic agent usage and tool integration.

* **Tests**
  * Added comprehensive end-to-end test suites covering Anthropic agent behavior, tool execution, model interactions, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->