### PR TITLE
feat(api): added automatic upload of adt roster to SFTP servers for HIEs

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -129,7 +129,17 @@ export class Hl7v2RosterGenerator {
 
     log(`Saved in S3: ${this.bucketName}/${fileName}`);
 
-    await uploadThroughSftp(config, rosterCsv);
+    const uploadTimer = initTimer();
+    try {
+      log(`Starting SFTP upload for config: ${config.name}`);
+      await uploadThroughSftp(config, rosterCsv);
+      log(`SFTP upload successful`);
+      //eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      log(`SFTP upload failed with error: ${err}`);
+    } finally {
+      log(`SFTP upload completed in ${uploadTimer.getElapsedTime()}ms`);
+    }
 
     return rosterCsv;
   }

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -129,11 +129,7 @@ export class Hl7v2RosterGenerator {
 
     log(`Saved in S3: ${this.bucketName}/${fileName}`);
 
-    const uploadTimer = initTimer();
-
-    log(`Starting SFTP upload for config: ${config.name}`);
     await uploadThroughSftp(config, rosterCsv);
-    log(`SFTP upload completed in ${uploadTimer.getElapsedTime()}ms`);
 
     return rosterCsv;
   }
@@ -183,11 +179,11 @@ export class Hl7v2RosterGenerator {
 export function createFileKeyHl7v2Roster(hieName: string): string {
   const todaysDate = buildDayjs();
   const folderDate = todaysDate.format(FOLDER_DATE_FORMAT);
-  const fileName = createFileHl7v2Roster(hieName);
+  const fileName = createFileNameHl7v2Roster(hieName);
   return `${folderDate}/${fileName}`;
 }
 
-export function createFileHl7v2Roster(hieName: string): string {
+export function createFileNameHl7v2Roster(hieName: string): string {
   const todaysDate = buildDayjs();
   const fileDate = todaysDate.format(FILE_DATE_FORMAT);
   return `Metriport_${hieName}_Patient_Enrollment_${fileDate}.${CSV_FILE_EXTENSION}`;

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -130,16 +130,10 @@ export class Hl7v2RosterGenerator {
     log(`Saved in S3: ${this.bucketName}/${fileName}`);
 
     const uploadTimer = initTimer();
-    try {
-      log(`Starting SFTP upload for config: ${config.name}`);
-      await uploadThroughSftp(config, rosterCsv);
-      log(`SFTP upload successful`);
-      //eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
-      log(`SFTP upload failed with error: ${err}`);
-    } finally {
-      log(`SFTP upload completed in ${uploadTimer.getElapsedTime()}ms`);
-    }
+
+    log(`Starting SFTP upload for config: ${config.name}`);
+    await uploadThroughSftp(config, rosterCsv);
+    log(`SFTP upload completed in ${uploadTimer.getElapsedTime()}ms`);
 
     return rosterCsv;
   }

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-uploader.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-uploader.ts
@@ -8,9 +8,10 @@ import { getSecretValueOrFail } from "../../external/aws/secret-manager";
 import { MetriportError } from "@metriport/shared";
 import { Config } from "../../util/config";
 import { initTimer } from "@metriport/shared/common/timer";
+import dayjs from "dayjs";
 
 const NUMBER_OF_ATTEMPTS = 3;
-const BASE_DELAY = 1000;
+const BASE_DELAY = dayjs.duration({ seconds: 1 });
 
 export async function uploadThroughSftp(
   config: HieConfig | VpnlessHieConfig,
@@ -45,7 +46,7 @@ export async function uploadThroughSftp(
   await executeWithRetries(() => sendViaSftp(sftpConfig, file, remotePath, remoteFileName), {
     maxAttempts: NUMBER_OF_ATTEMPTS,
     log,
-    initialDelay: BASE_DELAY,
+    initialDelay: BASE_DELAY.milliseconds(),
   });
   log(`SFTP upload completed in ${uploadTimer.getElapsedTime()}ms`);
 }

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-uploader.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-uploader.ts
@@ -1,5 +1,6 @@
 import { out } from "../../util";
 import { HieConfig } from "./types";
+import { SftpClient } from "../../external/sftp/client";
 
 // import { errorToString, executeWithNetworkRetries } from "@metriport/shared";
 // import dayjs from "dayjs";
@@ -14,6 +15,14 @@ import { HieConfig } from "./types";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function uploadThroughSftp(config: HieConfig, file: string): Promise<void> {
   const { log } = out("[STUB] - Hl7v2RosterUploader");
+
+  if (!config.sftpConfig) {
+    throw new Error("Sftp config is required");
+  }
+
+  const client = new SftpClient(config.sftpConfig);
+  await client.connect();
+
   // const { states, subscriptions } = config;
   // const loggingDetails = {
   //   hieName: config.name,

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-uploader.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-uploader.ts
@@ -35,7 +35,7 @@ export async function uploadToRemoteSftp(
   const remoteFileName = createFileNameHl7v2Roster(hieName);
 
   await simpleExecuteWithRetriesAsDuration(
-    () => sendViaSftp(sftpConfig, file, remoteFileName),
+    () => sendViaSftp(sftpConfig, file, remoteFileName, log),
     NUMBER_OF_ATTEMPTS,
     BASE_DELAY,
     log
@@ -43,10 +43,16 @@ export async function uploadToRemoteSftp(
   log(`SFTP upload completed in ${uploadTimer.getElapsedTime()}ms`);
 }
 
-async function sendViaSftp(sftpConfig: HieSftpConfig, file: string, remoteFileName: string) {
+async function sendViaSftp(
+  sftpConfig: HieSftpConfig,
+  file: string,
+  remoteFileName: string,
+  log: typeof console.log
+) {
   const remoteFolderPath = sftpConfig.remotePath;
   const password = Config.getSftpPasswordOrFail();
-
+  log(`The sftp config I got is: ${sftpConfig}`);
+  log(`The password I got is: ${password}`);
   const client = new SftpClient({
     ...sftpConfig,
     password,
@@ -60,7 +66,7 @@ async function sendViaSftp(sftpConfig: HieSftpConfig, file: string, remoteFileNa
     }
 
     const fullPath = `${remoteFolderPath}/${remoteFileName}`;
-
+    Ç;
     await client.write(fullPath, Buffer.from(file, "utf-8"));
   } finally {
     await client.disconnect();

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-uploader.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-uploader.ts
@@ -66,7 +66,7 @@ async function sendViaSftp(
     }
 
     const fullPath = `${remoteFolderPath}/${remoteFileName}`;
-    Ç;
+
     await client.write(fullPath, Buffer.from(file, "utf-8"));
   } finally {
     await client.disconnect();

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-uploader.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-uploader.ts
@@ -16,12 +16,22 @@ import { SftpClient } from "../../external/sftp/client";
 export async function uploadThroughSftp(config: HieConfig, file: string): Promise<void> {
   const { log } = out("[STUB] - Hl7v2RosterUploader");
 
-  if (!config.sftpConfig) {
+  if (!config.sftpConfig || !config.remotePath) {
     throw new Error("Sftp config is required");
   }
 
   const client = new SftpClient(config.sftpConfig);
-  await client.connect();
+
+  try {
+    await client.connect();
+    await client.write(config.remotePath, Buffer.from(file, "utf-8"));
+  } catch (error) {
+    log(`[SFTP] SFTP failed! ${error}`);
+    throw error;
+  } finally {
+    await client.disconnect();
+    log(`[SFTP] Connection cleaned up.`);
+  }
 
   // const { states, subscriptions } = config;
   // const loggingDetails = {

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -55,7 +55,6 @@ export type HieConfig = {
   subscriptions: Hl7v2Subscription[];
   cron: string;
   sftpConfig: HieSftpConfig;
-  remotePath?: string;
   mapping: HiePatientRosterMapping;
 };
 

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -2,14 +2,7 @@ import { USState } from "@metriport/shared";
 import { Patient } from "../../domain/patient";
 import { Hl7v2Subscription } from "../../domain/patient-settings";
 import { HieIanaTimezone } from "../../external/hl7-notification/hie-config-dictionary";
-
-export type SftpConfig = {
-  host: string;
-  port: number;
-  username: string;
-  password: string;
-  remotePath: string;
-};
+import { SftpConfig } from "../../external/sftp/types";
 
 export type RosterRowData = {
   id: string;
@@ -62,6 +55,7 @@ export type HieConfig = {
   subscriptions: Hl7v2Subscription[];
   cron: string;
   sftpConfig?: SftpConfig;
+  remotePath?: string;
   mapping: HiePatientRosterMapping;
 };
 

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -2,7 +2,7 @@ import { USState } from "@metriport/shared";
 import { Patient } from "../../domain/patient";
 import { Hl7v2Subscription } from "../../domain/patient-settings";
 import { HieIanaTimezone } from "../../external/hl7-notification/hie-config-dictionary";
-import { SftpConfig } from "../../external/sftp/types";
+import { HieSftpConfig } from "../../external/sftp/types";
 
 export type RosterRowData = {
   id: string;
@@ -54,7 +54,7 @@ export type HieConfig = {
   states: USState[];
   subscriptions: Hl7v2Subscription[];
   cron: string;
-  sftpConfig?: SftpConfig;
+  sftpConfig: HieSftpConfig;
   remotePath?: string;
   mapping: HiePatientRosterMapping;
 };

--- a/packages/core/src/external/sftp/types.ts
+++ b/packages/core/src/external/sftp/types.ts
@@ -32,6 +32,7 @@ export interface SftpConfig {
   port: number;
   username: string;
   password: string;
+  passwordSecretName?: string;
   privateKey?: string;
   logLevel?: "info" | "debug" | "none"; // default "none"
 }

--- a/packages/core/src/external/sftp/types.ts
+++ b/packages/core/src/external/sftp/types.ts
@@ -37,7 +37,6 @@ export interface SftpConfig {
 }
 
 export type HieSftpConfig = Omit<SftpConfig, "password" | "privateKey"> & {
-  passwordSecretName: string;
   remotePath: string;
 };
 

--- a/packages/core/src/external/sftp/types.ts
+++ b/packages/core/src/external/sftp/types.ts
@@ -32,10 +32,14 @@ export interface SftpConfig {
   port: number;
   username: string;
   password: string;
-  passwordSecretName?: string;
   privateKey?: string;
   logLevel?: "info" | "debug" | "none"; // default "none"
 }
+
+export type HieSftpConfig = Omit<SftpConfig, "password" | "privateKey"> & {
+  passwordSecretName: string;
+  remotePath: string;
+};
 
 export interface SftpFile {
   fileName: string;

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -1,5 +1,6 @@
 import { getEnvVarAsRecordOrFail } from "@metriport/shared/common/env-var";
 import { getEnvVar, getEnvVarOrFail } from "./env-var";
+import { ROSTER_UPLOAD_SFTP_PASSWORD } from "@metriport/shared/domain/tcm-encounter";
 
 /**
  * Shared configs, still defining how to work with this. For now:
@@ -398,6 +399,6 @@ export class Config {
   }
 
   static getRosterUploadSftpPasswordArn(): string {
-    return getEnvVarOrFail("ROSTER_UPLOAD_SFTP_PASSWORD_ARN");
+    return getEnvVarOrFail(`${ROSTER_UPLOAD_SFTP_PASSWORD}_ARN`);
   }
 }

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -396,4 +396,8 @@ export class Config {
   static getFhirToCsvBatchJobDefinitionArn(): string | undefined {
     return getEnvVar("FHIR_TO_CSV_BATCH_JOB_DEFINITION_ARN");
   }
+
+  static getSftpPasswordOrFail(): string {
+    return getEnvVarOrFail("SFTP_PASSWORD");
+  }
 }

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -397,7 +397,7 @@ export class Config {
     return getEnvVar("FHIR_TO_CSV_BATCH_JOB_DEFINITION_ARN");
   }
 
-  static getSftpPasswordOrFail(): string {
+  static getSftpPasswordArnOrFail(): string {
     return getEnvVarOrFail("SFTP_PASSWORD");
   }
 }

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -397,7 +397,7 @@ export class Config {
     return getEnvVar("FHIR_TO_CSV_BATCH_JOB_DEFINITION_ARN");
   }
 
-  static getSftpPasswordArnOrFail(): string {
-    return getEnvVarOrFail("SFTP_PASSWORD");
+  static getRosterUploadSftpPasswordArn(): string {
+    return getEnvVarOrFail("ROSTER_UPLOAD_SFTP_PASSWORD_ARN");
   }
 }

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -206,7 +206,6 @@ export const config: EnvConfigNonSandbox = {
           host: "your-sftp-host",
           port: 22,
           username: "your-sftp-username",
-          passwordSecretName: "SftpPassword-HieName",
           remotePath: "your-directory-path",
         },
       },

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -202,6 +202,13 @@ export const config: EnvConfigNonSandbox = {
           FACCODE: "cxShortcode",
           ASSIGNERID: "assigningAuthorityIdentifier",
         },
+        sftpConfig: {
+          host: "your-sftp-host",
+          port: 22,
+          username: "your-sftp-username",
+          passwordSecretName: "SftpPassword-HieName",
+          remotePath: "your-directory-path",
+        },
       },
     },
     dischargeNotificationSlackUrl: "url-to-slack-channel",

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -1027,6 +1027,7 @@ export class LambdasNestedStack extends NestedStack {
       Object.entries(hieConfigs).forEach(([hieName, hieConfig]) => {
         const isStag = isStaging(config);
         const passwordSecretName = getHiePasswordSecretName(hieName, isStag);
+        console.log(`RADMIR THIS IS FOR YOU :) ${hieName}: ${passwordSecretName}`);
 
         const lambda = createScheduledLambda({
           stack: this,

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -1043,7 +1043,7 @@ export class LambdasNestedStack extends NestedStack {
             HL7V2_ROSTER_BUCKET_NAME: hl7v2RosterBucket.bucketName,
             API_URL: config.loadBalancerDnsName,
             HL7_BASE64_SCRAMBLER_SEED: scramblerSeedSecretName,
-            SFTP_PASSWORD: passwordSecret.secretValue.toString(),
+            SFTP_PASSWORD: passwordSecret.secretArn,
             ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
           },
           layers: [lambdaLayers.shared],

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -27,7 +27,8 @@ import { createScheduledLambda } from "./shared/lambda-scheduled";
 import { buildSecret, Secrets } from "./shared/secrets";
 import { QueueAndLambdaSettings } from "./shared/settings";
 import { createQueue } from "./shared/sqs";
-import { isSandbox } from "./shared/util";
+import { isSandbox, isStaging } from "./shared/util";
+import { getHiePasswordSecretName } from "./secrets-stack";
 
 export const CDA_TO_VIS_TIMEOUT = Duration.minutes(15);
 
@@ -1024,7 +1025,8 @@ export class LambdasNestedStack extends NestedStack {
       const hieConfigs = config.hl7Notification.hieConfigs;
 
       Object.entries(hieConfigs).forEach(([hieName, hieConfig]) => {
-        const passwordSecretName = hieConfig.sftpConfig.passwordSecretName;
+        const isStag = isStaging(config);
+        const passwordSecretName = getHiePasswordSecretName(hieName, isStag);
 
         const lambda = createScheduledLambda({
           stack: this,

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -1024,6 +1024,8 @@ export class LambdasNestedStack extends NestedStack {
       const hieConfigs = config.hl7Notification.hieConfigs;
 
       Object.entries(hieConfigs).forEach(([hieName, hieConfig]) => {
+        const passwordSecretName = hieConfig.sftpConfig.passwordSecretName;
+
         const lambda = createScheduledLambda({
           stack: this,
           name: `Hl7v2RosterUpload-${hieName}`,
@@ -1035,6 +1037,7 @@ export class LambdasNestedStack extends NestedStack {
             HL7V2_ROSTER_BUCKET_NAME: hl7v2RosterBucket.bucketName,
             API_URL: config.loadBalancerDnsName,
             HL7_BASE64_SCRAMBLER_SEED: scramblerSeedSecretName,
+            SFTP_PASSWORD: passwordSecretName,
             ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
           },
           layers: [lambdaLayers.shared],

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -4,7 +4,6 @@ import { Construct } from "constructs";
 import { EnvConfig } from "../config/env-config";
 import { isSandbox } from "../lib/shared/util";
 import { PROBLEMATIC_IPSEC_CHARACTERS } from "./hl7-notification-stack/constants";
-import { MetriportError } from "@metriport/shared/dist/error/metriport-error";
 
 interface SecretStackProps extends StackProps {
   config: EnvConfig;
@@ -119,22 +118,12 @@ export class SecretsStack extends Stack {
         logSecretInfo(this, secret, secretName);
       }
 
-      const sftpSecretNames = Object.values(props.config.hl7Notification.hieConfigs).map(
-        c => c.sftpConfig?.passwordSecretName
+      const sftpSecretNames = Object.values(props.config.hl7Notification.hieConfigs).flatMap(c =>
+        c.sftpConfig ? [c.sftpConfig.passwordSecretName] : []
       );
 
       for (const secretName of sftpSecretNames) {
-        if (!secretName) {
-          throw new MetriportError("No sftp password secret name for hie", undefined, {
-            secretName,
-          });
-        }
-        const secret = makeSecret(secretName, {
-          generateSecretString: {
-            excludePunctuation: true,
-            excludeCharacters: PROBLEMATIC_IPSEC_CHARACTERS,
-          },
-        });
+        const secret = makeSecret(secretName);
         logSecretInfo(this, secret, secretName);
       }
 

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -118,9 +118,9 @@ export class SecretsStack extends Stack {
         logSecretInfo(this, secret, secretName);
       }
 
-      const hieNames = Object.values(props.config.hl7Notification.hieConfigs).flatMap(c =>
-        c.sftpConfig ? [c.name] : []
-      );
+      const hieNames = Object.values(props.config.hl7Notification.hieConfigs).flatMap(c => [
+        c.name,
+      ]);
 
       for (const hieName of hieNames) {
         const isStag = isStaging(props.config);
@@ -140,5 +140,5 @@ export class SecretsStack extends Stack {
 }
 
 export function getHiePasswordSecretName(hieName: string, isStaging: boolean): string {
-  return isStaging ? `SftpPassword-Staging-${hieName}` : `SftpPassword-${hieName}`;
+  return isStaging ? `SFTPPASSWORD_STAGING_${hieName}` : `SFTP_PASSWORD_${hieName}`;
 }

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -121,8 +121,9 @@ export class SecretsStack extends Stack {
       const hieNames = Object.values(props.config.hl7Notification.hieConfigs).flatMap(c => [
         c.name,
       ]);
-
+      console.log("Uhm what?:", hieNames.length);
       for (const hieName of hieNames) {
+        console.log("Uhm what?", hieName);
         const isStag = isStaging(props.config);
         const secretName = getHiePasswordSecretName(hieName, isStag);
         const secret = makeSecret(secretName);

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -2,7 +2,7 @@ import { CfnOutput, Stack, StackProps } from "aws-cdk-lib";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 import { EnvConfig } from "../config/env-config";
-import { isSandbox, isStaging } from "../lib/shared/util";
+import { isSandbox } from "../lib/shared/util";
 import { PROBLEMATIC_IPSEC_CHARACTERS } from "./hl7-notification-stack/constants";
 
 interface SecretStackProps extends StackProps {
@@ -118,14 +118,11 @@ export class SecretsStack extends Stack {
         logSecretInfo(this, secret, secretName);
       }
 
-      const hieNames = Object.values(props.config.hl7Notification.hieConfigs).flatMap(c => [
-        c.name,
-      ]);
-      console.log("Uhm what?:", hieNames.length);
-      for (const hieName of hieNames) {
-        console.log("Uhm what?", hieName);
-        const isStag = isStaging(props.config);
-        const secretName = getHiePasswordSecretName(hieName, isStag);
+      const hieSftpSecretNames = Object.values(props.config.hl7Notification.hieConfigs).map(c =>
+        getHieSftpPasswordSecretName(c.name)
+      );
+
+      for (const secretName of hieSftpSecretNames) {
         const secret = makeSecret(secretName);
         logSecretInfo(this, secret, secretName);
       }
@@ -140,6 +137,6 @@ export class SecretsStack extends Stack {
   }
 }
 
-export function getHiePasswordSecretName(hieName: string, isStaging: boolean): string {
-  return isStaging ? `SFTPPASSWORD_STAGING_${hieName}` : `SFTP_PASSWORD_${hieName}`;
+export function getHieSftpPasswordSecretName(hieName: string): string {
+  return `SftpPassword-${hieName}`;
 }

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -138,5 +138,5 @@ export class SecretsStack extends Stack {
 }
 
 export function getHieSftpPasswordSecretName(hieName: string): string {
-  return `SftpPassword-${hieName}`;
+  return `RosterUploadSftpPassword-${hieName}`;
 }

--- a/packages/infra/lib/secrets-stack.ts
+++ b/packages/infra/lib/secrets-stack.ts
@@ -120,7 +120,7 @@ export class SecretsStack extends Stack {
       }
 
       const sftpSecretNames = Object.values(props.config.hl7Notification.hieConfigs).map(
-        c => c.sftpConfig?.password
+        c => c.sftpConfig?.passwordSecretName
       );
 
       for (const secretName of sftpSecretNames) {

--- a/packages/infra/lib/shared/secrets.ts
+++ b/packages/infra/lib/shared/secrets.ts
@@ -2,9 +2,9 @@ import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 import { EnvConfig } from "../../config/env-config";
-import { isSandbox, isStaging } from "./util";
+import { isSandbox } from "./util";
 import { HieConfig, VpnlessHieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
-import { getHiePasswordSecretName } from "../secrets-stack";
+import { getHieSftpPasswordSecretName } from "../secrets-stack";
 
 export type Secrets = { [key: string]: secret.ISecret };
 
@@ -46,23 +46,18 @@ export function getSecrets(scope: Construct, config: EnvConfig): Secrets {
       : undefined),
     ...(!isSandbox(config) ? buildSecrets(scope, config.analyticsPlatform.secrets) : undefined),
     ...(!isSandbox(config)
-      ? buildSecrets(
-          scope,
-          collectHiePasswordSecretNames(config.hl7Notification.hieConfigs, config)
-        )
+      ? buildSecrets(scope, collectHiePasswordSecretNames(config.hl7Notification.hieConfigs))
       : undefined),
   };
   return secrets;
 }
 
 function collectHiePasswordSecretNames(
-  hies: Record<string, HieConfig | VpnlessHieConfig>,
-  config: EnvConfig
+  hies: Record<string, HieConfig | VpnlessHieConfig>
 ): Record<string, string> {
   const out: Record<string, string> = {};
   for (const hieConfig of Object.values(hies)) {
-    const isStag = isStaging(config);
-    const secretName = getHiePasswordSecretName(hieConfig.name, isStag);
+    const secretName = getHieSftpPasswordSecretName(hieConfig.name);
     if (secretName) {
       out[secretName] = secretName;
     }

--- a/packages/infra/lib/shared/secrets.ts
+++ b/packages/infra/lib/shared/secrets.ts
@@ -2,8 +2,9 @@ import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 import { EnvConfig } from "../../config/env-config";
-import { isSandbox } from "./util";
+import { isSandbox, isStaging } from "./util";
 import { HieConfig, VpnlessHieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
+import { getHiePasswordSecretName } from "../secrets-stack";
 
 export type Secrets = { [key: string]: secret.ISecret };
 
@@ -45,18 +46,23 @@ export function getSecrets(scope: Construct, config: EnvConfig): Secrets {
       : undefined),
     ...(!isSandbox(config) ? buildSecrets(scope, config.analyticsPlatform.secrets) : undefined),
     ...(!isSandbox(config)
-      ? buildSecrets(scope, collectHiePasswordSecretNames(config.hl7Notification.hieConfigs))
+      ? buildSecrets(
+          scope,
+          collectHiePasswordSecretNames(config.hl7Notification.hieConfigs, config)
+        )
       : undefined),
   };
   return secrets;
 }
 
 function collectHiePasswordSecretNames(
-  hies: Record<string, HieConfig | VpnlessHieConfig>
+  hies: Record<string, HieConfig | VpnlessHieConfig>,
+  config: EnvConfig
 ): Record<string, string> {
   const out: Record<string, string> = {};
-  for (const config of Object.values(hies)) {
-    const secretName = config?.sftpConfig?.passwordSecretName;
+  for (const hieConfig of Object.values(hies)) {
+    const isStag = isStaging(config);
+    const secretName = getHiePasswordSecretName(hieConfig.name, isStag);
     if (secretName) {
       out[secretName] = secretName;
     }

--- a/packages/infra/lib/shared/secrets.ts
+++ b/packages/infra/lib/shared/secrets.ts
@@ -3,6 +3,7 @@ import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 import { EnvConfig } from "../../config/env-config";
 import { isSandbox } from "./util";
+import { HieConfig, VpnlessHieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
 
 export type Secrets = { [key: string]: secret.ISecret };
 
@@ -43,8 +44,24 @@ export function getSecrets(scope: Construct, config: EnvConfig): Secrets {
       ? buildSecrets(scope, config.hl7Notification?.secrets)
       : undefined),
     ...(!isSandbox(config) ? buildSecrets(scope, config.analyticsPlatform.secrets) : undefined),
+    ...(!isSandbox(config)
+      ? buildSecrets(scope, collectHiePasswordSecretNames(config.hl7Notification.hieConfigs))
+      : undefined),
   };
   return secrets;
+}
+
+function collectHiePasswordSecretNames(
+  hies: Record<string, HieConfig | VpnlessHieConfig>
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const config of Object.values(hies)) {
+    const secretName = config?.sftpConfig?.passwordSecretName;
+    if (secretName) {
+      out[secretName] = secretName;
+    }
+  }
+  return out;
 }
 
 export function secretsToECS(secrets: Secrets): Record<string, ecs.Secret> {

--- a/packages/infra/lib/shared/secrets.ts
+++ b/packages/infra/lib/shared/secrets.ts
@@ -5,6 +5,7 @@ import { EnvConfig } from "../../config/env-config";
 import { isSandbox } from "./util";
 import { HieConfig, VpnlessHieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
 import { getHieSftpPasswordSecretName } from "../secrets-stack";
+import { ROSTER_UPLOAD_SFTP_PASSWORD } from "@metriport/shared/domain/tcm-encounter";
 
 export type Secrets = { [key: string]: secret.ISecret };
 
@@ -59,7 +60,7 @@ function collectHiePasswordSecretNames(
   for (const hieConfig of Object.values(hies)) {
     const secretName = getHieSftpPasswordSecretName(hieConfig.name);
     if (secretName) {
-      out[secretName] = secretName;
+      out[ROSTER_UPLOAD_SFTP_PASSWORD] = secretName;
     }
   }
   return out;

--- a/packages/lambdas/src/hl7v2-roster.ts
+++ b/packages/lambdas/src/hl7v2-roster.ts
@@ -1,5 +1,4 @@
 import { Hl7v2RosterGenerator } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-roster-generator";
-import { uploadThroughSftp } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-roster-uploader";
 import { HieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
 import { capture } from "./shared/capture";
 import { getEnvOrFail } from "./shared/env";
@@ -21,22 +20,7 @@ export const handler = capture.wrapHandler(async (config: HieConfig): Promise<vo
   });
 
   log(`Starting roster generation for config: ${config.name}`);
-  const rosterCsv = await new Hl7v2RosterGenerator(apiUrl, bucketName).execute(config);
+  await new Hl7v2RosterGenerator(apiUrl, bucketName).execute(config);
   log(`Roster generation completed in ${timer.getElapsedTime()}ms`);
-
-  if (rosterCsv) {
-    const uploadTimer = initTimer();
-    try {
-      log(`Starting SFTP upload for config: ${config.name}`);
-      await uploadThroughSftp(config, rosterCsv);
-      log(`SFTP upload successful`);
-      //eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
-      log(`SFTP upload failed with error: ${err}`);
-    } finally {
-      log(`SFTP upload completed in ${uploadTimer.getElapsedTime()}ms`);
-    }
-  }
-
   log(`Done. Total duration: ${timer.getElapsedTime()}ms`);
 });

--- a/packages/lambdas/src/hl7v2-roster.ts
+++ b/packages/lambdas/src/hl7v2-roster.ts
@@ -26,9 +26,16 @@ export const handler = capture.wrapHandler(async (config: HieConfig): Promise<vo
 
   if (rosterCsv) {
     const uploadTimer = initTimer();
-    log(`Starting SFTP upload for config: ${config.name}`);
-    await uploadThroughSftp(config, rosterCsv);
-    log(`SFTP upload completed in ${uploadTimer.getElapsedTime()}ms`);
+    try {
+      log(`Starting SFTP upload for config: ${config.name}`);
+      await uploadThroughSftp(config, rosterCsv);
+      log(`SFTP upload successful`);
+      //eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      log(`SFTP upload failed with error: ${err}`);
+    } finally {
+      log(`SFTP upload completed in ${uploadTimer.getElapsedTime()}ms`);
+    }
   }
 
   log(`Done. Total duration: ${timer.getElapsedTime()}ms`);

--- a/packages/shared/src/domain/tcm-encounter.ts
+++ b/packages/shared/src/domain/tcm-encounter.ts
@@ -68,3 +68,5 @@ export const tcmEncounterListQuerySchema = tcmEncounterQuerySchema;
 export type TcmEncounterListQuery = z.infer<typeof tcmEncounterListQuerySchema>;
 
 export type TcmEncounterUpsertInput = z.input<typeof tcmEncounterUpsertSchema>;
+
+export const ROSTER_UPLOAD_SFTP_PASSWORD = "ROSTER_UPLOAD_SFTP_PASSWORD";

--- a/packages/shared/src/net/retry.ts
+++ b/packages/shared/src/net/retry.ts
@@ -8,6 +8,7 @@ import {
 } from "../common/retry";
 import { NetworkError, networkTimeoutErrors } from "./error";
 import { isMetriportError } from "../error/metriport-error";
+import plugin from "dayjs/plugin/duration";
 
 export const tooManyRequestsStatus = 429;
 const tooManyRequestsMultiplier = 3;
@@ -131,5 +132,18 @@ export async function executeWithNetworkRetries<T>(
       );
     },
     getTimeToWait: networkGetTimeToWait,
+  });
+}
+
+export async function simpleExecuteWithRetriesAsDuration<T>(
+  functionToExecute: () => Promise<T>,
+  maxAttempts: number,
+  initialDelay: plugin.Duration,
+  log: typeof console.log
+) {
+  return await executeWithNetworkRetries(functionToExecute, {
+    maxAttempts,
+    initialDelay: initialDelay.asMilliseconds(),
+    log,
   });
 }

--- a/packages/shared/src/net/retry.ts
+++ b/packages/shared/src/net/retry.ts
@@ -8,7 +8,7 @@ import {
 } from "../common/retry";
 import { NetworkError, networkTimeoutErrors } from "./error";
 import { isMetriportError } from "../error/metriport-error";
-import plugin from "dayjs/plugin/duration";
+import type { Duration } from "dayjs/plugin/duration";
 
 export const tooManyRequestsStatus = 429;
 const tooManyRequestsMultiplier = 3;
@@ -138,7 +138,7 @@ export async function executeWithNetworkRetries<T>(
 export async function simpleExecuteWithRetriesAsDuration<T>(
   functionToExecute: () => Promise<T>,
   maxAttempts: number,
-  initialDelay: plugin.Duration,
+  initialDelay: Duration,
   log: typeof console.log
 ) {
   return await executeWithNetworkRetries(functionToExecute, {

--- a/packages/shared/src/net/retry.ts
+++ b/packages/shared/src/net/retry.ts
@@ -9,6 +9,8 @@ import {
 import { NetworkError, networkTimeoutErrors } from "./error";
 import { isMetriportError } from "../error/metriport-error";
 import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+dayjs.extend(duration);
 
 export const tooManyRequestsStatus = 429;
 const tooManyRequestsMultiplier = 3;

--- a/packages/shared/src/net/retry.ts
+++ b/packages/shared/src/net/retry.ts
@@ -8,7 +8,7 @@ import {
 } from "../common/retry";
 import { NetworkError, networkTimeoutErrors } from "./error";
 import { isMetriportError } from "../error/metriport-error";
-import type { Duration } from "dayjs/plugin/duration";
+import dayjs from "dayjs";
 
 export const tooManyRequestsStatus = 429;
 const tooManyRequestsMultiplier = 3;
@@ -135,11 +135,14 @@ export async function executeWithNetworkRetries<T>(
   });
 }
 
-export async function simpleExecuteWithRetriesAsDuration<T>(
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_INITIAL_DELAY_DURATION = dayjs.duration({ seconds: 1 });
+
+export async function simpleExecuteWithRetries<T>(
   functionToExecute: () => Promise<T>,
-  maxAttempts: number,
-  initialDelay: Duration,
-  log: typeof console.log
+  log: typeof console.log,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  initialDelay = DEFAULT_INITIAL_DELAY_DURATION
 ) {
   return await executeWithNetworkRetries(functionToExecute, {
     maxAttempts,


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-850

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/3177

### Description

added automatic upload of adt roster to SFTP servers for HIEs

### Testing

- Local
  - [x] Ran script locally to create and upload adt roster to local sftp
- Staging
  - [x] Ran script on staging to create and upload adt roster to local sftp server using ngrok
  - [ ] Ran script on staging to create and upload adt roster to staging Hixny (HIE with a staging environment)
- Production
  - [ ] Run script in production to create and upload adt roster to local sftp server using ngrok


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - End-to-end SFTP roster upload with remote-path validation and Secrets Manager–backed credentials.

- Improvements
  - Unified retry wrapper for network operations with improved timing/logging.
  - Standardized roster file naming and storage key generation; upload now included in generation flow.

- Chores
  - Automated provisioning and mapping of per-HIE SFTP password secrets; roster lambdas granted secret access and receive password ARNs.

- Docs/Config
  - Example config now includes SFTP connection settings for HIEs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->