### PR TITLE
Fixed typo in docs (address cannot be empty)

### DIFF
--- a/docs/_snippets/demographics.mdx
+++ b/docs/_snippets/demographics.mdx
@@ -41,8 +41,8 @@
 </ParamField>
 
 <ParamField body="address" type="Address[]" required>
-  An array of `Address` objects, representing the Patient's current and/or previous addresses. May
-  be empty.
+  An array of `Address` objects, representing the Patient's current and/or previous addresses.
+
   <Snippet file="patient-address.mdx" />
 </ParamField>
 


### PR DESCRIPTION
Part of eng-852

Issues:

- https://linear.app/metriport/issue/ENG-852

### Dependencies
None
### Description
removed "May be empty" from " ... [patient] address. May be empty." because it indeed cannot be empty.

### Testing
Before (currently whats on prod):
<img width="1063" height="799" alt="Screenshot 2025-08-19 at 7 47 35 PM" src="https://github.com/user-attachments/assets/83e2b178-2af9-44cb-b6e1-a120f3164776" />


After (local):
<img width="999" height="524" alt="Screenshot 2025-08-19 at 7 47 45 PM" src="https://github.com/user-attachments/assets/d70c90ef-316d-492b-bd83-ab4ccef06d2d" />


- [ ] make sure change is also in staging. Once merged.

