### PR TITLE
Eng 200 cert runner updates

### DIFF
--- a/packages/api/src/external/commonwell-v2/api.ts
+++ b/packages/api/src/external/commonwell-v2/api.ts
@@ -57,8 +57,12 @@ export function makeCommonWellAPI(orgName: string, orgOID: string, npi: string):
     return new CommonWellMock(orgName, orgOID);
   }
 
-  const isMemberAPI = orgOID === Config.getCWMemberOID();
-  if (isMemberAPI) throw new Error("Cannot use the member OID as an organization OID");
+  const isMemberAPI = [Config.getCWMemberOID(), Config.getSystemRootOID()].includes(orgOID);
+  if (isMemberAPI) {
+    throw new MetriportError("Cannot use the member/root OID as an organization OID", undefined, {
+      orgOID,
+    });
+  }
 
   return new CommonWell({
     orgCert: Config.getCWOrgCertificate(),

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -237,6 +237,7 @@ export class Config {
   static getCWMemberOrgName(): string {
     return getEnvVarOrFail("CW_MEMBER_NAME");
   }
+  /** @deprecated TODO ENG-554 Remove this - CW v1 only */
   static getCWMemberOID(): string {
     return getEnvVarOrFail("CW_MEMBER_OID");
   }

--- a/packages/commonwell-cert-runner/README.md
+++ b/packages/commonwell-cert-runner/README.md
@@ -96,8 +96,8 @@ Create a `.env` file with the following required variables:
 
 ```env
 # Member (Service Adopter) credentials
+ROOT_OID=1.2.3.4.5.678
 CW_MEMBER_ID=your-member-id
-CW_MEMBER_OID=1.2.3.4.5.678
 CW_MEMBER_NAME=Your Member Name
 CW_MEMBER_CERTIFICATE="-----BEGIN CERTIFICATE-----
 ...

--- a/packages/commonwell-cert-runner/src/env.ts
+++ b/packages/commonwell-cert-runner/src/env.ts
@@ -1,7 +1,7 @@
 import { getEnv, getEnvOrFail } from "./util";
 
+export const rootOID = getEnvOrFail("ROOT_OID");
 export const memberId = getEnvOrFail("CW_MEMBER_ID");
-export const memberOID = getEnvOrFail("CW_MEMBER_OID");
 export const memberName = getEnvOrFail("CW_MEMBER_NAME");
 export const memberCertificateString = getEnvOrFail("CW_MEMBER_CERTIFICATE");
 export const memberPrivateKeyString = getEnvOrFail("CW_MEMBER_PRIVATE_KEY");

--- a/packages/commonwell-cert-runner/src/env.ts
+++ b/packages/commonwell-cert-runner/src/env.ts
@@ -19,8 +19,9 @@ export const orgGatewayAuthorizationClientSecret = getEnvOrFail(
   "CW_ORG_GATEWAY_AUTHORIZATION_CLIENT_SECRET"
 );
 /** If set, the cert runner will use this org and not try to create a new one. */
-export const existingOrgId = getEnv("CW_ORG_ID");
-export const existingInitiatorOnlyOrgId = getEnv("CW_INITIATOR_ONLY_ORG_ID");
+export const existingOrgOid = getEnv("CW_ORG_OID");
+export const existingInitiatorOnlyOrgOid = getEnv("CW_INITIATOR_ONLY_ORG_OID");
 
+export const contribExistingOrgOid = getEnv("CW_CONTRIB_ORG_OID");
 export const contribServerUrl = getEnvOrFail("CONTRIB_SERVER_URL");
 export const contribServerPort = parseInt(getEnvOrFail("CONTRIB_SERVER_PORT"));

--- a/packages/commonwell-cert-runner/src/env.ts
+++ b/packages/commonwell-cert-runner/src/env.ts
@@ -20,6 +20,7 @@ export const orgGatewayAuthorizationClientSecret = getEnvOrFail(
 );
 /** If set, the cert runner will use this org and not try to create a new one. */
 export const existingOrgId = getEnv("CW_ORG_ID");
+export const existingInitiatorOnlyOrgId = getEnv("CW_INITIATOR_ONLY_ORG_ID");
 
 export const contribServerUrl = getEnvOrFail("CONTRIB_SERVER_URL");
 export const contribServerPort = parseInt(getEnvOrFail("CONTRIB_SERVER_PORT"));

--- a/packages/commonwell-cert-runner/src/flows/contribution/contribution-server.ts
+++ b/packages/commonwell-cert-runner/src/flows/contribution/contribution-server.ts
@@ -8,7 +8,7 @@ import {
   buildSearchSetBundle,
 } from "@metriport/core/external/fhir/bundle/bundle";
 import express, { Application, Request, Response } from "express";
-import { contribServerPort, contribServerUrl, memberOID } from "../../env";
+import { contribServerPort, contribServerUrl } from "../../env";
 import { makeBinary } from "./binary";
 import { makeDocumentReference } from "./document-reference";
 import { makeToken, verifySignature } from "./token";
@@ -100,7 +100,6 @@ app.get("/oauth/fhir/DocumentReference", async (req: Request, res: Response): Pr
 
   const binaryId = faker.string.uuid();
   const docRef = makeDocumentReference({
-    memberOID,
     orgId: commonWell.oid,
     orgName: commonWell.orgName,
     patientId,

--- a/packages/commonwell-cert-runner/src/flows/contribution/contribution-server.ts
+++ b/packages/commonwell-cert-runner/src/flows/contribution/contribution-server.ts
@@ -39,11 +39,11 @@ app.post(
   express.urlencoded({ extended: true }),
   (req: Request, res: Response): void => {
     try {
-      console.log(`\nToken request`);
-      console.log(`>>> Headers: ${JSON.stringify(req.headers, null, 2)}`);
-      console.log(`>>> Path: ${req.path}`);
-      console.log(`>>> Query: ${JSON.stringify(req.query, null, 2)}`);
-      console.log(`>>> Body: ${JSON.stringify(req.body, null, 2)}`);
+      console.log(`[server] \nToken request`);
+      console.log(`[server] >>> Headers: ${JSON.stringify(req.headers, null, 2)}`);
+      console.log(`[server] >>> Path: ${req.path}`);
+      console.log(`[server] >>> Query: ${JSON.stringify(req.query, null, 2)}`);
+      console.log(`[server] >>> Body: ${JSON.stringify(req.body, null, 2)}`);
 
       const accessToken = makeToken(req, commonWell.oid, commonWell.orgName);
 
@@ -53,7 +53,7 @@ app.post(
       };
       res.status(200).json(oauthResponse);
     } catch (error) {
-      console.log("Token generation failed:", error);
+      console.log("[server] Token generation failed:", error);
       res.status(400).json({
         error: "invalid_request",
         error_description: error instanceof Error ? error.message : "Unknown error",
@@ -78,22 +78,22 @@ app.post(
  * "patient": "<org-oid>|<patient-id>",
  */
 app.get("/oauth/fhir/DocumentReference", async (req: Request, res: Response): Promise<void> => {
-  console.log(`\nDocumentReference request`);
-  console.log(`>>> Headers: ${JSON.stringify(req.headers, null, 2)}`);
-  console.log(`>>> Path: ${req.path}`);
-  console.log(`>>> Query: ${JSON.stringify(req.query, null, 2)}`);
-  console.log(`>>> Body: ${JSON.stringify(req.body, null, 2)}`);
+  console.log(`[server] \nDocumentReference request`);
+  console.log(`[server] >>> Headers: ${JSON.stringify(req.headers, null, 2)}`);
+  console.log(`[server] >>> Path: ${req.path}`);
+  console.log(`[server] >>> Query: ${JSON.stringify(req.query, null, 2)}`);
+  console.log(`[server] >>> Body: ${JSON.stringify(req.body, null, 2)}`);
 
   if (!verifySignature(req)) {
-    console.log(`Token verification failed`);
+    console.log(`[server] Token verification failed`);
     res.sendStatus(401);
     return;
   }
-  console.log(`Token verification successful!!!`);
+  console.log(`[server] Token verification successful!!!`);
 
   const patientId = (req.query.patient ?? req.query.subject ?? "").toString();
   if (!patientId) {
-    console.log(`>>> No patient ID found in query`);
+    console.log(`[server] >>> No patient ID found in query`);
     res.status(400).json(buildResponseMessage("No patient ID found in query"));
     return;
   }
@@ -118,18 +118,18 @@ app.get("/oauth/fhir/DocumentReference", async (req: Request, res: Response): Pr
  * that endpoint.
  */
 app.get("/oauth/fhir/Binary/:id", async (req: Request, res: Response): Promise<void> => {
-  console.log(`\nBinary request`);
-  console.log(`>>> Headers: ${JSON.stringify(req.headers, null, 2)}`);
-  console.log(`>>> Path: ${req.path}`);
-  console.log(`>>> Query: ${JSON.stringify(req.query, null, 2)}`);
-  console.log(`>>> Body: ${JSON.stringify(req.body, null, 2)}`);
+  console.log(`[server] \nBinary request`);
+  console.log(`[server] >>> Headers: ${JSON.stringify(req.headers, null, 2)}`);
+  console.log(`[server] >>> Path: ${req.path}`);
+  console.log(`[server] >>> Query: ${JSON.stringify(req.query, null, 2)}`);
+  console.log(`[server] >>> Body: ${JSON.stringify(req.body, null, 2)}`);
 
   if (!verifySignature(req)) {
-    console.log(`Token verification failed`);
+    console.log(`[server] Token verification failed`);
     res.sendStatus(401);
     return;
   }
-  console.log(`Token verification successful!!!`);
+  console.log(`[server] Token verification successful!!!`);
 
   const binary = makeBinary();
 
@@ -139,11 +139,11 @@ app.get("/oauth/fhir/Binary/:id", async (req: Request, res: Response): Promise<v
 app.use(express.json({ limit: "2mb" }));
 
 app.all("*", async (req: Request, res: Response): Promise<void> => {
-  console.log(`\nNOT FOUND`);
-  console.log(`>>> Headers: ${JSON.stringify(req.headers, null, 2)}`);
-  console.log(`>>> Path: ${req.path}`);
-  console.log(`>>> Query: ${JSON.stringify(req.query, null, 2)}`);
-  console.log(`>>> Body: ${JSON.stringify(req.body, null, 2)}`);
+  console.log(`[server] \nNOT FOUND`);
+  console.log(`[server] >>> Headers: ${JSON.stringify(req.headers, null, 2)}`);
+  console.log(`[server] >>> Path: ${req.path}`);
+  console.log(`[server] >>> Query: ${JSON.stringify(req.query, null, 2)}`);
+  console.log(`[server] >>> Body: ${JSON.stringify(req.body, null, 2)}`);
   res.sendStatus(404);
 });
 
@@ -157,7 +157,7 @@ export async function initContributionHttpServer(commonWellParam: CommonWell) {
 
   const port = contribServerPort;
   app.listen(port, "0.0.0.0", async () => {
-    console.log(`[server]: HTTP server is running on port ${port}`);
+    console.log(`[server] HTTP server is running on port ${port}`);
   });
 }
 

--- a/packages/commonwell-cert-runner/src/flows/contribution/document-reference.ts
+++ b/packages/commonwell-cert-runner/src/flows/contribution/document-reference.ts
@@ -1,14 +1,12 @@
 import { nanoid } from "nanoid";
 
 export function makeDocumentReference({
-  memberOID,
   orgId,
   orgName,
   patientId,
   docUrl,
   binaryId,
 }: {
-  memberOID: string;
   orgId: string;
   orgName: string;
   patientId: string;
@@ -22,7 +20,7 @@ export function makeDocumentReference({
     "meta": {
         "versionId": "19",
         "lastUpdated": "2023-02-24T16:07:16.796+00:00",
-        "source": "${memberOID}"
+        "source": "${orgId.includes("urn:oid:") ? orgId : `urn:oid:${orgId}`}"
     },
     "contained": [
         {

--- a/packages/commonwell-cert-runner/src/flows/document-consumption.ts
+++ b/packages/commonwell-cert-runner/src/flows/document-consumption.ts
@@ -8,7 +8,7 @@ import { contentType, extension } from "mime-types";
 import { nanoid } from "nanoid";
 import { makePatient } from "../payloads";
 import { patientTracyCrane } from "../payloads/patient-tracy";
-import { getMetriportPatientIdOrFail, logError, waitSeconds } from "../util";
+import { getMetriportPatientIdOrFail, logError } from "../util";
 
 const runTimestamp = buildDayjs().toISOString();
 
@@ -48,7 +48,7 @@ export async function documentConsumption(commonWell: CommonWell, downloadAll = 
       assignAuthority: commonWell.oid,
     });
 
-    await waitSeconds(5);
+    // await waitSeconds(5);
 
     const documents = await queryDocuments(commonWell, encodedPatientId);
     console.log(`>>> Got ${documents.length} documents`);

--- a/packages/commonwell-cert-runner/src/flows/document-consumption.ts
+++ b/packages/commonwell-cert-runner/src/flows/document-consumption.ts
@@ -48,8 +48,6 @@ export async function documentConsumption(commonWell: CommonWell, downloadAll = 
       assignAuthority: commonWell.oid,
     });
 
-    // await waitSeconds(5);
-
     const documents = await queryDocuments(commonWell, encodedPatientId);
     console.log(`>>> Got ${documents.length} documents`);
     for (const doc of documents) {

--- a/packages/commonwell-cert-runner/src/flows/link-management.ts
+++ b/packages/commonwell-cert-runner/src/flows/link-management.ts
@@ -5,7 +5,7 @@ import { uniq } from "lodash";
 import { makePatient } from "../payloads";
 import { patientTracyCrane } from "../payloads/patient-tracy";
 import { createProbablePatientSina } from "../payloads/probable-patient-sina";
-import { getMetriportPatientIdOrFail, logError, waitSeconds } from "../util";
+import { getMetriportPatientIdOrFail, logError } from "../util";
 
 /**
  * This flow is used to test the patient link management API.
@@ -38,7 +38,7 @@ export async function linkManagement(commonWell: CommonWell) {
       assignAuthority: commonWell.oid,
     });
 
-    await waitSeconds(5);
+    // await waitSeconds(5);
 
     console.log(`>>> 2.1.2 Get Patient Links - ID ${patientWithLinksId}`);
     const resp_2_1_2 = await commonWell.getPatientLinksByPatientId(patientWithLinksIdEncoded);
@@ -71,7 +71,7 @@ export async function linkManagement(commonWell: CommonWell) {
     if (!patientWithProbableLinks) throw new Error("Did not get a patient from the response");
     console.log(">>> 2.2.1 URLs to manage links: " + stringify(patientWithProbableLinks?.Links));
 
-    await waitSeconds(5);
+    // await waitSeconds(5);
 
     console.log(`>>> 2.2.2 Get Patient Links for ID ${patientWithProbableLinksId}`);
     const resp_2_2_2 = await commonWell.getPatientLinksByPatientId(
@@ -134,7 +134,7 @@ export async function linkManagement(commonWell: CommonWell) {
       console.log(">>> 2.3.2 Response: " + stringify(resp_2_3_2));
     }
 
-    await waitSeconds(5);
+    // await waitSeconds(5);
     console.log(`>>> 2.3.3 Get Patient Links for ID ${patientWithProbableLinksId}`);
     const resp_2_3_3 = await commonWell.getPatientLinksByPatientId(
       patientWithProbableLinksIdEnconded
@@ -150,7 +150,7 @@ export async function linkManagement(commonWell: CommonWell) {
 
     // Don't unlink patient 2 so we can check the reset link works (it should unlink it automatically)
 
-    await waitSeconds(5);
+    // await waitSeconds(5);
     console.log(`>>> 2.4.2 Get Patient Links - ID ${patientWithProbableLinksId}`);
     const resp_2_4_2 = await commonWell.getPatientLinksByPatientId(
       patientWithProbableLinksIdEnconded
@@ -171,7 +171,7 @@ export async function linkManagement(commonWell: CommonWell) {
     console.log(">>> Transaction ID: " + commonWell.lastTransactionId);
     console.log(">>> 2.5.1 Response: " + stringify(resp_2_5_1));
 
-    await waitSeconds(5);
+    // await waitSeconds(5);
     console.log(`>>> 2.5.2 Get Patient Links - ID ${patientWithProbableLinksId}`);
     const resp_2_5_2 = await commonWell.getPatientLinksByPatientId(
       patientWithProbableLinksIdEnconded

--- a/packages/commonwell-cert-runner/src/flows/link-management.ts
+++ b/packages/commonwell-cert-runner/src/flows/link-management.ts
@@ -38,8 +38,6 @@ export async function linkManagement(commonWell: CommonWell) {
       assignAuthority: commonWell.oid,
     });
 
-    // await waitSeconds(5);
-
     console.log(`>>> 2.1.2 Get Patient Links - ID ${patientWithLinksId}`);
     const resp_2_1_2 = await commonWell.getPatientLinksByPatientId(patientWithLinksIdEncoded);
     console.log(">>> Transaction ID: " + commonWell.lastTransactionId);
@@ -70,8 +68,6 @@ export async function linkManagement(commonWell: CommonWell) {
     console.log(">>> 2.2.1 Get Patient Response: " + stringify(patientWithProbableLinks));
     if (!patientWithProbableLinks) throw new Error("Did not get a patient from the response");
     console.log(">>> 2.2.1 URLs to manage links: " + stringify(patientWithProbableLinks?.Links));
-
-    // await waitSeconds(5);
 
     console.log(`>>> 2.2.2 Get Patient Links for ID ${patientWithProbableLinksId}`);
     const resp_2_2_2 = await commonWell.getPatientLinksByPatientId(
@@ -134,7 +130,6 @@ export async function linkManagement(commonWell: CommonWell) {
       console.log(">>> 2.3.2 Response: " + stringify(resp_2_3_2));
     }
 
-    // await waitSeconds(5);
     console.log(`>>> 2.3.3 Get Patient Links for ID ${patientWithProbableLinksId}`);
     const resp_2_3_3 = await commonWell.getPatientLinksByPatientId(
       patientWithProbableLinksIdEnconded
@@ -150,7 +145,6 @@ export async function linkManagement(commonWell: CommonWell) {
 
     // Don't unlink patient 2 so we can check the reset link works (it should unlink it automatically)
 
-    // await waitSeconds(5);
     console.log(`>>> 2.4.2 Get Patient Links - ID ${patientWithProbableLinksId}`);
     const resp_2_4_2 = await commonWell.getPatientLinksByPatientId(
       patientWithProbableLinksIdEnconded
@@ -170,8 +164,6 @@ export async function linkManagement(commonWell: CommonWell) {
     const resp_2_5_1 = await commonWell.resetPatientLinks(urlToResetPatientLinks);
     console.log(">>> Transaction ID: " + commonWell.lastTransactionId);
     console.log(">>> 2.5.1 Response: " + stringify(resp_2_5_1));
-
-    // await waitSeconds(5);
     console.log(`>>> 2.5.2 Get Patient Links - ID ${patientWithProbableLinksId}`);
     const resp_2_5_2 = await commonWell.getPatientLinksByPatientId(
       patientWithProbableLinksIdEnconded

--- a/packages/commonwell-cert-runner/src/flows/org-management-initiator-only.ts
+++ b/packages/commonwell-cert-runner/src/flows/org-management-initiator-only.ts
@@ -1,0 +1,93 @@
+import { faker } from "@faker-js/faker";
+import { APIMode, CommonWell, CommonWellMember } from "@metriport/commonwell-sdk";
+import { errorToString } from "@metriport/shared";
+import {
+  existingInitiatorOnlyOrgId,
+  memberCertificateString,
+  memberId,
+  memberName,
+  memberPrivateKeyString,
+} from "../env";
+import { makeOrganization } from "../payloads";
+
+export type OrgManagementResponse = {
+  commonWell: CommonWell;
+};
+
+/**
+ * Flow to validate the org management API (item 8.2.2 in the spec).
+ *
+ * @see https://www.commonwellalliance.org/specification/
+ */
+export async function orgManagementInitiatorOnly(): Promise<void> {
+  const commonWellMember = new CommonWellMember({
+    orgCert: memberCertificateString,
+    rsaPrivateKey: memberPrivateKeyString,
+    memberName: memberName,
+    memberId,
+    apiMode: APIMode.integration,
+  });
+  const errors: unknown[] = [];
+
+  console.log(`>>> ---------------------- Initiator Only ----------------------`);
+  try {
+    console.log(`>>> Create an initiator only org`);
+    const initiatorOnlyOrgCreate = makeOrganization();
+    initiatorOnlyOrgCreate.securityTokenKeyType = null;
+    initiatorOnlyOrgCreate.authorizationInformation = null;
+    // console.log(`Request payload: ${JSON.stringify(org, null, 2)}`);
+    const respCreateInitiatorOnly = await commonWellMember.createOrg(initiatorOnlyOrgCreate);
+    console.log(">>> Transaction ID: " + commonWellMember.lastTransactionId);
+    console.log(">>> Response: " + JSON.stringify(respCreateInitiatorOnly, null, 2));
+    const initiatorOnlyOrgId = respCreateInitiatorOnly.organizationId;
+
+    console.log(`>>> Get one org`);
+    const respGetInitiatorOnly = await commonWellMember.getOneOrg(initiatorOnlyOrgId);
+    console.log(">>> Transaction ID: " + commonWellMember.lastTransactionId);
+    console.log(">>> Response: " + JSON.stringify(respGetInitiatorOnly, null, 2));
+    if (!respGetInitiatorOnly) throw new Error("No org on response from getOneOrg");
+    const initiatorOnlyOrg = respGetInitiatorOnly;
+
+    console.log(`>>> Update an org`);
+    initiatorOnlyOrg.locations[0].city = faker.location.city();
+    const respUpdateInitiatorOnly = await commonWellMember.updateOrg(initiatorOnlyOrg);
+    console.log(">>> Transaction ID: " + commonWellMember.lastTransactionId);
+    console.log(">>> Response: " + JSON.stringify(respUpdateInitiatorOnly, null, 2));
+  } catch (error) {
+    console.log(`Error (txId ${commonWellMember.lastTransactionId}): ${errorToString(error)}`);
+    errors.push(error);
+  }
+  try {
+    const orgId = existingInitiatorOnlyOrgId;
+    if (!orgId) throw new Error("No org ID to run initiator only org update flow");
+
+    console.log(`>>> Get one org`);
+    const respGetInitiatorOnly = await commonWellMember.getOneOrg(orgId);
+    console.log(">>> Transaction ID: " + commonWellMember.lastTransactionId);
+    console.log(">>> Response: " + JSON.stringify(respGetInitiatorOnly, null, 2));
+    if (!respGetInitiatorOnly) throw new Error("No org on response from getOneOrg");
+    const initiatorOnlyOrg = respGetInitiatorOnly;
+
+    if (initiatorOnlyOrg.securityTokenKeyType) {
+      console.log(`HEADS UP: Security token key type is not null`);
+    }
+    if (initiatorOnlyOrg.authorizationInformation) {
+      console.log(`HEADS UP: Authorization information is not null`);
+    }
+    initiatorOnlyOrg.authorizationInformation = null;
+    initiatorOnlyOrg.securityTokenKeyType = null;
+
+    console.log(`>>> Update the org`);
+    initiatorOnlyOrg.locations[0].city = faker.location.city();
+    const respUpdateInitiatorOnly = await commonWellMember.updateOrg(initiatorOnlyOrg);
+    console.log(">>> Transaction ID: " + commonWellMember.lastTransactionId);
+    console.log(">>> Response: " + JSON.stringify(respUpdateInitiatorOnly, null, 2));
+  } catch (error) {
+    console.log(`Error (txId ${commonWellMember.lastTransactionId}): ${errorToString(error)}`);
+    errors.push(error);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Failed to run org management initiator only flow: ${errors.join(", ")}`);
+  }
+}

--- a/packages/commonwell-cert-runner/src/flows/org-management-initiator-only.ts
+++ b/packages/commonwell-cert-runner/src/flows/org-management-initiator-only.ts
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker";
 import { APIMode, CommonWell, CommonWellMember } from "@metriport/commonwell-sdk";
 import { errorToString } from "@metriport/shared";
 import {
-  existingInitiatorOnlyOrgId,
+  existingInitiatorOnlyOrgOid,
   memberCertificateString,
   memberId,
   memberName,
@@ -58,7 +58,8 @@ export async function orgManagementInitiatorOnly(): Promise<void> {
     errors.push(error);
   }
   try {
-    const orgId = existingInitiatorOnlyOrgId;
+    const orgId = existingInitiatorOnlyOrgOid;
+    // TODO can try to create one if not provided - was failing before b/c of the cache issue on CW's end
     if (!orgId) throw new Error("No org ID to run initiator only org update flow");
 
     console.log(`>>> Get one org`);
@@ -68,14 +69,17 @@ export async function orgManagementInitiatorOnly(): Promise<void> {
     if (!respGetInitiatorOnly) throw new Error("No org on response from getOneOrg");
     const initiatorOnlyOrg = respGetInitiatorOnly;
 
-    if (initiatorOnlyOrg.securityTokenKeyType) {
+    if ("securityTokenKeyType" in initiatorOnlyOrg && initiatorOnlyOrg.securityTokenKeyType) {
       console.log(`HEADS UP: Security token key type is not null`);
+      delete initiatorOnlyOrg.securityTokenKeyType;
     }
-    if (initiatorOnlyOrg.authorizationInformation) {
+    if (
+      "authorizationInformation" in initiatorOnlyOrg &&
+      initiatorOnlyOrg.authorizationInformation
+    ) {
       console.log(`HEADS UP: Authorization information is not null`);
+      delete initiatorOnlyOrg.authorizationInformation;
     }
-    initiatorOnlyOrg.authorizationInformation = null;
-    initiatorOnlyOrg.securityTokenKeyType = null;
 
     console.log(`>>> Update the org`);
     initiatorOnlyOrg.locations[0].city = faker.location.city();

--- a/packages/commonwell-cert-runner/src/flows/org-management.ts
+++ b/packages/commonwell-cert-runner/src/flows/org-management.ts
@@ -8,7 +8,7 @@ import {
 } from "@metriport/commonwell-sdk";
 import { errorToString } from "@metriport/shared";
 import {
-  existingOrgId,
+  existingOrgOid,
   memberCertificateString,
   memberId,
   memberName,
@@ -39,7 +39,7 @@ export async function orgManagement(): Promise<OrgManagementResponse> {
   // TODO ENG-200 gotta set Gateway > FHIR and Auth server's info
 
   try {
-    let orgId: string | undefined = existingOrgId;
+    let orgId: string | undefined = existingOrgOid;
     if (orgId) {
       const org = await getOneOrg(commonWellMember, orgId);
       return buildResponse(org);
@@ -183,7 +183,7 @@ export async function getOneOrg(
 }
 
 export async function initApiForExistingOrg(): Promise<OrgManagementResponse> {
-  const orgId = existingOrgId;
+  const orgId = existingOrgOid;
   if (!orgId) {
     throw new Error("No existing orgId found in env, this is required");
   }

--- a/packages/commonwell-cert-runner/src/flows/org-management.ts
+++ b/packages/commonwell-cert-runner/src/flows/org-management.ts
@@ -7,7 +7,6 @@ import {
   Organization,
 } from "@metriport/commonwell-sdk";
 import { errorToString } from "@metriport/shared";
-import { makeNPI } from "@metriport/shared/common/__tests__/npi";
 import {
   existingOrgId,
   memberCertificateString,
@@ -46,13 +45,16 @@ export async function orgManagement(): Promise<OrgManagementResponse> {
       return buildResponse(org);
     }
 
-    console.log(`>>> Create an org`);
+    console.log(`>>> ---------------------- Initiator and Responder ----------------------`);
+
+    console.log(`>>> Create an initiator and responder org`);
     const orgToCreate = makeOrganization();
     // console.log(`Request payload: ${JSON.stringify(org, null, 2)}`);
     const respCreateOrg = await commonWellMember.createOrg(orgToCreate);
     console.log(">>> Transaction ID: " + commonWellMember.lastTransactionId);
     console.log(">>> Response: " + JSON.stringify(respCreateOrg, null, 2));
     orgId = respCreateOrg.organizationId;
+    if (!orgId) throw new Error("No orgId on response from createOrg");
 
     console.log(`>>> Get one org`);
     const respGetOneOrg = await commonWellMember.getOneOrg(orgId);
@@ -68,8 +70,6 @@ export async function orgManagement(): Promise<OrgManagementResponse> {
 
     console.log(`>>> Update an org`);
     org.locations[0].city = faker.location.city();
-    if (!org.npiType2) org.npiType2 = makeNPI();
-    if (!orgId) throw new Error("No orgId on response from createOrg");
     const respUpdateOrg = await commonWellMember.updateOrg(org);
     console.log(">>> Transaction ID: " + commonWellMember.lastTransactionId);
     console.log(">>> Response: " + JSON.stringify(respUpdateOrg, null, 2));

--- a/packages/commonwell-cert-runner/src/index.ts
+++ b/packages/commonwell-cert-runner/src/index.ts
@@ -6,6 +6,7 @@ import { documentConsumption } from "./flows/document-consumption";
 import { documentContribution } from "./flows/document-contribution";
 import { linkManagement } from "./flows/link-management";
 import { orgManagement } from "./flows/org-management";
+import { orgManagementInitiatorOnly } from "./flows/org-management-initiator-only";
 import { patientManagement } from "./flows/patient-management";
 import { logError } from "./util";
 
@@ -47,6 +48,7 @@ async function main() {
   try {
     // Run through the CommonWell certification test cases
     const { commonWell } = await orgManagement();
+    await orgManagementInitiatorOnly().catch(() => failedFlows.push("initiatorOnlyOrgManagement"));
     await patientManagement(commonWell).catch(() => failedFlows.push("patientManagement"));
     await linkManagement(commonWell).catch(() => failedFlows.push("linkManagement"));
     await documentConsumption(commonWell).catch(() => failedFlows.push("documentConsumption"));

--- a/packages/commonwell-cert-runner/src/payloads.ts
+++ b/packages/commonwell-cert-runner/src/payloads.ts
@@ -16,12 +16,12 @@ import * as nanoid from "nanoid";
 import {
   memberCertificateString,
   memberName,
-  memberOID,
   orgCertificateString,
   orgGatewayAuthorizationClientId,
   orgGatewayAuthorizationClientSecret,
   orgGatewayAuthorizationServerEndpoint,
   orgGatewayEndpoint,
+  rootOID,
 } from "./env";
 import { getCertificateContent, makeShortName } from "./util";
 
@@ -37,7 +37,7 @@ export function makeId(): string {
 }
 export function makeOrgId(orgId?: string): string {
   const org = orgId ?? makeId();
-  return `${memberOID}.${ORGANIZATION}.${org}`;
+  return `${rootOID}.${ORGANIZATION}.${org}`;
 }
 export function makeFacilityId(orgId?: string): string {
   const facility = makeId();
@@ -170,7 +170,7 @@ export function makeOrganization(suffixId?: string): OrganizationWithNetworkInfo
             queryResponder: true,
           },
         ],
-        // TODO ENG-200 address this
+        // TODO ENG-541 address this
         // doa: [],
       },
     ],

--- a/packages/commonwell-cert-runner/src/single-commands/init-contrib-server.ts
+++ b/packages/commonwell-cert-runner/src/single-commands/init-contrib-server.ts
@@ -3,7 +3,7 @@ dotenv.config();
 // keep that ^ above all other imports
 import { APIMode, CommonWell, Organization } from "@metriport/commonwell-sdk";
 import { makeNPI } from "@metriport/shared/common/__tests__/npi";
-import { existingOrgId, memberOID, orgCertificateString, orgPrivateKeyString } from "../env";
+import { existingOrgId, orgCertificateString, orgPrivateKeyString } from "../env";
 import { initContributionHttpServer } from "../flows/contribution/contribution-server";
 
 /**
@@ -23,7 +23,7 @@ export async function main() {
     rsaPrivateKey: orgPrivateKeyString,
     orgName: org.name,
     oid: org.organizationId,
-    homeCommunityId: memberOID,
+    homeCommunityId: org.organizationId,
     npi: org.npiType2,
     apiMode: APIMode.integration,
   });

--- a/packages/commonwell-cert-runner/src/single-commands/init-contrib-server.ts
+++ b/packages/commonwell-cert-runner/src/single-commands/init-contrib-server.ts
@@ -3,14 +3,14 @@ dotenv.config();
 // keep that ^ above all other imports
 import { APIMode, CommonWell, Organization } from "@metriport/commonwell-sdk";
 import { makeNPI } from "@metriport/shared/common/__tests__/npi";
-import { existingOrgId, orgCertificateString, orgPrivateKeyString } from "../env";
+import { existingOrgOid, orgCertificateString, orgPrivateKeyString } from "../env";
 import { initContributionHttpServer } from "../flows/contribution/contribution-server";
 
 /**
  * Supporting function used to get a patient by ID.
  */
 export async function main() {
-  const organizationId = existingOrgId;
+  const organizationId = existingOrgOid;
   if (!organizationId) throw new Error("Organization ID is required");
   const org: Pick<Organization, "name" | "organizationId" | "npiType2"> = {
     name: "Test Organization",


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-200

### Dependencies 
- Downstream: https://github.com/metriport/metriport/pull/4403

### Description
- Some updates to the `commonwell-cert-runner` - all of @leite08's work
- This doesn't handle the `initiatorOnly` scenario - that's addressed in the downstream PR

### Testing
- Refer to downstream PR

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added initiator-only organization management flow to the certification runner.

- Changes
  - Environment variables updated to use Root OID and new existing-org OIDs; support reusing a consumer org.
  - Document metadata now derives from the organization ID.
  - Server logs standardized with “[server]” prefix.
  - Removed artificial wait delays for faster flows; added an extra link-check for clearer results.

- Documentation
  - README updated to reflect ROOT_OID and environment variable changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->