### PR TITLE
fix(api): small fixes for filepath rebuilding

### DIFF
--- a/packages/core/src/domain/document/upload.ts
+++ b/packages/core/src/domain/document/upload.ts
@@ -35,7 +35,7 @@ export function createAttachmentUploadFilePath({
 }
 
 export function rebuildUploadsFilePath(id: string): string {
-  if (id.includes(UPLOADS_FOLDER)) return id;
+  if (id.includes(`/${UPLOADS_FOLDER}/`)) return id;
 
   const idWithoutLeadingSlash = id.startsWith("/") ? id.slice(1) : id;
   const fileNameParts = parseFileName(idWithoutLeadingSlash);

--- a/packages/core/src/domain/document/upload.ts
+++ b/packages/core/src/domain/document/upload.ts
@@ -37,8 +37,7 @@ export function createAttachmentUploadFilePath({
 export function rebuildUploadsFilePath(id: string): string {
   if (id.includes(`/${UPLOADS_FOLDER}/`)) return id;
 
-  const idWithoutLeadingSlash = id.startsWith("/") ? id.slice(1) : id;
-  const fileNameParts = parseFileName(idWithoutLeadingSlash);
+  const fileNameParts = parseFileName(id);
   if (!fileNameParts) return id;
 
   return createUploadFilePath(fileNameParts.cxId, fileNameParts.patientId, fileNameParts.fileId);

--- a/packages/core/src/domain/document/upload.ts
+++ b/packages/core/src/domain/document/upload.ts
@@ -35,7 +35,7 @@ export function createAttachmentUploadFilePath({
 }
 
 export function rebuildUploadsFilePath(id: string): string {
-  if (id.includes("/")) return id;
+  if (id.includes(UPLOADS_FOLDER)) return id;
 
   const fileNameParts = parseFileName(id);
   if (!fileNameParts) return id;

--- a/packages/core/src/domain/document/upload.ts
+++ b/packages/core/src/domain/document/upload.ts
@@ -37,7 +37,8 @@ export function createAttachmentUploadFilePath({
 export function rebuildUploadsFilePath(id: string): string {
   if (id.includes(UPLOADS_FOLDER)) return id;
 
-  const fileNameParts = parseFileName(id);
+  const idWithoutLeadingSlash = id.startsWith("/") ? id.slice(1) : id;
+  const fileNameParts = parseFileName(idWithoutLeadingSlash);
   if (!fileNameParts) return id;
 
   return createUploadFilePath(fileNameParts.cxId, fileNameParts.patientId, fileNameParts.fileId);

--- a/packages/core/src/shareback/metadata/parse-metadata-xml.ts
+++ b/packages/core/src/shareback/metadata/parse-metadata-xml.ts
@@ -106,29 +106,16 @@ export async function parseExtrinsicObjectXmlToDocumentReference({
 
   extrinsicObject.ExternalIdentifier.forEach(identifier => {
     switch (identifier.$.identificationScheme) {
-      case XDSDocumentEntryUniqueId:
-        {
-          const raw = identifier.$.value;
-          let decoded = raw;
-          try {
-            decoded = base64ToString(raw);
-          } catch {
-            // non-base64 input; keep raw to avoid hard-fail
-          }
-          const filePath = rebuildUploadsFilePath(decoded);
-          // S3 object keys should not start with '/', and should be URL-encoded
-          const s3Key = filePath.replace(/^\/+/, "");
-          const url = `https://${Config.getMedicalDocumentsBucketName()}.s3.${Config.getAWSRegion()}.amazonaws.com/${encodeURI(
-            s3Key
-          )}`;
-          const title = s3Key.split("/").pop() ?? s3Key;
-          docRefContent.attachment = {
-            ...docRefContent.attachment,
-            url,
-            title,
-          };
-        }
+      case XDSDocumentEntryUniqueId: {
+        const stringValue = base64ToString(identifier.$.value);
+        const filePath = rebuildUploadsFilePath(stringValue);
+        docRefContent.attachment = {
+          ...docRefContent.attachment,
+          url: `https://${Config.getMedicalDocumentsBucketName()}.s3.${Config.getAWSRegion()}.amazonaws.com/${filePath}`,
+          title: filePath,
+        };
         break;
+      }
     }
   });
   documentReference.content = [docRefContent];

--- a/packages/core/src/shareback/metadata/parse-metadata-xml.ts
+++ b/packages/core/src/shareback/metadata/parse-metadata-xml.ts
@@ -105,16 +105,15 @@ export async function parseExtrinsicObjectXmlToDocumentReference({
   });
 
   extrinsicObject.ExternalIdentifier.forEach(identifier => {
-    const value = rebuildUploadsFilePath(identifier.$.value);
+    const stringValue = base64ToString(identifier.$.value);
+    const filePath = rebuildUploadsFilePath(stringValue);
 
     switch (identifier.$.identificationScheme) {
       case XDSDocumentEntryUniqueId:
         docRefContent.attachment = {
           ...docRefContent.attachment,
-          url: `https://${Config.getMedicalDocumentsBucketName()}.s3.${Config.getAWSRegion()}.amazonaws.com/${base64ToString(
-            value
-          )}`,
-          title: base64ToString(value),
+          url: `https://${Config.getMedicalDocumentsBucketName()}.s3.${Config.getAWSRegion()}.amazonaws.com/${filePath}`,
+          title: filePath,
         };
         break;
     }


### PR DESCRIPTION
Part of ENG-000

Issues:

- https://linear.app/metriport/issue/ENG-000

### Description
- Fixing the logic for how we decide whether to rebuild the uploads filepath

### Testing
- Refer to this PR:
- https://github.com/metriport/metriport/pull/4424

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents incorrect early exits for IDs that merely include upload-folder segments, ensuring full path processing.
  * Decodes embedded identifier values before reconstructing paths so URLs and titles reflect the actual file location.
  * Preserves the fallback behavior when filename parsing fails, returning the original identifier unchanged.
  * Improves reliability of upload and metadata handling across varied ID formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->