### PR TITLE
ENG-881: Support custom column sorts in tcm encounter pagination

### DIFF
--- a/packages/api/src/routes/medical/tcm-encounter.ts
+++ b/packages/api/src/routes/medical/tcm-encounter.ts
@@ -66,6 +66,9 @@ router.get(
       ...(query.eventType ? { eventType: query.eventType } : {}),
       ...(query.coding ? { coding: query.coding } : {}),
       ...(query.status ? { status: query.status } : {}),
+      ...(query.admitTimeSort ? { admitTimeSort: query.admitTimeSort } : {}),
+      ...(query.dischargeTimeSort ? { dischargeTimeSort: query.dischargeTimeSort } : {}),
+      ...(query.lastOutreachDateSort ? { lastOutreachDateSort: query.lastOutreachDateSort } : {}),
     };
 
     const result = await paginated({

--- a/packages/shared/src/domain/tcm-encounter.ts
+++ b/packages/shared/src/domain/tcm-encounter.ts
@@ -67,8 +67,20 @@ const tcmEncounterQuerySchema = z
     eventType: z.enum(["Admitted", "Discharged"] as const).optional(),
     coding: z.enum(["cardiac"]).optional(),
     status: z.enum(outreachStatuses).optional(),
+    admitTimeSort: z.enum(["asc", "desc"]).optional(),
+    dischargeTimeSort: z.enum(["asc", "desc"]).optional(),
+    lastOutreachDateSort: z.enum(["asc", "desc"]).optional(),
   })
-  .and(createQueryMetaSchema(tcmEncounterMaxPageSize));
+  .and(createQueryMetaSchema(tcmEncounterMaxPageSize))
+  .refine(
+    data => {
+      const sortFields = [data.admitTimeSort, data.dischargeTimeSort, data.lastOutreachDateSort];
+      return sortFields.filter(Boolean).length <= 1;
+    },
+    {
+      message: "Only one sort field can be defined at a time",
+    }
+  );
 
 export const tcmEncounterListQuerySchema = tcmEncounterQuerySchema;
 export type TcmEncounterListQuery = z.infer<typeof tcmEncounterListQuerySchema>;


### PR DESCRIPTION
### Dependencies

- Downstream: https://github.com/metriport/metriport-internal/pull/3180

### Description

This adds custom sorts to our cursor based pagination functionality of the tcm encounters.

### Testing

See downstream for test cases.

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-column sorting on TCM Encounters by Admit Time, Discharge Time, or Last Outreach Date.
  * Sorting integrates with existing pagination and falls back to default ordering when no column sort is provided.
  * API accepts optional query parameters: admitTimeSort, dischargeTimeSort, lastOutreachDateSort (asc/desc).

* **Bug Fixes**
  * Enforces that only one sort parameter can be used at a time, returning a clear validation error if violated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->