### PR TITLE
PATCH RELEASE - ENG-887: Fixing Condition dates on FHIR converter

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Sections/Problems.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Problems.hbs
@@ -29,7 +29,7 @@
         {{#each (multipleToArray 2_16_840_1_113883_10_20_22_2_5_1.entry 2_16_840_1_113883_10_20_22_2_5.entry) as |problems|}}
             {{#each (toArray problems.act.entryRelationship) as |condEntry|}}
                 {{#if condEntry.observation}}
-                    {{>Resources/Condition.hbs conditionEntry=condEntry.observation ID=(generateUUID (toJsonString condEntry.observation))}},
+                    {{>Resources/Condition.hbs conditionEntry=condEntry.observation encounterDate=problems.act.effectiveTime ID=(generateUUID (toJsonString condEntry.observation))}},
                     {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
                         {{>References/Condition/subject.hbs ID=(generateUUID (toJsonString condEntry.observation)) REF=(concat 'Patient/' patientId.Id)}},
                     {{/with}}

--- a/packages/fhir-converter/src/templates/cda/Utils/PeriodOrDefaultPeriod.hbs
+++ b/packages/fhir-converter/src/templates/cda/Utils/PeriodOrDefaultPeriod.hbs
@@ -24,7 +24,7 @@
   //     CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.  
   // -------------------------------------------------------------------------------------------------
 --}}
-{{#if (nullFlavorAwareOr period.low period.high)}}
+{{#if (or (nullFlavorAwareOr period.low period.high) (nullFlavorAwareOr period.value))}}
     {{>DataType/Period.hbs period=period}}
 {{else}}
     {{>DataType/Period.hbs period=@encounterTimePeriod}}


### PR DESCRIPTION
Part of ENG-887

### Description

- Conditions from the Problems section now inherit the `act.effectiveTime` as the backup date, in case the Condition entry is missing it
- Conditions from the Encounters section will now properly inherit the Encounter date - there used to be a missing if-condition on the downstream function

### Testing

- Local
  - [x] Problematic file now shows proper dates! 🙌 
  - [x] Run the full FHIR testing suite
- Production
  - [ ] Rerun the problematic patient and confirm great results

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Conditions derived from problem entries now include the associated encounter date when available, improving clinical timelines.
- Bug Fixes
  - Time periods now render when a single period value is present, not only when start/end bounds exist, reducing unintended fallbacks to default encounter periods.
  - Improved consistency and completeness of condition and period dates across converted records, minimizing missing or misleading time information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->