### PR TITLE
PATCH ENG-850: Increase ADT roster upload timeouts

### DIFF
--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -1045,6 +1045,7 @@ export class LambdasNestedStack extends NestedStack {
             ROSTER_UPLOAD_SFTP_PASSWORD_ARN: passwordSecret.secretArn,
             ...(sentryDsn ? { SENTRY_DSN: sentryDsn } : {}),
           },
+          timeout: Duration.minutes(10),
           layers: [lambdaLayers.shared],
           memory: 4096,
           vpc,


### PR DESCRIPTION
### Dependencies

None

### Description

This fixes timeouts happening for longer running roster uploads because we currently have no index on the `patient_settings` table for adt subscriptions.

Ticket for future fix is [here](https://linear.app/metriport/issue/ENG-907/create-index-on-patient-settings-table-to-speed-up-roster-creation)

### Testing

Trivial

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum execution time for the scheduled roster upload job to prevent premature timeouts during large or slow runs, improving reliability and completion rates for bigger datasets and peak-load scenarios.

* **Chores**
  * Infrastructure configuration updated to support longer-running roster uploads without altering functional behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->