### PR TITLE
ENG-850: Add index to patient_subscriptions for faster roster generation

### DIFF
--- a/packages/api/src/sequelize/migrations/2025-08-20_00_add-patient-settings-subscriptions-gin-index.ts
+++ b/packages/api/src/sequelize/migrations/2025-08-20_00_add-patient-settings-subscriptions-gin-index.ts
@@ -1,0 +1,19 @@
+import type { Migration } from "..";
+
+const tableName = "patient_settings";
+const columnName = "subscriptions";
+const indexName = "idx_patient_settings_subscriptions_gin";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.query(`
+    CREATE INDEX ${indexName}
+    ON ${tableName} 
+    USING GIN (${columnName});
+  `);
+};
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.query(`
+    DROP INDEX IF EXISTS ${indexName};
+  `);
+};


### PR DESCRIPTION
### Dependencies

None

### Description

- The last PR was meant to add an index but i forgot to add the migration to the diff https://github.com/metriport/metriport/pull/4444

Roster generation is slow lets add an index on all the content in the subscriptions jsonb column since it's very common that we'll be wanting to run where clauses over the settings in the subscriptions column.

See issue [here](https://linear.app/metriport/issue/ENG-907/create-index-on-patient-settings-table-to-speed-up-roster-creation)

### Testing

- Local
  - [x] Migration applies successfully
  - [x] Migration rolls back successfully
- Production
  - [ ] Do adt roster gen

### Release Plan

- :warning: This contains a DB migration
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Performance
  * Faster lookups and filtering for patient subscriptions, improving responsiveness in areas that depend on patient settings.
* Improvements
  * More reliable patient roster uploads in cloud environments through standardized job naming.
  * Clearer runtime logging when generating HL7v2 patient rosters (environment and HIE name), aiding operational visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->