### PR TITLE
Eng 714 add roster generation reporting analytics

### DIFF
--- a/packages/core/src/external/analytics/posthog.ts
+++ b/packages/core/src/external/analytics/posthog.ts
@@ -70,6 +70,7 @@ export enum EventTypes {
   inboundDocumentQuery = "inbound.documentQuery",
   inboundDocumentRetrieval = "inbound.documentRetrieval",
   dischargeRequery = "dischargeRequery",
+  rosterUploadSummary = "rosterUploadSummary",
 }
 
 export enum EventErrMessage {

--- a/packages/core/src/external/aws/cloudwatch.ts
+++ b/packages/core/src/external/aws/cloudwatch.ts
@@ -1,7 +1,7 @@
 import AWS from "aws-sdk";
 import { Config } from "../../util/config";
 import { capture } from "../../util/notifications";
-import { MetriportError } from "@metriport/shared/";
+import { MetriportError } from "@metriport/shared";
 
 export const METRICS_NAMESPACE = "Metriport";
 

--- a/packages/core/src/external/aws/cloudwatch.ts
+++ b/packages/core/src/external/aws/cloudwatch.ts
@@ -1,6 +1,7 @@
 import AWS from "aws-sdk";
 import { Config } from "../../util/config";
 import { capture } from "../../util/notifications";
+import { MetriportError } from "@metriport/shared/";
 
 export const METRICS_NAMESPACE = "Metriport";
 
@@ -46,5 +47,10 @@ export function reportMetric(metric: Metric) {
   } catch (err) {
     console.error(`Error reporting metric ${JSON.stringify(metric)}: ${err}`);
     capture.error(err, { extra: { metric, context: "reportMetric" } });
+    throw new MetriportError(`Error reporting metric`, err, {
+      name: metric.name,
+      unit: metric.unit,
+      value: metric.value,
+    });
   }
 }

--- a/packages/core/src/external/aws/cloudwatch.ts
+++ b/packages/core/src/external/aws/cloudwatch.ts
@@ -1,0 +1,50 @@
+import AWS from "aws-sdk";
+import { Config } from "../../util/config";
+import { capture } from "../../util/notifications";
+
+export const METRICS_NAMESPACE = "Metriport";
+
+const cw = new AWS.CloudWatch({ apiVersion: "2010-08-01", region: Config.getAWSRegion() });
+
+export type Metric = {
+  name: string;
+  unit: "Milliseconds" | "Count";
+  value: number | string;
+  timestamp?: Date;
+  additionalDimension?: string;
+};
+
+export function reportMetric(metric: Metric) {
+  try {
+    const metricBase = {
+      MetricName: metric.name,
+      Timestamp: metric.timestamp ?? new Date(),
+      Unit: metric.unit,
+      Value: typeof metric.value === "string" ? parseFloat(metric.value) : metric.value,
+    };
+    return cw
+      .putMetricData({
+        MetricData: [
+          {
+            ...metricBase,
+            Dimensions: [
+              ...(metric.additionalDimension
+                ? [
+                    {
+                      Name: "Additional",
+                      Value: metric.additionalDimension,
+                    },
+                  ]
+                : []),
+            ],
+          },
+          { ...metricBase, Dimensions: [{ Name: "Service", Value: "OSS API" }] },
+        ],
+        Namespace: METRICS_NAMESPACE,
+      })
+      .promise();
+  } catch (err) {
+    console.error(`Error reporting metric ${JSON.stringify(metric)}: ${err}`);
+    capture.error(err, { extra: { metric, context: "reportMetric" } });
+  }
+}

--- a/packages/core/src/external/fhir/bundle/utils.ts
+++ b/packages/core/src/external/fhir/bundle/utils.ts
@@ -1,5 +1,4 @@
 import { Bundle, Resource } from "@medplum/fhirtypes";
-import { FhirBundleSdk } from "@metriport/fhir-sdk";
 import { MetriportError } from "@metriport/shared";
 import _, { cloneDeep } from "lodash";
 import { dangerouslyDeduplicateFhir } from "../../../fhir-deduplication/deduplicate-fhir";
@@ -58,8 +57,8 @@ export function dedupeAdtEncounters(existing: Bundle<Resource>): Bundle<Resource
   const encounterBundleEntries = [...dedupedEncountersMap.values()].map(buildBundleEntry);
   const nonEncounterBundleEntries = _(nonEncounters).compact().map(buildBundleEntry).value();
 
-  const newBundle = FhirBundleSdk.createSync(existing).toObject();
-  newBundle.entry = [...encounterBundleEntries, ...nonEncounterBundleEntries];
+  //const newBundle = FhirBundleSdk.createSync(existing).toObject();
+  existing.entry = [...encounterBundleEntries, ...nonEncounterBundleEntries];
 
-  return newBundle;
+  return existing;
 }

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -1,5 +1,6 @@
 import { getEnvVarAsRecordOrFail } from "@metriport/shared/common/env-var";
 import { getEnvVar, getEnvVarOrFail } from "./env-var";
+import { SLACK_ADT_ROSTER_NOTIFICATION_URL } from "@metriport/shared/domain/tcm-encounter";
 
 /**
  * Shared configs, still defining how to work with this. For now:
@@ -395,5 +396,9 @@ export class Config {
   }
   static getFhirToCsvBatchJobDefinitionArn(): string | undefined {
     return getEnvVar("FHIR_TO_CSV_BATCH_JOB_DEFINITION_ARN");
+  }
+
+  static getSlackAdtRosterNotificationArn(): string {
+    return getEnvVarOrFail(SLACK_ADT_ROSTER_NOTIFICATION_URL);
   }
 }

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -164,6 +164,7 @@ export const config: EnvConfigNonSandbox = {
     },
     secrets: {
       HL7_BASE64_SCRAMBLER_SEED: "your-base64-scrambler-seed",
+      SLACK_ADT_ROSTER_NOTIFICATION_URL: "your-slack-url",
     },
     mllpServer: {
       sentryDSN: "your-sentry-dsn",

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -3,6 +3,7 @@ import { HieConfig, VpnlessHieConfig } from "@metriport/core/command/hl7v2-subsc
 export interface Hl7NotificationConfig {
   secrets: {
     HL7_BASE64_SCRAMBLER_SEED: string;
+    SLACK_ADT_ROSTER_NOTIFICATION_URL: string;
   };
   deprecatedIncomingMessageBucketName: string;
   incomingMessageBucketName: string;

--- a/packages/shared/src/domain/tcm-encounter.ts
+++ b/packages/shared/src/domain/tcm-encounter.ts
@@ -74,3 +74,4 @@ export const tcmEncounterListQuerySchema = tcmEncounterQuerySchema;
 export type TcmEncounterListQuery = z.infer<typeof tcmEncounterListQuerySchema>;
 
 export type TcmEncounterUpsertInput = z.input<typeof tcmEncounterUpsertSchema>;
+export const SLACK_ADT_ROSTER_NOTIFICATION_URL = "SLACK_ADT_ROSTER_NOTIFICATION_URL";


### PR DESCRIPTION
_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-714

### Dependencies

- Downstream: yes but later

### Description
added posthog + slack + cloudwatch analytics

### Testing

- Local
  - [ ] Test locally to make sure posthog + slack + cloudwatch all appears
- Staging
  - [ ] Test to make sure posthog + slack + cloudwatch all appears
- Production
  - [ ] Test to make sure posthog + slack + cloudwatch all appears
