### PR TITLE
ENG-864: fix(infra) - updates cron expression in scheduled Lambda

### DIFF
--- a/packages/infra/lib/quest/scheduled-lambda.ts
+++ b/packages/infra/lib/quest/scheduled-lambda.ts
@@ -25,8 +25,8 @@ export interface ScheduledLambdaConfig extends ScheduledLambdaProps {
 const lambdaTimeout = Duration.seconds(60);
 const httpTimeout = Duration.seconds(50);
 
-function createDownloadResponseConfig(props: ScheduledLambdaProps): ScheduledLambdaConfig {
-  return {
+export function createDownloadResponseScheduledLambda(props: ScheduledLambdaProps): Lambda {
+  return createQuestScheduledLambda({
     ...props,
     name: "QuestScheduledResponseDownload",
     /**
@@ -37,19 +37,18 @@ function createDownloadResponseConfig(props: ScheduledLambdaProps): ScheduledLam
     scheduleExpression: [
       Schedule.cron({
         minute: "0",
-        hour: "12",
+        hour: "1",
         day: "*",
         month: "*",
         year: "*",
-        weekDay: "?",
-      }).expressionString, // Every day at 12:00pm UTC (5:00am PST)
+      }).expressionString, // Every day at 6:00pm PST (1:00am UTC)
     ],
     url: `http://${props.apiAddress}/internal/quest/download-response`,
-  };
+  });
 }
 
-function createUploadRosterConfig(props: ScheduledLambdaProps): ScheduledLambdaConfig {
-  return {
+export function createUploadRosterScheduledLambda(props: ScheduledLambdaProps): Lambda {
+  return createQuestScheduledLambda({
     ...props,
     name: "QuestScheduledRosterUpload",
     /**
@@ -61,22 +60,13 @@ function createUploadRosterConfig(props: ScheduledLambdaProps): ScheduledLambdaC
       Schedule.cron({
         minute: "0",
         hour: "12",
-        day: "?",
         month: "*",
         year: "*",
         weekDay: "MON",
       }).expressionString, // Every Monday at 12:00pm UTC (5:00am PST)
     ],
     url: `http://${props.apiAddress}/internal/quest/upload-roster`,
-  };
-}
-
-export function createDownloadResponseScheduledLambda(props: ScheduledLambdaProps): Lambda {
-  return createQuestScheduledLambda(createDownloadResponseConfig(props));
-}
-
-export function createUploadRosterScheduledLambda(props: ScheduledLambdaProps): Lambda {
-  return createQuestScheduledLambda(createUploadRosterConfig(props));
+  });
 }
 
 function createQuestScheduledLambda(props: ScheduledLambdaConfig): Lambda {


### PR DESCRIPTION
metriport/metriport-internal#3045

Issues:

- https://linear.app/metriport/issue/ENG-864

### Dependencies

- Upstream: None
- Downstream: None

### Description

Fixes the cron expression for scheduled Lambdas. Apparently you cannot specify both `day` and `weekDay` - good reminder to always run `cdk diff` for infra changes :(

```
Error: Cannot supply both 'day' and 'weekDay', use at most one
    at Function.cron (/home/runner/work/***/***/***/node_modules/aws-cdk-lib/aws-events/lib/schedule.js:1:1513)
    at createUploadRosterConfig (/home/runner/work/***/***/***/packages/infra/lib/quest/scheduled-lambda.ts:61:16)
    at createUploadRosterScheduledLambda (/home/runner/work/***/***/***/packages/infra/lib/quest/scheduled-lambda.ts:79:37)
```

### Testing

- Local
  - [x] `cdk diff`

### Release Plan

- [ ] Merge this
