### PR TITLE
ENG-864: fix(infra) - Quest cron schedule fix

### DIFF
--- a/packages/infra/lib/quest/scheduled-lambda.ts
+++ b/packages/infra/lib/quest/scheduled-lambda.ts
@@ -34,7 +34,7 @@ export function createDownloadResponseScheduledLambda(props: ScheduledLambdaProp
      * @see: https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html
      */
     scheduleExpression: [
-      "0 1 * * * *", // Every day at 6:00pm PST (1:00am UTC)
+      "0 1 * * ? *", // Every day at 6:00pm PST (1:00am UTC)
     ],
     url: `http://${props.apiAddress}/internal/quest/download-response`,
   });


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-864

### Dependencies

- Upstream: None
- Downstream: None

### Description

Fixes a new bug introduced where the scheduling expression is wrapped in a layer of abstraction, that adds `cron(...)` around the string (effectively generating it twice). 

```
You can't use * in both the Day-of-month and Day-of-week fields. If you use it in one, you must use ? in the other.
```

Is much clearer how to set up scheduled Lambdas, will not need to do this much patching next time!

### Testing

- Local
  - [x] `cdk diff`

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized scheduled task configuration to explicit cron expressions for consistency and easier maintenance. Daily runs occur at 01:00 UTC and Monday runs at 12:00 UTC. No user-facing changes.
- Refactor
  - Simplified internal scheduling logic without altering behavior or public interfaces. Ensures schedules remain aligned with previous intent while improving clarity and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->