### PR TITLE
ENG-864: fix(infra): fixing other Quest cron expression

### DIFF
--- a/packages/infra/lib/quest/scheduled-lambda.ts
+++ b/packages/infra/lib/quest/scheduled-lambda.ts
@@ -50,7 +50,7 @@ export function createUploadRosterScheduledLambda(props: ScheduledLambdaProps): 
      * @see: https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html
      */
     scheduleExpression: [
-      "0 12 * * 1 *", // Every Monday at 12:00pm UTC (5:00am PST)
+      "0 12 ? * 1 *", // Every Monday at 12:00pm UTC (5:00am PST)
     ],
     url: `http://${props.apiAddress}/internal/quest/upload-roster`,
   });


### PR DESCRIPTION
metriport/metriport-internal#3045

Issues:

- https://linear.app/metriport/issue/ENG-864

### Dependencies

- Upstream: None
- Downstream: None

### Description

The tried and completely verified solution for setting the schedule expression. Wrote a simple script to test that this works and also checked both schedule expressions thoroughly.

EventBridge Scheduler uses AWS cron syntax, which is slightly different from standard UNIX cron. AWS cron has 6 required fields (not 5 like UNIX):

`cron(Minutes Hours Day-of-month Month Day-of-week Year)`

- `cron(0 1 * * ? *)` - valid, means At 01:00 AM UTC every day (the ? says "no specific value" for day-of-week)
- `cron(0 12 * * 1 *)` - ❌ This is invalid, because if the day of week is `1-7`, you cannot use * for day-of-month and a number for day-of-week at the same time. This was an issue fixed in the previous PR for the other correct cron, but not this one.

**Correct cron**: `cron(0 12 ? * 1 *)` - Mondays at 12:00 UTC

### Testing

- Local
  - [x] Wrote a script to check directly with eventbridge scheduler

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the scheduled job configuration to reliably run the roster upload every Monday at 12:00 UTC.
  * Improves consistency and reliability of weekly uploads without altering any user-facing behavior or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->