### PR TITLE
feat(api): patient syncing issues with Elation & Healthie

### DIFF
--- a/packages/api/src/external/ehr/elation/command/sync-patient.ts
+++ b/packages/api/src/external/ehr/elation/command/sync-patient.ts
@@ -88,6 +88,7 @@ export async function syncElationPatientIntoMetriport({
   }
 
   log("no existing mapping found");
+  let metriportPatientId: string | undefined;
   try {
     const elationPatient = await elationApi.getPatient({ cxId, patientId: elationPatientId });
     const demographics = createMetriportPatientDemographics(elationPatient);
@@ -100,10 +101,10 @@ export async function syncElationPatientIntoMetriport({
       inputMetriportPatientId,
     });
     log("Metriport patient created/retrieved:", metriportPatient.id);
-    const metriportPatientId = metriportPatient.id;
+    metriportPatientId = metriportPatient.id;
     const facilityId = await getPatientPrimaryFacilityIdOrFail({
       cxId,
-      patientId: metriportPatient.id,
+      patientId: metriportPatientId,
     });
     if (triggerDq) {
       queryDocumentsAcrossHIEs({
@@ -134,7 +135,8 @@ export async function syncElationPatientIntoMetriport({
       elationPracticeId,
       elationPatientId,
       elationApi,
-    }).catch(processAsyncError(`Elation createElationPatientMetadata`));
+      metriportPatientId,
+    }).catch(processAsyncError(`Elation createElationPatientMetadata error`));
     throw error;
   }
 }

--- a/packages/api/src/external/ehr/healthie/command/sync-patient.ts
+++ b/packages/api/src/external/ehr/healthie/command/sync-patient.ts
@@ -91,45 +91,55 @@ export async function syncHealthiePatientIntoMetriport({
   }
 
   log("no existing mapping found");
-  const healthiePatient = await healthieApi.getPatient({ cxId, patientId: healthiePatientId });
-  const demographics = createMetriportPatientDemographics(healthiePatient);
+  try {
+    const healthiePatient = await healthieApi.getPatient({ cxId, patientId: healthiePatientId });
+    const demographics = createMetriportPatientDemographics(healthiePatient);
 
-  const metriportPatient = await getOrCreateMetriportPatient({
-    source: EhrSources.healthie,
-    cxId,
-    practiceId: healthiePracticeId,
-    demographics,
-    externalId: healthiePatientId,
-    inputMetriportPatientId,
-  });
-  log("Metriport patient created/retrieved:", metriportPatient.id);
-  const metriportPatientId = metriportPatient.id;
-  const facilityId = await getPatientPrimaryFacilityIdOrFail({
-    cxId,
-    patientId: metriportPatient.id,
-  });
-  if (triggerDq) {
-    queryDocumentsAcrossHIEs({
-      cxId,
-      patientId: metriportPatientId,
-      facilityId,
-    }).catch(processAsyncError(`Healthie queryDocumentsAcrossHIEs`));
-  }
-  await Promise.all([
-    findOrCreatePatientMapping({
-      cxId,
-      patientId: metriportPatientId,
-      externalId: healthiePatientId,
+    const metriportPatient = await getOrCreateMetriportPatient({
       source: EhrSources.healthie,
-    }),
-    updateHealthiePatientQuickNotes({
+      cxId,
+      practiceId: healthiePracticeId,
+      demographics,
+      externalId: healthiePatientId,
+      inputMetriportPatientId,
+    });
+    log("Metriport patient created/retrieved:", metriportPatient.id);
+    const metriportPatientId = metriportPatient.id;
+    const facilityId = await getPatientPrimaryFacilityIdOrFail({
+      cxId,
+      patientId: metriportPatient.id,
+    });
+    if (triggerDq) {
+      queryDocumentsAcrossHIEs({
+        cxId,
+        patientId: metriportPatientId,
+        facilityId,
+      }).catch(processAsyncError(`Healthie queryDocumentsAcrossHIEs`));
+    }
+    await Promise.all([
+      findOrCreatePatientMapping({
+        cxId,
+        patientId: metriportPatientId,
+        externalId: healthiePatientId,
+        source: EhrSources.healthie,
+      }),
+      updateHealthiePatientQuickNotes({
+        cxId,
+        healthiePracticeId,
+        healthiePatientId,
+        healthieApi,
+      }),
+    ]);
+    return metriportPatientId;
+  } catch (error) {
+    await updateHealthiePatientQuickNotes({
       cxId,
       healthiePracticeId,
       healthiePatientId,
       healthieApi,
-    }),
-  ]);
-  return metriportPatientId;
+    }).catch(processAsyncError(`Healthie updateHealthiePatientQuickNotes error`));
+    throw error;
+  }
 }
 
 function createMetriportPatientDemographics(patient: HealthiePatient): PatientDemoData {


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/CS-1657

### Dependencies

- Upstream: none
- Downstream: none

### Description

- Allows elation users to update data and resolve patient linking

### Testing


- Local
  - [x] recreate patient link on failure 
- Staging
- [x] Elation 
- [x] Healthie
  - [x] create a patient on elation with bad demos (missing address)
  - [x] link the patient via api
  - [x] click the link, see the bad demos error
  - [x] validate the elation patient's metadata got updated with a new link
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] A migration query to fix old patients
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of patient synchronization by ensuring metadata is recorded even if the sync process fails.
  * Ensured quick-notes/metadata updates are attempted on error paths to reduce lost context.
  * Preserved successful sync behavior and patient linking to avoid regressions.
  * Maintained document query triggering for consistent results across integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->