### PR TITLE
ENG-850: fixed test not using a constant date resulting in error

### DIFF
--- a/packages/core/src/external/quest/__tests__/file-generator.test.ts
+++ b/packages/core/src/external/quest/__tests__/file-generator.test.ts
@@ -1,8 +1,14 @@
 import { buildRosterFile } from "../file/file-generator";
 import { getArtifact } from "./shared";
+import { jest } from "@jest/globals";
 
 describe("File generator test", () => {
   const externalId = "50WNPYD8VT363CR";
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-08-22T12:00:00-07:00"));
+  });
 
   it("should generate a roster file", () => {
     const rosterFile = buildRosterFile([
@@ -23,7 +29,7 @@ describe("File generator test", () => {
         dob: "1990-01-01",
         genderAtBirth: "M",
         externalId,
-        dateCreated: new Date().toISOString(),
+        dateCreated: new Date("2025-08-22T12:00:00-07:00").toISOString(),
       },
     ]);
 


### PR DESCRIPTION
Part of ENG-850

### Dependencies
None
### Description
 fixed test not using a constant date resulting in error
### Testing

- [x] Ran the test locally 

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Stabilized time-dependent tests by freezing the system clock, ensuring deterministic outputs and eliminating flakiness in date-related assertions.
  * Improves consistency across environments and increases CI reliability.
  * No changes to user-facing functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->