### PR TITLE
RELEASE CW XCPD gateways fixes

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/gateways.ts
@@ -1,4 +1,4 @@
-import { XCAGateway, XCPDGateway, SamlAttributes } from "@metriport/ihe-gateway-sdk";
+import { SamlAttributes, XCAGateway, XCPDGateway } from "@metriport/ihe-gateway-sdk";
 import { validate as validateUuid } from "uuid";
 import { wrapIdInUrnUuid } from "../../../util/urn";
 
@@ -25,7 +25,8 @@ export const centralOhioPrimaryCarePhysiciansOid = "1.2.840.114350.1.13.698.2.7.
 export const familyCareNetworkOid = "1.2.840.114350.1.13.699.2.7.3.688884.100";
 export const hattiesburgClinicOid = "1.2.840.114350.1.13.281.2.7.3.688884.100";
 export const healthPointOid = "1.2.840.114350.1.13.756.2.7.3.688884.100";
-export const surescriptsOid = "2.16.840.1.113883.3.2054.2.1.1";
+export const surescriptsOid = "2.16.840.1.113883.3.2054.2.1.1"; // RLS
+export const commonwellOid = "2.16.840.1.113883.3.9960.2.25.1"; // RLS
 
 export const epicOidPrefix = "1.2.840.114350.1.13";
 export const redoxOidPrefix = "2.16.840.1.113883.3.6147";
@@ -41,11 +42,6 @@ export function doesGatewayUseSha1(oid: string): boolean {
   }
   return false;
 }
-
-/*
- * These gateways only accept a single document reference per request.
- */
-const gatewaysThatAcceptOneDocRefPerRequest = [pointClickCareOid, surescriptsOid];
 
 const prefixDocRefsPerRequest: Record<string, number> = {
   [epicOidPrefix]: 9,
@@ -128,8 +124,4 @@ export function getHomeCommunityId(
 
 export function requiresUrnInSoapBody(gateway: XCPDGateway): boolean {
   return gateway.url != specialNamespaceRequiredUrl;
-}
-
-export function requiresOnlyOneDocRefPerRequest(gateway: XCAGateway): boolean {
-  return gatewaysThatAcceptOneDocRefPerRequest.includes(gateway.homeCommunityId);
 }


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-912

### Description
- https://github.com/metriport/metriport/pull/4454

### Testing

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support sending multiple document references in a single request to IHE gateways (previous one-per-request limit removed).

- Bug Fixes
  - More accurate organization discovery by consistently detecting URL XCPD presence.
  - Corrected handling of unmanaged vs. managed organizations, improving search results.
  - Excludes certain public networks from results to reduce noise and prevent unintended matches.

- Refactor
  - Centralized query logic for cleaner, more reliable filtering across Record Locator Service and standalone organization lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->