### PR TITLE
feat(core): cant create patient with different demo but same contact …

### DIFF
--- a/packages/core/src/mpi/get-patient-by-demo.ts
+++ b/packages/core/src/mpi/get-patient-by-demo.ts
@@ -3,7 +3,6 @@ import { Patient, PatientData } from "../domain/patient";
 import { log } from "../util/log";
 import {
   jaroWinklerSimilarity,
-  matchingContactDetailsRule,
   matchingPersonalIdentifiersRule,
   matchPatients,
 } from "./match-patients";
@@ -21,7 +20,7 @@ const SIMILARITY_THRESHOLD = 0.96;
  * @param demo - The demographic information of the patient.
  * @returns The matched patient object if found, otherwise undefined.
  */
-export const getPatientByDemo = async ({
+export async function getPatientByDemo({
   cxId,
   demo,
   patientLoader,
@@ -29,7 +28,7 @@ export const getPatientByDemo = async ({
   cxId: string;
   demo: PatientData;
   patientLoader: PatientLoader;
-}): Promise<Patient | undefined> => {
+}): Promise<Patient | undefined> {
   // Normalize the patient demographic data
   const normalizedPatientDemo = normalizePatient(demo);
   if (!normalizedPatientDemo) return undefined;
@@ -51,7 +50,7 @@ export const getPatientByDemo = async ({
   // Match the found patients with the normalized patient using the similarity function
   const matchingPatients = matchPatients(
     jaroWinklerSimilarity,
-    [matchingPersonalIdentifiersRule, matchingContactDetailsRule],
+    [matchingPersonalIdentifiersRule],
     foundPatients.map(patientToPatientMPI),
     normalizedPatientDemo,
     SIMILARITY_THRESHOLD,
@@ -67,4 +66,4 @@ export const getPatientByDemo = async ({
   if (!mpiPatient) return undefined;
 
   return patientLoader.getOneOrFail({ id: mpiPatient.id, cxId });
-};
+}


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/CS-2031

### Dependencies

- Upstream: none
- Downstream: none

### Description

Before: 
- two patient having the same dob, gender, and phone number (or email) are considered to be the same record - which is actually incorrect

Current:
- Removing contact info (phone & email) to be unique. Now these 2 items will go through a similarity algorithm that takes into account more data points to decides if records are similar enough. 

### Testing

- Local
  - [ ] reproduce the probem
  - [ ] test fix resolves the problem 
- Staging
  - [ ] test fix resolves the problem 
- Sandbox
  - [ ] test fix resolves the problem 
- Production
  - none

### Release Plan

- [ ] Merge this
