### PR TITLE
ENG-874 add data source for each resource (ADTs)

### DIFF
--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender.ts
@@ -7,6 +7,7 @@ export const hl7NotificationSenderParamsSchema = z.object({
   sourceTimestamp: z.string(),
   messageReceivedTimestamp: z.string(),
   rawDataFileKey: z.string(),
+  hieName: z.string(),
 });
 
 export type Hl7NotificationSenderParams = z.infer<typeof hl7NotificationSenderParamsSchema>;

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
@@ -16,6 +16,7 @@ export type Hl7ToFhirParams = {
   rawDataFileKey: string;
   hieName: string;
 };
+type ResourceWithExtension = Resource & { extension?: Extension[] };
 
 /**
  * Converts an HL7v2 message to a FHIR Bundle. Currently only supports ADT messages.
@@ -74,15 +75,17 @@ export function appendExtensionToEachResource(
     ...bundle,
     entry: bundle.entry.map(e => {
       const resource = e.resource;
-      if (!resource || !("extension" in resource)) return e;
+      if (!resource) return e;
 
-      const existing = resource.extension ?? [];
+      const existing: Extension[] = (resource as ResourceWithExtension).extension ?? [];
+      const extension = [...existing, newExtension];
+
       return {
         ...e,
         resource: {
           ...resource,
-          extension: [...existing, newExtension],
-        },
+          extension: extension,
+        } as Resource,
       };
     }),
   };

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
@@ -41,7 +41,9 @@ export function convertHl7v2MessageToFhir({
     log(`Conversion completed in ${duration} ms`);
     const docIdExtension = buildDocIdFhirExtension(rawDataFileKey, "hl7");
     const sourceExtension = createExtensionDataSource(hieName.toUpperCase());
-    return addHl7SourceExtensions(bundle, [docIdExtension, sourceExtension]);
+    let updatedBundle = addHl7SourceExtension(bundle, docIdExtension);
+    updatedBundle = addHl7SourceExtension(bundle, sourceExtension);
+    return updatedBundle;
   }
 
   const msg = "HL7 message type isn't supported";
@@ -61,9 +63,9 @@ export function convertHl7v2MessageToFhir({
   throw new MetriportError(msg, undefined, extraProps);
 }
 
-function addHl7SourceExtensions(
+function addHl7SourceExtension(
   bundle: BundleWithEntry<Resource>,
-  newExtensions: Extension[]
+  newExtension: Extension
 ): Bundle<Resource> {
   return {
     ...bundle,
@@ -76,7 +78,7 @@ function addHl7SourceExtensions(
         ...e,
         resource: {
           ...e.resource,
-          extension: [...existing, ...newExtensions],
+          extension: [...existing, newExtension],
         },
       };
     }),

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
@@ -41,8 +41,8 @@ export function convertHl7v2MessageToFhir({
     log(`Conversion completed in ${duration} ms`);
     const docIdExtension = buildDocIdFhirExtension(rawDataFileKey, "hl7");
     const sourceExtension = createExtensionDataSource(hieName.toUpperCase());
-    let updatedBundle = addHl7SourceExtension(bundle, docIdExtension);
-    updatedBundle = addHl7SourceExtension(bundle, sourceExtension);
+    let updatedBundle = appendExtensionToEachResource(bundle, docIdExtension);
+    updatedBundle = appendExtensionToEachResource(bundle, sourceExtension);
     return updatedBundle;
   }
 
@@ -63,21 +63,21 @@ export function convertHl7v2MessageToFhir({
   throw new MetriportError(msg, undefined, extraProps);
 }
 
-function addHl7SourceExtension(
+function appendExtensionToEachResource(
   bundle: BundleWithEntry<Resource>,
   newExtension: Extension
 ): Bundle<Resource> {
   return {
     ...bundle,
     entry: bundle.entry.map(e => {
-      if (!e.resource) return e;
-      //eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const resource = e.resource as any;
+      const resource = e.resource;
+      if (!resource || !("extension" in resource)) return e;
+
       const existing = resource.extension ?? [];
       return {
         ...e,
         resource: {
-          ...e.resource,
+          ...resource,
           extension: [...existing, newExtension],
         },
       };

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
@@ -2,7 +2,7 @@ import { Hl7Message } from "@medplum/core";
 import { Bundle, Extension, Resource } from "@medplum/fhirtypes";
 import { MetriportError } from "@metriport/shared";
 import { elapsedTimeFromNow } from "@metriport/shared/common/date";
-import { BundleWithEntry, buildBundleFromResources } from "../../../external/fhir/bundle/bundle";
+import { buildBundleFromResources } from "../../../external/fhir/bundle/bundle";
 import { buildDocIdFhirExtension } from "../../../external/fhir/shared/extensions/doc-id-extension";
 import { capture, out } from "../../../util";
 import { convertAdtToFhirResources } from "./adt/encounter";
@@ -63,10 +63,13 @@ export function convertHl7v2MessageToFhir({
   throw new MetriportError(msg, undefined, extraProps);
 }
 
-function appendExtensionToEachResource(
-  bundle: BundleWithEntry<Resource>,
+export function appendExtensionToEachResource(
+  bundle: Bundle<Resource>,
   newExtension: Extension
 ): Bundle<Resource> {
+  if (!bundle.entry) {
+    throw new Error("No entry in bundle");
+  }
   return {
     ...bundle,
     entry: bundle.entry.map(e => {

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
@@ -1,5 +1,5 @@
 import { Hl7Message } from "@medplum/core";
-import { Bundle, Resource } from "@medplum/fhirtypes";
+import { Bundle, Extension, Resource } from "@medplum/fhirtypes";
 import { MetriportError } from "@metriport/shared";
 import { elapsedTimeFromNow } from "@metriport/shared/common/date";
 import { BundleWithEntry, buildBundleFromResources } from "../../../external/fhir/bundle/bundle";
@@ -7,12 +7,14 @@ import { buildDocIdFhirExtension } from "../../../external/fhir/shared/extension
 import { capture, out } from "../../../util";
 import { convertAdtToFhirResources } from "./adt/encounter";
 import { getHl7MessageTypeOrFail } from "./msh";
+import { createExtensionDataSource } from "../../../external/fhir/shared/extensions/extension";
 
 export type Hl7ToFhirParams = {
   cxId: string;
   patientId: string;
   message: Hl7Message;
   rawDataFileKey: string;
+  hieName: string;
 };
 
 /**
@@ -23,6 +25,7 @@ export function convertHl7v2MessageToFhir({
   patientId,
   message,
   rawDataFileKey,
+  hieName,
 }: Hl7ToFhirParams): Bundle<Resource> {
   const { log } = out(`hl7v2 to fhir - cx: ${cxId}, pt: ${patientId}`);
   log("Beginning conversion.");
@@ -36,7 +39,9 @@ export function convertHl7v2MessageToFhir({
     const duration = elapsedTimeFromNow(startedAt);
 
     log(`Conversion completed in ${duration} ms`);
-    return addHl7SourceExtension(bundle, rawDataFileKey);
+    const docIdExtension = buildDocIdFhirExtension(rawDataFileKey, "hl7");
+    const sourceExtension = createExtensionDataSource(hieName.toUpperCase());
+    return addHl7SourceExtensions(bundle, [docIdExtension, sourceExtension]);
   }
 
   const msg = "HL7 message type isn't supported";
@@ -56,20 +61,22 @@ export function convertHl7v2MessageToFhir({
   throw new MetriportError(msg, undefined, extraProps);
 }
 
-function addHl7SourceExtension(
+function addHl7SourceExtensions(
   bundle: BundleWithEntry<Resource>,
-  sourcePath: string
+  newExtensions: Extension[]
 ): Bundle<Resource> {
-  const ext = buildDocIdFhirExtension(sourcePath, "hl7");
   return {
     ...bundle,
     entry: bundle.entry.map(e => {
       if (!e.resource) return e;
+      //eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const resource = e.resource as any;
+      const existing = resource.extension ?? [];
       return {
         ...e,
         resource: {
           ...e.resource,
-          extension: [ext],
+          extension: [...existing, ...newExtensions],
         },
       };
     }),

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -87,6 +87,7 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
           sourceTimestamp: timestamp,
           messageReceivedTimestamp: new Date().toISOString(),
           rawDataFileKey,
+          hieName,
         });
 
         connection.send(message.buildAck());

--- a/packages/utils/src/hl7v2-notifications/convert-adt-to-fhir-local-example.ts
+++ b/packages/utils/src/hl7v2-notifications/convert-adt-to-fhir-local-example.ts
@@ -18,6 +18,7 @@ import { buildGetDirPathInside, initRunsFolder } from "../shared/folder";
  *   - Each message starts with "MSH|"
  *   - Messages can be separated by newlines
  *   - The file should be placed in the input folder
+ * - Expects an hieName.
  *
  * Output:
  * - Creates a "converted" folder with individual JSON files for each converted message
@@ -30,6 +31,7 @@ import { buildGetDirPathInside, initRunsFolder } from "../shared/folder";
  */
 
 const filePath = "";
+const hieName = "";
 const getDirPath = buildGetDirPathInside("hl7v2-conversion");
 
 async function convertAdtToFhir() {
@@ -62,6 +64,7 @@ async function convertAdtToFhir() {
           cxId,
           patientId,
           rawDataFileKey: fileName,
+          hieName,
         });
 
         if (!fs.existsSync(outputFolder)) {

--- a/packages/utils/src/hl7v2-notifications/hl7-to-fhir-converter-logic.ts
+++ b/packages/utils/src/hl7v2-notifications/hl7-to-fhir-converter-logic.ts
@@ -45,6 +45,7 @@ const apiUrl = getEnvVarOrFail("API_URL");
 
 const filePath = "";
 const fileName = "";
+const hieName = "";
 
 function invokeLambdaLogic() {
   const hl7Text = fs.readFileSync(`${filePath}/${fileName}`, "utf-8");
@@ -64,6 +65,7 @@ function invokeLambdaLogic() {
         sourceTimestamp: timestamp,
         messageReceivedTimestamp: new Date().toISOString(),
         rawDataFileKey: `${cxId}/${patientId}/hl7-to-fhir-converter-script-${timestamp}.hl7`,
+        hieName,
       });
     } catch (err) {
       errors.push({

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/backfill-datasource-extension.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/backfill-datasource-extension.ts
@@ -40,8 +40,8 @@ async function deduplicateExistingBundles(
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
     const resource = entry.resource as any;
     resource.extension = [...(resource.extension ?? []), dataSourceExtension];
-    return bundle;
   }
+  return bundle;
 }
 
 main();

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/backfill-datasource-extension.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/backfill-datasource-extension.ts
@@ -1,0 +1,47 @@
+/* eslint-disable no-useless-escape */
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+
+import { FhirBundleSdk } from "@metriport/fhir-sdk";
+import { reprocessAdtConversionBundles } from "./common";
+import { createExtensionDataSource } from "@metriport/core/external/fhir/shared/extensions/extension";
+
+/**
+ *
+ * This script pulls down every conversion bundle from S3, and adds the datasource to each resource.
+ *
+ * Steps:
+ * 1. Ensure your .env file has the required AWS and bucket configuration (HL7_CONVERSION_BUCKET_NAME)
+ * 2. Update the prefixes array on line 26 with the customer IDs to process
+ * 3. Run the script:
+ *    npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/backfill-datasource-extension.ts
+ *
+ * Usage:
+ * Run with: npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/backfill-datasource-extension.ts
+ *
+ * Note: This script modifies data in S3. Ensure you have backups if needed.
+ */
+
+const prefixes: string[] = [];
+const dryRun = true;
+const hieName = "";
+
+async function main() {
+  console.log(`Adding datasource ${hieName} to resources. Make sure this is correct.`);
+  await reprocessAdtConversionBundles(prefixes, deduplicateExistingBundles, dryRun);
+}
+
+async function deduplicateExistingBundles(
+  bundle: FhirBundleSdk
+): Promise<FhirBundleSdk | undefined> {
+  for (const entry of bundle.entry) {
+    const dataSourceExtension = createExtensionDataSource(hieName.toUpperCase());
+    //eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const resource = entry.resource as any;
+    resource.extension = [...(resource.extension ?? []), dataSourceExtension];
+    return bundle;
+  }
+}
+
+main();

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/common.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/common.ts
@@ -50,9 +50,12 @@ export async function reprocessAdtConversionBundles(
   const promises = prefixes.map(async prefix => {
     const { log } = out(prefix);
     const results = await s3Utils.listObjects(bucketName, prefix);
-    log(`Found ${results.length} objects for prefix: ${prefix}`);
+    const noFolderResults = results.filter(result => {
+      return result.Size !== 0;
+    });
+    log(`Found ${noFolderResults.length} objects for prefix: ${prefix}`);
     let processedCount = 0;
-    const fileProcessingPromises = results.map(async result => {
+    const fileProcessingPromises = noFolderResults.map(async result => {
       const [cxId, ptId] = prefix.replace("cxId=", "").replace("ptId=", "").split("/");
       if (result.Key === undefined) {
         log("Key is undefined - and it shouldn't be");


### PR DESCRIPTION
Part of ENG-874

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-874

### Dependencies
NONE 

### Description
Add data source for each resource.
Add backfill script to add data source for each resource in a bundle.

### Testing

Thoughts on how to test? I guess I gotta send a msg to mllp server? 
- Local
  - [x] Run script on on a few test bundles
  - [x] Send HL7 message to server
- Staging
  - [ ] Run script on a few test bundles
  - [ ] Send HL7 message to server
- Production
  - [ ] Run script on a few test bundles
  - [ ] Send HL7 message to server


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - HL7 notification payloads now include the HIE name for richer context across ingestion and webhook flows.
  - FHIR conversion now appends a Source (HIE) extension and a Document-ID extension to produced resources for improved traceability.

- **Chores**
  - Added a dry-run-capable utility to backfill data-source extensions on existing FHIR bundles.
  - Reprocessing now ignores zero-sized S3 objects (folders) to avoid unnecessary work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->