### PR TITLE
ENG-926: US Census Geocoder

### DIFF
--- a/packages/core/src/external/census-geocoder/census-geocoder.ts
+++ b/packages/core/src/external/census-geocoder/census-geocoder.ts
@@ -1,0 +1,51 @@
+import axios from "axios";
+import { Address } from "../../domain/address";
+import { normalizeState } from "@metriport/shared";
+import {
+  CensusGeocoderParams,
+  censusGeocoderResponseSchema,
+  CensusGeocoderResponse,
+} from "./types";
+import { CENSUS_GEOCODER_ADDRESS_URL } from "./constants";
+
+export async function getNormalizedAddress(
+  address: Address,
+  { benchmark = "Public_AR_Current" }: CensusGeocoderParams = {}
+) {
+  const params = new URLSearchParams({
+    street: getStreetFromAddress(address),
+    city: address.city,
+    state: normalizeState(address.state),
+    zip: address.zip,
+    benchmark,
+    format: "json",
+  });
+  const response = await axios.get<CensusGeocoderResponse>(CENSUS_GEOCODER_ADDRESS_URL, {
+    params,
+  });
+  const { result } = censusGeocoderResponseSchema.parse(response.data);
+  const firstMatch = result.addressMatches[0];
+  if (!firstMatch) {
+    return address;
+  }
+  const components = firstMatch.addressComponents;
+  return {
+    addressLine1:
+      `${components.preDirection} ${components.streetName} ${components.suffixDirection}`.trim(),
+    addressLine2: `${components.fromAddress} - ${components.toAddress}`.trim(),
+    city: components.city,
+    state: components.state,
+    zip: components.zip,
+    coordinates: {
+      lat: firstMatch.coordinates.y,
+      lon: firstMatch.coordinates.x,
+    },
+  };
+}
+
+function getStreetFromAddress(address: Address): string {
+  if (address.addressLine2) {
+    return `${address.addressLine1} ${address.addressLine2}`;
+  }
+  return address.addressLine1;
+}

--- a/packages/core/src/external/census-geocoder/constants.ts
+++ b/packages/core/src/external/census-geocoder/constants.ts
@@ -1,0 +1,6 @@
+export const CENSUS_GEOCODER_ADDRESS_URL =
+  "https://geocoding.geo.census.gov/geocoder/locations/address";
+export const CENSUS_GEOCODER_ONE_LINE_ADDRESS_URL =
+  "https://geocoding.geo.census.gov/geocoder/locations/onelineaddress";
+export const CENSUS_GEOCODER_BATCH_URL =
+  "https://geocoding.geo.census.gov/geocoder/locations/addressbatch";

--- a/packages/core/src/external/census-geocoder/types.ts
+++ b/packages/core/src/external/census-geocoder/types.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+const BENCHMARK_NAME = ["Public_AR_Current", "Public_AR_ACS2024", "Public_AR_Census2020"] as const;
+type BenchmarkName = (typeof BENCHMARK_NAME)[number];
+
+export interface CensusGeocoderParams {
+  benchmark?: BenchmarkName;
+}
+
+export const addressMatchSchema = z.object({
+  tigerLine: z.object({
+    side: z.string(),
+    tigerLineId: z.string(),
+  }),
+  coordinates: z.object({
+    x: z.number(),
+    y: z.number(),
+  }),
+  addressComponents: z.object({
+    zip: z.string(),
+    streetName: z.string(),
+    preType: z.string(),
+    city: z.string(),
+    preDirection: z.string(),
+    suffixDirection: z.string(),
+    fromAddress: z.string(),
+    state: z.string(),
+    suffixType: z.string(),
+    toAddress: z.string(),
+    suffixQualifier: z.string(),
+    preQualifier: z.string(),
+  }),
+});
+
+export const censusGeocoderResponseSchema = z.object({
+  result: z.object({
+    input: z.object({
+      address: z.object({
+        zip: z.string(),
+        street: z.string(),
+        city: z.string(),
+        state: z.string(),
+      }),
+    }),
+    addressMatches: z.array(addressMatchSchema),
+  }),
+});
+
+export type CensusGeocoderResponse = z.infer<typeof censusGeocoderResponseSchema>;
+export type AddressMatch = z.infer<typeof addressMatchSchema>;


### PR DESCRIPTION
metriport/metriport-internal#1040

Issues:

- https://linear.app/metriport/issue/ENG-926

### Dependencies

- Upstream: None
- Downstream: None

### Description

Adds API support for the US Census Geocoder. 

### Testing

- Local
  - [ ] `cd packages/core && npx jest census-geocoder`

### Release Plan

- [ ] Merge this
