### PR TITLE
feat(ehr): rate limiting handling for token generation

### DIFF
--- a/packages/core/src/external/ehr/athenahealth/index.ts
+++ b/packages/core/src/external/ehr/athenahealth/index.ts
@@ -18,6 +18,7 @@ import {
   NotFoundError,
   sleep,
   toTitleCase,
+  executeWithNetworkRetries,
 } from "@metriport/shared";
 import { buildDayjs } from "@metriport/shared/common/date";
 import {
@@ -302,13 +303,15 @@ class AthenaHealthApi {
     };
 
     try {
-      const response = await axios.post(url, createDataParams(data), {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        auth: {
-          username: this.config.clientKey,
-          password: this.config.clientSecret,
-        },
-      });
+      const response = await executeWithNetworkRetries(() =>
+        axios.post(url, createDataParams(data), {
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          auth: {
+            username: this.config.clientKey,
+            password: this.config.clientSecret,
+          },
+        })
+      );
       if (!response.data) throw new MetriportError("No body returned from token endpoint");
       const tokenData = athenaClientJwtTokenResponseSchema.parse(response.data);
       return {

--- a/packages/core/src/external/ehr/canvas/index.ts
+++ b/packages/core/src/external/ehr/canvas/index.ts
@@ -17,6 +17,7 @@ import {
   MetriportError,
   NotFoundError,
   sleep,
+  executeWithNetworkRetries,
 } from "@metriport/shared";
 import { buildDayjs } from "@metriport/shared/common/date";
 import {
@@ -198,9 +199,11 @@ class CanvasApi {
     const payload = `grant_type=client_credentials&client_id=${this.config.clientKey}&client_secret=${this.config.clientSecret}`;
 
     try {
-      const response = await axios.post(url, payload, {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      });
+      const response = await executeWithNetworkRetries(() =>
+        axios.post(url, payload, {
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        })
+      );
       if (!response.data) throw new MetriportError("No body returned from token endpoint");
       const tokenData = canvasClientJwtTokenResponseSchema.parse(response.data);
       return {

--- a/packages/core/src/external/ehr/elation/index.ts
+++ b/packages/core/src/external/ehr/elation/index.ts
@@ -15,6 +15,7 @@ import {
   NotFoundError,
   sleep,
   toTitleCase,
+  executeWithNetworkRetries,
 } from "@metriport/shared";
 import { buildDayjs } from "@metriport/shared/common/date";
 import {
@@ -275,9 +276,11 @@ class ElationApi {
     };
 
     try {
-      const response = await axios.post(url, createDataParams(data), {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      });
+      const response = await executeWithNetworkRetries(() =>
+        axios.post(url, createDataParams(data), {
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        })
+      );
       if (!response.data) throw new MetriportError("No body returned from token endpoint");
       const tokenData = elationClientJwtTokenResponseSchema.parse(response.data);
       return {
@@ -634,22 +637,23 @@ class ElationApi {
       document_date: this.formatDateTime(chartDate.toISOString()),
     } as ElationGroupedVital;
     const data = vitals.reduce((existingVital, newVital) => {
-      if (existingVital.bp && newVital.bp) {
-        const existingBp = existingVital.bp as { systolic?: string; diastolic?: string }[];
+      let existingVitalNew = existingVital;
+      if (existingVitalNew.bp && newVital.bp) {
+        const existingBp = existingVitalNew.bp as { systolic?: string; diastolic?: string }[];
         const newBp = newVital.bp as { systolic?: string; diastolic?: string }[];
-        existingVital.bp = [
+        existingVitalNew.bp = [
           {
             ...existingBp[0],
             ...newBp[0],
           },
         ];
       } else {
-        existingVital = {
-          ...existingVital,
+        existingVitalNew = {
+          ...existingVitalNew,
           ...newVital,
         } as ElationGroupedVital;
       }
-      return existingVital;
+      return existingVitalNew;
     }, baseData);
     try {
       const nonVisitNote = await this.createNonVisitNote({

--- a/packages/infra/lib/ehr-nested-stack.ts
+++ b/packages/infra/lib/ehr-nested-stack.ts
@@ -116,15 +116,13 @@ function settings(): {
       alarmMaxAgeOfOldestMessage: Duration.hours(2),
       maxMessageCountAlarmThreshold: 5_000,
       maxReceiveCount: 3,
-      visibilityTimeout: Duration.seconds(
-        computeResourceDiffBundlesLambdaTimeout.toSeconds() * 2 + 1
-      ),
+      visibilityTimeout: Duration.seconds(5),
       createRetryLambda: false,
     },
     eventSource: {
       batchSize: 1,
       reportBatchItemFailures: true,
-      maxConcurrency: 4,
+      maxConcurrency: 2,
     },
     waitTime: waitTimeComputeResourceDiff,
   };
@@ -141,13 +139,13 @@ function settings(): {
       alarmMaxAgeOfOldestMessage: Duration.hours(2),
       maxMessageCountAlarmThreshold: 5_000,
       maxReceiveCount: 3,
-      visibilityTimeout: Duration.seconds(refreshEhrBundlesLambdaTimeout.toSeconds() * 2 + 1),
+      visibilityTimeout: Duration.seconds(5),
       createRetryLambda: false,
     },
     eventSource: {
       batchSize: 1,
       reportBatchItemFailures: true,
-      maxConcurrency: 4,
+      maxConcurrency: 2,
     },
     waitTime: waitTimeRefreshBundle,
   };
@@ -162,10 +160,8 @@ function settings(): {
     queue: {
       alarmMaxAgeOfOldestMessage: Duration.hours(4),
       maxMessageCountAlarmThreshold: 5_000,
-      maxReceiveCount: 3,
-      visibilityTimeout: Duration.seconds(
-        contributeResourceDiffBundlesLambdaTimeout.toSeconds() * 2 + 1
-      ),
+      maxReceiveCount: 1,
+      visibilityTimeout: Duration.seconds(5),
       createRetryLambda: false,
     },
     eventSource: {
@@ -186,10 +182,8 @@ function settings(): {
     queue: {
       alarmMaxAgeOfOldestMessage: Duration.hours(4),
       maxMessageCountAlarmThreshold: 5_000,
-      maxReceiveCount: 3,
-      visibilityTimeout: Duration.seconds(
-        writeBackResourceDiffBundlesLambdaTimeout.toSeconds() * 2 + 1
-      ),
+      maxReceiveCount: 1,
+      visibilityTimeout: Duration.seconds(5),
       createRetryLambda: false,
     },
     eventSource: {


### PR DESCRIPTION
Ref: ENG-559

### Description

- network retries within clients for token generation
- only try contribution / writeback once to cut down on noise and idempotenency
- shrink visibility timeouts so that the queues process much faster

### Testing

- Local
  - [x] athena / canvas / elation clients still work generating tokens
- Staging
  - [ ] N/A
- Sandbox
  - [ ] N/A
- Production
  - [ ] N/A
  
### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved reliability of EHR authentication by adding automatic network retries for token retrieval (Athenahealth, Canvas, Elation), reducing transient failures.
  - Tuned background processing queues: lowered concurrency, standardized short visibility timeouts, and adjusted retry counts to improve throughput stability and reduce duplicate work.

- Refactor
  - Simplified vitals aggregation logic to avoid in-place mutations when merging values (including blood pressure), preserving data shape while improving consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->