### PR TITLE
ENG-939 improve Sandbox Experience - WebHooks api & setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ To debug the backend, you can attach a debugger to the running Docker container 
 
 The `./packages/utils` folder contains utilities that help with the development of this and other opensource Metriport projects:
 
-- [mock-webhook](https://github.com/metriport/metriport/blob/develop/packages/utils/src/mock-webhook.ts): implements the Metriport webhook protocol, can be used by applications integrating with Metriport API as a reference to the behavior expected from these applications when using the webhook feature.
+- [mock-webhook](https://github.com/metriport/metriport/blob/master/samples/typescript-express/src/mock-webhook.ts): implements the Metriport webhook protocol, can be used by applications integrating with Metriport API as a reference to the behavior expected from these applications when using the webhook feature.
 - [fhir-uploader](https://github.com/metriport/metriport/blob/develop/packages/utils/src/fhir-uploader.ts): useful to insert synthetic/mock data from [Synthea](https://github.com/synthetichealth/synthea) into [FHIR](https://www.hl7.org/fhir) servers (see https://github.com/metriport/hapi-fhir-jpaserver).
 
 Check the scripts on the folder's [package.json](https://github.com/metriport/metriport/blob/develop/packages/utils/package.json) to see how to run these.

--- a/docs/medical-api/getting-started/webhooks.mdx
+++ b/docs/medical-api/getting-started/webhooks.mdx
@@ -140,7 +140,7 @@ accept a `POST` request with this body...
 }
 ```
 
-You can check the [webhook mock server available on our repository](https://github.com/metriport/metriport/blob/master/packages/utils/src/mock-webhook.ts)
+You can check the [webhook mock server available on our repository](https://github.com/metriport/metriport/blob/master/samples/typescript-express/src/mock-webhook.ts)
 for a simple implementation of this message.
 
 ### Medical API messages
@@ -191,6 +191,7 @@ The format follows:
       The additional data you passed to the Metriport API when you called the endpoint related to this Webhook message.
       This does not exist in webhooks for [realtime patient notifications](//medical-api/handling-data/realtime-patient-notifications). See more details [here](/medical-api/handling-data/webhooks#passing-metadata).
     </ResponseField>
+
   </Expandable>
 </ResponseField>
 
@@ -201,8 +202,10 @@ to your app. In these cases, Metriport will store the failed requests, and you c
 either the dashboard, or the API.
 
 <Warning>
-  If you do not have the Webhook URL configured, the Metriport will not attempt to deliver Webhook
-  messages for the Medical API - in which case retries are not applicable.
+  If you do not have the Webhook URL configured, the
+  Metriport will not attempt to deliver Webhook messages for
+  the Medical API - in which case retries are not
+  applicable.
 </Warning>
 
 ### Retry Using the Dashboard
@@ -210,7 +213,10 @@ either the dashboard, or the API.
 On the [Developers page](https://dash.metriport.com/developers) in the dashboard, you're able to see the count of
 Webhook requests currently processing, and a count of outstanding ones that failed:
 
-<img className="h-100" src="/images/dash-webhook-retry.png" />
+<img
+  className="h-100"
+  src="/images/dash-webhook-retry.png"
+/>
 
 To retry failed requests, simply click the `Retry` button, and those requests will be sent to your app again.
 
@@ -220,6 +226,6 @@ To retry failed requests, simply click the `Retry` button, and those requests wi
 1. Then, use the [Retry Webhook requests endpoint](/medical-api/api-reference/settings/retry-webhook), to kick off the retry.
 
 <Warning>
-  Currently, the Metriport API doesn't implement automatic retries - let us know if this is
-  something you need.
+  Currently, the Metriport API doesn't implement automatic
+  retries - let us know if this is something you need.
 </Warning>

--- a/docs/medical-api/getting-started/webhooks.mdx
+++ b/docs/medical-api/getting-started/webhooks.mdx
@@ -202,10 +202,9 @@ to your app. In these cases, Metriport will store the failed requests, and you c
 either the dashboard, or the API.
 
 <Warning>
-  If you do not have the Webhook URL configured, the
-  Metriport will not attempt to deliver Webhook messages for
-  the Medical API - in which case retries are not
-  applicable.
+  If you do not have the Webhook URL configured, Metriport
+  will not attempt to deliver Webhook messages for the
+  Medical API - in which case retries are not applicable.
 </Warning>
 
 ### Retry Using the Dashboard

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -44,7 +44,7 @@ async function missingWHSettings(
   const product = getProductFromWebhookRequest(webhookRequest);
   const msg = `[${product}] Missing webhook config, skipping sending it, WH req ID ${webhookRequest.id}`;
   const loggableKey = webhookKey ? "<defined>" : "<not-defined>";
-  log(msg + ` (url: ${webhookUrl}, key: ${loggableKey}`);
+  log(msg + ` (url: ${webhookUrl}, key: ${loggableKey})`);
   // mark this WH request as failed
   await updateWebhookRequest({
     id: webhookRequest.id,

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -293,7 +293,6 @@ export async function sendTestPayload(url: string, key: string, cxId: string): P
   return (
     typeof whResponse === "object" &&
     whResponse !== null &&
-    "pong" in whResponse &&
     typeof (whResponse as Record<string, unknown>).pong === "string" &&
     (whResponse as Record<string, unknown>).pong === ping
   );

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -11,7 +11,7 @@ import crypto from "crypto";
 import stringify from "json-stringify-safe";
 import { nanoid } from "nanoid";
 import { v4 as uuidv4 } from "uuid";
-import { z, ZodError } from "zod";
+import { ZodError } from "zod";
 import { Product } from "../../domain/product";
 import { WebhookRequestStatus } from "../../domain/webhook";
 import WebhookError from "../../errors/webhook";
@@ -69,7 +69,7 @@ export async function processRequest(
   additionalWHRequestMeta?: Record<string, string>,
   cxWHRequestMeta?: unknown
 ): Promise<boolean> {
-  const sendAnalytics = (status: string, properties?: Record<string, string>) => {
+  function sendAnalytics(status: string, properties?: Record<string, string>) {
     analytics({
       distinctId: webhookRequest.cxId,
       event: EventTypes.webhook,
@@ -80,7 +80,7 @@ export async function processRequest(
         ...(properties ? properties : {}),
       },
     });
-  };
+  }
 
   const { webhookUrl, webhookKey, webhookEnabled } = settings;
   if (!webhookUrl || !webhookKey) {
@@ -231,14 +231,6 @@ async function updateWhStatusWithError(
   }
 }
 
-const webhookResponseSchema = z
-  .object({
-    pong: z.string().optional(),
-  })
-  .or(z.string());
-
-type WebhookResponse = z.infer<typeof webhookResponseSchema>;
-
 export async function sendPayload(
   payload: unknown,
   url: string,
@@ -246,7 +238,7 @@ export async function sendPayload(
   timeout = DEFAULT_TIMEOUT_SEND_PAYLOAD_MS
 ): Promise<{
   status: number;
-  webhookResponse: WebhookResponse;
+  webhookResponse: unknown;
   url: string;
   durationMillis: number;
 }> {
@@ -262,10 +254,9 @@ export async function sendPayload(
       maxRedirects: 0, // disable redirects to prevent SSRF
     });
     const duration = Date.now() - before;
-    const webhookResponse = webhookResponseSchema.parse(res.data);
     return {
       status: res.status,
-      webhookResponse,
+      webhookResponse: res.data,
       url,
       durationMillis: duration,
     };
@@ -299,9 +290,13 @@ export async function sendTestPayload(url: string, key: string, cxId: string): P
   if (isWebhookPongDisabled) return true;
   // check for a matching pong response, unless FF is enabled to skip that check
   const whResponse = sendResponse.webhookResponse;
-  return typeof whResponse !== "string" && whResponse.pong && whResponse.pong === ping
-    ? true
-    : false;
+  return (
+    typeof whResponse === "object" &&
+    whResponse !== null &&
+    "pong" in whResponse &&
+    typeof (whResponse as Record<string, unknown>).pong === "string" &&
+    (whResponse as Record<string, unknown>).pong === ping
+  );
 }
 
 async function isWebhookPongDisabledForCxSafe(cxId: string): Promise<boolean> {

--- a/packages/api/src/routes/settings.ts
+++ b/packages/api/src/routes/settings.ts
@@ -1,4 +1,5 @@
-import { BadRequestError, getEnvVarOrFail } from "@metriport/shared";
+import { Config } from "@metriport/core/util/config";
+import { BadRequestError } from "@metriport/shared";
 import dayjs from "dayjs";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
@@ -255,8 +256,7 @@ router.post(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const id = getCxIdOrFail(req);
-    const envType = getEnvVarOrFail("ENV_TYPE");
-    if (envType === "production") {
+    if (Config.isProduction()) {
       throw new BadRequestError("Webhook sample payload is not available in production");
     }
     const { webhookUrl, webhookKey } = await getSettingsOrFail({ id });

--- a/packages/shared/src/medical/webhook/webhook-request.ts
+++ b/packages/shared/src/medical/webhook/webhook-request.ts
@@ -182,8 +182,8 @@ export const patientAdmitWebhookPayloadSchema = z.object({
   patientId: z.string(),
   externalId: z.string().optional(),
   additionalIds: z.record(z.string(), z.string().array()).optional(),
-  admitTimestamp: z.string(),
-  whenSourceSent: z.string().optional(),
+  admitTimestamp: dateSchema,
+  whenSourceSent: dateSchema.optional(),
 });
 export type PatientAdmitPayload = z.infer<typeof patientAdmitWebhookPayloadSchema>;
 
@@ -192,15 +192,15 @@ export const patientTransferWebhookPayloadSchema = z.object({
   patientId: z.string(),
   externalId: z.string().optional(),
   additionalIds: z.record(z.string(), z.string().array()).optional(),
-  admitTimestamp: z.string(),
+  admitTimestamp: dateSchema,
   transfers: z.array(
     z.object({
-      timestamp: z.string(),
+      timestamp: dateSchema,
       sourceLocation: z.object({ name: z.string(), type: z.string() }),
       destinationLocation: z.object({ name: z.string(), type: z.string() }),
     })
   ),
-  whenSourceSent: z.string().optional(),
+  whenSourceSent: dateSchema.optional(),
 });
 
 export type PatientTransferPayload = z.infer<typeof patientTransferWebhookPayloadSchema>;
@@ -210,9 +210,9 @@ export const patientDischargeWebhookPayloadSchema = z.object({
   patientId: z.string(),
   externalId: z.string().optional(),
   additionalIds: z.record(z.string(), z.string().array()).optional(),
-  admitTimestamp: z.string(),
-  dischargeTimestamp: z.string(),
-  whenSourceSent: z.string().optional(),
+  admitTimestamp: dateSchema,
+  dischargeTimestamp: dateSchema,
+  whenSourceSent: dateSchema.optional(),
 });
 export type PatientDischargePayload = z.infer<typeof patientDischargeWebhookPayloadSchema>;
 
@@ -255,78 +255,53 @@ export class WebhookRequestParsingFailure {
 }
 
 export function isPingWebhookRequest(whRequest: WebhookRequest): whRequest is PingWebhookRequest {
-  if (whRequest.meta.type === "ping") return true;
-  return false;
+  return whRequest.meta.type === "ping";
 }
 
 export function isConsolidatedWebhookRequest(
   whRequest: WebhookRequest
 ): whRequest is ConsolidatedWebhookRequest {
-  if (whRequest.meta.type === "medical.consolidated-data") {
-    return true;
-  }
-  return false;
+  return whRequest.meta.type === "medical.consolidated-data";
 }
 
 export function isDocumentDownloadWebhookRequest(
   whRequest: WebhookRequest
 ): whRequest is DocumentDownloadWebhookRequest {
-  if (whRequest.meta.type === "medical.document-download") {
-    return true;
-  }
-  return false;
+  return whRequest.meta.type === "medical.document-download";
 }
 
 export function isDocumentConversionWebhookRequest(
   whRequest: WebhookRequest
 ): whRequest is DocumentConversionWebhookRequest {
-  if (whRequest.meta.type === "medical.document-conversion") {
-    return true;
-  }
-  return false;
+  return whRequest.meta.type === "medical.document-conversion";
 }
 
 export function isDocumentBulkDownloadWebhookRequest(
   whRequest: WebhookRequest
 ): whRequest is DocumentBulkDownloadWebhookRequest {
-  if (whRequest.meta.type === "medical.document-bulk-download-urls") {
-    return true;
-  }
-  return false;
+  return whRequest.meta.type === "medical.document-bulk-download-urls";
 }
 
 export function isBulkPatientImportWebhookRequest(
   whRequest: WebhookRequest
 ): whRequest is BulkPatientImportWebhookRequest {
-  if (whRequest.meta.type === "medical.bulk-patient-create") {
-    return true;
-  }
-  return false;
+  return whRequest.meta.type === "medical.bulk-patient-create";
 }
 
 export function isPatientAdmitWebhookRequest(
   whRequest: WebhookRequest
 ): whRequest is PatientAdmitWebhookRequest {
-  if (whRequest.meta.type === "patient.admit") {
-    return true;
-  }
-  return false;
+  return whRequest.meta.type === "patient.admit";
 }
 
 export function isPatientTransferWebhookRequest(
   whRequest: WebhookRequest
 ): whRequest is PatientTransferWebhookRequest {
-  if (whRequest.meta.type === "patient.transfer") {
-    return true;
-  }
-  return false;
+  return whRequest.meta.type === "patient.transfer";
 }
 
 export function isPatientDischargeWebhookRequest(
   whRequest: WebhookRequest
 ): whRequest is PatientDischargeWebhookRequest {
-  if (whRequest.meta.type === "patient.discharge") {
-    return true;
-  }
-  return false;
+  return whRequest.meta.type === "patient.discharge";
 }

--- a/samples/typescript-express/src/mock-webhook.ts
+++ b/samples/typescript-express/src/mock-webhook.ts
@@ -9,6 +9,9 @@ import {
   isDocumentConversionWebhookRequest,
   isDocumentDownloadWebhookRequest,
   isPingWebhookRequest,
+  isPatientAdmitWebhookRequest,
+  isPatientTransferWebhookRequest,
+  isPatientDischargeWebhookRequest,
 } from "@metriport/shared/medical";
 import express, { Application, raw, Request, Response } from "express";
 import fs from "fs";
@@ -149,6 +152,39 @@ app.post("/", raw({ type: "*/*" }), async (req: Request, res: Response): Promise
     } else {
       console.log("Failed to process the bulk patient create");
     }
+    processed = true;
+  }
+
+  if (isPatientAdmitWebhookRequest(payload)) {
+    console.log(`Received patient admit webhook`);
+    const admitPayload = payload.payload;
+    // process admit message
+    console.log(
+      `Patient admitted: ${admitPayload.patientId}, externalId: ${admitPayload.externalId}`
+    );
+    console.log(JSON.stringify(admitPayload, undefined, 2));
+    processed = true;
+  }
+
+  if (isPatientTransferWebhookRequest(payload)) {
+    console.log(`Received patient transfer webhook`);
+    const transferPayload = payload.payload;
+    // process transfer message
+    console.log(
+      `Patient transferred: ${transferPayload.patientId}, externalId: ${transferPayload.externalId}`
+    );
+    console.log(JSON.stringify(transferPayload, undefined, 2));
+    processed = true;
+  }
+
+  if (isPatientDischargeWebhookRequest(payload)) {
+    console.log(`Received patient discharge webhook`);
+    const dischargePayload = payload.payload;
+    // process discharge message
+    console.log(
+      `Patient discharged: ${dischargePayload.patientId}, externalId: ${dischargePayload.externalId}`
+    );
+    console.log(JSON.stringify(dischargePayload, undefined, 2));
     processed = true;
   }
 


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-939

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/3204

### Description

- update docs
- add schemas
- update mock-webhoook server
- add a new api to test webhooks from UI

### Testing


- Local
  - [x] can send webhooks
  - [x] can receive webhooks
- Staging
  - unknown
- Sandbox
  - [ ] can send webhooks
  - [ ] can receive webhooks
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for patient webhook events: patient.admit, patient.transfer, patient.discharge.
  * New protected endpoint to send a sample webhook payload for testing (disabled in production).

* **Infrastructure**
  * Sample webhook server updated to recognize and log new patient events.

* **Documentation**
  * Webhook docs and README links updated; minor formatting and wording clarifications.

* **Behavior**
  * Webhook sender now returns raw webhook responses with looser response validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->