### PR TITLE
fix(docs): fix docs to display correct demos for new sandbox data

### DIFF
--- a/docs/medical-api/getting-started/sandbox.mdx
+++ b/docs/medical-api/getting-started/sandbox.mdx
@@ -61,7 +61,7 @@ Jane Smith has a history of depression and other mental health conditions.
     {
       "addressLine1": "123 DustyDepot Ave",
       "city": "Springfield",
-      "state": "Oregon",
+      "state": "OR",
       "zip": "00000",
       "country": "USA"
     }
@@ -83,7 +83,7 @@ Chris Smith has chronic kidney disease (CKD)
     {
       "addressLine1": "123 DustyDepot Ave",
       "city": "Springfield",
-      "state": "Oregon",
+      "state": "OR",
       "zip": "00000",
       "country": "USA"
     }
@@ -105,7 +105,7 @@ Ollie Brown has generalized anxiety disorder (GAD).
     {
       "addressLine1": "123 DustyDepot Ave",
       "city": "Springfield",
-      "state": "Oregon",
+      "state": "OR",
       "zip": "00000",
       "country": "USA"
     }
@@ -127,7 +127,7 @@ Kyla Brown has chronic hypertension and diabetes.
     {
       "addressLine1": "123 DustyDepot Ave",
       "city": "Springfield",
-      "state": "Oregon",
+      "state": "OR",
       "zip": "00000",
       "country": "USA"
     }
@@ -149,7 +149,7 @@ Andreas Brown has type 2 diabetes and kidney disease.
     {
       "addressLine1": "123 DustyDepot Ave",
       "city": "Springfield",
-      "state": "Oregon",
+      "state": "OR",
       "zip": "00000",
       "country": "USA"
     }


### PR DESCRIPTION
Part of ENG-957

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-957

### Dependencies
NONE 
### Description
Fix docs to have correct patient demos.
And display what each patient's main disorder is.

### Testing

- Local
  - [x] Preview changes to make sure they are there
- Production
  - [ ] See changes to make sure they are there



https://github.com/user-attachments/assets/e19838f0-21bc-4c1b-a298-a177d54fb5d7






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sandbox guide with clearer patient profiles and conditions.
  * Renamed two sample patients for consistency across examples.
  * Standardized all sample addresses to a new placeholder set.
  * Synced embedded examples and JSON snippets with updated names/addresses.
  * Improved readability with minor formatting tweaks to warnings and tips.
  * Guidance structure remains the same; no functional changes to the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->