### PR TITLE
fix(core): fix failing test for Quest date parsing

### DIFF
--- a/packages/core/src/external/quest/schema/shared.ts
+++ b/packages/core/src/external/quest/schema/shared.ts
@@ -1,5 +1,5 @@
 import { MetriportError } from "@metriport/shared";
-import { convertDateToString } from "@metriport/shared/common/date";
+import { buildDayjs, convertDateToString } from "@metriport/shared/common/date";
 
 /**
  * Describes a single field mapping from an object to a column in a space-padded
@@ -208,13 +208,7 @@ export function fromQuestDate<O extends FieldOption>(option: O = {} as O) {
       }
       throw new MetriportError(`Invalid date: ${value}`);
     }
-    const year = parseInt(value.substring(0, 4), 10);
-    const month = parseInt(value.substring(4, 6), 10);
-    const day = parseInt(value.substring(6, 8), 10);
-
-    // Month in JS Date is 0-based, so subtract 1
-    const date = new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0));
-    return date;
+    return buildDayjs(value, "YYYYMMDD").toDate();
   };
 }
 

--- a/packages/core/src/external/quest/schema/shared.ts
+++ b/packages/core/src/external/quest/schema/shared.ts
@@ -205,15 +205,15 @@ export function fromQuestDate<O extends FieldOption>(option: O = {} as O) {
     if (value.length !== 8) {
       if (option.optional && value.length === 0) {
         return undefined as FieldTypeFromQuest<Date, O>;
-      } else {
-        throw new MetriportError(`Invalid date: ${value}`);
       }
+      throw new MetriportError(`Invalid date: ${value}`);
     }
-    const date = new Date();
-    date.setUTCFullYear(parseInt(value.substring(0, 4), 10));
-    date.setUTCMonth(parseInt(value.substring(4, 6), 10) - 1);
-    date.setUTCDate(parseInt(value.substring(6, 8), 10));
-    date.setUTCHours(0, 0, 0, 0);
+    const year = parseInt(value.substring(0, 4), 10);
+    const month = parseInt(value.substring(4, 6), 10);
+    const day = parseInt(value.substring(6, 8), 10);
+
+    // Month in JS Date is 0-based, so subtract 1
+    const date = new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0));
     return date;
   };
 }


### PR DESCRIPTION
metriport/metriport-internal#3045

Issues:

- https://linear.app/metriport/issue/ENG-823

### Dependencies

- Upstream: None
- Downstream: None

### Description

Fixes `fromQuestDate` parser to ensure that the UTC date is being parsed correctly, somehow this is causing a fuzzy test otherwise at around 5 pm (needs further investigation, unclogging the build pipeline for now).

### Testing

- Local
  - [x] `cd core && npx jest quest/__tests` 

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Corrected date parsing to use UTC consistently, preventing timezone shifts and off-by-one month/day issues.
  - Improved validation: optional empty dates are accepted; non-empty invalid inputs now produce a clear “Invalid date” error.
  - Ensures consistent behavior across locales and platforms, reducing unexpected date discrepancies in user-facing flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->