### PR TITLE
RELEASE ...WIP

### DIFF
--- a/packages/api/src/external/commonwell-v1/document/document-query.ts
+++ b/packages/api/src/external/commonwell-v1/document/document-query.ts
@@ -36,7 +36,7 @@ import {
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 import { Config } from "../../../shared/config";
 import { mapDocRefToMetriport } from "../../../shared/external";
-import { reportMetric } from "../../aws/cloudwatch";
+import { reportMetric } from "@metriport/core/external/aws/cloudwatch";
 import { convertCDAToFHIR, isConvertible } from "../../fhir-converter/converter";
 import { makeFhirApi } from "../../fhir/api/api-factory";
 import { cwToFHIR } from "../../fhir/document";

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-uploader.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-uploader.ts
@@ -54,10 +54,16 @@ async function sendViaSftp(sftpConfig: HieSftpConfig, file: string, remoteFileNa
       throw new Error("Folder does not exist.");
     }
 
-    const fullPath = `${remoteFolderPath}/${remoteFileName}`;
+    const fullPath = getFullPath(remoteFolderPath, remoteFileName);
 
     await client.write(fullPath, Buffer.from(file, "utf-8"));
   } finally {
     await client.disconnect();
   }
+}
+
+function getFullPath(folderPath: string, filePath: string): string {
+  const cleanFolder = folderPath.replace(/\/+$/, "");
+  const cleanFile = filePath.replace(/^\/+/, "");
+  return `${cleanFolder}/${cleanFile}`;
 }

--- a/packages/core/src/external/analytics/posthog.ts
+++ b/packages/core/src/external/analytics/posthog.ts
@@ -70,6 +70,7 @@ export enum EventTypes {
   inboundDocumentQuery = "inbound.documentQuery",
   inboundDocumentRetrieval = "inbound.documentRetrieval",
   dischargeRequery = "dischargeRequery",
+  rosterUploadSummary = "rosterUploadSummary",
 }
 
 export enum EventErrMessage {

--- a/packages/core/src/external/aws/cloudwatch.ts
+++ b/packages/core/src/external/aws/cloudwatch.ts
@@ -1,29 +1,20 @@
 import AWS from "aws-sdk";
-import { Config } from "../../shared/config";
-import { capture } from "../../shared/notifications";
+import { Config } from "../../util/config";
+import { capture } from "../../util/notifications";
 
-/**
- * @deprecated Move this to @metriport/core
- */
 export const METRICS_NAMESPACE = "Metriport";
 
 const cw = new AWS.CloudWatch({ apiVersion: "2010-08-01", region: Config.getAWSRegion() });
 
-/**
- * @deprecated Move this to @metriport/core
- */
 export type Metric = {
   name: string;
-  unit: "Milliseconds";
+  unit: "Milliseconds" | "Count";
   value: number | string;
   timestamp?: Date;
   additionalDimension?: string;
 };
 
-/**
- * @deprecated Move this to @metriport/core
- */
-export function reportMetric(metric: Metric) {
+export async function reportMetric(metric: Metric) {
   try {
     const metricBase = {
       MetricName: metric.name,
@@ -31,7 +22,7 @@ export function reportMetric(metric: Metric) {
       Unit: metric.unit,
       Value: typeof metric.value === "string" ? parseFloat(metric.value) : metric.value,
     };
-    return cw
+    await cw
       .putMetricData({
         MetricData: [
           {

--- a/packages/core/src/external/fhir/bundle/utils.ts
+++ b/packages/core/src/external/fhir/bundle/utils.ts
@@ -1,5 +1,4 @@
 import { Bundle, Resource } from "@medplum/fhirtypes";
-import { FhirBundleSdk } from "@metriport/fhir-sdk";
 import { MetriportError } from "@metriport/shared";
 import _, { cloneDeep } from "lodash";
 import { dangerouslyDeduplicateFhir } from "../../../fhir-deduplication/deduplicate-fhir";
@@ -7,6 +6,7 @@ import { groupSameEncountersDatetimeOnly } from "../../../fhir-deduplication/res
 import { normalizeFhir } from "../normalization/normalize-fhir";
 import { isEncounter } from "../shared";
 import { buildBundle, buildBundleEntry, RequiredBundleType } from "./bundle";
+import { FhirBundleSdk } from "@metriport/fhir-sdk";
 
 export function mergeBundles({
   cxId,


### PR DESCRIPTION
- **feat(core): add FF to enable cxs to CW v2**
- **refactor(core): add onError to executeWithRetries**
- **refactor(api): remove /organization MAPI routes**
- **fix(api): revert of revert for cw v2**
- **feat(core): add FF to enable cxs to CW v2**
- **refactor(core): add onError to executeWithRetries**
- **refactor(api): remove /organization MAPI routes**
- **refactor(core): move document and extension to cw and cw-v2 folders**
- **refactor(api): org and facility internal routes to cw v2**
- **refactor(core): updates for org create and update**
- **refactor(core): minor fixes**
- **fix(api): a bunch of fixes for the organization and facility flows**
- **fix(commonwell-sdk): added improved error reporting on commonwell-sdk**
- **fix(api): minor updates**
- **fix(api): minor fix**
- **fix(api): revert of revert for cw v2**
- **refactor(core): move document and extension to cw and cw-v2 folders**
- **refactor(api): org and facility internal routes to cw v2**
- **refactor(core): updates for org create and update**
- **refactor(core): minor fixes**
- **fix(api): a bunch of fixes for the organization and facility flows**
- **fix(commonwell-sdk): added improved error reporting on commonwell-sdk**
- **fix(api): minor updates**
- **fix(api): minor fix**
- **fix(api): some commonwell api client upd + minor upd on facility create**
- **build: memberID on OSS API config**
- **fix(api): npm i**
- **fix(api): minor pkg updates**
- **chore(release): publish**
- **chore(release): publish**
- **fix(api): fixed the cw org treatment types and mapped to our types**
- **fix(api): minor fixes based on rabbit comments**
- **fix(commonwell-sdk): minor fix to reporting errors + added cw org type**
- **fix(commonwell-sdk): better error handling**
- **fix(commonwell-sdk): small update to error handling**
- **chore(release): publish**
- **fix(commonwell-sdk): returning undefined on getorg if not found**
- **chore(release): publish**
- **feat(api): some minor fixes based on comments**
- **refactor: address rabbit's comment**
- **refactor(api): cw v2 org logic uses get only, no getOrFail**
- **refactor(cw-sdk): return descriptive error instead of throwing it**
- **refactor(api): proper cw sdk error handler + retry on update/get org**
- **refactor(cw-sdk): parse state as 2 letter code**
- **chore(release): publish**
- **chore(release): publish**
- **refactor(api): cw v2 using -OBO-**
- **refactor(cw-sdk): adj getDescriptiveError on CW SDK**
- **fix(cw-sdk): add pix cert type**
- **chore(release): publish**

Issues:

- https://linear.app/metriport/issue/ENG-xxx
- https://linear.app/metriport/issue/ENG-xxx

### Dependencies

- Upstream: _[this PR points to another PR or depends on its release]_
- Downstream: _[PRs that depend on this one, either point to this or can only be released after this one is released]_

### Description

- ...
- ...

### Testing

Check each PR.

### Release Plan

_[How does the changes on this PR impact/interact with the existing environment (database, configs, secrets, FFs, api contracts, etc.)?
Consider creating 2+ PRs if we need to ship those changes in a staged way]_

_[This is the release plan for production]_

_[You should execute the exact same steps when releasing to staging to validate it works]_

_[Add and remove items below accordingly]_

- :warning: Points to `master`
- :warning: This contains a DB migration
- [ ] Maintenance window scheduled/created at Checkly (if needed)
- [ ] Execute this on <env1>, <env2>
  - [ ] _step1_
  - [ ] _step2_
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (deprecates a feature that needs to be communicated with customers)
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (introduce a feature that would be useful customers)
- [ ] Upstream dependencies are met/released
- [ ] Release NPM packages
- [ ] Fern Definition Updated
- [ ] Release Fern SDKs
- [ ] FFs have been set in Staging, Production, and Sandbox
- [ ] Happy-path E2E test created checking new FF flow
- [ ] No dependencies between API and Infra that will cause errors during deployment
- [ ] _[action n-1]_
- [ ] _[action n]_
- [ ] Merge this
