### PR TITLE
Fix re-assignment bug for adding data source extension

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/__tests__/hl7v2-to-fhir-conversion.test.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/__tests__/hl7v2-to-fhir-conversion.test.ts
@@ -1,5 +1,5 @@
 import { Hl7Message } from "@medplum/core";
-import { convertHl7v2MessageToFhir, ResourceWithExtension } from "..";
+import { convertHl7v2MessageToFhir } from "..";
 import { Bundle } from "@medplum/fhirtypes";
 import * as configModule from "../../../../util/config";
 
@@ -51,8 +51,12 @@ DG1|5|I10|E03.9^Hypothyroidism, unspecified^I10|Hypothyroidism, unspecified
     }
     for (const entry of bundle.entry) {
       expect(entry.resource).toBeDefined();
-
-      const ext = (entry.resource as ResourceWithExtension).extension;
+      if (!entry.resource || !("extension" in entry.resource)) {
+        throw new Error(
+          "Extension not defined in entry.resource hl7message -> FHIR conversion test"
+        );
+      }
+      const ext = entry.resource.extension;
       expect(ext).toBeDefined();
       expect(ext).toEqual(
         expect.arrayContaining([

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/__tests__/hl7v2-to-fhir-conversion.test.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/__tests__/hl7v2-to-fhir-conversion.test.ts
@@ -6,7 +6,7 @@ import { getCxIdAndPatientIdOrFail } from "../shared";
 describe("Hl7v2 to FHIR conversion", () => {
   const hl7Msg = `MSH|^~|HEALTHSHARE|HMHW|METRIPORTPA|METRIPORTPA|20250507034313||ADT^A03|100000^111222333|P|2.5.1
 EVN|A03|20250102060000|||||AHHH^SOMEWHERE
-PID|1||cOEe2QLs2M43J1X3ER1bNu==_RWpXFS0oT3+BKiMrFHHvYu==^^METRIPORTPA^MR|123456789^^^ABCDEF^MR|LAST^FIRST^MIDDLE^^^^||22211117|F||C^^L|SOMEWHERE^77777^USA^L^^THOMAS||(666)-666-6666^^||^^L|^^L|^^L|2101206259758|000-00-0000|||^^L||||||||N
+PID|1||cOEe2QLs2M43J1X3ER1bNu==_RWpXFS0oT3+BKiMrFHHvYu==^^METRIPORTPA^MR|123456789^^^ABCDEF^MR|LAST^FIRST^MIDDLE^^^^||1111111|F||C^^L|SOMEWHERE^77777^USA^L^^THOMAS||(666)-666-6666^^||^^L|^^L|^^L|2101206259758|000-00-0000|||^^L||||||||N
 PV1|1|O|^^^^||||10000000^SMITH^JANE^^^^^^^^^^NPI|||||||2|||||10000|||||||||||||||||||||||||20250829024816|20250830024816
 PV2|1|^^L||||||20250502180000||||PRE-ADMISSION TESTING VISIT||||||||||N|SOMEWHERE|||||||||N
 DG1|1|I10|I65.21^Occlusion and stenosis of right carotid artery^I10|Occlusion and stenosis of right carotid |20250101181500
@@ -38,7 +38,7 @@ DG1|5|I10|E03.9^Hypothyroidism, unspecified^I10|Hypothyroidism, unspecified
 
     expect(bundle.entry?.length).toBeGreaterThan(0);
     if (!bundle.entry) {
-      throw new Error("No entries in bundle after hl7message ->FHIR conversion");
+      throw new Error("No entries in bundle after hl7message -> FHIR conversion");
     }
     for (const entry of bundle.entry) {
       expect(entry.resource).toBeDefined();

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/__tests__/hl7v2-to-fhir-conversion.test.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/__tests__/hl7v2-to-fhir-conversion.test.ts
@@ -2,7 +2,7 @@ import { Hl7Message } from "@medplum/core";
 import { convertHl7v2MessageToFhir, ResourceWithExtension } from "..";
 import { Bundle } from "@medplum/fhirtypes";
 import { getCxIdAndPatientIdOrFail } from "../shared";
-import * as packIdsModule from "../../utils";
+import * as packIdsModule from "../shared";
 
 describe("Hl7v2 to FHIR conversion", () => {
   const hl7Msg = `MSH|^~|HEALTHSHARE|HMHW|METRIPORTPA|METRIPORTPA|20250507034313||ADT^A03|100000^111222333|P|2.5.1
@@ -22,14 +22,14 @@ DG1|5|I10|E03.9^Hypothyroidism, unspecified^I10|Hypothyroidism, unspecified
 
   const DOC_ID_URL = "https://public.metriport.com/fhir/StructureDefinition/doc-id-extension.json";
   const DATA_SOURCE_URL = "https://public.metriport.com/fhir/StructureDefinition/data-source.json";
-  let scrambleIdMock: jest.SpyInstance;
+  let unpackPidFieldOrFailMock: jest.SpyInstance;
   let scrambledId: string;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    scrambleIdMock = jest.spyOn(packIdsModule, "createScrambledId");
+    unpackPidFieldOrFailMock = jest.spyOn(packIdsModule, "unpackPidFieldOrFail");
     scrambledId = `${cxId}_${patientId}`;
-    scrambleIdMock.mockReturnValueOnce(scrambledId);
+    unpackPidFieldOrFailMock.mockReturnValueOnce(scrambledId);
   });
 
   afterAll(() => {

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/__tests__/hl7v2-to-fhir-conversion.test.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/__tests__/hl7v2-to-fhir-conversion.test.ts
@@ -1,8 +1,7 @@
 import { Hl7Message } from "@medplum/core";
 import { convertHl7v2MessageToFhir, ResourceWithExtension } from "..";
 import { Bundle } from "@medplum/fhirtypes";
-import { getCxIdAndPatientIdOrFail } from "../shared";
-import * as packIdsModule from "../shared";
+import * as configModule from "../../../../util/config";
 
 describe("Hl7v2 to FHIR conversion", () => {
   const hl7Msg = `MSH|^~|HEALTHSHARE|HMHW|METRIPORTPA|METRIPORTPA|20250507034313||ADT^A03|100000^111222333|P|2.5.1
@@ -18,18 +17,14 @@ DG1|4|I10|E78.5^Dyslipidemia^I10|Dyslipidemia
 DG1|5|I10|E03.9^Hypothyroidism, unspecified^I10|Hypothyroidism, unspecified
 `;
   const hl7Message = Hl7Message.parse(hl7Msg);
-  const { cxId, patientId } = getCxIdAndPatientIdOrFail(hl7Message);
+  const cxId = "1000000";
+  const patientId = "1000000";
 
   const DOC_ID_URL = "https://public.metriport.com/fhir/StructureDefinition/doc-id-extension.json";
   const DATA_SOURCE_URL = "https://public.metriport.com/fhir/StructureDefinition/data-source.json";
-  let unpackPidFieldOrFailMock: jest.SpyInstance;
-  let scrambledId: string;
 
   beforeEach(() => {
-    jest.clearAllMocks();
-    unpackPidFieldOrFailMock = jest.spyOn(packIdsModule, "unpackPidFieldOrFail");
-    scrambledId = `${cxId}_${patientId}`;
-    unpackPidFieldOrFailMock.mockReturnValueOnce(scrambledId);
+    jest.spyOn(configModule.Config, "getHl7Base64ScramblerSeed").mockReturnValue("unit-test-seed");
   });
 
   afterAll(() => {

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/__tests__/hl7v2-to-fhir-conversion.test.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/__tests__/hl7v2-to-fhir-conversion.test.ts
@@ -2,6 +2,7 @@ import { Hl7Message } from "@medplum/core";
 import { convertHl7v2MessageToFhir, ResourceWithExtension } from "..";
 import { Bundle } from "@medplum/fhirtypes";
 import { getCxIdAndPatientIdOrFail } from "../shared";
+import * as packIdsModule from "../../utils";
 
 describe("Hl7v2 to FHIR conversion", () => {
   const hl7Msg = `MSH|^~|HEALTHSHARE|HMHW|METRIPORTPA|METRIPORTPA|20250507034313||ADT^A03|100000^111222333|P|2.5.1
@@ -21,6 +22,19 @@ DG1|5|I10|E03.9^Hypothyroidism, unspecified^I10|Hypothyroidism, unspecified
 
   const DOC_ID_URL = "https://public.metriport.com/fhir/StructureDefinition/doc-id-extension.json";
   const DATA_SOURCE_URL = "https://public.metriport.com/fhir/StructureDefinition/data-source.json";
+  let scrambleIdMock: jest.SpyInstance;
+  let scrambledId: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    scrambleIdMock = jest.spyOn(packIdsModule, "createScrambledId");
+    scrambledId = `${cxId}_${patientId}`;
+    scrambleIdMock.mockReturnValueOnce(scrambledId);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
 
   it("Converter adds datasource and docId extensions", () => {
     const fileName = "someFileName";

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/__tests__/hl7v2-to-fhir-conversion.test.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/__tests__/hl7v2-to-fhir-conversion.test.ts
@@ -1,0 +1,69 @@
+import { Hl7Message } from "@medplum/core";
+import { convertHl7v2MessageToFhir, ResourceWithExtension } from "..";
+import { Bundle } from "@medplum/fhirtypes";
+import { getCxIdAndPatientIdOrFail } from "../shared";
+
+describe("Hl7v2 to FHIR conversion", () => {
+  const hl7Msg = `MSH|^~|HEALTHSHARE|HMHW|METRIPORTPA|METRIPORTPA|20250507034313||ADT^A03|100000^111222333|P|2.5.1
+EVN|A03|20250102060000|||||AHHH^SOMEWHERE
+PID|1||cOEe2QLs2M43J1X3ER1bNu==_RWpXFS0oT3+BKiMrFHHvYu==^^METRIPORTPA^MR|123456789^^^ABCDEF^MR|LAST^FIRST^MIDDLE^^^^||22211117|F||C^^L|SOMEWHERE^77777^USA^L^^THOMAS||(666)-666-6666^^||^^L|^^L|^^L|2101206259758|000-00-0000|||^^L||||||||N
+PV1|1|O|^^^^||||10000000^SMITH^JANE^^^^^^^^^^NPI|||||||2|||||10000|||||||||||||||||||||||||20250829024816|20250830024816
+PV2|1|^^L||||||20250502180000||||PRE-ADMISSION TESTING VISIT||||||||||N|SOMEWHERE|||||||||N
+DG1|1|I10|I65.21^Occlusion and stenosis of right carotid artery^I10|Occlusion and stenosis of right carotid |20250101181500
+DG1|2|I10|Z01.818^Encounter for other preprocedural examination^I10|Encounter for other preprocedural examin
+DG1|2|I10|E11.9^Type 2 diabetes mellitus without complications^I10|Type 2 diabetes mellitus without complications
+DG1|3|I10|I10.9^Essential (primary) hypertension^I10|Essential (primary) hypertension
+DG1|4|I10|E78.5^Dyslipidemia^I10|Dyslipidemia
+DG1|5|I10|E03.9^Hypothyroidism, unspecified^I10|Hypothyroidism, unspecified
+`;
+  const hl7Message = Hl7Message.parse(hl7Msg);
+  const { cxId, patientId } = getCxIdAndPatientIdOrFail(hl7Message);
+
+  const DOC_ID_URL = "https://public.metriport.com/fhir/StructureDefinition/doc-id-extension.json";
+  const DATA_SOURCE_URL = "https://public.metriport.com/fhir/StructureDefinition/data-source.json";
+
+  it("Converter adds datasource and docId extensions", () => {
+    const fileName = "someFileName";
+    const expectedFileKey = "location_hl7/someFileName";
+    const hieName = "TestHIE";
+    const expectedCode = hieName.toUpperCase();
+
+    const bundle = convertHl7v2MessageToFhir({
+      message: hl7Message,
+      cxId,
+      patientId,
+      rawDataFileKey: fileName,
+      hieName,
+    }) as Bundle;
+
+    expect(bundle.entry?.length).toBeGreaterThan(0);
+    if (!bundle.entry) {
+      throw new Error("No entries in bundle after hl7message ->FHIR conversion");
+    }
+    for (const entry of bundle.entry) {
+      expect(entry.resource).toBeDefined();
+
+      const ext = (entry.resource as ResourceWithExtension).extension;
+      expect(ext).toBeDefined();
+      expect(ext).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            url: DOC_ID_URL,
+            valueString: expectedFileKey,
+          }),
+        ])
+      );
+      expect(ext).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            url: DATA_SOURCE_URL,
+            valueCoding: {
+              system: DATA_SOURCE_URL,
+              code: expectedCode,
+            },
+          }),
+        ])
+      );
+    }
+  });
+});

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
@@ -42,8 +42,10 @@ export function convertHl7v2MessageToFhir({
     log(`Conversion completed in ${duration} ms`);
     const docIdExtension = buildDocIdFhirExtension(rawDataFileKey, "hl7");
     const sourceExtension = createExtensionDataSource(hieName.toUpperCase());
-    let updatedBundle = appendExtensionToEachResource(bundle, docIdExtension);
-    updatedBundle = appendExtensionToEachResource(bundle, sourceExtension);
+    const updatedBundle = appendExtensionToEachResource(
+      appendExtensionToEachResource(bundle, docIdExtension),
+      sourceExtension
+    );
     return updatedBundle;
   }
 

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
@@ -16,7 +16,7 @@ export type Hl7ToFhirParams = {
   rawDataFileKey: string;
   hieName: string;
 };
-type ResourceWithExtension = Resource & { extension?: Extension[] };
+export type ResourceWithExtension = Resource & { extension?: Extension[] };
 
 /**
  * Converts an HL7v2 message to a FHIR Bundle. Currently only supports ADT messages.

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared.ts
@@ -69,11 +69,9 @@ export function getRequiredValueFromMessage(
   const segment = getSegmentByNameOrFail(msg, targetSegmentName);
   const value = getOptionalValueFromSegment(segment, fieldIndex, componentIndex);
   if (!value) {
-    const patientIds = getCxIdAndPatientIdOrFail(msg);
     const datetime = getMessageDatetime(msg);
     const messageId = getMessageUniqueIdentifier(msg);
     throw new MetriportError("Missing required value", undefined, {
-      ids: JSON.stringify(patientIds),
       targetSegmentName,
       fieldIndex,
       componentIndex,

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/backfill-datasource-extension.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/backfill-datasource-extension.ts
@@ -24,9 +24,9 @@ import { appendExtensionToEachResource } from "@metriport/core/command/hl7v2-sub
  * Note: This script modifies data in S3. Ensure you have backups if needed.
  */
 
-const prefixes: string[] = ["cxId=testing/ptId=testing/"];
-const dryRun = false;
-const hieName = "MyTestHIE";
+const prefixes: string[] = [""];
+const dryRun = true;
+const hieName = "";
 
 async function main() {
   console.log(`Adding datasource ${hieName} to resources. Make sure this is correct.`);

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/backfill-datasource-extension.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/backfill-datasource-extension.ts
@@ -24,7 +24,7 @@ import { appendExtensionToEachResource } from "@metriport/core/command/hl7v2-sub
  * Note: This script modifies data in S3. Ensure you have backups if needed.
  */
 
-const prefixes: string[] = [""];
+const prefixes: string[] = [];
 const dryRun = true;
 const hieName = "";
 


### PR DESCRIPTION
Part of ENG-874

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-874

### Dependencies
None

### Description
Fix re-assignment bug for adding data source extension so that the second extension is also added.
Remove let to follow guidelines and not have this type of bug happen again.
add unit test
remove infinite loop bug

### Testing
- Local
  - [x] Run testcase locally
- Staging
  - [ ] Should run during CI
- Production
  - [ ] Should run during CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Converted FHIR bundles now consistently include both document-ID and data-source extensions on each resource.
  * Error payloads for missing values/segments no longer include patient identifier details.

* **Tools**
  * Reprocessing utility now runs when executed and defaults to dry-run with no prefixes or HIE configured.

* **Tests**
  * Added unit test verifying both extensions are attached to converted resources.

* **Refactor**
  * Simplified extension-application flow and made the resource-with-extension type publicly available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->