### PR TITLE
ENG-513 - Address left-over comments on previous deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28656,6 +28656,7 @@
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "file:packages/commonwell-sdk",
+        "@metriport/shared": "file:packages/shared",
         "axios": "^1.8.2",
         "commander": "^9.5.0",
         "dayjs": "^1.11.7",
@@ -28684,6 +28685,10 @@
     },
     "packages/commonwell-cert-runner/node_modules/@metriport/commonwell-sdk": {
       "resolved": "packages/commonwell-cert-runner/packages/commonwell-sdk",
+      "link": true
+    },
+    "packages/commonwell-cert-runner/node_modules/@metriport/shared": {
+      "resolved": "packages/commonwell-cert-runner/packages/shared",
       "link": true
     },
     "packages/commonwell-cert-runner/node_modules/@types/jsonwebtoken": {
@@ -28741,6 +28746,7 @@
       }
     },
     "packages/commonwell-cert-runner/packages/commonwell-sdk": {},
+    "packages/commonwell-cert-runner/packages/shared": {},
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
       "version": "1.27.1",

--- a/packages/api/src/command/medical/patient/get-patient-facilities.ts
+++ b/packages/api/src/command/medical/patient/get-patient-facilities.ts
@@ -35,11 +35,12 @@ export async function getPatientPrimaryFacilityIdOrFail({
 }: GetPatientFacilitiesCmd): Promise<string> {
   const patient = await getPatientOrFail({ id: patientId, cxId });
   const facilityIds = patient.facilityIds;
-  if (facilityIds.length < 1) {
+  const facilityId = facilityIds[0];
+  if (!facilityId) {
     throw new MetriportError("Patient has no facilities", undefined, {
       patientId,
       cxId,
     });
   }
-  return facilityIds[0];
+  return facilityId;
 }

--- a/packages/api/src/external/commonwell-v1/document/document-query.ts
+++ b/packages/api/src/external/commonwell-v1/document/document-query.ts
@@ -17,6 +17,7 @@ import { createDocumentRenderFilePaths } from "@metriport/core/domain/document/f
 import { addOidPrefix } from "@metriport/core/domain/oid";
 import { Patient } from "@metriport/core/domain/patient";
 import { analytics, EventTypes } from "@metriport/core/external/analytics/posthog";
+import { reportMetric } from "@metriport/core/external/aws/cloudwatch";
 import { S3Utils } from "@metriport/core/external/aws/s3";
 import { DownloadResult } from "@metriport/core/external/commonwell/document/document-downloader";
 import { MedicalDataSource } from "@metriport/core/external/index";
@@ -36,7 +37,6 @@ import {
 import { getPatientOrFail } from "../../../command/medical/patient/get-patient";
 import { Config } from "../../../shared/config";
 import { mapDocRefToMetriport } from "../../../shared/external";
-import { reportMetric } from "@metriport/core/external/aws/cloudwatch";
 import { convertCDAToFHIR, isConvertible } from "../../fhir-converter/converter";
 import { makeFhirApi } from "../../fhir/api/api-factory";
 import { cwToFHIR } from "../../fhir/document";
@@ -813,7 +813,11 @@ async function triggerDownloadDocument({
   };
 
   try {
-    const result = await docDownloader.download({ document, fileInfo: adjustedFileInfo, cxId });
+    const result = await docDownloader.download({
+      sourceDocument: document,
+      destinationFileInfo: adjustedFileInfo,
+      cxId,
+    });
     return {
       ...result,
       isNew: true,

--- a/packages/api/src/external/fhir/document/__tests__/index-to-fhir.test.ts
+++ b/packages/api/src/external/fhir/document/__tests__/index-to-fhir.test.ts
@@ -46,7 +46,7 @@ describe("cwToFHIR", () => {
 
 describe("getBestDateFromCWDocRef", () => {
   it("returns indexed when indexed is not today", async () => {
-    const indexed = buildDayjs(faker.date.past()).toISOString();
+    const indexed = buildDayjs(faker.date.past()).subtract(2, "day").toISOString();
     const period = makePeriod();
     const content: DocumentContent = makeDocumentContent({
       indexed,

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@metriport/commonwell-sdk": "file:packages/commonwell-sdk",
+    "@metriport/shared": "file:packages/shared",
     "axios": "^1.8.2",
     "commander": "^9.5.0",
     "dayjs": "^1.11.7",

--- a/packages/commonwell-cert-runner/src/single-commands/org-get.ts
+++ b/packages/commonwell-cert-runner/src/single-commands/org-get.ts
@@ -4,7 +4,7 @@ dotenv.config();
 import { APIMode, CommonWellMember } from "@metriport/commonwell-sdk";
 import { memberCertificateString, memberId, memberName, memberPrivateKeyString } from "../env";
 
-const orgOID: string = process.argv[2]; // read OID from command line argument
+const orgOID: string | undefined = process.argv[2]; // read OID from command line argument
 
 /**
  * Utility to get an Organization by OID.

--- a/packages/commonwell-cert-runner/src/single-commands/patient-delete.ts
+++ b/packages/commonwell-cert-runner/src/single-commands/patient-delete.ts
@@ -4,7 +4,7 @@ dotenv.config();
 import { encodeToCwPatientId } from "@metriport/commonwell-sdk/common/util";
 import { initApiForExistingOrg } from "../flows/org-management";
 
-const patientId: string = process.argv[2]; // read patient ID from command line argument
+const patientId: string | undefined = process.argv[2]; // read patient ID from command line argument
 
 /**
  * Utility to delete a patient from CommonWell.

--- a/packages/commonwell-cert-runner/src/single-commands/patient-get-links.ts
+++ b/packages/commonwell-cert-runner/src/single-commands/patient-get-links.ts
@@ -4,7 +4,7 @@ dotenv.config();
 import { encodeToCwPatientId } from "@metriport/commonwell-sdk/common/util";
 import { initApiForExistingOrg } from "../flows/org-management";
 
-const patientId: string = process.argv[2]; // read patient ID from command line argument
+const patientId: string | undefined = process.argv[2]; // read patient ID from command line argument
 
 /**
  * Utility to get links for a patient by ID.

--- a/packages/commonwell-cert-runner/src/single-commands/patient-get.ts
+++ b/packages/commonwell-cert-runner/src/single-commands/patient-get.ts
@@ -4,7 +4,7 @@ dotenv.config();
 import { encodeToCwPatientId } from "@metriport/commonwell-sdk/common/util";
 import { initApiForExistingOrg } from "../flows/org-management";
 
-const patientId: string = process.argv[2]; // read patient ID from command line argument
+const patientId: string | undefined = process.argv[2]; // read patient ID from command line argument
 
 /**
  * Utility to get a patient by ID.

--- a/packages/commonwell-sdk/src/client/commonwell-member.ts
+++ b/packages/commonwell-sdk/src/client/commonwell-member.ts
@@ -379,7 +379,7 @@ export class CommonWellMember extends CommonWellBase implements CommonWellMember
     return { Authorization: `Bearer ${jwt}` };
   }
 
-  private getDescriptiveError(error: unknown, title: string): unknown {
+  private getDescriptiveError(error: unknown, title: string): Error {
     if (isAxiosError(error)) {
       const status = error.response?.status;
       const data = error.response?.data;
@@ -394,6 +394,6 @@ export class CommonWellMember extends CommonWellBase implements CommonWellMember
       }
       return new MetriportError(title, error, { status, cwReference, responseBody });
     }
-    return error;
+    return error instanceof Error ? error : new MetriportError(title, error);
   }
 }

--- a/packages/core/src/external/commonwell-v1/document/__tests__/document-downloader-lambda.test.ts
+++ b/packages/core/src/external/commonwell-v1/document/__tests__/document-downloader-lambda.test.ts
@@ -9,15 +9,15 @@ import { DocumentDownloaderLambda } from "../../../commonwell/document/document-
 
 class DocumentDownloaderLambdaForTest extends DocumentDownloaderLambda {
   override download({
-    document,
-    fileInfo,
+    sourceDocument,
+    destinationFileInfo,
     cxId,
   }: {
-    document: Document;
-    fileInfo: FileInfo;
+    sourceDocument: Document;
+    destinationFileInfo: FileInfo;
     cxId: string;
   }): Promise<DownloadResult> {
-    return super.download({ document, fileInfo, cxId });
+    return super.download({ sourceDocument, destinationFileInfo, cxId });
   }
 }
 
@@ -57,8 +57,8 @@ describe.skip("document-downloader", () => {
 
     await expect(
       docDownloader.download({
-        document,
-        fileInfo: {
+        sourceDocument: document,
+        destinationFileInfo: {
           name: docRef.fileName,
           location: bucketName,
         },

--- a/packages/core/src/external/commonwell-v1/document/document-downloader-local.ts
+++ b/packages/core/src/external/commonwell-v1/document/document-downloader-local.ts
@@ -48,30 +48,30 @@ export class DocumentDownloaderLocal extends DocumentDownloader {
   }
 
   override async download({
-    document,
-    fileInfo,
+    sourceDocument,
+    destinationFileInfo,
   }: {
-    document: Document;
-    fileInfo: FileInfo;
+    sourceDocument: Document;
+    destinationFileInfo: FileInfo;
   }): Promise<DownloadResult> {
     const { log } = out("S3.download");
     let downloadedDocument = "";
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const onData = (chunk: any) => {
+    function onData(chunk: any) {
       downloadedDocument += chunk;
-    };
-    const onEnd = () => {
+    }
+    function onEnd() {
       log("Finished downloading document");
-    };
+    }
     let downloadResult = await executeWithNetworkRetries(
-      () => this.downloadFromCommonwellIntoS3(document, fileInfo, onData, onEnd),
+      () => this.downloadFromCommonwellIntoS3(sourceDocument, destinationFileInfo, onData, onEnd),
       { retryOnTimeout: true, initialDelay: 500, maxAttempts: 5 }
     );
 
     // Check if the detected file type is in the accepted content types and update it if not
     downloadResult = await this.checkAndUpdateMimeType({
-      document,
-      fileInfo,
+      sourceDocument,
+      destinationFileInfo,
       downloadedDocument,
       downloadResult,
     });
@@ -84,11 +84,11 @@ export class DocumentDownloaderLocal extends DocumentDownloader {
       contentType: downloadResult.contentType,
     };
 
-    if (downloadedDocument && isMimeTypeXML(document.mimeType)) {
+    if (downloadedDocument && isMimeTypeXML(sourceDocument.mimeType)) {
       return this.parseXmlFile({
         ...newlyDownloadedFile,
         contents: downloadedDocument,
-        requestedFileInfo: fileInfo,
+        requestedFileInfo: destinationFileInfo,
       });
     }
     return newlyDownloadedFile;
@@ -99,33 +99,33 @@ export class DocumentDownloaderLocal extends DocumentDownloader {
    * and extension in S3 and returns the updated download result.
    */
   async checkAndUpdateMimeType({
-    document,
-    fileInfo,
+    sourceDocument,
+    destinationFileInfo,
     downloadedDocument,
     downloadResult,
   }: {
-    document: Document;
-    fileInfo: FileInfo;
+    sourceDocument: Document;
+    destinationFileInfo: FileInfo;
     downloadedDocument: string;
     downloadResult: DownloadResult;
   }): Promise<DownloadResult> {
     const { log } = out("checkAndUpdateMimeType");
-    if (isContentTypeAccepted(document.mimeType)) {
+    if (isContentTypeAccepted(sourceDocument.mimeType)) {
       return { ...downloadResult };
     }
 
-    const old_extension = path.extname(fileInfo.name);
+    const old_extension = path.extname(destinationFileInfo.name);
     const documentBuffer = Buffer.from(downloadedDocument);
     const { mimeType, fileExtension } = detectFileType(documentBuffer);
 
     // If the file type has not changed
-    if (mimeType === document.mimeType || old_extension === fileExtension) {
+    if (mimeType === sourceDocument.mimeType || old_extension === fileExtension) {
       return downloadResult;
     }
 
     // If the file type has changed
     log(
-      `Updating content type in S3 ${fileInfo.name} from previous mimeType: ${document.mimeType} to detected mimeType ${mimeType} and ${fileExtension}`
+      `Updating content type in S3 ${destinationFileInfo.name} from previous mimeType: ${sourceDocument.mimeType} to detected mimeType ${mimeType} and ${fileExtension}`
     );
     const newKey = await this.s3Utils.updateContentTypeInS3(
       downloadResult.bucket,

--- a/packages/core/src/external/commonwell-v2/document/document-downloader-local-v2.ts
+++ b/packages/core/src/external/commonwell-v2/document/document-downloader-local-v2.ts
@@ -1,5 +1,6 @@
 import { CommonWellAPI, CommonwellError } from "@metriport/commonwell-sdk";
 import {
+  errorToString,
   executeWithNetworkRetries,
   getNetworkErrorDetails,
   MetriportError,
@@ -246,6 +247,14 @@ export class DocumentDownloaderLocalV2 extends DocumentDownloader {
       location: document.location,
       getStream: () => writeStream,
       resetStream: () => {
+        if (writeStream && !writeStream.destroyed) {
+          try {
+            writeStream.removeAllListeners();
+            writeStream.destroy();
+          } catch (error) {
+            log(`Failed to cleanup old stream: ${errorToString(error)}`);
+          }
+        }
         const resp = setOrResetStream();
         writeStream = resp.writeStream;
         downloadIntoS3 = resp.promise;

--- a/packages/core/src/external/commonwell/document/document-downloader-lambda.ts
+++ b/packages/core/src/external/commonwell/document/document-downloader-lambda.ts
@@ -15,8 +15,8 @@ export type DocumentDownloaderLambdaRequest = {
   orgName: string;
   orgOid: string;
   npi: string;
-  document: Document;
-  fileInfo: FileInfo;
+  sourceDocument: Document;
+  destinationFileInfo: FileInfo;
   cxId: string;
 };
 
@@ -37,17 +37,17 @@ export class DocumentDownloaderLambda extends DocumentDownloader {
   }
 
   async download({
-    document,
-    fileInfo,
+    sourceDocument,
+    destinationFileInfo,
     cxId,
   }: {
-    document: Document;
-    fileInfo: FileInfo;
+    sourceDocument: Document;
+    destinationFileInfo: FileInfo;
     cxId: string;
   }): Promise<DownloadResult> {
     const payload: DocumentDownloaderLambdaRequest = {
-      document,
-      fileInfo,
+      sourceDocument,
+      destinationFileInfo,
       cxId,
       orgName: this.orgName,
       orgOid: this.orgOid,

--- a/packages/core/src/external/commonwell/document/document-downloader.ts
+++ b/packages/core/src/external/commonwell/document/document-downloader.ts
@@ -29,12 +29,12 @@ export abstract class DocumentDownloader {
   constructor(readonly config: DocumentDownloaderConfig) {}
 
   abstract download({
-    document,
-    fileInfo,
+    sourceDocument,
+    destinationFileInfo,
     cxId,
   }: {
-    document: Document;
-    fileInfo: FileInfo;
+    sourceDocument: Document;
+    destinationFileInfo: FileInfo;
     cxId: string;
   }): Promise<DownloadResult>;
 }

--- a/packages/core/src/util/file-type.ts
+++ b/packages/core/src/util/file-type.ts
@@ -64,6 +64,8 @@ const ASCII_CARRIAGE_RETURN = 13;
 const ASCII_SPACE = 32;
 const ASCII_TILDE = 126;
 
+export const maxBytesNeededForDetectFileType = 6;
+
 export function isASCIIChar(char: number): boolean {
   return (
     char !== undefined &&
@@ -136,8 +138,7 @@ export function detectFileType(param: Buffer | string): DetectedFileType {
   } else {
     documentBuffer = Buffer.from(param);
   }
-  const maxBytesNeeded = 6;
-  const bytesBuffer = documentBuffer.slice(0, maxBytesNeeded);
+  const bytesBuffer = documentBuffer.slice(0, maxBytesNeededForDetectFileType);
   if (
     (bytesBuffer[0] === TIFF_MAGIC_NUMBER_1 &&
       bytesBuffer[1] === TIFF_MAGIC_NUMBER_2 &&

--- a/packages/core/src/util/file-type.ts
+++ b/packages/core/src/util/file-type.ts
@@ -64,8 +64,6 @@ const ASCII_CARRIAGE_RETURN = 13;
 const ASCII_SPACE = 32;
 const ASCII_TILDE = 126;
 
-export const maxBytesNeededForDetectFileType = 6;
-
 export function isASCIIChar(char: number): boolean {
   return (
     char !== undefined &&
@@ -138,7 +136,8 @@ export function detectFileType(param: Buffer | string): DetectedFileType {
   } else {
     documentBuffer = Buffer.from(param);
   }
-  const bytesBuffer = documentBuffer.slice(0, maxBytesNeededForDetectFileType);
+  const maxBytesNeeded = 6;
+  const bytesBuffer = documentBuffer.slice(0, maxBytesNeeded);
   if (
     (bytesBuffer[0] === TIFF_MAGIC_NUMBER_1 &&
       bytesBuffer[1] === TIFF_MAGIC_NUMBER_2 &&

--- a/packages/lambdas/src/document-downloader.ts
+++ b/packages/lambdas/src/document-downloader.ts
@@ -104,7 +104,7 @@ export const handler = capture.wrapHandler(
       commonWell: { api: commonWell },
       capture,
     });
-    const result = await docDownloader.download({ document, fileInfo });
+    const result = await docDownloader.download({ cxId, document, fileInfo });
 
     console.log(`Done - ${JSON.stringify(result)}`);
     return result;


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4445
- Downstream: https://github.com/metriport/metriport/pull/4470

### Description

Addressing comments on [this release](https://github.com/metriport/metriport/pull/4500):
- **build(cw-cert-runner): add missing lib (shared)**
- **refactor(api): fix brittle test**
- **refactor(cw-cert-runner): fix bad type to process params**
- **refactor(core): many improvements on cw doc download local v2**
- **refactor(cw-sdk): always return Error on getDescriptiveError**

### Testing

Downstream.

### Release Plan

- [ ] Merge this
- [ ] Needs to be merged/shipped with the downstream PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - More reliable document downloads with automatic stream reset, cxId-aware behavior, and improved content-type handling.
- Bug Fixes
  - Corrected file type detection and filename extensions for downloaded documents.
  - Consistent, descriptive errors returned across failure paths.
- Improvements
  - Enhanced operational logging for document downloads (v2).
  - Safer CLI argument handling in certification runner commands.
- Tests
  - Updated date calculation in a document reference test.
- Chores
  - Added shared workspace dependency to certification runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->