### PR TITLE
fix patient being added after appending extensions

### DIFF
--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -10,7 +10,6 @@ import {
   mergeBundleIntoAdtSourcedEncounter,
   saveAdtConversionBundle,
 } from "../../external/fhir/adt-encounters";
-import { buildBundleEntry, buildCollectionBundle } from "../../external/fhir/bundle/bundle";
 import { toFHIR as toFhirPatient } from "../../external/fhir/patient/conversion";
 import { capture, out } from "../../util";
 import { Config } from "../../util/config";
@@ -101,18 +100,15 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
     );
     const fhirPatient = toFhirPatient({ id: patientId, data: patient.data });
 
-    const conversionResult = convertHl7v2MessageToFhir({
+    const newEncounterData = convertHl7v2MessageToFhir({
       message,
       cxId,
       patientId,
       rawDataFileKey: params.rawDataFileKey,
       hieName: params.hieName,
-    });
-
-    const newEncounterData = prependPatientToBundle({
-      bundle: conversionResult,
       fhirPatient,
     });
+
     log(`Conversion complete and patient entry added`);
 
     const clinicalInformation = this.extractClinicalInformation(newEncounterData);
@@ -254,16 +250,4 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
 
     return clinicalInformation;
   }
-}
-
-function prependPatientToBundle({
-  bundle,
-  fhirPatient,
-}: {
-  bundle: Bundle<Resource>;
-  fhirPatient: Resource;
-}): Bundle<Resource> {
-  const fhirPatientEntry = buildBundleEntry(fhirPatient);
-  const combinedEntries = bundle.entry ? [fhirPatientEntry, ...bundle.entry] : [];
-  return buildCollectionBundle(combinedEntries);
 }

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
@@ -1,8 +1,12 @@
 import { Hl7Message } from "@medplum/core";
-import { Bundle, Extension, Resource } from "@medplum/fhirtypes";
+import { Bundle, Extension, Patient, Resource } from "@medplum/fhirtypes";
 import { MetriportError } from "@metriport/shared";
 import { elapsedTimeFromNow } from "@metriport/shared/common/date";
-import { buildBundleFromResources } from "../../../external/fhir/bundle/bundle";
+import {
+  buildBundleEntry,
+  buildBundleFromResources,
+  buildCollectionBundle,
+} from "../../../external/fhir/bundle/bundle";
 import { buildDocIdFhirExtension } from "../../../external/fhir/shared/extensions/doc-id-extension";
 import { capture, out } from "../../../util";
 import { convertAdtToFhirResources } from "./adt/encounter";
@@ -15,6 +19,7 @@ export type Hl7ToFhirParams = {
   message: Hl7Message;
   rawDataFileKey: string;
   hieName: string;
+  fhirPatient: Patient;
 };
 export type ResourceWithExtension = Resource & { extension?: Extension[] };
 
@@ -27,6 +32,7 @@ export function convertHl7v2MessageToFhir({
   message,
   rawDataFileKey,
   hieName,
+  fhirPatient,
 }: Hl7ToFhirParams): Bundle<Resource> {
   const { log } = out(`hl7v2 to fhir - cx: ${cxId}, pt: ${patientId}`);
   log("Beginning conversion.");
@@ -42,8 +48,12 @@ export function convertHl7v2MessageToFhir({
     log(`Conversion completed in ${duration} ms`);
     const docIdExtension = buildDocIdFhirExtension(rawDataFileKey, "hl7");
     const sourceExtension = createExtensionDataSource(hieName.toUpperCase());
+    const newEncounterData = prependPatientToBundle({
+      bundle: bundle,
+      fhirPatient,
+    });
     const updatedBundle = appendExtensionToEachResource(
-      appendExtensionToEachResource(bundle, docIdExtension),
+      appendExtensionToEachResource(newEncounterData, docIdExtension),
       sourceExtension
     );
     return updatedBundle;
@@ -91,4 +101,16 @@ export function appendExtensionToEachResource(
       };
     }),
   };
+}
+
+function prependPatientToBundle({
+  bundle,
+  fhirPatient,
+}: {
+  bundle: Bundle<Resource>;
+  fhirPatient: Resource;
+}): Bundle<Resource> {
+  const fhirPatientEntry = buildBundleEntry(fhirPatient);
+  const combinedEntries = bundle.entry ? [fhirPatientEntry, ...bundle.entry] : [];
+  return buildCollectionBundle(combinedEntries);
 }


### PR DESCRIPTION
Part of ENG-874

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-874

### Dependencies
NONE

### Description
fix patient being added after appending extensions resulting in patient not having the extensions we are adding (obviously because the patient is not in the bundle yet...).

### Testing
- Local
  - [ ] Ran script + test locally
- Production
  - [ ] Check recent ADT to make sure patient has data extension

_[Release PRs:]_

Check each PR.

