### PR TITLE
add ._ to name to get the real name string instead of an object

### DIFF
--- a/packages/fhir-converter/src/ccda-to-fhir-lambda.js
+++ b/packages/fhir-converter/src/ccda-to-fhir-lambda.js
@@ -132,8 +132,6 @@ async function ccdaToFhir(ccda, patientId) {
                   ),
                 });
               } catch (convertErr) {
-                console.log("FSAFSA< ", convertErr);
-
                 reject({
                   status: 400,
                   resultMsg: "Error during template evaluation. " + convertErr.toString(),


### PR DESCRIPTION
Part of ENG-975

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-975

### Dependencies
None

### Description
Name is an object not a string. 
Fix to get the string not the object.
[Context is here](https://metriport.slack.com/archives/C04T256DQPQ/p1756757386681559?thread_ts=1755636743.027779&cid=C04T256DQPQ)

### Testing
Any ideas for testing Lucas?
- Local
  - [x] Run a convert locally to make sure it converts properly

VVVV THIS IS RAN ON THE FAILING FILE VVVVV 

https://github.com/user-attachments/assets/bf1a0415-1ff5-4941-bb24-f2d31263bd79




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved location ID generation to correctly handle location names provided in alternate structures, preventing malformed IDs.
  - Reduces conversion errors for edge-case location data, improving reliability of FHIR output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->