### PR TITLE
ENG-976: Deduplication of ServiceRequests with disjoint sets

### DIFF
--- a/packages/core/src/external/fhir/resources/service-request.ts
+++ b/packages/core/src/external/fhir/resources/service-request.ts
@@ -1,3 +1,5 @@
+import { ServiceRequest } from "@medplum/fhirtypes";
+
 // Service request statuses in order of deduplication priority
 export const SERVICE_REQUEST_STATUS_CODES = [
   "unknown",
@@ -9,3 +11,9 @@ export const SERVICE_REQUEST_STATUS_CODES = [
   "completed",
 ] as const;
 export type ServiceRequestStatusCode = (typeof SERVICE_REQUEST_STATUS_CODES)[number];
+
+export function compareServiceRequestsByStatus(a: ServiceRequest, b: ServiceRequest): number {
+  const aIndex = SERVICE_REQUEST_STATUS_CODES.indexOf(a.status ?? "unknown");
+  const bIndex = SERVICE_REQUEST_STATUS_CODES.indexOf(b.status ?? "unknown");
+  return aIndex - bIndex;
+}

--- a/packages/core/src/external/fhir/resources/service-request.ts
+++ b/packages/core/src/external/fhir/resources/service-request.ts
@@ -1,0 +1,11 @@
+// Service request statuses in order of deduplication priority
+export const SERVICE_REQUEST_STATUS_CODES = [
+  "unknown",
+  "draft",
+  "active",
+  "on-hold",
+  "revoked",
+  "entered-in-error",
+  "completed",
+] as const;
+export type ServiceRequestStatusCode = (typeof SERVICE_REQUEST_STATUS_CODES)[number];

--- a/packages/core/src/fhir-deduplication/comparators.ts
+++ b/packages/core/src/fhir-deduplication/comparators.ts
@@ -7,7 +7,7 @@ export function sameResourceId(resourceA: Resource, resourceB: Resource) {
   return idOfResourceA === idOfResourceB;
 }
 
-export function sameResourceIdentifiers(
+export function sameResourceIdentifier(
   resourceA: Resource & { identifier?: Identifier[] },
   resourceB: Resource & { identifier?: Identifier[] }
 ) {

--- a/packages/core/src/fhir-deduplication/comparators.ts
+++ b/packages/core/src/fhir-deduplication/comparators.ts
@@ -1,0 +1,25 @@
+import { Identifier, Resource } from "@medplum/fhirtypes";
+
+export function sameResourceId(resourceA: Resource, resourceB: Resource) {
+  const idOfResourceA = resourceA.id;
+  const idOfResourceB = resourceB.id;
+  if (idOfResourceA === undefined || idOfResourceB === undefined) return false;
+  return idOfResourceA === idOfResourceB;
+}
+
+export function sameResourceIdentifiers(
+  resourceA: Resource & { identifier?: Identifier[] },
+  resourceB: Resource & { identifier?: Identifier[] }
+) {
+  const identifiersOfResourceA = resourceA.identifier;
+  const identifiersOfResourceB = resourceB.identifier;
+  if (identifiersOfResourceA === undefined || identifiersOfResourceB === undefined) return false;
+  return identifiersOfResourceA.some(identifierOfResourceA => {
+    return identifiersOfResourceB.some(identifierOfResourceB => {
+      return (
+        identifierOfResourceA.system === identifierOfResourceB.system &&
+        identifierOfResourceA.value === identifierOfResourceB.value
+      );
+    });
+  });
+}

--- a/packages/core/src/fhir-deduplication/disjoint-set-union.ts
+++ b/packages/core/src/fhir-deduplication/disjoint-set-union.ts
@@ -1,0 +1,75 @@
+import { Resource } from "@medplum/fhirtypes";
+import { Comparator } from "lodash";
+
+/**
+ * Disjoint Set Union (DSU) is a data structure that keeps track of a set of elements partitioned into a number of disjoint (non-overlapping) subsets,
+ * which are referred to in this implementation as "groups".
+ */
+export class DisjointSetUnion<R extends Resource> {
+  private resources: R[];
+  private groupId: number[];
+
+  /**
+   * Every resource is initialized with its own index as its group ID.
+   * @param resources - The FHIR resources to initialize the DSU with
+   */
+  constructor(resources: R[]) {
+    this.resources = resources;
+    this.groupId = new Array(resources.length);
+    for (let i = 0; i < resources.length; i++) {
+      this.groupId[i] = i;
+    }
+  }
+
+  /**
+   * Performs deduplication on the given resources using the given set of equality comparators.
+   * @param comparators
+   */
+  deduplicate(comparators: Comparator<R>[]) {
+    for (let i = 0; i < this.groupId.length; i++) {
+      for (let j = i + 1; j < this.groupId.length; j++) {
+        const resourceI = this.resources[i];
+        const resourceJ = this.resources[j];
+        if (!resourceI || !resourceJ) continue;
+        const equal = comparators.some(comparator => comparator(resourceI, resourceJ));
+        if (equal) {
+          this.unionGroup(i, j);
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns the group ID for the given index.
+   * @param index - The index to get the group ID for
+   * @returns The root group ID for the given index, or -1 if the index is invalid
+   */
+  findGroup(index: number): number {
+    const groupIdAtIndex = this.groupId[index];
+    if (groupIdAtIndex === undefined) return -1;
+    // If this is a root node with no reference to another index as a parent
+    if (groupIdAtIndex === index) {
+      return groupIdAtIndex;
+    }
+    // If this is a child node with a reference to another index as a parent,
+    // return the root ID and collapse any intermediate references to parent IDs.
+    else {
+      const rootGroupId = this.findGroup(groupIdAtIndex);
+      this.groupId[index] = rootGroupId;
+      return rootGroupId;
+    }
+  }
+
+  /**
+   * Joins the resources at the given indices into the same group.
+   * @param x - The index of the first resource to join
+   * @param y - The index of the second resource to join
+   */
+  unionGroup(x: number, y: number) {
+    const parentX = this.findGroup(x);
+    const parentY = this.findGroup(y);
+    if (parentX !== parentY) {
+      this.groupId[parentY] = parentX;
+    }
+  }
+}

--- a/packages/core/src/fhir-deduplication/disjoint-set-union.ts
+++ b/packages/core/src/fhir-deduplication/disjoint-set-union.ts
@@ -2,7 +2,7 @@ import { Resource, ResourceType } from "@medplum/fhirtypes";
 import { Comparator } from "lodash";
 
 // Merges multiple resources into a single resource, and guaranteed to have at least one resource
-export type MergeFunction<R extends Resource> = (resources: R[]) => R;
+export type MergeFunction<R extends Resource> = (resources: R[]) => R | undefined;
 
 export type DeduplicationResult<R extends Resource> = {
   resourceMap: Map<string, R>;

--- a/packages/core/src/fhir-deduplication/resources/service-request.ts
+++ b/packages/core/src/fhir-deduplication/resources/service-request.ts
@@ -7,12 +7,13 @@ export function groupSameServiceRequests(serviceRequests: ServiceRequest[]): {
   refReplacementMap: Map<string, string>;
   danglingReferences: Set<string>;
 } {
-  const disjointSets = new DisjointSetUnion({
+  const disjointSetUnion = new DisjointSetUnion({
+    resourceType: "ServiceRequest",
     resources: serviceRequests,
     comparators: [sameResourceId, sameResourceIdentifier],
     merge: mergeServiceRequests,
   });
-  const { resourceMap, refReplacementMap, danglingReferences } = disjointSets.deduplicate();
+  const { resourceMap, refReplacementMap, danglingReferences } = disjointSetUnion.deduplicate();
 
   return {
     serviceRequestsMap: resourceMap,

--- a/packages/core/src/fhir-deduplication/resources/service-request.ts
+++ b/packages/core/src/fhir-deduplication/resources/service-request.ts
@@ -1,4 +1,6 @@
 import { ServiceRequest } from "@medplum/fhirtypes";
+import { DisjointSetUnion } from "../disjoint-set-union";
+import { sameResourceId } from "../comparators";
 
 export function groupSameServiceRequests(serviceRequests: ServiceRequest[]): {
   serviceRequestsMap: Map<string, ServiceRequest>;
@@ -8,6 +10,9 @@ export function groupSameServiceRequests(serviceRequests: ServiceRequest[]): {
   const serviceRequestsMap = new Map<string, ServiceRequest>();
   const refReplacementMap = new Map<string, string>();
   const danglingReferences = new Set<string>();
+
+  const disjointSets = new DisjointSetUnion(serviceRequests);
+  disjointSets.deduplicate([sameResourceId]);
 
   console.log("serviceRequests", serviceRequests);
 

--- a/packages/core/src/fhir-deduplication/resources/service-request.ts
+++ b/packages/core/src/fhir-deduplication/resources/service-request.ts
@@ -7,21 +7,15 @@ export function groupSameServiceRequests(serviceRequests: ServiceRequest[]): {
   refReplacementMap: Map<string, string>;
   danglingReferences: Set<string>;
 } {
-  const serviceRequestsMap = new Map<string, ServiceRequest>();
-  const refReplacementMap = new Map<string, string>();
-  const danglingReferences = new Set<string>();
-
   const disjointSets = new DisjointSetUnion({
     resources: serviceRequests,
     comparators: [sameResourceId, sameResourceIdentifier],
     merge: mergeServiceRequests,
   });
-  disjointSets.deduplicate();
-
-  console.log("serviceRequests", serviceRequests);
+  const { resourceMap, refReplacementMap, danglingReferences } = disjointSets.deduplicate();
 
   return {
-    serviceRequestsMap,
+    serviceRequestsMap: resourceMap,
     refReplacementMap,
     danglingReferences,
   };

--- a/packages/core/src/fhir-deduplication/resources/service-request.ts
+++ b/packages/core/src/fhir-deduplication/resources/service-request.ts
@@ -1,6 +1,6 @@
 import { ServiceRequest } from "@medplum/fhirtypes";
 import { DisjointSetUnion } from "../disjoint-set-union";
-import { sameResourceId } from "../comparators";
+import { sameResourceId, sameResourceIdentifier } from "../comparators";
 
 export function groupSameServiceRequests(serviceRequests: ServiceRequest[]): {
   serviceRequestsMap: Map<string, ServiceRequest>;
@@ -11,8 +11,12 @@ export function groupSameServiceRequests(serviceRequests: ServiceRequest[]): {
   const refReplacementMap = new Map<string, string>();
   const danglingReferences = new Set<string>();
 
-  const disjointSets = new DisjointSetUnion(serviceRequests);
-  disjointSets.deduplicate([sameResourceId]);
+  const disjointSets = new DisjointSetUnion({
+    resources: serviceRequests,
+    comparators: [sameResourceId, sameResourceIdentifier],
+    merge: mergeServiceRequests,
+  });
+  disjointSets.deduplicate();
 
   console.log("serviceRequests", serviceRequests);
 
@@ -21,4 +25,8 @@ export function groupSameServiceRequests(serviceRequests: ServiceRequest[]): {
     refReplacementMap,
     danglingReferences,
   };
+}
+
+function mergeServiceRequests(serviceRequests: ServiceRequest[]): ServiceRequest {
+  return serviceRequests[0] as ServiceRequest;
 }

--- a/packages/core/src/fhir-deduplication/resources/service-request.ts
+++ b/packages/core/src/fhir-deduplication/resources/service-request.ts
@@ -1,0 +1,19 @@
+import { ServiceRequest } from "@medplum/fhirtypes";
+
+export function groupSameServiceRequests(serviceRequests: ServiceRequest[]): {
+  serviceRequestsMap: Map<string, ServiceRequest>;
+  refReplacementMap: Map<string, string>;
+  danglingReferences: Set<string>;
+} {
+  const serviceRequestsMap = new Map<string, ServiceRequest>();
+  const refReplacementMap = new Map<string, string>();
+  const danglingReferences = new Set<string>();
+
+  console.log("serviceRequests", serviceRequests);
+
+  return {
+    serviceRequestsMap,
+    refReplacementMap,
+    danglingReferences,
+  };
+}


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-976

### Dependencies

- Upstream: None
- Downstream: None

### Description

Uses a [disjoint set data structure](https://en.wikipedia.org/wiki/Disjoint-set_data_structure) to deduplicate `ServiceRequest` FHIR resources.

### Testing

- Local
  - [ ] `npx jest`
- Staging
  - [ ] Deduplicating staging laboratory resources with ServiceRequests
- Production
  - [ ] Deduplicating lab data for production integration

### Release Plan

- [ ] Merge this
