### PR TITLE
ENG-513 - Publish npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28437,7 +28437,7 @@
       }
     },
     "packages/api": {
-      "version": "1.29.1",
+      "version": "1.29.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.800.0",
@@ -28523,11 +28523,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/shared": "^0.26.1",
+        "@metriport/shared": "^0.26.2",
         "axios": "^1.8.2",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -28616,11 +28616,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.20.1",
+      "version": "1.20.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.21.1",
-        "@metriport/shared": "^0.26.1"
+        "@metriport/ihe-gateway-sdk": "^0.21.2",
+        "@metriport/shared": "^0.26.2"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -28628,7 +28628,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -28652,7 +28652,7 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "file:packages/commonwell-sdk",
@@ -28749,7 +28749,7 @@
     "packages/commonwell-cert-runner/packages/shared": {},
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.27.1",
+      "version": "1.27.2",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^5.9.20",
@@ -28860,10 +28860,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "6.2.3",
+      "version": "6.2.4",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.26.1",
+        "@metriport/shared": "^0.26.2",
         "axios": "^1.8.2",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -28911,7 +28911,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.26.1",
+      "version": "1.26.2",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -29299,7 +29299,7 @@
     "packages/core/packages/shared": {},
     "packages/eslint-rules": {
       "name": "@metriport/eslint-plugin-eslint-rules",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/rule-tester": "^6.0.0",
@@ -29315,7 +29315,7 @@
     },
     "packages/fhir-sdk": {
       "name": "@metriport/fhir-sdk",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.2.10",
@@ -29439,17 +29439,17 @@
     "packages/fhir-sdk/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.26.1",
+        "@metriport/shared": "^0.26.2",
         "axios": "^1.8.2",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.24.1",
+      "version": "1.24.2",
       "dependencies": {
         "@metriport/core": "file:packages/core",
         "@metriport/shared": "file:packages/shared",
@@ -29512,7 +29512,7 @@
     "packages/infra/packages/core": {},
     "packages/infra/packages/shared": {},
     "packages/mllp-server": {
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "ISC",
       "dependencies": {
         "@medplum/core": "^3.2.33",
@@ -29710,7 +29710,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.26.1",
+      "version": "0.26.2",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -29763,7 +29763,7 @@
       "dev": true
     },
     "packages/utils": {
-      "version": "1.27.1",
+      "version": "1.27.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.800.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/shared": "^0.26.1",
+    "@metriport/shared": "^0.26.2",
     "axios": "^1.8.2",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.21.1",
-    "@metriport/shared": "^0.26.1"
+    "@metriport/ihe-gateway-sdk": "^0.21.2",
+    "@metriport/shared": "^0.26.2"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.26.1",
+    "@metriport/shared": "^0.26.2",
     "axios": "^1.8.2",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/eslint-rules/package.json
+++ b/packages/eslint-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/eslint-plugin-eslint-rules",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Custom ESLint rules for Metriport's monorepo",
   "main": "index.js",
   "keywords": [

--- a/packages/fhir-sdk/package.json
+++ b/packages/fhir-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/fhir-sdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "FHIR Bundle SDK for parsing, querying, and manipulating FHIR bundles with reference resolution",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.26.1",
+    "@metriport/shared": "^0.26.2",
     "axios": "^1.8.2",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mllp-server",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "MLLP server that reads HL7 messages off of a raw tcp connection",
   "main": "app.js",
   "private": true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "description": "",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Ref: #000

 - api@1.29.2
 - @metriport/api-sdk@18.0.2
 - @metriport/carequality-cert-runner@1.20.2
 - @metriport/carequality-sdk@1.9.2
 - @metriport/commonwell-cert-runner@2.1.2
 - @metriport/commonwell-jwt-maker@1.27.2
 - @metriport/commonwell-sdk@6.2.4
 - @metriport/core@1.26.2
 - @metriport/eslint-plugin-eslint-rules@1.2.2
 - @metriport/fhir-sdk@1.2.2
 - @metriport/ihe-gateway-sdk@0.21.2
 - infrastructure@1.24.2
 - mllp-server@0.5.2
 - @metriport/shared@0.26.2
 - utils@1.27.2

Signed-off-by: Rafael Leite <2132564+leite08@users.noreply.github.com>

### Dependencies

- Upstream: _[this PR points to another PR or depends on its release]_
- Downstream: _[PRs that depend on this one, either point to this or can only be released after this one is released]_

### Description

_[Document your changes, give context for reviewers, add images/videos of UI changes]_

### Testing

_[Plan ahead how you're validating your changes work and don't break other features. Add tests to validate the happy
path and the alternative ones. Be specific.]_

- Local
  - [ ] _[Indicate how you tested this, on local or staging]_
  - [ ] ...
- Staging
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Sandbox
  - [ ] _testing step 1_
  - [ ] _testing step 2_
- Production
  - [ ] _testing step 1_
  - [ ] _testing step 2_

### Release Plan

_[How does the changes on this PR impact/interact with the existing environment (database, configs, secrets, FFs, api contracts, etc.)?
Consider creating 2+ PRs if we need to ship those changes in a staged way]_

_[This is the release plan for production]_

_[You should execute the exact same steps when releasing to staging to validate it works]_

_[Add and remove items below accordingly]_

- :warning: This contains a DB migration
- [ ] Maintenance window scheduled/created at Checkly (if needed)
- [ ] Execute this on <env1>, <env2>
  - [ ] _step1_
  - [ ] _step2_
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (deprecates a feature that needs to be communicated with customers)
- [ ] Added to [monthly product update](https://www.notion.so/metriport/Customer-Updates-21b4e9d3ad5f4fd68db587a11db28cff?pvs=4) (introduce a feature that would be useful customers)
- [ ] Upstream dependencies are met/released
- [ ] Release NPM packages
- [ ] Fern Definition Updated
- [ ] Release Fern SDKs
- [ ] FFs have been set in Staging, Production, and Sandbox
- [ ] Happy-path E2E test created checking new FF flow
- [ ] No dependencies between API and Infra that will cause errors during deployment
- [ ] FHIR Integration Test ran with validation
- [ ] _[action n-1]_
- [ ] _[action n]_
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Released coordinated patch updates across multiple SDKs and tooling to align versions.
  - Updated internal shared libraries to the latest patch for improved stability and compatibility.
  - No changes to public APIs or user-visible behavior; this is a maintenance release.
  - No action required for end-users; existing integrations continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->