### PR TITLE
PATCH: patient linking

### DIFF
--- a/packages/core/src/mpi/__tests__/filter-patients.test.ts
+++ b/packages/core/src/mpi/__tests__/filter-patients.test.ts
@@ -750,7 +750,7 @@ describe("evaluatePatientMatch", () => {
         ...basePatient2,
         firstName: "Jane",
         lastName: "Smith",
-        contact: [{ phone: "555-123-4567", email: "different@email.com" }], // Matches validLink1 phone
+        contact: [{ phone: "555-123-4567", email: "different@email.com" }],
       };
 
       const invalidLink2 = {
@@ -807,14 +807,14 @@ describe("evaluatePatientMatch", () => {
         ...basePatient,
         firstName: "John",
         lastName: "Doe",
-        contact: [{ phone: "555-123-4567" }], // Phone only
+        contact: [{ phone: "555-123-4567" }],
       };
 
       const invalidLink = {
         ...basePatient2,
         firstName: "Jane",
         lastName: "Smith",
-        contact: [{ phone: "555-123-4567", email: "different@email.com" }], // Same phone, different email
+        contact: [{ phone: "555-123-4567", email: "different@email.com" }],
       };
 
       const validLinks = [validLink];
@@ -855,14 +855,14 @@ describe("evaluatePatientMatch", () => {
         ...basePatient,
         firstName: "John",
         lastName: "Doe",
-        contact: [{ email: "john.doe@email.com" }], // Email only
+        contact: [{ email: "john.doe@email.com" }],
       };
 
       const invalidLink = {
         ...basePatient2,
         firstName: "Jane",
         lastName: "Smith",
-        contact: [{ phone: "555-999-9999", email: "john.doe@email.com" }], // Same email, different phone
+        contact: [{ phone: "555-999-9999", email: "john.doe@email.com" }],
       };
 
       const validLinks = [validLink];
@@ -874,10 +874,21 @@ describe("evaluatePatientMatch", () => {
       expect(result[0]).toEqual(invalidLink);
     });
 
-    it("should validate through last name match", () => {
+    it("should validate through last name match with additional field match", () => {
       const invalidLink = {
         ...basePatient,
+        firstName: "John",
         lastName: "Doe",
+        dob: "1990-01-02",
+        contact: [{ phone: "555-999-9999", email: "different@email.com" }],
+        address: [
+          {
+            addressLine1: "999 Different St",
+            city: "Different City",
+            state: USState.TX,
+            zip: "99999",
+          },
+        ],
       };
 
       const validLinks = [basePatient];
@@ -887,6 +898,31 @@ describe("evaluatePatientMatch", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(invalidLink);
+    });
+
+    it("should not validate through last name match alone without additional field match", () => {
+      const invalidLink = {
+        ...basePatient,
+        firstName: "Jane",
+        lastName: "Doe",
+        dob: "1990-01-02",
+        contact: [{ phone: "555-999-9999", email: "different@email.com" }],
+        address: [
+          {
+            addressLine1: "999 Different St",
+            city: "Different City",
+            state: USState.TX,
+            zip: "99999",
+          },
+        ],
+      };
+
+      const validLinks = [basePatient];
+      const invalidLinks = [invalidLink];
+
+      const result = crossValidateInvalidLinks(validLinks, invalidLinks);
+
+      expect(result).toHaveLength(0);
     });
   });
 

--- a/packages/core/src/mpi/filter-patients/cross-validate-links.ts
+++ b/packages/core/src/mpi/filter-patients/cross-validate-links.ts
@@ -2,7 +2,8 @@ import { intersectionWith } from "lodash";
 import { PatientData } from "../../domain/patient";
 import { isContactMatch } from "./match-contact";
 import { hasAddressMatch } from "./match-address";
-import { calculateLastNameScore } from "./match-name";
+import { calculateLastNameScore, calculateFirstNameScore } from "./match-name";
+import { calculateDobScore } from "./match-dob";
 
 export function crossValidateInvalidLinks(
   validLinks: PatientData[],
@@ -20,7 +21,13 @@ function isLinkValidByAssociation(invalidLink: PatientData, validLinks: PatientD
     const hasLastNameMatch = calculateLastNameScore(invalidLink, validLink);
 
     if (hasLastNameMatch) {
-      return true;
+      const hasFirstNameMatch = calculateFirstNameScore(invalidLink, validLink);
+      const hasDobMatch = calculateDobScore(invalidLink, validLink) > 0;
+      const hasAddressMatchByAssociation = hasAddressMatch(invalidLink, validLink);
+
+      if (hasFirstNameMatch || hasDobMatch || hasAddressMatchByAssociation) {
+        return true;
+      }
     }
 
     const hasContactMatchByAssociation =

--- a/packages/core/src/mpi/filter-patients/cross-validate-links.ts
+++ b/packages/core/src/mpi/filter-patients/cross-validate-links.ts
@@ -22,10 +22,10 @@ function isLinkValidByAssociation(invalidLink: PatientData, validLinks: PatientD
 
     if (hasLastNameMatch) {
       const hasFirstNameMatch = calculateFirstNameScore(invalidLink, validLink);
-      const hasDobMatch = calculateDobScore(invalidLink, validLink) > 0;
+      const hasExactDobMatch = calculateDobScore(invalidLink, validLink) === 8;
       const hasAddressMatchByAssociation = hasAddressMatch(invalidLink, validLink);
 
-      if (hasFirstNameMatch || hasDobMatch || hasAddressMatchByAssociation) {
+      if (hasFirstNameMatch || hasExactDobMatch || hasAddressMatchByAssociation) {
         return true;
       }
     }

--- a/packages/core/src/mpi/filter-patients/cross-validate-links.ts
+++ b/packages/core/src/mpi/filter-patients/cross-validate-links.ts
@@ -2,6 +2,7 @@ import { intersectionWith } from "lodash";
 import { PatientData } from "../../domain/patient";
 import { isContactMatch } from "./match-contact";
 import { hasAddressMatch } from "./match-address";
+import { calculateLastNameScore } from "./match-name";
 
 export function crossValidateInvalidLinks(
   validLinks: PatientData[],
@@ -16,6 +17,12 @@ export function crossValidateInvalidLinks(
 
 function isLinkValidByAssociation(invalidLink: PatientData, validLinks: PatientData[]): boolean {
   for (const validLink of validLinks) {
+    const hasLastNameMatch = calculateLastNameScore(invalidLink, validLink);
+
+    if (hasLastNameMatch) {
+      return true;
+    }
+
     const hasContactMatchByAssociation =
       invalidLink.contact &&
       validLink.contact &&

--- a/packages/core/src/mpi/filter-patients/match-business-rules.ts
+++ b/packages/core/src/mpi/filter-patients/match-business-rules.ts
@@ -20,9 +20,9 @@ export function checkBusinessRules(
     return "No Name Match";
   }
 
-  // Rule: If last name is wrong and address is incorrect, it's not the same person
+  // Rule: If last name is wrong and address is incorrect and contact is not a match, it's not the same person
   if (isLastNameAndAddressMismatch(metriportPatient, externalPatient, scores)) {
-    return "Last Name Wrong + Address Incorrect";
+    return "Last Name Wrong + Address Incorrect + No Contact Match";
   }
 
   // Rule: If DOB has 2+ parts wrong and address isn't the same, it's probably not the same person
@@ -56,9 +56,16 @@ function isLastNameAndAddressMismatch(
   externalPatient: PatientData,
   scores: {
     address: number;
+    phone: number;
+    email: number;
   }
 ): boolean {
-  return !calculateLastNameScore(metriportPatient, externalPatient) && scores.address < 2;
+  return (
+    calculateLastNameScore(metriportPatient, externalPatient) === 0 &&
+    scores.address < 2 &&
+    scores.phone === 0 &&
+    scores.email === 0
+  );
 }
 
 function isNameAddressAndContactMismatch(scores: {

--- a/packages/core/src/mpi/filter-patients/match-contact.ts
+++ b/packages/core/src/mpi/filter-patients/match-contact.ts
@@ -1,31 +1,51 @@
 import { PatientData } from "../../domain/patient";
 import { Contact } from "../../domain/contact";
+import { normalizePhoneNumber } from "@metriport/shared";
+import { normalizeEmail } from "../normalize-patient";
 
 export function calculateContactScores(
   metriportPatient: PatientData,
   externalPatient: PatientData
 ): { phoneScore: number; emailScore: number } {
   return {
-    phoneScore: calculateScore("phone", metriportPatient, externalPatient),
-    emailScore: calculateScore("email", metriportPatient, externalPatient),
+    phoneScore: calculatePhoneScore(metriportPatient, externalPatient),
+    emailScore: calculateEmailScore(metriportPatient, externalPatient),
   };
 }
 
-function calculateScore(
-  field: "phone" | "email",
-  metriportPatient: PatientData,
-  externalPatient: PatientData
-): number {
+function calculatePhoneScore(metriportPatient: PatientData, externalPatient: PatientData): number {
   const directMatch = metriportPatient.contact?.some(c1 =>
-    externalPatient.contact?.some(c2 => c1[field] && c2[field] && c1[field] === c2[field])
+    externalPatient.contact?.some(c2 => {
+      if (!c1.phone || !c2.phone) return false;
+      return normalizePhoneNumber(c1.phone) === normalizePhoneNumber(c2.phone);
+    })
+  );
+
+  return directMatch ? 2 : 0;
+}
+
+function calculateEmailScore(metriportPatient: PatientData, externalPatient: PatientData): number {
+  const directMatch = metriportPatient.contact?.some(c1 =>
+    externalPatient.contact?.some(c2 => {
+      if (!c1.email || !c2.email) return false;
+      return normalizeEmail(c1.email) === normalizeEmail(c2.email);
+    })
   );
 
   return directMatch ? 2 : 0;
 }
 
 export function isContactMatch(contact1: Contact, contact2: Contact): boolean {
-  const phoneMatch = Boolean(contact1.phone && contact2.phone && contact1.phone === contact2.phone);
-  const emailMatch = Boolean(contact1.email && contact2.email && contact1.email === contact2.email);
+  const phoneMatch = Boolean(
+    contact1.phone &&
+      contact2.phone &&
+      normalizePhoneNumber(contact1.phone) === normalizePhoneNumber(contact2.phone)
+  );
+  const emailMatch = Boolean(
+    contact1.email &&
+      contact2.email &&
+      normalizeEmail(contact1.email) === normalizeEmail(contact2.email)
+  );
 
   return phoneMatch || emailMatch;
 }


### PR DESCRIPTION
Part of cs-2038

Issues:

- https://linear.app/metriport/issue/CS-2038

### Dependencies

- Upstream: none
- Downstream: none

### Description

- Optimizing patient linking to properly validate links coming in

### Testing

- Local
  - [x] Local script going through list of links
  - [x] unit tests
- Production
  - [ ] Monitor production to ensure links are being flagged accordingly

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger contact matching using normalized phone and email.
  * Cross-link validation now accepts last-name matches when paired with first name, exact DOB, or address.

* **Bug Fixes**
  * Address matching more resilient to apartment/unit formatting and reordered lines.
  * Phone formats (e.g., (555)123-4567 vs 5551234567) normalized to avoid false mismatches.
  * Business-rule failure messages now include "No Contact Match" when applicable.

* **Tests**
  * Expanded tests covering address interoperability, cross-link scenarios, and contact-edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->