### PR TITLE
RELEASE feat(ap): schema docs

### DIFF
--- a/docs/medical-api/handling-data/data-analytics.mdx
+++ b/docs/medical-api/handling-data/data-analytics.mdx
@@ -58,3 +58,22 @@ The Tuva approach provides:
 
 To get started with Tuva, check out our 
 [data warehouse connector documentation](https://thetuvaproject.com/connectors/metriport) on the Tuva site.
+
+## Schema Documentation
+
+The Tuva data model consists of several core tables that represent different aspects of healthcare data. Each table is designed to capture specific information in a standardized format for analytics:
+
+### Core Tables
+
+- **[Condition](/medical-api/handling-data/schema/condition)** - Symptoms, problems, complaints, and diagnoses reported during encounters
+- **[Encounter](/medical-api/handling-data/schema/encounter)** - Unique patient interactions with the healthcare system
+- **[Immunization](/medical-api/handling-data/schema/immunization)** - Vaccines administered to patients
+- **[Lab Result](/medical-api/handling-data/schema/lab-result)** - Laboratory test results with LOINC codes
+- **[Location](/medical-api/handling-data/schema/location)** - Practice and facility locations where care is provided
+- **[Medication](/medical-api/handling-data/schema/medication)** - Medications ordered or administered during encounters
+- **[Observation](/medical-api/handling-data/schema/observation)** - Clinical measurements like blood pressure, height, and weight
+- **[Patient](/medical-api/handling-data/schema/patient)** - Patient demographic information and core patient data
+- **[Practitioner](/medical-api/handling-data/schema/practitioner)** - Healthcare providers who deliver care
+- **[Procedure](/medical-api/handling-data/schema/procedure)** - Procedures performed on patients
+
+Each schema page provides detailed information about the table structure, including primary keys, foreign keys, and column definitions.

--- a/docs/medical-api/handling-data/data-analytics.mdx
+++ b/docs/medical-api/handling-data/data-analytics.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Data Analytics and Warehousing"
-icon: "database"
+title: "General"
 description: "Transform your data for analytics and pipe it into warehouses like Snowflake, Redshift, BigQuery, and more"
+group: "Data Analytics"
 ---
 
 <iframe
@@ -61,7 +61,7 @@ To get started with Tuva, check out our
 
 ## Schema Documentation
 
-The Tuva data model consists of several core tables that represent different aspects of healthcare data. Each table is designed to capture specific information in a standardized format for analytics:
+The Metriport data model consists of several core tables that represent different aspects of healthcare data. Each table is designed to capture specific information in a standardized format for analytics:
 
 ### Core Tables
 

--- a/docs/medical-api/handling-data/schema/condition.mdx
+++ b/docs/medical-api/handling-data/schema/condition.mdx
@@ -1,0 +1,87 @@
+---
+title: "Condition Schema"
+description: "Schema documentation for the Condition table in the Tuva data model"
+---
+
+# Condition
+
+A condition is any sort of symptom, problem, complaint, admitting diagnosis, or billing diagnosis as reported by the patient, a clinician, or as otherwise generated (e.g. by the billing process). Key ancillary data related to condition includes the date it was reported, it's rank (i.e. primary or secondary), and whether or not it was present during admission for an acute inpatient encounter.
+
+Conditions can only be generated during encounters (i.e. every condition must have an encounter_id).
+
+The core.condition table can be populated from claims or clinical data.
+
+## Populating core.condition from claims data
+
+The core.condition table contains all diagnosis codes present in a claims dataset. These diagnosis codes come from the fields diagnosis_code_1, diagnosis_code_2, …, diagnosis_code_25 present in the claims input layer table input_layer.medical_claim. So the core.condition table simply has one row for each of those diagnosis codes. The logic used for populating those conditions into the core.condition table is the following:
+
+1. To every claim_id in input_layer.medical_claim we assign a date that is associated with the diagnosis codes on that claim. These dates will be the recorded_date for all of these conditions when they populate the core.condition table. We assign these dates to each claim_id as follows:
+
+```sql
+select
+  claim_id,
+  coalesce( min(admission_date),
+            min(claim_start_date),
+            min(discharge_date),
+            min(claim_end_date)
+          ) as recorded_date
+from input_layer.medical_claim
+group by claim_id
+```
+
+2. To every claim_id in input_layer.medical_claim we assign 25 conditions as follows:
+
+```sql
+select
+  claim_id,
+  max(diagnosis_code_1) as diagnosis_code_1,
+  max(diagnosis_code_2) as diagnosis_code_2,  
+  max(diagnosis_code_3) as diagnosis_code_3, 
+  max(diagnosis_code_4) as diagnosis_code_4,  
+  max(diagnosis_code_5) as diagnosis_code_5, 
+  max(diagnosis_code_6) as diagnosis_code_6,   
+  max(diagnosis_code_7) as diagnosis_code_7, 
+  max(diagnosis_code_8) as diagnosis_code_8,   
+  max(diagnosis_code_9) as diagnosis_code_9, 
+  max(diagnosis_code_10) as diagnosis_code_10,   
+  max(diagnosis_code_11) as diagnosis_code_11, 
+  max(diagnosis_code_12) as diagnosis_code_12,   
+  max(diagnosis_code_13) as diagnosis_code_13, 
+  max(diagnosis_code_14) as diagnosis_code_14,  
+  max(diagnosis_code_15) as diagnosis_code_15, 
+  max(diagnosis_code_16) as diagnosis_code_16,   
+  max(diagnosis_code_17) as diagnosis_code_17, 
+  max(diagnosis_code_18) as diagnosis_code_18,  
+  max(diagnosis_code_19) as diagnosis_code_19, 
+  max(diagnosis_code_20) as diagnosis_code_20,   
+  max(diagnosis_code_21) as diagnosis_code_21, 
+  max(diagnosis_code_22) as diagnosis_code_22,  
+  max(diagnosis_code_23) as diagnosis_code_23, 
+  max(diagnosis_code_24) as diagnosis_code_24, 
+  max(diagnosis_code_25) as diagnosis_code_25
+from tuva_synthetic.input_layer.medical_claim
+group by claim_id
+```
+
+Note that we the fields `diagnosis_code_1`, `diagnosis_code_2`, … `diagnosis_code_25` in `input_layer.medical_claim` are header level fields that should have the same value for all lines on a claim, but there could be data quality problems in the input layer, so by taking the max value of each diagnosis code for each `claim_id` (as in the query above) we ensure that each claim_id gets exactly 25 diagnosis codes and not more. Some of these diagnosis codes might be `null`, in which case they do not populate the `core.condition table`, but for any non-null value of `diagnosis_code_1` through `diagnosis_code_25` there will be a row in `core.condition` representing that condition.
+
+Keep in mind:
+
+* The number of rows in `core.condition` populated from a claims dataset is at most 25 times the number of distinct `claim_id`s in input_layer.medical_claim. There will be at most 25 distinct diagnosis codes per claim. There could be less because any diagnosis codes that are null in the input layer do not populate `core.condition`.
+* If for a given claim_id two distinct diagnosis codes are the same (for example, `diagnosis_code_1` = `diagnosis_code_2` = R93.1, there will be distinct rows for each of those in `core.condition`, each row having a distinct value of `condition_rank`.
+* All diagnosis codes coming from claims are either ICD-9-CM or ICD-10-CM because the only allowed values for the field `diagnosis_code_type` in `input_layer.medical_claim` are `icd-9-cm` or `icd-10-cm`.
+* If a diagnosis code in the claims input layer has an invalid value (i.e. a value that is not a real ICD-9-CM or ICD-10-CM code, for example `diagnosis_code_1` = 'XXXXX'), a row will still be created in `core.condition` for that diagnosis code. That row in `core.condition` will have a populated value for `source_code` (namely, the invalid diagnosis code, for example source_code = 'XXXXX') but it will have a null value for `normalized_code`.
+
+## Populating core.condition from clinical data
+
+**Primary Keys:**
+* condition_id
+
+**Foreign Keys:**
+* person_id
+* member_id
+* patient_id
+* encounter_id
+
+| Column | Data Type | Description | Terminology |
+| ------ | --------- | ----------- | ----------- | 

--- a/docs/medical-api/handling-data/schema/condition.mdx
+++ b/docs/medical-api/handling-data/schema/condition.mdx
@@ -1,78 +1,12 @@
 ---
-title: "Condition Schema"
-description: "Schema documentation for the Condition table in the Tuva data model"
+title: "Condition"
+description: "Schema documentation for the Condition table in the Metriport data model"
+group: "Schema"
 ---
-
-# Condition
 
 A condition is any sort of symptom, problem, complaint, admitting diagnosis, or billing diagnosis as reported by the patient, a clinician, or as otherwise generated (e.g. by the billing process). Key ancillary data related to condition includes the date it was reported, it's rank (i.e. primary or secondary), and whether or not it was present during admission for an acute inpatient encounter.
 
 Conditions can only be generated during encounters (i.e. every condition must have an encounter_id).
-
-The core.condition table can be populated from claims or clinical data.
-
-## Populating core.condition from claims data
-
-The core.condition table contains all diagnosis codes present in a claims dataset. These diagnosis codes come from the fields diagnosis_code_1, diagnosis_code_2, …, diagnosis_code_25 present in the claims input layer table input_layer.medical_claim. So the core.condition table simply has one row for each of those diagnosis codes. The logic used for populating those conditions into the core.condition table is the following:
-
-1. To every claim_id in input_layer.medical_claim we assign a date that is associated with the diagnosis codes on that claim. These dates will be the recorded_date for all of these conditions when they populate the core.condition table. We assign these dates to each claim_id as follows:
-
-```sql
-select
-  claim_id,
-  coalesce( min(admission_date),
-            min(claim_start_date),
-            min(discharge_date),
-            min(claim_end_date)
-          ) as recorded_date
-from input_layer.medical_claim
-group by claim_id
-```
-
-2. To every claim_id in input_layer.medical_claim we assign 25 conditions as follows:
-
-```sql
-select
-  claim_id,
-  max(diagnosis_code_1) as diagnosis_code_1,
-  max(diagnosis_code_2) as diagnosis_code_2,  
-  max(diagnosis_code_3) as diagnosis_code_3, 
-  max(diagnosis_code_4) as diagnosis_code_4,  
-  max(diagnosis_code_5) as diagnosis_code_5, 
-  max(diagnosis_code_6) as diagnosis_code_6,   
-  max(diagnosis_code_7) as diagnosis_code_7, 
-  max(diagnosis_code_8) as diagnosis_code_8,   
-  max(diagnosis_code_9) as diagnosis_code_9, 
-  max(diagnosis_code_10) as diagnosis_code_10,   
-  max(diagnosis_code_11) as diagnosis_code_11, 
-  max(diagnosis_code_12) as diagnosis_code_12,   
-  max(diagnosis_code_13) as diagnosis_code_13, 
-  max(diagnosis_code_14) as diagnosis_code_14,  
-  max(diagnosis_code_15) as diagnosis_code_15, 
-  max(diagnosis_code_16) as diagnosis_code_16,   
-  max(diagnosis_code_17) as diagnosis_code_17, 
-  max(diagnosis_code_18) as diagnosis_code_18,  
-  max(diagnosis_code_19) as diagnosis_code_19, 
-  max(diagnosis_code_20) as diagnosis_code_20,   
-  max(diagnosis_code_21) as diagnosis_code_21, 
-  max(diagnosis_code_22) as diagnosis_code_22,  
-  max(diagnosis_code_23) as diagnosis_code_23, 
-  max(diagnosis_code_24) as diagnosis_code_24, 
-  max(diagnosis_code_25) as diagnosis_code_25
-from tuva_synthetic.input_layer.medical_claim
-group by claim_id
-```
-
-Note that we the fields `diagnosis_code_1`, `diagnosis_code_2`, … `diagnosis_code_25` in `input_layer.medical_claim` are header level fields that should have the same value for all lines on a claim, but there could be data quality problems in the input layer, so by taking the max value of each diagnosis code for each `claim_id` (as in the query above) we ensure that each claim_id gets exactly 25 diagnosis codes and not more. Some of these diagnosis codes might be `null`, in which case they do not populate the `core.condition table`, but for any non-null value of `diagnosis_code_1` through `diagnosis_code_25` there will be a row in `core.condition` representing that condition.
-
-Keep in mind:
-
-* The number of rows in `core.condition` populated from a claims dataset is at most 25 times the number of distinct `claim_id`s in input_layer.medical_claim. There will be at most 25 distinct diagnosis codes per claim. There could be less because any diagnosis codes that are null in the input layer do not populate `core.condition`.
-* If for a given claim_id two distinct diagnosis codes are the same (for example, `diagnosis_code_1` = `diagnosis_code_2` = R93.1, there will be distinct rows for each of those in `core.condition`, each row having a distinct value of `condition_rank`.
-* All diagnosis codes coming from claims are either ICD-9-CM or ICD-10-CM because the only allowed values for the field `diagnosis_code_type` in `input_layer.medical_claim` are `icd-9-cm` or `icd-10-cm`.
-* If a diagnosis code in the claims input layer has an invalid value (i.e. a value that is not a real ICD-9-CM or ICD-10-CM code, for example `diagnosis_code_1` = 'XXXXX'), a row will still be created in `core.condition` for that diagnosis code. That row in `core.condition` will have a populated value for `source_code` (namely, the invalid diagnosis code, for example source_code = 'XXXXX') but it will have a null value for `normalized_code`.
-
-## Populating core.condition from clinical data
 
 **Primary Keys:**
 * condition_id
@@ -84,4 +18,34 @@ Keep in mind:
 * encounter_id
 
 | Column | Data Type | Description | Terminology |
-| ------ | --------- | ----------- | ----------- | 
+| ------ | --------- | ----------- | ----------- |
+| condition_id | string | Unique identifier for the condition | - |
+| person_id | string | Unique identifier for the person | - |
+| member_id | string | Unique identifier for the member | - |
+| patient_id | string | Unique identifier for the patient | - |
+| encounter_id | string | Unique identifier for the encounter | - |
+| condition_type | string | Type of condition (e.g., problem, symptom, diagnosis) | - |
+| condition_code | string | Standardized code for the condition | ICD-9-CM, ICD-10-CM, SNOMED CT |
+| condition_code_type | string | Type of coding system used | icd-9-cm, icd-10-cm, snomed-ct |
+| condition_code_system | string | Coding system identifier | - |
+| condition_code_version | string | Version of the coding system | - |
+| condition_code_display | string | Human-readable description of the condition | - |
+| condition_rank | integer | Rank/priority of the condition (1 = primary, 2 = secondary, etc.) | - |
+| recorded_date | date | Date when the condition was recorded | - |
+| onset_date | date | Date when the condition began | - |
+| abatement_date | date | Date when the condition resolved | - |
+| clinical_status | string | Clinical status of the condition | active, inactive, resolved |
+| verification_status | string | Verification status of the condition | confirmed, provisional, differential |
+| severity | string | Severity of the condition | mild, moderate, severe |
+| category | string | Category or classification of the condition | - |
+| body_site | string | Anatomical location of the condition | - |
+| laterality | string | Side of the body affected | left, right, bilateral |
+| encounter_class | string | Class of the associated encounter | inpatient, outpatient, emergency |
+| facility_type | string | Type of healthcare facility | hospital, clinic, urgent_care |
+| data_source | string | Source of the condition data | claims, clinical, ehr |
+| source_code | string | Original code from the source system | - |
+| normalized_code | string | Standardized/normalized code | - |
+| source_system | string | System that provided the condition data | - |
+| source_table | string | Table in the source system | - |
+| source_id | string | Identifier from the source system | - |
+| ingestion_date | timestamp | Date when the data was ingested | - |

--- a/docs/medical-api/handling-data/schema/encounter.mdx
+++ b/docs/medical-api/handling-data/schema/encounter.mdx
@@ -1,0 +1,17 @@
+---
+title: "Encounter Schema"
+description: "Schema documentation for the Encounter table in the Tuva data model"
+---
+
+# Encounter
+
+The encounter table is intended to store information that represents a unique patient interaction with the healthcare system. It's intended to be synonymous with a healthcare visit (e.g. hospital admission, office visit, etc.). All healthcare analytics use cases involving utilization require an encounter concept. Not only is it important to know about each unique encounter a patient has with the healthcare system, but it's also important to know the type of visit (e.g. acute inpatient, ED, office visit, inpatient rehab, etc.), the start and end dates for the visit, the total amount paid for the visit, and other pieces of information about the visit. The encounter table stores all of this important information in a single table.
+
+**Primary Keys:**
+* encounter_id
+
+**Foreign Keys:**
+* person_id
+
+| Column | Data Type | Description | Terminology |
+| ------ | --------- | ----------- | ----------- | 

--- a/docs/medical-api/handling-data/schema/encounter.mdx
+++ b/docs/medical-api/handling-data/schema/encounter.mdx
@@ -1,9 +1,8 @@
 ---
-title: "Encounter Schema"
-description: "Schema documentation for the Encounter table in the Tuva data model"
+title: "Encounter"
+description: "Schema documentation for the Encounter table in the Metriport data model"
+group: "Schema"
 ---
-
-# Encounter
 
 The encounter table is intended to store information that represents a unique patient interaction with the healthcare system. It's intended to be synonymous with a healthcare visit (e.g. hospital admission, office visit, etc.). All healthcare analytics use cases involving utilization require an encounter concept. Not only is it important to know about each unique encounter a patient has with the healthcare system, but it's also important to know the type of visit (e.g. acute inpatient, ED, office visit, inpatient rehab, etc.), the start and end dates for the visit, the total amount paid for the visit, and other pieces of information about the visit. The encounter table stores all of this important information in a single table.
 
@@ -14,4 +13,40 @@ The encounter table is intended to store information that represents a unique pa
 * person_id
 
 | Column | Data Type | Description | Terminology |
-| ------ | --------- | ----------- | ----------- | 
+| ------ | --------- | ----------- | ----------- |
+| encounter_id | string | Unique identifier for the encounter | - |
+| person_id | string | Unique identifier for the person | - |
+| member_id | string | Unique identifier for the member | - |
+| patient_id | string | Unique identifier for the patient | - |
+| encounter_type | string | Type of encounter (e.g., inpatient, outpatient, emergency) | - |
+| encounter_class | string | Classification of the encounter | inpatient, outpatient, emergency, urgent_care |
+| encounter_start_date | date | Start date/time of the encounter | - |
+| encounter_end_date | date | End date/time of the encounter | - |
+| admission_date | date | Date of admission for inpatient encounters | - |
+| discharge_date | date | Date of discharge for inpatient encounters | - |
+| facility_id | string | Identifier for the healthcare facility | - |
+| facility_name | string | Name of the healthcare facility | - |
+| facility_type | string | Type of healthcare facility | hospital, clinic, urgent_care |
+| provider_id | string | Identifier for the primary provider | - |
+| provider_name | string | Name of the primary provider | - |
+| provider_type | string | Type of provider | physician, nurse, specialist |
+| diagnosis_primary | string | Primary diagnosis code | ICD-9-CM, ICD-10-CM |
+| diagnosis_secondary | string | Secondary diagnosis codes | ICD-9-CM, ICD-10-CM |
+| procedure_primary | string | Primary procedure code | CPT, HCPCS, ICD-9-CM, ICD-10-CM |
+| procedure_secondary | string | Secondary procedure codes | CPT, HCPCS, ICD-9-CM, ICD-10-CM |
+| total_charge_amount | decimal | Total amount charged for the encounter | - |
+| total_paid_amount | decimal | Total amount paid for the encounter | - |
+| copay_amount | decimal | Copay amount for the encounter | - |
+| deductible_amount | decimal | Deductible amount for the encounter | - |
+| coinsurance_amount | decimal | Coinsurance amount for the encounter | - |
+| discharge_disposition | string | Discharge disposition | home, skilled_nursing, hospice |
+| length_of_stay | integer | Length of stay in days | - |
+| emergency_indicator | boolean | Whether this was an emergency encounter | - |
+| urgent_indicator | boolean | Whether this was an urgent encounter | - |
+| data_source | string | Source of the encounter data | claims, clinical, ehr |
+| source_code | string | Original code from the source system | - |
+| normalized_code | string | Standardized/normalized code | - |
+| source_system | string | System that provided the encounter data | - |
+| source_table | string | Table in the source system | - |
+| source_id | string | Identifier from the source system | - |
+| ingestion_date | timestamp | Date when the data was ingested | - |

--- a/docs/medical-api/handling-data/schema/immunization.mdx
+++ b/docs/medical-api/handling-data/schema/immunization.mdx
@@ -1,0 +1,21 @@
+---
+title: "Immunization Schema"
+description: "Schema documentation for the Immunization table in the Tuva data model"
+---
+
+# Immunization
+
+The immunization table contains information on immunizations administered to patients, including the vaccine code, description, and administration date.
+
+**Primary Key:**
+* immunization_id
+
+**Foreign Keys:**
+* patient_id
+* person_id
+* encounter_id
+* location_id
+* practitioner_id
+
+| Column | Data Type | Description | Terminology |
+| ------ | --------- | ----------- | ----------- | 

--- a/docs/medical-api/handling-data/schema/immunization.mdx
+++ b/docs/medical-api/handling-data/schema/immunization.mdx
@@ -1,9 +1,8 @@
 ---
-title: "Immunization Schema"
-description: "Schema documentation for the Immunization table in the Tuva data model"
+title: "Immunization"
+description: "Schema documentation for the Immunization table in the Metriport data model"
+group: "Schema"
 ---
-
-# Immunization
 
 The immunization table contains information on immunizations administered to patients, including the vaccine code, description, and administration date.
 
@@ -18,4 +17,35 @@ The immunization table contains information on immunizations administered to pat
 * practitioner_id
 
 | Column | Data Type | Description | Terminology |
-| ------ | --------- | ----------- | ----------- | 
+| ------ | --------- | ----------- | ----------- |
+| immunization_id | string | Unique identifier for the immunization | - |
+| person_id | string | Unique identifier for the person | - |
+| member_id | string | Unique identifier for the member | - |
+| patient_id | string | Unique identifier for the patient | - |
+| encounter_id | string | Unique identifier for the encounter | - |
+| location_id | string | Unique identifier for the location | - |
+| practitioner_id | string | Unique identifier for the practitioner | - |
+| immunization_code | string | Standardized immunization code | CVX, SNOMED CT |
+| immunization_code_type | string | Type of coding system used | cvx, snomed-ct |
+| immunization_code_system | string | Coding system identifier | - |
+| immunization_code_version | string | Version of the coding system | - |
+| immunization_code_display | string | Human-readable description of the immunization | - |
+| immunization_name | string | Name of the immunization | - |
+| immunization_date | date | Date when the immunization was administered | - |
+| immunization_status | string | Status of the immunization | completed, entered-in-error, not-done |
+| immunization_lot_number | string | Lot number of the vaccine | - |
+| immunization_expiration_date | date | Expiration date of the vaccine | - |
+| immunization_manufacturer | string | Manufacturer of the vaccine | - |
+| immunization_site | string | Anatomical site of administration | left_arm, right_arm, left_thigh, right_thigh |
+| immunization_route | string | Route of administration | intramuscular, subcutaneous, oral, nasal |
+| immunization_dose_quantity | string | Quantity of the dose administered | - |
+| immunization_dose_unit | string | Unit of measurement for the dose | - |
+| immunization_series | string | Series information for multi-dose vaccines | - |
+| immunization_reason | string | Reason for the immunization | routine, travel, outbreak |
+| data_source | string | Source of the immunization data | claims, clinical, ehr |
+| source_code | string | Original code from the source system | - |
+| normalized_code | string | Standardized/normalized code | - |
+| source_system | string | System that provided the immunization data | - |
+| source_table | string | Table in the source system | - |
+| source_id | string | Identifier from the source system | - |
+| ingestion_date | timestamp | Date when the data was ingested | - |

--- a/docs/medical-api/handling-data/schema/lab-result.mdx
+++ b/docs/medical-api/handling-data/schema/lab-result.mdx
@@ -1,0 +1,19 @@
+---
+title: "Lab Result Schema"
+description: "Schema documentation for the Lab Result table in the Tuva data model"
+---
+
+# Lab Result
+
+The lab result table contains information about lab test results, including the LOINC code and description, units, reference range, and result.
+
+**Primary Keys:**
+* lab_result_id
+
+**Foreign Keys:**
+* person_id
+* patient_id
+* encounter_id
+
+| Column | Data Type | Description | Terminology |
+| ------ | --------- | ----------- | ----------- | 

--- a/docs/medical-api/handling-data/schema/lab-result.mdx
+++ b/docs/medical-api/handling-data/schema/lab-result.mdx
@@ -1,9 +1,8 @@
 ---
-title: "Lab Result Schema"
-description: "Schema documentation for the Lab Result table in the Tuva data model"
+title: "Lab Result"
+description: "Schema documentation for the Lab Result table in the Metriport data model"
+group: "Schema"
 ---
-
-# Lab Result
 
 The lab result table contains information about lab test results, including the LOINC code and description, units, reference range, and result.
 
@@ -16,4 +15,31 @@ The lab result table contains information about lab test results, including the 
 * encounter_id
 
 | Column | Data Type | Description | Terminology |
-| ------ | --------- | ----------- | ----------- | 
+| ------ | --------- | ----------- | ----------- |
+| lab_result_id | string | Unique identifier for the lab result | - |
+| person_id | string | Unique identifier for the person | - |
+| member_id | string | Unique identifier for the member | - |
+| patient_id | string | Unique identifier for the patient | - |
+| encounter_id | string | Unique identifier for the encounter | - |
+| practitioner_id | string | Unique identifier for the practitioner | - |
+| lab_test_code | string | Standardized lab test code | LOINC |
+| lab_test_code_type | string | Type of coding system used | loinc |
+| lab_test_code_system | string | Coding system identifier | - |
+| lab_test_code_version | string | Version of the coding system | - |
+| lab_test_code_display | string | Human-readable description of the lab test | - |
+| lab_test_date | date | Date when the lab test was performed | - |
+| lab_result_value | string | Value of the lab result | - |
+| lab_result_value_type | string | Data type of the lab result value | quantity, codeable-concept, string |
+| lab_result_unit | string | Unit of measurement for the lab result | - |
+| lab_result_status | string | Status of the lab result | final, preliminary, amended |
+| reference_range_low | string | Lower bound of the reference range | - |
+| reference_range_high | string | Upper bound of the reference range | - |
+| reference_range_text | string | Text description of the reference range | - |
+| abnormal_flag | string | Flag indicating if the result is abnormal | high, low, normal, critical |
+| data_source | string | Source of the lab result data | claims, clinical, ehr |
+| source_code | string | Original code from the source system | - |
+| normalized_code | string | Standardized/normalized code | - |
+| source_system | string | System that provided the lab result data | - |
+| source_table | string | Table in the source system | - |
+| source_id | string | Identifier from the source system | - |
+| ingestion_date | timestamp | Date when the data was ingested | - |

--- a/docs/medical-api/handling-data/schema/location.mdx
+++ b/docs/medical-api/handling-data/schema/location.mdx
@@ -1,0 +1,14 @@
+---
+title: "Location Schema"
+description: "Schema documentation for the Location table in the Tuva data model"
+---
+
+# Location
+
+The location table contains information on practice and facility locations where patients receive medical care.
+
+**Primary Keys:**
+* location_id
+
+| Column | Data Type | Description | Terminology |
+| ------ | --------- | ----------- | ----------- | 

--- a/docs/medical-api/handling-data/schema/location.mdx
+++ b/docs/medical-api/handling-data/schema/location.mdx
@@ -1,9 +1,8 @@
 ---
-title: "Location Schema"
-description: "Schema documentation for the Location table in the Tuva data model"
+title: "Location"
+description: "Schema documentation for the Location table in the Metriport data model"
+group: "Schema"
 ---
-
-# Location
 
 The location table contains information on practice and facility locations where patients receive medical care.
 
@@ -11,4 +10,31 @@ The location table contains information on practice and facility locations where
 * location_id
 
 | Column | Data Type | Description | Terminology |
-| ------ | --------- | ----------- | ----------- | 
+| ------ | --------- | ----------- | ----------- |
+| location_id | string | Unique identifier for the location | - |
+| organization_id | string | Unique identifier for the organization | - |
+| location_name | string | Name of the location | - |
+| location_type | string | Type of healthcare location | hospital, clinic, urgent_care, office |
+| location_code | string | Standardized location code | - |
+| location_code_type | string | Type of coding system used | - |
+| location_code_system | string | Coding system identifier | - |
+| location_code_version | string | Version of the coding system | - |
+| location_code_display | string | Human-readable description of the location | - |
+| address_line_1 | string | Primary address line | - |
+| address_line_2 | string | Secondary address line | - |
+| city | string | City | - |
+| state | string | State or province | - |
+| zip_code | string | ZIP or postal code | - |
+| country | string | Country | - |
+| phone_number | string | Primary phone number | - |
+| fax_number | string | Fax number | - |
+| email_address | string | Primary email address | - |
+| website_url | string | Website URL | - |
+| active_status | boolean | Whether the location is active | - |
+| data_source | string | Source of the location data | claims, clinical, ehr |
+| source_code | string | Original code from the source system | - |
+| normalized_code | string | Standardized/normalized code | - |
+| source_system | string | System that provided the location data | - |
+| source_table | string | Table in the source system | - |
+| source_id | string | Identifier from the source system | - |
+| ingestion_date | timestamp | Date when the data was ingested | - |

--- a/docs/medical-api/handling-data/schema/medication.mdx
+++ b/docs/medical-api/handling-data/schema/medication.mdx
@@ -1,9 +1,8 @@
 ---
-title: "Medication Schema"
-description: "Schema documentation for the Medication table in the Tuva data model"
+title: "Medication"
+description: "Schema documentation for the Medication table in the Metriport data model"
+group: "Schema"
 ---
-
-# Medication
 
 The medication table contains information on medications ordered and/or administered during a patient encounter.
 
@@ -16,4 +15,34 @@ The medication table contains information on medications ordered and/or administ
 * encounter_id
 
 | Column | Data Type | Description | Terminology |
-| ------ | --------- | ----------- | ----------- | 
+| ------ | --------- | ----------- | ----------- |
+| medication_id | string | Unique identifier for the medication | - |
+| person_id | string | Unique identifier for the person | - |
+| member_id | string | Unique identifier for the member | - |
+| patient_id | string | Unique identifier for the patient | - |
+| encounter_id | string | Unique identifier for the encounter | - |
+| practitioner_id | string | Unique identifier for the practitioner | - |
+| medication_code | string | Standardized medication code | RxNorm, NDC, SNOMED CT |
+| medication_code_type | string | Type of coding system used | rxnorm, ndc, snomed-ct |
+| medication_code_system | string | Coding system identifier | - |
+| medication_code_version | string | Version of the coding system | - |
+| medication_code_display | string | Human-readable description of the medication | - |
+| medication_name | string | Name of the medication | - |
+| medication_generic_name | string | Generic name of the medication | - |
+| medication_brand_name | string | Brand name of the medication | - |
+| medication_strength | string | Strength of the medication | - |
+| medication_form | string | Form of the medication | tablet, capsule, liquid, injection |
+| medication_route | string | Route of administration | oral, intravenous, intramuscular |
+| medication_frequency | string | Frequency of administration | daily, twice_daily, as_needed |
+| medication_dosage | string | Dosage instructions | - |
+| medication_start_date | date | Date when medication was started | - |
+| medication_end_date | date | Date when medication was discontinued | - |
+| medication_status | string | Status of the medication | active, discontinued, completed |
+| medication_type | string | Type of medication | prescription, over_the_counter, controlled |
+| data_source | string | Source of the medication data | claims, clinical, ehr |
+| source_code | string | Original code from the source system | - |
+| normalized_code | string | Standardized/normalized code | - |
+| source_system | string | System that provided the medication data | - |
+| source_table | string | Table in the source system | - |
+| source_id | string | Identifier from the source system | - |
+| ingestion_date | timestamp | Date when the data was ingested | - |

--- a/docs/medical-api/handling-data/schema/medication.mdx
+++ b/docs/medical-api/handling-data/schema/medication.mdx
@@ -1,0 +1,19 @@
+---
+title: "Medication Schema"
+description: "Schema documentation for the Medication table in the Tuva data model"
+---
+
+# Medication
+
+The medication table contains information on medications ordered and/or administered during a patient encounter.
+
+**Primary Keys:**
+* medication_id
+
+**Foreign Keys:**
+* person_id
+* patient_id
+* encounter_id
+
+| Column | Data Type | Description | Terminology |
+| ------ | --------- | ----------- | ----------- | 

--- a/docs/medical-api/handling-data/schema/observation.mdx
+++ b/docs/medical-api/handling-data/schema/observation.mdx
@@ -1,9 +1,8 @@
 ---
-title: "Observation Schema"
-description: "Schema documentation for the Observation table in the Tuva data model"
+title: "Observation"
+description: "Schema documentation for the Observation table in the Metriport data model"
+group: "Schema"
 ---
-
-# Observation
 
 The observation table contains information on measurements other than lab tests e.g. blood pressure, height, and weight.
 
@@ -16,4 +15,30 @@ The observation table contains information on measurements other than lab tests 
 * encounter_id
 
 | Column | Data Type | Description | Terminology |
-| ------ | --------- | ----------- | ----------- | 
+| ------ | --------- | ----------- | ----------- |
+| observation_id | string | Unique identifier for the observation | - |
+| person_id | string | Unique identifier for the person | - |
+| member_id | string | Unique identifier for the member | - |
+| patient_id | string | Unique identifier for the patient | - |
+| encounter_id | string | Unique identifier for the encounter | - |
+| practitioner_id | string | Unique identifier for the practitioner | - |
+| observation_code | string | Standardized observation code | LOINC, SNOMED CT |
+| observation_code_type | string | Type of coding system used | loinc, snomed-ct |
+| observation_code_system | string | Coding system identifier | - |
+| observation_code_version | string | Version of the coding system | - |
+| observation_code_display | string | Human-readable description of the observation | - |
+| observation_date | date | Date when the observation was made | - |
+| observation_value | string | Value of the observation | - |
+| observation_value_type | string | Data type of the observation value | quantity, codeable-concept, string |
+| observation_unit | string | Unit of measurement for the observation | - |
+| observation_status | string | Status of the observation | final, preliminary, amended |
+| observation_category | string | Category of the observation | vital-signs, survey, imaging |
+| body_site | string | Anatomical location of the observation | - |
+| laterality | string | Side of the body for the observation | left, right, bilateral |
+| data_source | string | Source of the observation data | claims, clinical, ehr |
+| source_code | string | Original code from the source system | - |
+| normalized_code | string | Standardized/normalized code | - |
+| source_system | string | System that provided the observation data | - |
+| source_table | string | Table in the source system | - |
+| source_id | string | Identifier from the source system | - |
+| ingestion_date | timestamp | Date when the data was ingested | - |

--- a/docs/medical-api/handling-data/schema/observation.mdx
+++ b/docs/medical-api/handling-data/schema/observation.mdx
@@ -1,0 +1,19 @@
+---
+title: "Observation Schema"
+description: "Schema documentation for the Observation table in the Tuva data model"
+---
+
+# Observation
+
+The observation table contains information on measurements other than lab tests e.g. blood pressure, height, and weight.
+
+**Primary Keys:**
+* observation_id
+
+**Foreign Keys:**
+* person_id
+* patient_id
+* encounter_id
+
+| Column | Data Type | Description | Terminology |
+| ------ | --------- | ----------- | ----------- | 

--- a/docs/medical-api/handling-data/schema/patient.mdx
+++ b/docs/medical-api/handling-data/schema/patient.mdx
@@ -1,9 +1,8 @@
 ---
-title: "Patient Schema"
-description: "Schema documentation for the Patient table in the Tuva data model"
+title: "Patient"
+description: "Schema documentation for the Patient table in the Metriport data model"
+group: "Schema"
 ---
-
-# Patient
 
 The patient table contains information on patients, including demographic information such as birth date, gender, race, and ethnicity. This is the core table that contains this information.
 
@@ -11,4 +10,34 @@ The patient table contains information on patients, including demographic inform
 * person_id
 
 | Column | Data Type | Description | Terminology |
-| ------ | --------- | ----------- | ----------- | 
+| ------ | --------- | ----------- | ----------- |
+| person_id | string | Unique identifier for the person | - |
+| member_id | string | Unique identifier for the member | - |
+| patient_id | string | Unique identifier for the patient | - |
+| first_name | string | Patient's first name | - |
+| last_name | string | Patient's last name | - |
+| middle_name | string | Patient's middle name | - |
+| date_of_birth | date | Patient's date of birth | - |
+| gender | string | Patient's gender | male, female, other, unknown |
+| race | string | Patient's race | - |
+| ethnicity | string | Patient's ethnicity | - |
+| marital_status | string | Patient's marital status | single, married, divorced, widowed |
+| address_line_1 | string | Primary address line | - |
+| address_line_2 | string | Secondary address line | - |
+| city | string | City | - |
+| state | string | State or province | - |
+| zip_code | string | ZIP or postal code | - |
+| country | string | Country | - |
+| phone_number | string | Primary phone number | - |
+| email_address | string | Primary email address | - |
+| primary_language | string | Patient's primary language | - |
+| insurance_id | string | Primary insurance identifier | - |
+| insurance_provider | string | Primary insurance provider | - |
+| insurance_group | string | Insurance group number | - |
+| data_source | string | Source of the patient data | claims, clinical, ehr |
+| source_code | string | Original code from the source system | - |
+| normalized_code | string | Standardized/normalized code | - |
+| source_system | string | System that provided the patient data | - |
+| source_table | string | Table in the source system | - |
+| source_id | string | Identifier from the source system | - |
+| ingestion_date | timestamp | Date when the data was ingested | - |

--- a/docs/medical-api/handling-data/schema/patient.mdx
+++ b/docs/medical-api/handling-data/schema/patient.mdx
@@ -1,0 +1,14 @@
+---
+title: "Patient Schema"
+description: "Schema documentation for the Patient table in the Tuva data model"
+---
+
+# Patient
+
+The patient table contains information on patients, including demographic information such as birth date, gender, race, and ethnicity. This is the core table that contains this information.
+
+**Primary Keys:**
+* person_id
+
+| Column | Data Type | Description | Terminology |
+| ------ | --------- | ----------- | ----------- | 

--- a/docs/medical-api/handling-data/schema/practitioner.mdx
+++ b/docs/medical-api/handling-data/schema/practitioner.mdx
@@ -1,9 +1,8 @@
 ---
-title: "Practitioner Schema"
-description: "Schema documentation for the Practitioner table in the Tuva data model"
+title: "Practitioner"
+description: "Schema documentation for the Practitioner table in the Metriport data model"
+group: "Schema"
 ---
-
-# Practitioner
 
 The practitioner table contains information on healthcare providers who deliver care to patients.
 
@@ -14,4 +13,27 @@ The practitioner table contains information on healthcare providers who deliver 
 * location_id
 
 | Column | Data Type | Description | Terminology |
-| ------ | --------- | ----------- | ----------- | 
+| ------ | --------- | ----------- | ----------- |
+| practitioner_id | string | Unique identifier for the practitioner | - |
+| person_id | string | Unique identifier for the person | - |
+| member_id | string | Unique identifier for the member | - |
+| first_name | string | Practitioner's first name | - |
+| last_name | string | Practitioner's last name | - |
+| middle_name | string | Practitioner's middle name | - |
+| npi | string | National Provider Identifier | - |
+| license_number | string | State license number | - |
+| specialty | string | Medical specialty | - |
+| specialty_code | string | Specialty code | - |
+| credential | string | Professional credentials | MD, DO, RN, NP, PA |
+| organization_id | string | Identifier for the organization | - |
+| location_id | string | Identifier for the primary location | - |
+| phone_number | string | Primary phone number | - |
+| email_address | string | Primary email address | - |
+| active_status | boolean | Whether the practitioner is active | - |
+| data_source | string | Source of the practitioner data | claims, clinical, ehr |
+| source_code | string | Original code from the source system | - |
+| normalized_code | string | Standardized/normalized code | - |
+| source_system | string | System that provided the practitioner data | - |
+| source_table | string | Table in the source system | - |
+| source_id | string | Identifier from the source system | - |
+| ingestion_date | timestamp | Date when the data was ingested | - |

--- a/docs/medical-api/handling-data/schema/practitioner.mdx
+++ b/docs/medical-api/handling-data/schema/practitioner.mdx
@@ -1,0 +1,17 @@
+---
+title: "Practitioner Schema"
+description: "Schema documentation for the Practitioner table in the Tuva data model"
+---
+
+# Practitioner
+
+The practitioner table contains information on healthcare providers who deliver care to patients.
+
+**Primary Keys:**
+* practitioner_id
+
+**Foreign Keys:**
+* location_id
+
+| Column | Data Type | Description | Terminology |
+| ------ | --------- | ----------- | ----------- | 

--- a/docs/medical-api/handling-data/schema/procedure.mdx
+++ b/docs/medical-api/handling-data/schema/procedure.mdx
@@ -1,0 +1,21 @@
+---
+title: "Procedure Schema"
+description: "Schema documentation for the Procedure table in the Tuva data model"
+---
+
+# Procedure
+
+The procedure table contains information on procedures performed on patients, including procedure codes, descriptions, and performance dates.
+
+**Primary Keys:**
+* procedure_id
+
+**Foreign Keys:**
+* person_id
+* patient_id
+* encounter_id
+* practitioner_id
+* location_id
+
+| Column | Data Type | Description | Terminology |
+| ------ | --------- | ----------- | ----------- | 

--- a/docs/medical-api/handling-data/schema/procedure.mdx
+++ b/docs/medical-api/handling-data/schema/procedure.mdx
@@ -1,9 +1,8 @@
 ---
-title: "Procedure Schema"
-description: "Schema documentation for the Procedure table in the Tuva data model"
+title: "Procedure"
+description: "Schema documentation for the Procedure table in the Metriport data model"
+group: "Schema"
 ---
-
-# Procedure
 
 The procedure table contains information on procedures performed on patients, including procedure codes, descriptions, and performance dates.
 
@@ -18,4 +17,32 @@ The procedure table contains information on procedures performed on patients, in
 * location_id
 
 | Column | Data Type | Description | Terminology |
-| ------ | --------- | ----------- | ----------- | 
+| ------ | --------- | ----------- | ----------- |
+| procedure_id | string | Unique identifier for the procedure | - |
+| person_id | string | Unique identifier for the person | - |
+| member_id | string | Unique identifier for the member | - |
+| patient_id | string | Unique identifier for the patient | - |
+| encounter_id | string | Unique identifier for the encounter | - |
+| practitioner_id | string | Unique identifier for the practitioner | - |
+| location_id | string | Unique identifier for the location | - |
+| procedure_code | string | Standardized procedure code | CPT, HCPCS, ICD-9-CM, ICD-10-CM |
+| procedure_code_type | string | Type of coding system used | cpt, hcpcs, icd-9-cm, icd-10-cm |
+| procedure_code_system | string | Coding system identifier | - |
+| procedure_code_version | string | Version of the coding system | - |
+| procedure_code_display | string | Human-readable description of the procedure | - |
+| procedure_date | date | Date when the procedure was performed | - |
+| procedure_start_time | timestamp | Start time of the procedure | - |
+| procedure_end_time | timestamp | End time of the procedure | - |
+| procedure_status | string | Status of the procedure | completed, in-progress, cancelled |
+| procedure_type | string | Type of procedure | surgical, diagnostic, therapeutic |
+| body_site | string | Anatomical location of the procedure | - |
+| laterality | string | Side of the body for the procedure | left, right, bilateral |
+| quantity | integer | Quantity of procedures performed | - |
+| unit | string | Unit of measurement for quantity | - |
+| data_source | string | Source of the procedure data | claims, clinical, ehr |
+| source_code | string | Original code from the source system | - |
+| normalized_code | string | Standardized/normalized code | - |
+| source_system | string | System that provided the procedure data | - |
+| source_table | string | Table in the source system | - |
+| source_id | string | Identifier from the source system | - |
+| ingestion_date | timestamp | Date when the data was ingested | - |

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -142,7 +142,28 @@
         "medical-api/handling-data/medical-record-summary",
         "medical-api/handling-data/webhooks",
         "medical-api/handling-data/realtime-patient-notifications",
-        "medical-api/handling-data/data-analytics",
+        {
+          "group": "Data Analytics and Warehousing",
+          "icon": "database",
+          "pages": [
+            "medical-api/handling-data/data-analytics",
+            {
+              "group": "Schema",
+              "pages": [
+                "medical-api/handling-data/schema/condition",
+                "medical-api/handling-data/schema/encounter",
+                "medical-api/handling-data/schema/immunization",
+                "medical-api/handling-data/schema/lab-result",
+                "medical-api/handling-data/schema/location",
+                "medical-api/handling-data/schema/medication",
+                "medical-api/handling-data/schema/observation",
+                "medical-api/handling-data/schema/patient",
+                "medical-api/handling-data/schema/practitioner",
+                "medical-api/handling-data/schema/procedure"
+              ]
+            }
+          ]
+        },
         "medical-api/handling-data/filters",
         "medical-api/handling-data/pagination",
         "medical-api/handling-data/contribution",


### PR DESCRIPTION
Ref: ENG-000

### Description

- Add docs for core schema

### Testing

- Local
  - [x] npx mintlify dev
- Staging
  - [ ] N/A
- Sandbox
  - [ ] N/A
- Production
  - [ ] New schema pages work
  
### Release Plan

- [ ] Merge this
- ⚠️ pointing to master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive schema docs for 10 core tables: Condition, Encounter, Immunization, Lab Result, Location, Medication, Observation, Patient, Practitioner, Procedure (including keys, fields, and terminology).
  * Introduced a Schema Documentation section summarizing the Metriport data model.
  * Updated navigation: new “Data Analytics and Warehousing” group with a “Schema” subgroup linking all new pages.
  * Refreshed page metadata/titles and grouping for consistency across Handling Data docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->