### PR TITLE
feat(api): api: link back to eCW patient page from ADT event

### DIFF
--- a/packages/api/src/command/medical/tcm-encounter/__tests__/fixtures.ts
+++ b/packages/api/src/command/medical/tcm-encounter/__tests__/fixtures.ts
@@ -34,6 +34,7 @@ export function makeEncounter(
     admitTime: new Date("2023-01-01"),
     dischargeTime: null,
     clinicalInformation: {},
+    outreachLogs: overrides.outreachLogs ?? [],
     PatientModel: patient,
     get: jest.fn().mockReturnValue(patient),
   };
@@ -44,6 +45,7 @@ export function makeEncounter(
     dataValues: {
       ...baseEncounter,
       ...overrides,
+      outreachLogs: overrides.outreachLogs ?? [],
       PatientModel: patient,
     },
   };

--- a/packages/api/src/command/medical/tcm-encounter/__tests__/get-tcm-encounter.test.ts
+++ b/packages/api/src/command/medical/tcm-encounter/__tests__/get-tcm-encounter.test.ts
@@ -244,5 +244,30 @@ describe("TCM Encounter Commands", () => {
         }),
       ]);
     });
+
+    it("returns outreachLogs in the encounter result", async () => {
+      const outreachLogs = [
+        { status: "Attempted", timestamp: "2024-01-01T12:00:00Z" },
+        { status: "Completed", timestamp: "2024-01-02T12:00:00Z" },
+      ];
+      const encounter = makeEncounter({ outreachLogs });
+      const mockQueryResult = [
+        {
+          ...encounter,
+          dataValues: {
+            ...encounter.dataValues,
+            outreachLogs,
+            patient_data: encounter.PatientModel.data,
+          },
+        },
+      ];
+      mockSequelize.query.mockResolvedValue(mockQueryResult);
+      const cmd = {
+        cxId: "cx-123",
+        pagination: { count: 10, fromItem: undefined, toItem: undefined },
+      };
+      const result = await getTcmEncounters(cmd);
+      expect(result[0].outreachLogs).toEqual(outreachLogs);
+    });
   });
 });

--- a/packages/api/src/command/medical/tcm-encounter/__tests__/upsert-tcm-encounter.test.ts
+++ b/packages/api/src/command/medical/tcm-encounter/__tests__/upsert-tcm-encounter.test.ts
@@ -24,6 +24,7 @@ describe("Upsert TCM Encounter Command", () => {
         class: "inpatient encounter",
         clinicalInformation: {},
         outreachStatus: "Not Started" as const,
+        outreachLogs: [],
         ...overrides,
       };
     }

--- a/packages/api/src/command/medical/tcm-encounter/create-sample-tcm-encounter.ts
+++ b/packages/api/src/command/medical/tcm-encounter/create-sample-tcm-encounter.ts
@@ -48,6 +48,7 @@ export async function createSampleTcmEncounters(cxId: string, patientId: string)
         dischargeTime: enc.dischargeTime?.toDate(),
         clinicalInformation: enc.clinicalInformation,
         outreachStatus: "Not Started",
+        outreachLogs: [],
         freetextNote: `Sample freetext note for ${enc.latestEvent} encounter`,
       });
     })

--- a/packages/api/src/models/medical/tcm-encounter.ts
+++ b/packages/api/src/models/medical/tcm-encounter.ts
@@ -18,6 +18,9 @@ export class TcmEncounterModel extends BaseModel<TcmEncounterModel> implements T
   declare dischargeSummaryPath: string | undefined;
   declare outreachStatus: CreationOptional<"Not Started" | "Attempted" | "Completed">;
   declare lastOutreachDate: CreationOptional<Date>;
+  declare outreachLogs: CreationOptional<
+    { status: "Attempted" | "Completed"; timestamp: string }[]
+  >;
 
   // This is a stored generated column, its derived from clinical_information.
   declare readonly hasCardiacCode: CreationOptional<boolean>;
@@ -78,6 +81,11 @@ export class TcmEncounterModel extends BaseModel<TcmEncounterModel> implements T
         },
         lastOutreachDate: {
           type: DataTypes.DATE,
+        },
+        outreachLogs: {
+          type: DataTypes.JSONB,
+          defaultValue: [],
+          allowNull: false,
         },
         hasCardiacCode: {
           type: DataTypes.BOOLEAN,

--- a/packages/api/src/routes/internal/__tests__/tcm-encounter.test.ts
+++ b/packages/api/src/routes/internal/__tests__/tcm-encounter.test.ts
@@ -28,6 +28,7 @@ describe("Create TCM Encounter Command", () => {
         class: "Inpatient",
         clinicalInformation: {},
         outreachStatus: "Not Started" as const,
+        outreachLogs: [],
         ...overrides,
       };
     }

--- a/packages/api/src/sequelize/migrations/2025-09-03_00_alter_tcm-encounter_add-outreach-logs.ts
+++ b/packages/api/src/sequelize/migrations/2025-09-03_00_alter_tcm-encounter_add-outreach-logs.ts
@@ -1,0 +1,33 @@
+import { DataTypes, Sequelize } from "sequelize";
+import type { Migration } from "..";
+
+const tableName = "tcm_encounter";
+const columnName = "outreach_logs";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.addColumn(
+      tableName,
+      columnName,
+      {
+        type: DataTypes.JSONB,
+        allowNull: false,
+        defaultValue: Sequelize.literal(`'[]'::jsonb`),
+      },
+      { transaction }
+    );
+    await queryInterface.sequelize.query(
+      `CREATE INDEX IF NOT EXISTS idx_tcm_encounter_outreach_logs ON ${tableName} USING gin (${columnName});`,
+      { transaction }
+    );
+  });
+};
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.sequelize.transaction(async transaction => {
+    await queryInterface.removeColumn(tableName, columnName, { transaction });
+    await queryInterface.sequelize.query(`DROP INDEX IF EXISTS idx_tcm_encounter_outreach_logs;`, {
+      transaction,
+    });
+  });
+};

--- a/packages/shared/src/domain/tcm-encounter.ts
+++ b/packages/shared/src/domain/tcm-encounter.ts
@@ -29,6 +29,14 @@ export const tcmEncounterBaseSchema = z.strictObject({
     .transform(val => buildDayjs(val).toDate())
     .nullish()
     .transform(val => (val === null ? undefined : val)),
+  outreachLogs: z
+    .array(
+      z.object({
+        status: z.enum(["Attempted", "Completed"] as const),
+        timestamp: z.string().datetime(),
+      })
+    )
+    .default([]),
   clinicalInformation: z.record(z.unknown()).optional().default({}),
   freetextNote: z.string().optional(),
   dischargeSummaryPath: z.string().optional(),


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-962

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/3214

### Description

- construct external url for ecw
- see downstream PR

Testing
- See downstream PR

Release Plan
- [ ]  Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds outreachLogs to encounters (stored, returned, and usable for tracking outreach attempts).

* **Enhancements**
  * Includes patient mapping records with each encounter (external IDs and sources).
  * Adds external URL metadata for encounters to link into supported external systems.

* **Tests**
  * Expanded tests and fixtures to cover outreachLogs handling.

* **Chores**
  * DB migration adds outreachLogs column and index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->