### PR TITLE
ENG-484: Surescripts query parameter for DQ

### DIFF
--- a/packages/api/src/command/medical/document/pharmacy-query.ts
+++ b/packages/api/src/command/medical/document/pharmacy-query.ts
@@ -1,0 +1,23 @@
+import { PharmacyQueryProgress } from "@metriport/core/domain/document-query";
+import { out } from "@metriport/core/util/log";
+import { uuidv7 } from "@metriport/core/util/uuid-v7";
+
+export async function queryDocumentsAcrossPharmacies({
+  cxId,
+  patientId,
+  facilityId,
+}: {
+  cxId: string;
+  patientId: string;
+  facilityId: string;
+}): Promise<PharmacyQueryProgress> {
+  const { log } = out(`Pharmacies DQ - cxId ${cxId}, patient ${patientId}`);
+
+  log("Running pharmacies DQ for " + facilityId + " and CX " + cxId);
+
+  return {
+    status: "processing",
+    startedAt: new Date(),
+    requestId: uuidv7(),
+  };
+}

--- a/packages/api/src/domain/patient-mapping.ts
+++ b/packages/api/src/domain/patient-mapping.ts
@@ -1,12 +1,13 @@
 import { BaseDomain } from "@metriport/core/domain/base-domain";
 import { ehrSources } from "@metriport/shared/interface/external/ehr/source";
 import { questSource } from "@metriport/shared/interface/external/quest/source";
+import { surescriptsSource } from "@metriport/shared/interface/external/surescripts/source";
 
 export type PatientSourceIdentifierMap = {
   [key in string]: string[];
 };
 
-const patientMappingSource = [...ehrSources, questSource] as const;
+const patientMappingSource = [...ehrSources, questSource, surescriptsSource] as const;
 export type PatientMappingSource = (typeof patientMappingSource)[number];
 export function isPatientMappingSource(source: string): source is PatientMappingSource {
   return patientMappingSource.includes(source as PatientMappingSource);

--- a/packages/core/src/domain/document-query.ts
+++ b/packages/core/src/domain/document-query.ts
@@ -25,8 +25,8 @@ export type DocumentQueryProgress = Partial<
 
 export type PharmacyQueryProgress = {
   status: "processing" | "completed" | "failed";
-  startedAt: Date;
-  requestId: string;
+  startedAt?: Date;
+  requestId?: string;
 };
 
 export const convertResult = ["success", "failed"] as const;

--- a/packages/core/src/domain/document-query.ts
+++ b/packages/core/src/domain/document-query.ts
@@ -19,8 +19,15 @@ export type DocumentQueryProgress = Partial<
     requestId: string;
     startedAt: Date;
     triggerConsolidated: boolean;
+    pharmacy?: PharmacyQueryProgress;
   }
 >;
+
+export type PharmacyQueryProgress = {
+  status: "processing" | "completed" | "failed";
+  startedAt: Date;
+  requestId: string;
+};
 
 export const convertResult = ["success", "failed"] as const;
 export type ConvertResult = (typeof convertResult)[number];

--- a/packages/shared/src/interface/external/surescripts/source.ts
+++ b/packages/shared/src/interface/external/surescripts/source.ts
@@ -1,0 +1,1 @@
+export const surescriptsSource = "surescripts";


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-484

### Dependencies

- Upstream: None
- Downstream: None

### Description

Implements the `pharmacies` query parameter for DQ, which initiates a parallel execution of all pharmacy integrations (currently only Surescripts).

### Testing

Running the API from the SFTP testing service is a reliable way to ensure that the entire flow is working E2E.

- TODO

### Release Plan

- [ ] Merge this
