### PR TITLE
ENG-513 Override CW v1 patient ID 

### DIFF
--- a/packages/api/src/external/commonwell-v2/patient/patient.ts
+++ b/packages/api/src/external/commonwell-v2/patient/patient.ts
@@ -245,7 +245,7 @@ export async function updatePatientAndLinksInCwV2({
 
   try {
     const commonwellPatientId = await getCommonwellPatientId(patient);
-    if (!commonwellPatientId) {
+    if (!commonwellPatientId || isIdFromCwV1(commonwellPatientId)) {
       log(`Could not find external data on Patient, creating it @ CW`);
       await registerAndLinkPatientInCwV2({
         patient,
@@ -585,7 +585,6 @@ async function registerPatient({
 
   const respPatient = await commonWell.createOrUpdatePatient(commonwellPatient);
   debug(`resp registerPatient: `, () => JSON.stringify(respPatient));
-  log(`respPatient: `, JSON.stringify(respPatient));
   const commonwellPatientId = getCwPatientIdFromLinks(respPatient.Links);
   if (!commonwellPatientId) {
     const msg = `Could not determine the patient ID from CW`;
@@ -906,4 +905,8 @@ function patientCollectionItemToCwLinkV2(networkLink: NetworkLink): CwLinkV2 {
     ...networkLink,
     version: 2,
   };
+}
+
+function isIdFromCwV1(id: string): boolean {
+  return id.includes("urn%3aoid%3a");
 }


### PR DESCRIPTION
Part of ENG-513

### Description

- During testing, I realized that the presence of the CW v1 patient ID breaks the flow for CW v2, since the API think there's already a patient with that ID on the CW v2 system
- Added the fix, which allows us to identify CW v1 IDs and overwrite them with CW v2 IDs instead

### Testing

- Local
  - [x] Update a patient on CW v2 when they already existed on CW v1 and ensure there are no errors
- Staging
  - [ ] Update a patient on CW v2 when they already existed on CW v1 and ensure there are no errors

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of legacy patient identifiers to prevent update failures. When an older ID is detected or missing, the system now automatically creates and links the patient in the newer flow, improving reliability and compatibility with existing records.

* **Chores**
  * Removed overly verbose response logging to reduce noise in system logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->