### PR TITLE
ENG-513 Check Facility ID/OID on CW v2 FF

### DIFF
--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -26,7 +26,11 @@ export async function queryAndProcessDocuments({
   getOrgIdExcludeList: () => Promise<string[]>;
   triggerConsolidated?: boolean;
 }): Promise<void> {
-  const isCwV2Enabled = await isCommonwellV2EnabledForCx(patientParam.cxId);
+  const [isCwV2EnabledCx, isCwV2EnabledFacility] = await Promise.all([
+    isCommonwellV2EnabledForCx(patientParam.cxId),
+    isCommonwellV2EnabledForCx(facilityId ?? "NA"),
+  ]);
+  const isCwV2Enabled = isCwV2EnabledCx && isCwV2EnabledFacility;
 
   // TODO ENG-554 Remove FF and v1 code
   if (!isCwV2Enabled) {

--- a/packages/api/src/external/commonwell/patient/patient.ts
+++ b/packages/api/src/external/commonwell/patient/patient.ts
@@ -69,7 +69,12 @@ export async function create({
 }): Promise<{ commonwellPatientId: string } | void> {
   const { log, debug } = out(`CW create - M patientId ${patient.id}`);
 
-  const isCwV2Enabled = await isCommonwellV2EnabledForCx(patient.cxId);
+  const [isCwV2EnabledCx, isCwV2EnabledFacility] = await Promise.all([
+    isCommonwellV2EnabledForCx(patient.cxId),
+    isCommonwellV2EnabledForCx(facilityId),
+  ]);
+  const isCwV2Enabled = isCwV2EnabledCx && isCwV2EnabledFacility;
+
   const isCwEnabled = await validateCWEnabled({
     patient,
     facilityId,
@@ -133,7 +138,12 @@ export async function update({
 }: UpdatePatientCmd): Promise<void> {
   const { log, debug } = out(`CW update - M patientId ${patient.id}`);
 
-  const isCwV2Enabled = await isCommonwellV2EnabledForCx(patient.cxId);
+  const [isCwV2EnabledCx, isCwV2EnabledFacility] = await Promise.all([
+    isCommonwellV2EnabledForCx(patient.cxId),
+    isCommonwellV2EnabledForCx(facilityId),
+  ]);
+  const isCwV2Enabled = isCwV2EnabledCx && isCwV2EnabledFacility;
+
   const isCwEnabled = await validateCWEnabled({
     patient,
     facilityId,
@@ -190,7 +200,11 @@ export async function update({
 export async function remove({ patient, facilityId }: UpdatePatientCmd): Promise<void> {
   const { log } = out(`CW remove - patientId ${patient.id}`);
 
-  const isCwV2Enabled = await isCommonwellV2EnabledForCx(patient.cxId);
+  const [isCwV2EnabledCx, isCwV2EnabledFacility] = await Promise.all([
+    isCommonwellV2EnabledForCx(patient.cxId),
+    isCommonwellV2EnabledForCx(facilityId),
+  ]);
+  const isCwV2Enabled = isCwV2EnabledCx && isCwV2EnabledFacility;
   if (!isCwV2Enabled) {
     await removeInCwV1(patient, facilityId);
     log(`Removed patient from CW v1`);

--- a/packages/lambdas/src/document-downloader.ts
+++ b/packages/lambdas/src/document-downloader.ts
@@ -74,11 +74,15 @@ export const handler = capture.wrapHandler(
         `sourceDocument: ${JSON.stringify(sourceDocument)}`
     );
 
-    const [cwOrgCertificate, cwOrgPrivateKey, isV2Enabled] = await Promise.all([
-      getSecret(cwOrgCertificateSecret) as Promise<string>,
-      getSecret(cwOrgPrivateKeySecret) as Promise<string>,
-      isCommonwellV2EnabledForCx(cxId),
-    ]);
+    // TODO REVERT THE CHECK FOR OID
+    const [cwOrgCertificate, cwOrgPrivateKey, isV2EnabledCx, isV2EnabledFacility] =
+      await Promise.all([
+        getSecret(cwOrgCertificateSecret) as Promise<string>,
+        getSecret(cwOrgPrivateKeySecret) as Promise<string>,
+        isCommonwellV2EnabledForCx(cxId),
+        isCommonwellV2EnabledForCx(orgOid),
+      ]);
+    const isV2Enabled = isV2EnabledCx && isV2EnabledFacility;
 
     if (!cwOrgCertificate) {
       throw new Error(`Config error - CW_ORG_CERTIFICATE doesn't exist`);


### PR DESCRIPTION
### Dependencies

none

### Description

Check Facility ID/OID on CW v2 FF

### Testing

none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened CommonWell V2 eligibility: V2 now activates only when both the organization and facility are enabled, rather than organization alone.
  * Applied consistent gating across patient create/update/remove, document queries, and document downloads to ensure correct feature access.
  * Prevents unintended V2 behavior when either level is not enabled; falls back to V1 as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->