### PR TITLE
correctly identify malformed XMLs

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/constants.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/constants.ts
@@ -372,6 +372,11 @@ export const testFiles = [
   { name: "test-little-endian.tiff", mimeType: "image/tiff", fileExtension: ".tiff" },
   { name: "test-big-endian.tiff", mimeType: "image/tiff", fileExtension: ".tiff" },
   { name: "test-with-declaration.xml", mimeType: "application/xml", fileExtension: ".xml" },
+  {
+    name: "test-with-commented-declaration.xml",
+    mimeType: "application/xml",
+    fileExtension: ".xml",
+  },
   { name: "test-no-declaration.xml", mimeType: "application/xml", fileExtension: ".xml" },
   { name: "test.txt", mimeType: "text/plain", fileExtension: ".txt" },
   { name: "test.jpeg", mimeType: "image/jpeg", fileExtension: ".jpeg" },

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/files/test-with-commented-declaration.xml
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/__tests__/files/test-with-commented-declaration.xml
@@ -1,0 +1,4 @@
+<!-- <?xml version="1.0" encoding="UTF-8"?> -->
+<ClinicalDocument xmlns="urn:hl7-org:v3">
+    <realmCode code="US" />
+</ClinicalDocument>

--- a/packages/core/src/external/commonwell-v1/document/document-downloader-local.ts
+++ b/packages/core/src/external/commonwell-v1/document/document-downloader-local.ts
@@ -14,7 +14,7 @@ import AWS from "aws-sdk";
 import path from "path";
 import * as stream from "stream";
 import { DOMParser } from "xmldom";
-import { detectFileType } from "../../../util/file-type";
+import { detectFileType, isContentTypeAccepted } from "../../../util/file-type";
 import { out } from "../../../util/log";
 import { isMimeTypeXML } from "../../../util/mime";
 import { makeS3Client, S3Utils } from "../../aws/s3";
@@ -110,7 +110,9 @@ export class DocumentDownloaderLocal extends DocumentDownloader {
     downloadResult: DownloadResult;
   }): Promise<DownloadResult> {
     const { log } = out("checkAndUpdateMimeType");
-
+    if (isContentTypeAccepted(sourceDocument.mimeType)) {
+      return { ...downloadResult };
+    }
     const old_extension = path.extname(destinationFileInfo.name);
     const documentBuffer = Buffer.from(downloadedDocument);
     const { mimeType, fileExtension } = detectFileType(documentBuffer);

--- a/packages/core/src/external/commonwell-v1/document/document-downloader-local.ts
+++ b/packages/core/src/external/commonwell-v1/document/document-downloader-local.ts
@@ -14,7 +14,7 @@ import AWS from "aws-sdk";
 import path from "path";
 import * as stream from "stream";
 import { DOMParser } from "xmldom";
-import { detectFileType, isContentTypeAccepted } from "../../../util/file-type";
+import { detectFileType } from "../../../util/file-type";
 import { out } from "../../../util/log";
 import { isMimeTypeXML } from "../../../util/mime";
 import { makeS3Client, S3Utils } from "../../aws/s3";
@@ -110,9 +110,6 @@ export class DocumentDownloaderLocal extends DocumentDownloader {
     downloadResult: DownloadResult;
   }): Promise<DownloadResult> {
     const { log } = out("checkAndUpdateMimeType");
-    if (isContentTypeAccepted(sourceDocument.mimeType)) {
-      return { ...downloadResult };
-    }
 
     const old_extension = path.extname(destinationFileInfo.name);
     const documentBuffer = Buffer.from(downloadedDocument);

--- a/packages/core/src/util/file-type.ts
+++ b/packages/core/src/util/file-type.ts
@@ -49,6 +49,8 @@ const XML_MAGIC_NUMBER_9 = 0x6c;
 const XML_MAGIC_NUMBER_10 = 0x69;
 const XML_MAGIC_NUMBER_11 = 0x6e;
 const XML_MAGIC_NUMBER_12 = 0x69;
+const XML_MAGIC_NUMBER_13 = 0x21;
+const XML_MAGIC_NUMBER_14 = 0x2d;
 const PNG_MAGIC_NUMBER_1 = 0x89;
 const PNG_MAGIC_NUMBER_2 = 0x50;
 const PNG_MAGIC_NUMBER_3 = 0x4e;
@@ -226,6 +228,11 @@ export function isXMLContentType(bytesBuffer: Buffer): boolean {
       bytesBuffer[2] === XML_MAGIC_NUMBER_9 &&
       bytesBuffer[3] === XML_MAGIC_NUMBER_10 &&
       bytesBuffer[4] === XML_MAGIC_NUMBER_11 &&
-      bytesBuffer[5] === XML_MAGIC_NUMBER_12)
+      bytesBuffer[5] === XML_MAGIC_NUMBER_12) ||
+    (bytesBuffer[0] === XML_MAGIC_NUMBER_1 &&
+      bytesBuffer[1] === XML_MAGIC_NUMBER_13 &&
+      bytesBuffer[2] === XML_MAGIC_NUMBER_14 &&
+      bytesBuffer[3] === XML_MAGIC_NUMBER_14 &&
+      bytesBuffer[4] === ASCII_SPACE)
   );
 }

--- a/packages/core/src/util/file-type.ts
+++ b/packages/core/src/util/file-type.ts
@@ -232,7 +232,6 @@ export function isXMLContentType(bytesBuffer: Buffer): boolean {
     (bytesBuffer[0] === XML_MAGIC_NUMBER_1 &&
       bytesBuffer[1] === XML_MAGIC_NUMBER_13 &&
       bytesBuffer[2] === XML_MAGIC_NUMBER_14 &&
-      bytesBuffer[3] === XML_MAGIC_NUMBER_14 &&
-      bytesBuffer[4] === ASCII_SPACE)
+      bytesBuffer[3] === XML_MAGIC_NUMBER_14)
   );
 }

--- a/packages/core/src/util/file-type.ts
+++ b/packages/core/src/util/file-type.ts
@@ -193,10 +193,15 @@ export function isContentTypeAccepted(mimeType: string | undefined): boolean {
   const acceptedContentTypes = [
     JSON_APP_MIME_TYPE,
     JSON_TXT_MIME_TYPE,
-    JPG_MIME_TYPE,
-    HTML_MIME_TYPE,
-    TIF_MIME_TYPE,
     XML_TXT_MIME_TYPE,
+    PDF_MIME_TYPE,
+    TIFF_MIME_TYPE,
+    TIF_MIME_TYPE,
+    PNG_MIME_TYPE,
+    JPEG_MIME_TYPE,
+    JPG_MIME_TYPE,
+    BMP_MIME_TYPE,
+    HTML_MIME_TYPE,
   ];
 
   return !!mimeType && acceptedContentTypes.includes(mimeType);
@@ -222,7 +227,7 @@ export function isXMLContentType(bytesBuffer: Buffer): boolean {
       bytesBuffer[3] === XML_MAGIC_NUMBER_10 &&
       bytesBuffer[4] === XML_MAGIC_NUMBER_11 &&
       bytesBuffer[5] === XML_MAGIC_NUMBER_12) ||
-    (bytesBuffer[0] === XML_MAGIC_NUMBER_1 &&
+    (bytesBuffer[0] === XML_MAGIC_NUMBER_1 && //Checking for [<!--] (XML style comment)
       bytesBuffer[1] === XML_MAGIC_NUMBER_13 &&
       bytesBuffer[2] === XML_MAGIC_NUMBER_14 &&
       bytesBuffer[3] === XML_MAGIC_NUMBER_14)

--- a/packages/core/src/util/file-type.ts
+++ b/packages/core/src/util/file-type.ts
@@ -193,17 +193,10 @@ export function isContentTypeAccepted(mimeType: string | undefined): boolean {
   const acceptedContentTypes = [
     JSON_APP_MIME_TYPE,
     JSON_TXT_MIME_TYPE,
-    XML_APP_MIME_TYPE,
-    XML_TXT_MIME_TYPE,
-    PDF_MIME_TYPE,
-    TIFF_MIME_TYPE,
-    TIF_MIME_TYPE,
-    PNG_MIME_TYPE,
-    JPEG_MIME_TYPE,
     JPG_MIME_TYPE,
-    BMP_MIME_TYPE,
-    TXT_MIME_TYPE,
     HTML_MIME_TYPE,
+    TIF_MIME_TYPE,
+    XML_TXT_MIME_TYPE,
   ];
 
   return !!mimeType && acceptedContentTypes.includes(mimeType);


### PR DESCRIPTION
Part of ENG-986

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-986

### Dependencies
None

### Description
TICKET:
https://linear.app/metriport/issue/ENG-986/fix-incorrect-type-on-downloaded-documents-from-cw

Remove if statement checking if we accept this mime type.
Just because we accept mime this mime type doesn't mean it's correct we should be doing our own checks.
Add checking for <!-- (XML/HTML style comment)

Note: Currently any HTML docs we get that are also malformed in the same way will be incorrectly classified as XML

[CONTEXT](https://metriport.slack.com/archives/C04DMKE9DME/p1756869108007699)

### Testing

Local testing using script
- [x] Tested xml with comment
- [x] Tested xml with no comment
- [x] Tested random txt file

https://github.com/user-attachments/assets/18e1913c-6c82-4d6d-bac3-3c4a870ee193

<img width="822" height="90" alt="Screenshot 2025-09-03 at 11 04 50 AM" src="https://github.com/user-attachments/assets/3b5e8aa1-93f8-4957-8384-706942d28538" />

<img width="483" height="104" alt="Screenshot 2025-09-03 at 1 25 12 PM" src="https://github.com/user-attachments/assets/aee63783-cf7f-452a-b863-48c2f664c07c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced XML detection to recognize an additional XML header variant (handles commented XML prolog).
  * Narrowed accepted MIME types used for content classification to reduce false positives.
* **Tests**
  * Added test coverage for XML files where the XML declaration appears only as a comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->