### PR TITLE
ENG-881: feat(api): add back group by clause

### DIFF
--- a/packages/api/src/command/medical/tcm-encounter/get-tcm-encounters.ts
+++ b/packages/api/src/command/medical/tcm-encounter/get-tcm-encounters.ts
@@ -120,6 +120,7 @@ export async function getTcmEncounters({
       ${/* COMPOSITE CURSOR PaginationV2 */ ""}
       ${toItemClause.clause}
       ${fromItemClause.clause}
+      GROUP BY tcm_encounter.id, patient.id, patient.data, patient.facility_ids
       ${orderByClause}
       LIMIT :count
     `;


### PR DESCRIPTION
### Dependencies

None

### Description

Fixes TCM viewer duplicate rows due to a bad merge conflict resolution.

### Testing

None, was verified as working pre-merge conflict resolution

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate TCM encounter entries in results; each encounter now appears once with its correct patient mappings.
  * Improved consistency of TCM encounter data returned to clients.

* **Reliability**
  * Query results are now aligned with aggregated patient mappings for more accurate output.
  * Total counts and pagination remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->