### PR TITLE
ENG-513 Remove unneded contact use type validation

### DIFF
--- a/packages/commonwell-sdk/src/models/contact.ts
+++ b/packages/commonwell-sdk/src/models/contact.ts
@@ -4,40 +4,6 @@ import { emptyStringToUndefinedSchema } from "../common/zod";
 import { periodSchema } from "./period";
 
 /**
- * How to use the contact/address.
- * @see: https://hl7.org/fhir/R4/valueset-contact-point-use.html
- */
-export enum ContactUseCodes {
-  home = "home",
-  work = "work",
-  temp = "temp",
-  old = "old",
-  mobile = "mobile",
-}
-export const contactUseCodesSchema = z
-  .string()
-  .transform(zodToLowerCase)
-  .transform(normalizeContactUse)
-  .pipe(z.nativeEnum(ContactUseCodes));
-
-function normalizeContactUse(use: unknown): unknown {
-  if (typeof use !== "string") return use;
-  switch (use.toLowerCase()) {
-    case "cell":
-      return "mobile";
-    case "mc":
-      return "mobile";
-    case "hp":
-      return "home";
-    case "h":
-      return "home";
-    case "wp":
-      return "work";
-  }
-  return use;
-}
-
-/**
  * Describes the kind of contact.
  * @see: https://hl7.org/fhir/R4/valueset-contact-point-system.html
  */
@@ -71,7 +37,7 @@ function normalizeContactSystem(system: unknown): unknown {
 export const contactSchema = z.object({
   value: z.string().nullish(),
   system: emptyStringToUndefinedSchema.pipe(contactSystemCodesSchema.nullish()),
-  use: emptyStringToUndefinedSchema.pipe(contactUseCodesSchema.nullish()),
+  use: z.string().nullish(),
   period: periodSchema.nullish(),
 });
 export type Contact = z.infer<typeof contactSchema>;


### PR DESCRIPTION
Part of ENG-513

### Description

- We had a zod schema for the contact use type coming from external links, but it seems that CW doesn't enforce it to the standard values we expected. Let's just remove this schema validation and accept any string.
- Additional context - [link](https://metriport.slack.com/archives/C04T256DQPQ/p1756928317011739?thread_ts=1753196698.493009&cid=C04T256DQPQ)

### Testing

- Local
  - [x] Get the problematic patient's links locally using the updated commonwell-sdk methods
- Production
  - [ ] Rerun PD for the patient that errorred

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The contact “use” field now accepts any string or can be left blank, increasing compatibility with partner data.
  - Fewer validation errors when importing or syncing contacts that include non-standard “use” values.
  - Other contact fields and behavior remain unchanged.
  - This update improves interoperability with varied datasets and reduces manual data cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->