### PR TITLE
ENG-934 Minor fix for unlink endpoint

### DIFF
--- a/packages/api/src/command/hie/unlink-patient-from-organization.ts
+++ b/packages/api/src/command/hie/unlink-patient-from-organization.ts
@@ -386,17 +386,17 @@ async function findAndInvalidateLinks(
     // Only get CW access objects if we have links to process
     const promises: Promise<unknown>[] = [
       createOrUpdateInvalidLinks({ id: patientId, cxId, invalidLinks }),
-      invalidLinks.carequality.length > 0
-        ? updateCQPatientData({
-            id: patientId,
-            cxId,
-            cqLinksToInvalidate: invalidLinks.carequality,
-          })
-        : Promise.resolve(),
-      invalidLinks.commonwell.length > 0
-        ? updateCwPatientData({ id: patientId, cxId, cwLinksToInvalidate: invalidLinks.commonwell })
-        : Promise.resolve(),
     ];
+    if (invalidLinks.carequality.length > 0) {
+      promises.push(
+        updateCQPatientData({ id: patientId, cxId, cqLinksToInvalidate: invalidLinks.carequality })
+      );
+    }
+    if (invalidLinks.commonwell.length > 0) {
+      promises.push(
+        updateCwPatientData({ id: patientId, cxId, cwLinksToInvalidate: invalidLinks.commonwell })
+      );
+    }
 
     // Add CW v1 downgrade requests if needed
     if (cwV1Links.length > 0) {

--- a/packages/api/src/command/hie/unlink-patient-from-organization.ts
+++ b/packages/api/src/command/hie/unlink-patient-from-organization.ts
@@ -382,28 +382,36 @@ async function findAndInvalidateLinks(
     // Separate CW v1 and v2 links
     const [cwV1Links, cwV2Links] = partition(invalidLinks.commonwell, isCwLinkV1);
 
-    const cwUnlinkkPromises = [];
+    const cwUnlinkPromises = [];
     // Only get CW access objects if we have links to process
     const promises: Promise<unknown>[] = [
       createOrUpdateInvalidLinks({ id: patientId, cxId, invalidLinks }),
-      updateCQPatientData({ id: patientId, cxId, cqLinksToInvalidate: invalidLinks.carequality }),
-      updateCwPatientData({ id: patientId, cxId, cwLinksToInvalidate: invalidLinks.commonwell }),
+      invalidLinks.carequality.length > 0
+        ? updateCQPatientData({
+            id: patientId,
+            cxId,
+            cqLinksToInvalidate: invalidLinks.carequality,
+          })
+        : Promise.resolve(),
+      invalidLinks.commonwell.length > 0
+        ? updateCwPatientData({ id: patientId, cxId, cwLinksToInvalidate: invalidLinks.commonwell })
+        : Promise.resolve(),
     ];
 
     // Add CW v1 downgrade requests if needed
     if (cwV1Links.length > 0) {
       const cwV1Promises = await createCwV1DowngradePromises(cxId, patientId, cwV1Links);
-      cwUnlinkkPromises.push(...cwV1Promises);
+      cwUnlinkPromises.push(...cwV1Promises);
     }
 
     // Add CW v2 unlink requests if needed
     if (cwV2Links.length > 0) {
       const cwV2Promises = await createCwV2UnlinkPromises(cxId, patientId, cwV2Links);
-      cwUnlinkkPromises.push(...cwV2Promises);
+      cwUnlinkPromises.push(...cwV2Promises);
     }
 
-    log(`Removing ${cwUnlinkkPromises.length} links`);
-    promises.push(...cwUnlinkkPromises);
+    log(`Removing ${cwUnlinkPromises.length} links`);
+    promises.push(...cwUnlinkPromises);
     await Promise.allSettled(promises);
   } catch (error) {
     log(`Error invalidating links: ${errorToString(error)}`);

--- a/packages/commonwell-sdk/src/models/contact.ts
+++ b/packages/commonwell-sdk/src/models/contact.ts
@@ -37,7 +37,7 @@ function normalizeContactSystem(system: unknown): unknown {
 export const contactSchema = z.object({
   value: z.string().nullish(),
   system: emptyStringToUndefinedSchema.pipe(contactSystemCodesSchema.nullish()),
-  use: z.string().nullish(),
+  use: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
   period: periodSchema.nullish(),
 });
 export type Contact = z.infer<typeof contactSchema>;


### PR DESCRIPTION
### Issue 
- https://linear.app/metriport/issue/ENG-934/update-low-prio-flows-to-use-cw-v2

### Description
- If `cq_patient_data` has no entry for the patient, we fail to unlink even for CW because we use getCqPatientDataOrFail under the hood. This PR fixes that
- Small typo fix
- Small fix for CW SDK - [discussed here](https://metriport.slack.com/archives/C04T256DQPQ/p1756936998496759?thread_ts=1753196698.493009&cid=C04T256DQPQ) 

### Testing

- Local
  - [x] Unlink patients from a CW link when pt has no CQ data

### Release Plan

- [ ] Merge this
