### PR TITLE
ENG-992 Updating the XML processing instructions

### DIFF
--- a/packages/core/src/external/cda/remove-b64.ts
+++ b/packages/core/src/external/cda/remove-b64.ts
@@ -29,19 +29,7 @@ export function removeBase64PdfEntries(payloadRaw: string): {
   documentContents: string;
   b64Attachments: B64Attachments | undefined;
 } {
-  const parser = createXMLParser({
-    ignoreAttributes: false,
-    attributeNamePrefix: "_",
-    removeNSPrefix: true,
-  });
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let json: any;
-  try {
-    json = parser.parse(payloadRaw);
-  } catch (error) {
-    json = parser.parse(sanitizeXmlProcessingInstructions(payloadRaw));
-  }
+  const json = getJsonFromXml(payloadRaw);
 
   const b64Attachments: B64Attachments = {
     acts: [],
@@ -141,6 +129,21 @@ function isTextAttachment(attachment: CdaOriginalText | CdaValueEd | undefined):
   }
 
   return mimeType === TXT_MIME_TYPE;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getJsonFromXml(payloadRaw: string): any {
+  const parser = createXMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "_",
+    removeNSPrefix: true,
+  });
+
+  try {
+    return parser.parse(payloadRaw);
+  } catch (error) {
+    return parser.parse(sanitizeXmlProcessingInstructions(payloadRaw));
+  }
 }
 
 /**

--- a/packages/core/src/external/cda/remove-b64.ts
+++ b/packages/core/src/external/cda/remove-b64.ts
@@ -1,6 +1,7 @@
-import { toArray } from "@metriport/shared";
+import { BadRequestError, toArray } from "@metriport/shared";
 import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { XMLBuilder } from "fast-xml-parser";
+import fs from "fs";
 import { cloneDeep } from "lodash";
 import {
   CdaOriginalText,
@@ -104,6 +105,7 @@ export function removeBase64PdfEntries(payloadRaw: string): {
       }
     });
   }
+  console.log("b64Attachments", b64Attachments);
 
   const builder = new XMLBuilder({
     format: false,
@@ -113,6 +115,8 @@ export function removeBase64PdfEntries(payloadRaw: string): {
     suppressBooleanAttributes: false,
   });
   const xml = builder.build(json);
+  console.log("lets save the new shit");
+  fs.writeFileSync("new.xml", xml);
 
   return {
     documentContents: xml,
@@ -147,7 +151,7 @@ function isTextAttachment(attachment: CdaOriginalText | CdaValueEd | undefined):
 function sanitizeXmlProcessingInstructions(xml: string): string {
   const indexOfDocumentStart = xml.indexOf("<Clinical");
   if (indexOfDocumentStart === -1) {
-    throw new Error("No ClinicalDocument found in XML");
+    throw new BadRequestError("No ClinicalDocument found in XML");
   }
 
   return xmlProcessingInstructions.concat(xml.substring(indexOfDocumentStart));

--- a/packages/core/src/external/cda/remove-b64.ts
+++ b/packages/core/src/external/cda/remove-b64.ts
@@ -1,7 +1,6 @@
 import { BadRequestError, toArray } from "@metriport/shared";
 import { createXMLParser } from "@metriport/shared/common/xml-parser";
 import { XMLBuilder } from "fast-xml-parser";
-import fs from "fs";
 import { cloneDeep } from "lodash";
 import {
   CdaOriginalText,
@@ -105,8 +104,6 @@ export function removeBase64PdfEntries(payloadRaw: string): {
       }
     });
   }
-  console.log("b64Attachments", b64Attachments);
-
   const builder = new XMLBuilder({
     format: false,
     ignoreAttributes: false,
@@ -115,8 +112,6 @@ export function removeBase64PdfEntries(payloadRaw: string): {
     suppressBooleanAttributes: false,
   });
   const xml = builder.build(json);
-  console.log("lets save the new shit");
-  fs.writeFileSync("new.xml", xml);
 
   return {
     documentContents: xml,
@@ -148,6 +143,11 @@ function isTextAttachment(attachment: CdaOriginalText | CdaValueEd | undefined):
   return mimeType === TXT_MIME_TYPE;
 }
 
+/**
+ * Sometimes, the XML processing instructions are faulty, resulting in a parse error.
+ * For example, sometimes they indicate it as being a text file, rather than XML,
+ * which is why we need to sanitize the XML processing instructions.
+ */
 function sanitizeXmlProcessingInstructions(xml: string): string {
   const indexOfDocumentStart = xml.indexOf("<Clinical");
   if (indexOfDocumentStart === -1) {

--- a/packages/utils/src/fhir/fhir-converter/fhir-resource-counts/develop-fhir-resource-count.json
+++ b/packages/utils/src/fhir/fhir-converter/fhir-resource-counts/develop-fhir-resource-count.json
@@ -1,5 +1,5 @@
 {
-  "total": 400605,
+  "total": 400603,
   "countPerType": {
     "AllergyIntolerance": 817,
     "CarePlan": 8082,
@@ -13,7 +13,7 @@
     "MedicationStatement": 8342,
     "Observation": 162901,
     "Organization": 15360,
-    "Practitioner": 59780,
+    "Practitioner": 59778,
     "RelatedPerson": 12260,
     "DiagnosticReport": 28008,
     "Encounter": 10408,


### PR DESCRIPTION
XPart of ENG-992

### Description

- Sometimes, the XML processing instructions at the top are malformed, and tell the parser that it's a text or some other shit. If parser fails to convert it to json, we're gonna replace the instructions with something that works and try again

### Testing

- Local
  - [x] Convert a problematic file locally
  - [x] Run the test fhir suite
- Production
  - [ ] Rerun for a problematic patient

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CDA XML parsing to handle XML prologs and malformed inputs more robustly, sanitizing documents when needed.
  * Rejects invalid CDA payloads that lack required ClinicalDocument content with a clear error.
  * Base64 PDF attachment extraction now only returns attachments when present and always produces a cleaned XML output.

* **Data**
  * Adjusted overall resource counts (total and Practitioner counts decreased by 2).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->