### PR TITLE
ENG-993: Explicit merge function for deduplication

### DIFF
--- a/packages/core/src/fhir-deduplication/__tests__/bundles/conditions/source.json
+++ b/packages/core/src/fhir-deduplication/__tests__/bundles/conditions/source.json
@@ -17,15 +17,11 @@
         ],
         "category": [
           {
-            "coding": [
-              { "system": "http://snomed.info/sct", "code": "282291009" }
-            ]
+            "coding": [{ "system": "http://snomed.info/sct", "code": "282291009" }]
           }
         ],
         "code": {
-          "coding": [
-            { "system": "http://snomed.info/sct", "code": "443253003" }
-          ],
+          "coding": [{ "system": "http://snomed.info/sct", "code": "443253003" }],
           "text": "Acute on chronic HFrEF (heart failure with reduced ejection fraction) (CMS/HCC)"
         },
         "subject": {
@@ -64,15 +60,11 @@
         ],
         "category": [
           {
-            "coding": [
-              { "system": "http://snomed.info/sct", "code": "282291009" }
-            ]
+            "coding": [{ "system": "http://snomed.info/sct", "code": "282291009" }]
           }
         ],
         "code": {
-          "coding": [
-            { "system": "http://snomed.info/sct", "code": "443254009" }
-          ],
+          "coding": [{ "system": "http://snomed.info/sct", "code": "443254009" }],
           "text": "Acute systolic congestive heart failure (CMS/HCC)"
         },
         "subject": {
@@ -111,15 +103,11 @@
         ],
         "category": [
           {
-            "coding": [
-              { "system": "http://snomed.info/sct", "code": "282291009" }
-            ]
+            "coding": [{ "system": "http://snomed.info/sct", "code": "282291009" }]
           }
         ],
         "code": {
-          "coding": [
-            { "system": "http://snomed.info/sct", "code": "190855004" }
-          ],
+          "coding": [{ "system": "http://snomed.info/sct", "code": "190855004" }],
           "text": "Hypomagnesemia"
         },
         "subject": {

--- a/packages/core/src/fhir-deduplication/merge-resources.ts
+++ b/packages/core/src/fhir-deduplication/merge-resources.ts
@@ -1,0 +1,23 @@
+import { Resource } from "@medplum/fhirtypes";
+import { MetriportError } from "@metriport/shared";
+import { mergeIntoTargetResource } from "./shared";
+
+export type MergeFunction<R extends Resource> = (resources: R[]) => R;
+
+export function buildMergeFunction<R extends Resource>(): MergeFunction<R> {
+  return function (resources: R[]): R {
+    if (resources.length === 0) {
+      throw new MetriportError("Merge is always called with at least one resource");
+    }
+    const masterResource = resources[0];
+    if (!masterResource) {
+      throw new MetriportError("Merge is always called with at least one resource");
+    }
+    for (let i = 1; i < resources.length; i++) {
+      const resource = resources[i];
+      if (!resource) continue;
+      mergeIntoTargetResource(masterResource, resource);
+    }
+    return masterResource;
+  };
+}

--- a/packages/core/src/fhir-deduplication/merge-resources.ts
+++ b/packages/core/src/fhir-deduplication/merge-resources.ts
@@ -3,21 +3,78 @@ import { MetriportError } from "@metriport/shared";
 import { mergeIntoTargetResource } from "./shared";
 
 export type MergeFunction<R extends Resource> = (resources: R[]) => R;
+export type MergeKeyFunction<R extends Resource, K extends keyof R> = (values: Array<R[K]>) => R[K];
 
-export function buildMergeFunction<R extends Resource>(): MergeFunction<R> {
+export interface MergeConfig<R extends Resource> {
+  resourceType: string;
+  /**
+   * Precedence of resource statuses from highest to lowest.
+   */
+  chooseMasterResource?: (resources: R[]) => R;
+  statusPrecedence?: string[];
+  mergeKey: {
+    [K in keyof R]?: MergeKeyFunction<R, K>;
+  };
+}
+
+export function buildMergeFunction<R extends Resource>({
+  statusPrecedence,
+  chooseMasterResource,
+}: MergeConfig<R>): MergeFunction<R> {
+  const orderingFunction = statusPrecedence
+    ? buildStatusOrderingFunction<R>(statusPrecedence)
+    : (resources: R[]) => resources;
+  const masterResourceFunction = chooseMasterResource ? chooseMasterResource : chooseLastResource;
+
   return function (resources: R[]): R {
-    if (resources.length === 0) {
-      throw new MetriportError("Merge is always called with at least one resource");
-    }
-    const masterResource = resources[0];
-    if (!masterResource) {
-      throw new MetriportError("Merge is always called with at least one resource");
-    }
+    const orderedResources = orderingFunction(resources);
+    const masterResource = masterResourceFunction(orderedResources);
+
     for (let i = 1; i < resources.length; i++) {
       const resource = resources[i];
-      if (!resource) continue;
+      if (!resource || resource === masterResource) continue;
       mergeIntoTargetResource(masterResource, resource);
     }
     return masterResource;
   };
+}
+
+function chooseLastResource<R extends Resource>(resources: R[]): R {
+  const lastResource = resources[resources.length - 1];
+  if (!lastResource) {
+    throw new MetriportError("Merge is always called with at least one resource");
+  }
+  return lastResource;
+}
+
+function buildStatusOrderingFunction<R extends Resource>(
+  statusPrecedence: string[]
+): (resources: R[]) => R[] {
+  const statusPrecedenceIndex = new Map(statusPrecedence.map((status, index) => [status, index]));
+
+  return function (resources: R[]): R[] {
+    return [...resources].sort((a, b) => {
+      const aStatus = getStatus(a);
+      if (!aStatus) return -1;
+      const bStatus = getStatus(b);
+      if (!bStatus) return 1;
+
+      const aIndex = statusPrecedenceIndex.get(aStatus);
+      const bIndex = statusPrecedenceIndex.get(bStatus);
+      if (aIndex === undefined || bIndex === undefined) {
+        return 0;
+      }
+      return aIndex - bIndex;
+    });
+  };
+}
+
+function getStatus(resource: Resource): string | undefined {
+  if (!("status" in resource)) {
+    return undefined;
+  }
+  if (typeof resource.status !== "string") {
+    return undefined;
+  }
+  return resource.status;
 }

--- a/packages/core/src/fhir-deduplication/merge/build-merge.ts
+++ b/packages/core/src/fhir-deduplication/merge/build-merge.ts
@@ -1,25 +1,9 @@
 import { Resource } from "@medplum/fhirtypes";
 import { MetriportError } from "@metriport/shared";
-import { mergeIntoTargetResource } from "./shared";
+import { MergeConfig, MergeFunction, OrderingFunction } from "./types";
 
-export type OrderingFunction<R extends Resource> = (resources: R[]) => R[];
-const defaultOrderingFunction = function <R extends Resource>(resources: R[]): R[] {
+function defaultOrderingFunction<R extends Resource>(resources: R[]): R[] {
   return resources;
-};
-
-export type MergeFunction<R extends Resource> = (resources: R[]) => R;
-export type MergeKeyFunction<R extends Resource, K extends keyof R> = (values: Array<R[K]>) => R[K];
-
-export interface MergeConfig<R extends Resource> {
-  resourceType: string;
-  /**
-   * Precedence of resource statuses from highest to lowest.
-   */
-  chooseMasterResource?: (resources: R[]) => R;
-  statusPrecedence?: string[];
-  mergeKey: {
-    [K in keyof R]?: MergeKeyFunction<R, K>;
-  };
 }
 
 export function buildMergeFunction<R extends Resource>({
@@ -38,7 +22,7 @@ export function buildMergeFunction<R extends Resource>({
 
     for (const resource of orderedResources) {
       if (resource === masterResource) continue;
-      mergeIntoTargetResource(masterResource, resource);
+      // mergeIntoTargetResource(masterResource, resource);
     }
     return masterResource;
   };

--- a/packages/core/src/fhir-deduplication/merge/resource/specimen.ts
+++ b/packages/core/src/fhir-deduplication/merge/resource/specimen.ts
@@ -1,0 +1,12 @@
+import { Specimen } from "@medplum/fhirtypes";
+import { MergeConfig } from "../types";
+import { mergeIdentifiers, mergeArrays } from "../strategy";
+
+export const specimenMergeConfig: MergeConfig<Specimen> = {
+  mergeStrategy: {
+    accessionIdentifier: mergeIdentifiers,
+    processing: mergeArrays,
+    container: mergeArrays,
+    note: mergeArrays,
+  },
+};

--- a/packages/core/src/fhir-deduplication/merge/strategy.ts
+++ b/packages/core/src/fhir-deduplication/merge/strategy.ts
@@ -1,0 +1,48 @@
+import { Identifier } from "@medplum/fhirtypes";
+
+export function mergeArrays<T>(masterArray: T[] | undefined, values: T[][]): T[] | undefined {
+  const mergedArray = masterArray ? [...masterArray] : [];
+  for (const value of values) {
+    mergedArray.push(...value);
+  }
+  return mergedArray;
+}
+
+export function mergeIdentifiers(
+  masterIdentifier: Identifier | undefined,
+  identifiers: Identifier[]
+): Identifier | undefined {
+  const firstIdentifier = masterIdentifier ? masterIdentifier : identifiers[0];
+  if (!firstIdentifier) return undefined;
+  return firstIdentifier;
+}
+
+export function mergeIdentifierArrays(
+  masterIdentifiers: Identifier[],
+  resourceIdentifiers: Identifier[][]
+): Identifier[] | undefined {
+  const systemIdentifierMap: Record<string, Record<string, Identifier>> = {};
+
+  for (const identifier of masterIdentifiers) {
+    if (!identifier.system || !identifier.value) continue;
+    let systemMap = systemIdentifierMap[identifier.system];
+    if (!systemMap) {
+      systemMap = systemIdentifierMap[identifier.system] = {};
+    }
+    systemMap[identifier.value] = identifier;
+  }
+
+  for (const identifiers of resourceIdentifiers) {
+    for (const identifier of identifiers) {
+      if (!identifier.system || !identifier.value) continue;
+      let systemMap = systemIdentifierMap[identifier.system];
+      if (!systemMap) {
+        systemMap = systemIdentifierMap[identifier.system] = {};
+      }
+      systemMap[identifier.value] = identifier;
+    }
+  }
+  return Object.entries(systemIdentifierMap).flatMap(([, values]) => {
+    return Object.values(values);
+  });
+}

--- a/packages/core/src/fhir-deduplication/merge/types.ts
+++ b/packages/core/src/fhir-deduplication/merge/types.ts
@@ -1,0 +1,20 @@
+import { Resource } from "@medplum/fhirtypes";
+
+export type OrderingFunction<R extends Resource> = (resources: R[]) => R[];
+
+export type MergeFunction<R extends Resource> = (resources: R[]) => R;
+export type MergeStrategy<R extends Resource, K extends keyof R> = (
+  masterValue: R[K],
+  values: Array<NonNullable<R[K]>>
+) => R[K];
+
+export interface MergeConfig<R extends Resource> {
+  /**
+   * Precedence of resource statuses from highest to lowest.
+   */
+  chooseMasterResource?: (resources: R[]) => R;
+  statusPrecedence?: string[];
+  mergeStrategy: {
+    [K in keyof R]?: MergeStrategy<R, K>;
+  };
+}


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-993

### Dependencies

- Upstream: None
- Downstream: None

### Description

Improves a [previous PR](https://github.com/metriport/metriport/pull/4558) with a more rigorous approach to merging FHIR resources.

### Testing

- Local
  - [x] `npx jest fhir-deduplication`
- Staging
  - [ ] Check deduplication for lab resources
- Production
  - [ ] Check deduplication for lab resources

### Release Plan

- [ ] Merge this
