### PR TITLE
fix(converter): add procedure -> report reference

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Sections/Procedures.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Procedures.hbs
@@ -47,7 +47,6 @@
                             {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString procEntry.procedure)) REF=(concat 'Practitioner/' practitionerId.Id)}},
                         {{/with}}
                     {{/if}}
-                    {{!-- TODO: Look into adding report --}}
                 {{/if}}
                 
                 {{#if procEntry.observation}}
@@ -63,7 +62,7 @@
                     
                     {{#if procEntry.observation.author.assignedAuthor}}
                         {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=procEntry.observation.author.assignedAuthor) as |practitionerId|}}
-                                {{>Resources/Practitioner.hbs practitioner=procEntry.procedure.observation.author.assignedAuthor ID=practitionerId.Id}},
+                                {{>Resources/Practitioner.hbs practitioner=procEntry.observation.author.assignedAuthor ID=practitionerId.Id}},
                                 {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString procEntry.observation)) REF=(concat 'Practitioner/' practitionerId.Id)}},
                         {{/with}}
                     {{/if}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
@@ -65,7 +65,6 @@
                             {{/if}}
                         {{/if}}
                     {{/if}}
-
                     {{#each (toArray drEntry.organizer.component) as |obsEntry|}}
                         {{#if obsEntry.observation}}
                             {{#if (not obsEntry.observation.value._b64)}}
@@ -104,13 +103,12 @@
                             {{>Resources/Procedure.hbs procedureEntry=obsEntry.procedure ID=(generateUUID (toJsonString obsEntry.procedure))}}
                             {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
                                 {{>References/Procedure/subject.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'Patient/' patientId.Id)}},
+                                {{>References/Procedure/report.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'DiagnosticReport/' (generateUUID (toJsonString drEntry.organizer)))}}
                             {{/with}}
-
                             {{#if drEntry.organizer.performer.assignedEntity}}
                                 {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=drEntry.organizer.performer.assignedEntity) as |practitionerId|}}
                                     {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'Practitioner/' practitionerId.Id)}}
                                 {{/with}}
-
                                 {{#if drEntry.organizer.performer.assignedEntity.representedOrganization}}
                                     {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=drEntry.organizer.performer.assignedEntity.representedOrganization) as |orgId|}}
                                         {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'Organization/' orgId.Id)}},
@@ -120,7 +118,6 @@
                                 {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=drEntry.organizer.author.assignedAuthor) as |practitionerId|}}
                                     {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'Practitioner/' practitionerId.Id)}},
                                 {{/with}}
-
                                 {{#if drEntry.organizer.author.assignedAuthor.representedOrganization}}
                                     {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=drEntry.organizer.author.assignedAuthor.representedOrganization) as |orgId|}}
                                         {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'Organization/' orgId.Id)}},


### PR DESCRIPTION
Part of ENG-1006

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1006

### Dependencies
None

### Description
Add procedure -> report reference

### Testing
- Local
  - [x] Run integration test suite.
  - [x] Run original XML through FHIR converter and make sure document references are added to procedures.
 
 Before code changes (for xml in ticket):
 
<img width="1141" height="81" alt="Screenshot 2025-09-07 at 4 16 03 PM" src="https://github.com/user-attachments/assets/8f3e32a8-e992-414d-a5c3-b58b5c6dd1a8" />

After code changes (for xml in ticket):

<img width="880" height="196" alt="Screenshot 2025-09-07 at 4 15 05 PM" src="https://github.com/user-attachments/assets/f5244935-1fcc-4695-a393-c7cd6d09fdcb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a direct link from Procedure to the corresponding DiagnosticReport, improving traceability of results.
- Bug Fixes
  - Corrected the observation author reference to use the proper context, ensuring the practitioner is accurately associated.
- Refactor
  - Simplified relationships by removing multiple performer/author links to Practitioner and Organization from results, reducing unnecessary cross-links.
- Chores
  - Removed a stale TODO comment and cleaned up minor formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->