### PR TITLE
PATCH RELEASE add deletion for dangling report references

### DIFF
--- a/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
+++ b/packages/core/src/fhir-deduplication/deduplicate-fhir.ts
@@ -399,7 +399,6 @@ function removeDanglingReferences<T extends Resource>(
   }
   if ("report" in entry) {
     entry.report = entry.report?.filter(r => r.reference && !danglingLinks.has(r.reference));
-    console.log(entry.report);
     if (!entry.report?.length) delete entry.report;
   }
 


### PR DESCRIPTION
Part of ENG-1014

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1014/remove-duplicatedangling-report-resource-references

### Dependencies
None

### Description
Fix a bug where report references are dangling after dedup and not being deleted.
Fix a bug where multiple references in the same report array are pointing to the same diagnostic report.

### Testing

- Local
  - [x] Locally run dedup on a file and compare.

Before change vs after my change

<img width="718" height="84" alt="image" src="https://github.com/user-attachments/assets/12ed2822-0063-460f-ba54-94290adecc79" />


- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed dangling report references across resources to prevent broken links.
  - Deduplicated report references in Procedures to eliminate duplicates.
  - Updated Procedure report references after deduplication to maintain consistency.
  - Ensures cleaner, more reliable Procedure data and improved reporting accuracy for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->