### PR TITLE
ENG-1019: create and update patients on both cw versions

### DIFF
--- a/packages/api/src/external/commonwell-v2/patient/patient.ts
+++ b/packages/api/src/external/commonwell-v2/patient/patient.ts
@@ -394,6 +394,8 @@ async function runNextPdOnNewDemographics({
         links: newDemographicsHere,
       }),
     ]);
+  }
+  if (shouldUpdateDb) {
     update({
       patient: updatedPatient,
       facilityId,

--- a/packages/api/src/external/commonwell/patient/patient.ts
+++ b/packages/api/src/external/commonwell/patient/patient.ts
@@ -102,7 +102,7 @@ export async function create({
 
   // TODO ENG-554 Remove FF and v1 code
   if (!isCwV2Enabled) {
-    return await registerAndLinkPatientInCwV1({
+    await registerAndLinkPatientInCwV1({
       patient: createAugmentedPatient(updatedPatient),
       facilityId,
       getOrgIdExcludeList,
@@ -113,6 +113,19 @@ export async function create({
       initiator,
       update,
     });
+    await registerAndLinkPatientInCwV2({
+      patient: createAugmentedPatient(updatedPatient),
+      facilityId,
+      getOrgIdExcludeList,
+      rerunPdOnNewDemographics: cxRerunPdOnNewDemographics,
+      requestId,
+      startedAt,
+      debug,
+      initiator,
+      update,
+      shouldUpdateDb: false,
+    });
+    return;
   }
 
   return await registerAndLinkPatientInCwV2({
@@ -181,6 +194,17 @@ export async function update({
       startedAt,
       debug,
       update,
+    });
+    await updatePatientAndLinksInCwV2({
+      patient: createAugmentedPatient(updatedPatient),
+      facilityId,
+      getOrgIdExcludeList,
+      rerunPdOnNewDemographics: cxRerunPdOnNewDemographics,
+      requestId,
+      startedAt,
+      debug,
+      update,
+      shouldUpdateDb: false,
     });
     return;
   }


### PR DESCRIPTION
### Description

- For orgs active on CW v1, we will also create/update pts on cw v2, but won't save any of v2 data on the db, and won't run DQ
- For orgs active on CW v2, we will keep the flow as is

### Testing

- Local
  - [x] Create a new patient
    - [x] Make sure it exists on CW v1 and related data is saved on db
    - [x] Make sure it exists on CW v2, but data is not saved on db
  - [x] Update a patient
    - [x] Make sure it's updated on CW v1 and related data is saved on db
    - [x] Make sure it's updated on CW v2, but data is not saved on db
- Staging
  - [ ] TBD
- Production
  - [ ] TBD
  - [ ] Monitor to make sure patients are created on both platforms

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a controllable "no-write" mode for CommonWell v2 patient operations to run flows without persisting database changes.

- Improvements
  - Gated database mutations across patient linking, updates, and demographics flows to reduce unintended writes.
  - Standardized CommonWell v2 ID normalization for consistent ID usage.
  - When v2 is disabled, v2 flows now run alongside v1 in a non-mutating mode.

- Documentation
  - Updated API parameter descriptions to document the new no-write option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->