### PR TITLE
feat(core): fix lotNumber is a number not a string

### DIFF
--- a/packages/core/src/external/fhir/export/string/resources/immunization.ts
+++ b/packages/core/src/external/fhir/export/string/resources/immunization.ts
@@ -54,7 +54,7 @@ export class ImmunizationToString implements FHIRResourceToString<Immunization> 
       parts.push(manufacturerStr);
     }
 
-    const lotNumber = emptyIfDenied(immunization.lotNumber);
+    const lotNumber = emptyIfDenied(immunization.lotNumber?.toString());
     if (lotNumber) {
       parts.push(isDebug ? `Lot Number: ${lotNumber}` : lotNumber);
       hasMinimumData = true;


### PR DESCRIPTION


Issues:

- none

### Dependencies

- none

### Description

- seeing example bundles with lotNumber as number, resulting in type error: `value.trim is not a function`

### Testing

- Local
  - [x] test using toString() on undefined, "", 723, "732"
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the Immunization Lot Number to ensure it’s consistently recognized and displayed/exported, even when provided as a numeric value.
  - Reduced instances where the Lot Number could appear blank or trigger validation issues, resulting in more reliable immunization data presentation across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->