### PR TITLE
Matching algorithm for procedures and reports

### DIFF
--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
@@ -1,13 +1,14 @@
 import { buildDayjs } from "@metriport/shared/common/date";
+import { Procedure } from "@medplum/fhirtypes";
 import {
-  linkProceduresToDiagnosticReports,
+  dangerouslyLinkProceduresToDiagnosticReports,
   doAnyDatesMatchThroughWindow,
   SIZE_OF_WINDOW,
 } from "../link-procedures-to-reports";
 import { makeProcedure } from "../../../../fhir-to-cda/cda-templates/components/__tests__/make-procedure";
 import { makeDiagnosticReport } from "../../../../fhir-to-cda/cda-templates/components/__tests__/make-diagnostic-report";
 
-describe("linkProceduresToDiagnosticReports", () => {
+describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
   const baseMs = Date.now();
   const DATE_TO_MATCH = buildDayjs(baseMs).toISOString();
 
@@ -67,7 +68,7 @@ describe("linkProceduresToDiagnosticReports", () => {
     });
   });
 
-  describe("linkProceduresToDiagnosticReports", () => {
+  describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
     it("should link procedure to diagnostic report when codes match and dates are within window", () => {
       const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
       const sharedCode = "55555";
@@ -108,14 +109,12 @@ describe("linkProceduresToDiagnosticReports", () => {
         ],
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.procedures[0]).toBeDefined();
-      expect(result.procedures[0]?.report).toBeDefined();
-      expect(result.procedures[0]?.report).toHaveLength(1);
-      expect(result.procedures[0]?.report?.[0]?.reference).toBe(
-        `DiagnosticReport/${diagnosticReport.id}`
-      );
+      expect(procedure).toBeDefined();
+      expect(procedure.report).toBeDefined();
+      expect(procedure.report).toHaveLength(1);
+      expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
     });
 
     it("should not link when codes don't match", () => {
@@ -157,10 +156,10 @@ describe("linkProceduresToDiagnosticReports", () => {
         ],
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.procedures[0]).toBeDefined();
-      expect(result.procedures[0]?.report).toBeUndefined();
+      expect(procedure).toBeDefined();
+      expect(procedure.report).toBeUndefined();
     });
 
     it("should not link when dates are outside the window", () => {
@@ -193,10 +192,10 @@ describe("linkProceduresToDiagnosticReports", () => {
         identifier: defaultIdentifier,
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.procedures[0]).toBeDefined();
-      expect(result.procedures[0]?.report).toBeUndefined();
+      expect(procedure).toBeDefined();
+      expect(procedure.report).toBeUndefined();
     });
 
     it("should link based on identifier values", () => {
@@ -223,12 +222,10 @@ describe("linkProceduresToDiagnosticReports", () => {
         effectiveDateTime: matchingDate,
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.procedures[0]?.report).toBeDefined();
-      expect(result.procedures[0]?.report?.[0]?.reference).toBe(
-        `DiagnosticReport/${diagnosticReport.id}`
-      );
+      expect(procedure.report).toBeDefined();
+      expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
     });
 
     it("should match identifier values", () => {
@@ -254,12 +251,10 @@ describe("linkProceduresToDiagnosticReports", () => {
         effectiveDateTime: matchingDate,
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.procedures[0]?.report).toBeDefined();
-      expect(result.procedures[0]?.report?.[0]?.reference).toBe(
-        `DiagnosticReport/${diagnosticReport.id}`
-      );
+      expect(procedure.report).toBeDefined();
+      expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
     });
 
     it("should filter out bad identifier values", () => {
@@ -285,10 +280,10 @@ describe("linkProceduresToDiagnosticReports", () => {
         effectiveDateTime: matchingDate,
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.procedures[0]).toBeDefined();
-      expect(result.procedures[0]?.report).toBeUndefined();
+      expect(procedure).toBeDefined();
+      expect(procedure.report).toBeUndefined();
     });
 
     it("should filter out all known useless display values", () => {
@@ -316,10 +311,10 @@ describe("linkProceduresToDiagnosticReports", () => {
           effectiveDateTime: matchingDate,
         });
 
-        const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+        dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-        expect(result.procedures[0]).toBeDefined();
-        expect(result.procedures[0]?.report).toBeUndefined();
+        expect(procedure).toBeDefined();
+        expect(procedure.report).toBeUndefined();
       }
     });
 
@@ -346,9 +341,9 @@ describe("linkProceduresToDiagnosticReports", () => {
         effectiveDateTime: matchingDate,
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.procedures[0]?.report).toBeUndefined();
+      expect(procedure.report).toBeUndefined();
     });
 
     it("should remove trailing carets from identifier values", () => {
@@ -375,15 +370,13 @@ describe("linkProceduresToDiagnosticReports", () => {
         effectiveDateTime: matchingDate,
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.procedures[0]?.report).toBeDefined();
-      expect(result.procedures[0]?.report?.[0]?.reference).toBe(
-        `DiagnosticReport/${diagnosticReport.id}`
-      );
+      expect(procedure.report).toBeDefined();
+      expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
     });
 
-    it("should handle multiple matching diagnostic reports and link to the first one", () => {
+    it("should handle multiple matching diagnostic reports and link to all of them", () => {
       const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
       const sharedCode = "55555";
 
@@ -426,17 +419,16 @@ describe("linkProceduresToDiagnosticReports", () => {
         identifier: defaultIdentifier,
       });
 
-      const result = linkProceduresToDiagnosticReports(
+      dangerouslyLinkProceduresToDiagnosticReports(
         [procedure],
         [diagnosticReport1, diagnosticReport2]
       );
 
-      expect(result.procedures[0]?.report).toBeDefined();
-      expect(result.procedures[0]?.report).toHaveLength(1);
-      // Should link to the first matching report
-      expect(result.procedures[0]?.report?.[0]?.reference).toBe(
-        `DiagnosticReport/${diagnosticReport1.id}`
-      );
+      expect(procedure.report).toBeDefined();
+      expect(procedure.report).toHaveLength(2);
+      // Should link to both matching reports
+      expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport1.id}`);
+      expect(procedure.report?.[1]?.reference).toBe(`DiagnosticReport/${diagnosticReport2.id}`);
     });
 
     it("should not add duplicate references", () => {
@@ -470,14 +462,12 @@ describe("linkProceduresToDiagnosticReports", () => {
         identifier: defaultIdentifier,
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.procedures[0]?.report).toBeDefined();
-      expect(result.procedures[0]?.report).toHaveLength(2);
-      expect(result.procedures[0]?.report?.[0]?.reference).toBe(`DiagnosticReport/existing-id`);
-      expect(result.procedures[0]?.report?.[1]?.reference).toBe(
-        `DiagnosticReport/${diagnosticReport.id}`
-      );
+      expect(procedure.report).toBeDefined();
+      expect(procedure.report).toHaveLength(2);
+      expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/existing-id`);
+      expect(procedure.report?.[1]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
     });
 
     it("should handle procedures without dates", () => {
@@ -509,9 +499,9 @@ describe("linkProceduresToDiagnosticReports", () => {
         identifier: defaultIdentifier,
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.procedures[0]?.report).toBeUndefined();
+      expect(procedure.report).toBeUndefined();
     });
 
     it("should handle diagnostic reports without dates", () => {
@@ -543,16 +533,16 @@ describe("linkProceduresToDiagnosticReports", () => {
         identifier: defaultIdentifier,
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.procedures[0]?.report).toBeUndefined();
+      expect(procedure.report).toBeUndefined();
     });
 
     it("should handle empty arrays", () => {
-      const result = linkProceduresToDiagnosticReports([], []);
+      const procedures: Procedure[] = [];
+      dangerouslyLinkProceduresToDiagnosticReports(procedures, []);
 
-      expect(result.procedures).toEqual([]);
-      expect(result.reports).toEqual([]);
+      expect(procedures).toEqual([]);
     });
 
     it("should handle procedures with no matching reports", () => {
@@ -592,9 +582,9 @@ describe("linkProceduresToDiagnosticReports", () => {
         ],
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.procedures[0]?.report).toBeUndefined();
+      expect(procedure.report).toBeUndefined();
     });
 
     it("should handle diagnostic reports with no matching procedures", () => {
@@ -634,9 +624,9 @@ describe("linkProceduresToDiagnosticReports", () => {
         ],
       });
 
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(result.reports).toEqual([diagnosticReport]);
+      // Reports are not returned since they're not modified
     });
 
     it("should comprehensively link multiple procedures to multiple diagnostic reports", () => {
@@ -775,24 +765,23 @@ describe("linkProceduresToDiagnosticReports", () => {
       const procedures = [procedure1, procedure2, procedure3];
       const reports = [report1, report2, report3, report4];
 
-      const result = linkProceduresToDiagnosticReports(procedures, reports);
+      dangerouslyLinkProceduresToDiagnosticReports(procedures, reports);
 
-      // Verify all procedures and reports are returned
-      expect(result.procedures).toHaveLength(3);
-      expect(result.reports).toHaveLength(4);
+      // Verify all procedures are still there
+      expect(procedures).toHaveLength(3);
 
       // Procedure1 should link to Report1 (same code, dates within window)
-      expect(result.procedures[0]?.report).toBeDefined();
-      expect(result.procedures[0]?.report).toHaveLength(1);
-      expect(result.procedures[0]?.report?.[0]?.reference).toBe(`DiagnosticReport/${report1.id}`);
+      expect(procedure1.report).toBeDefined();
+      expect(procedure1.report).toHaveLength(1);
+      expect(procedure1.report?.[0]?.reference).toBe(`DiagnosticReport/${report1.id}`);
 
       // Procedure2 should link to Report2 (same code, dates within window)
-      expect(result.procedures[1]?.report).toBeDefined();
-      expect(result.procedures[1]?.report).toHaveLength(1);
-      expect(result.procedures[1]?.report?.[0]?.reference).toBe(`DiagnosticReport/${report2.id}`);
+      expect(procedure2.report).toBeDefined();
+      expect(procedure2.report).toHaveLength(1);
+      expect(procedure2.report?.[0]?.reference).toBe(`DiagnosticReport/${report2.id}`);
 
       // Procedure3 should NOT link to Report3 (same code but dates outside window)
-      expect(result.procedures[2]?.report).toBeUndefined();
+      expect(procedure3.report).toBeUndefined();
 
       // Report4 should remain unlinked (different code)
       // This is verified by the fact that no procedure links to it

--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
@@ -1,14 +1,14 @@
 import { buildDayjs } from "@metriport/shared/common/date";
 import { Procedure } from "@medplum/fhirtypes";
 import {
-  dangerouslyLinkProceduresToDiagnosticReports,
+  linkProceduresToDiagnosticReports,
   doAnyDatesMatchThroughWindow,
   SIZE_OF_WINDOW,
 } from "../link-procedures-to-reports";
 import { makeProcedure } from "../../../../fhir-to-cda/cda-templates/components/__tests__/make-procedure";
 import { makeDiagnosticReport } from "../../../../fhir-to-cda/cda-templates/components/__tests__/make-diagnostic-report";
 
-describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
+describe("linkProceduresToDiagnosticReports", () => {
   const baseMs = Date.now();
   const DATE_TO_MATCH = buildDayjs(baseMs).toISOString();
 
@@ -68,7 +68,7 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
     });
   });
 
-  describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
+  describe("linkProceduresToDiagnosticReports", () => {
     it("should link procedure to diagnostic report when codes match and dates are within window", () => {
       const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
       const sharedCode = "55555";
@@ -109,12 +109,13 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         ],
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(procedure).toBeDefined();
-      expect(procedure.report).toBeDefined();
-      expect(procedure.report).toHaveLength(1);
-      expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
+      expect(result).toBeDefined();
+      expect(result[0]).toBeDefined();
+      expect(result[0]?.report).toBeDefined();
+      expect(result[0]?.report).toHaveLength(1);
+      expect(result[0]?.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
     });
 
     it("should not link when codes don't match", () => {
@@ -156,10 +157,11 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         ],
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(procedure).toBeDefined();
-      expect(procedure.report).toBeUndefined();
+      expect(result).toBeDefined();
+      expect(result[0]).toBeDefined();
+      expect(result[0]?.report).toBeUndefined();
     });
 
     it("should not link when dates are outside the window", () => {
@@ -192,10 +194,11 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         identifier: defaultIdentifier,
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(procedure).toBeDefined();
-      expect(procedure.report).toBeUndefined();
+      expect(result).toBeDefined();
+      expect(result[0]).toBeDefined();
+      expect(result[0]?.report).toBeUndefined();
     });
 
     it("should link based on identifier values", () => {
@@ -222,10 +225,10 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         effectiveDateTime: matchingDate,
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(procedure.report).toBeDefined();
-      expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
+      expect(result[0]?.report).toBeDefined();
+      expect(result[0]?.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
     });
 
     it("should match identifier values", () => {
@@ -251,10 +254,10 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         effectiveDateTime: matchingDate,
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(procedure.report).toBeDefined();
-      expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
+      expect(result[0]?.report).toBeDefined();
+      expect(result[0]?.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
     });
 
     it("should filter out bad identifier values", () => {
@@ -280,10 +283,10 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         effectiveDateTime: matchingDate,
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(procedure).toBeDefined();
-      expect(procedure.report).toBeUndefined();
+      expect(result).toBeDefined();
+      expect(result[0]?.report).toBeUndefined();
     });
 
     it("should filter out all known useless display values", () => {
@@ -311,10 +314,10 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
           effectiveDateTime: matchingDate,
         });
 
-        dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+        const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-        expect(procedure).toBeDefined();
-        expect(procedure.report).toBeUndefined();
+        expect(result).toBeDefined();
+        expect(result[0]?.report).toBeUndefined();
       }
     });
 
@@ -341,9 +344,9 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         effectiveDateTime: matchingDate,
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(procedure.report).toBeUndefined();
+      expect(result[0]?.report).toBeUndefined();
     });
 
     it("should remove trailing carets from identifier values", () => {
@@ -370,10 +373,10 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         effectiveDateTime: matchingDate,
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(procedure.report).toBeDefined();
-      expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
+      expect(result[0]?.report).toBeDefined();
+      expect(result[0]?.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
     });
 
     it("should handle multiple matching diagnostic reports and link to all of them", () => {
@@ -419,15 +422,15 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         identifier: defaultIdentifier,
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports(
+      const result = linkProceduresToDiagnosticReports(
         [procedure],
         [diagnosticReport1, diagnosticReport2]
       );
 
-      expect(procedure.report).toBeDefined();
-      expect(procedure.report).toHaveLength(2);
-      expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport1.id}`);
-      expect(procedure.report?.[1]?.reference).toBe(`DiagnosticReport/${diagnosticReport2.id}`);
+      expect(result[0]?.report).toBeDefined();
+      expect(result[0]?.report).toHaveLength(2);
+      expect(result[0]?.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport1.id}`);
+      expect(result[0]?.report?.[1]?.reference).toBe(`DiagnosticReport/${diagnosticReport2.id}`);
     });
 
     it("should not add duplicate references", () => {
@@ -461,12 +464,12 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         identifier: defaultIdentifier,
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(procedure.report).toBeDefined();
-      expect(procedure.report).toHaveLength(2);
-      expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/existing-id`);
-      expect(procedure.report?.[1]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
+      expect(result[0]?.report).toBeDefined();
+      expect(result[0]?.report).toHaveLength(2);
+      expect(result[0]?.report?.[0]?.reference).toBe(`DiagnosticReport/existing-id`);
+      expect(result[0]?.report?.[1]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
     });
 
     it("should handle procedures without dates", () => {
@@ -497,9 +500,9 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         identifier: defaultIdentifier,
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(procedure.report).toBeUndefined();
+      expect(result[0]?.report).toBeUndefined();
     });
 
     it("should handle diagnostic reports without dates", () => {
@@ -530,16 +533,16 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         identifier: defaultIdentifier,
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(procedure.report).toBeUndefined();
+      expect(result[0]?.report).toBeUndefined();
     });
 
     it("should handle empty arrays", () => {
       const procedures: Procedure[] = [];
-      dangerouslyLinkProceduresToDiagnosticReports(procedures, []);
+      const result = linkProceduresToDiagnosticReports(procedures, []);
 
-      expect(procedures).toEqual([]);
+      expect(result).toEqual([]);
     });
 
     it("should handle procedures with no matching reports", () => {
@@ -579,9 +582,9 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         ],
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-      expect(procedure.report).toBeUndefined();
+      expect(result[0]?.report).toBeUndefined();
     });
 
     it("should handle diagnostic reports with no matching procedures", () => {
@@ -621,7 +624,7 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         ],
       });
 
-      dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+      linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
     });
 
     it("should comprehensively link multiple procedures to multiple diagnostic reports", () => {
@@ -731,7 +734,7 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         effectiveDateTime: outsideWindow,
         identifier: [
           {
-            value: "DR003_DIFFERENT", // Different identifier to avoid identifier-based matching
+            value: "DR003_DIFFERENT",
             system: "http://example.com/ids",
           },
         ],
@@ -741,7 +744,7 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         code: {
           coding: [
             {
-              code: "99999", // Different code, should not match
+              code: "99999",
               system: "http://www.ama-assn.org/go/cpt",
             },
           ],
@@ -758,18 +761,18 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
       const procedures = [procedure1, procedure2, procedure3];
       const reports = [report1, report2, report3, report4];
 
-      dangerouslyLinkProceduresToDiagnosticReports(procedures, reports);
+      const result = linkProceduresToDiagnosticReports(procedures, reports);
 
-      expect(procedures).toHaveLength(3);
+      expect(result).toHaveLength(3);
 
-      expect(procedure1.report).toBeDefined();
-      expect(procedure1.report).toHaveLength(1);
-      expect(procedure1.report?.[0]?.reference).toBe(`DiagnosticReport/${report1.id}`);
+      expect(result[0]?.report).toBeDefined();
+      expect(result[0]?.report).toHaveLength(1);
+      expect(result[0]?.report?.[0]?.reference).toBe(`DiagnosticReport/${report1.id}`);
 
-      expect(procedure2.report).toBeDefined();
-      expect(procedure2.report).toHaveLength(1);
-      expect(procedure2.report?.[0]?.reference).toBe(`DiagnosticReport/${report2.id}`);
-      expect(procedure3.report).toBeUndefined();
+      expect(result[1]?.report).toBeDefined();
+      expect(result[1]?.report).toHaveLength(1);
+      expect(result[1]?.report?.[0]?.reference).toBe(`DiagnosticReport/${report2.id}`);
+      expect(result[2]?.report).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
@@ -82,12 +82,6 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         performedDateTime: DATE_TO_MATCH,
-        identifier: [
-          {
-            value: "PROC123",
-            system: "http://example.com/ids",
-          },
-        ],
       });
 
       const diagnosticReport = makeDiagnosticReport({
@@ -100,7 +94,6 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         effectiveDateTime: matchingDate,
-        identifier: defaultIdentifier,
       });
 
       const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
@@ -125,12 +118,6 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         performedDateTime: DATE_TO_MATCH,
-        identifier: [
-          {
-            value: "PROC123",
-            system: "http://example.com/ids",
-          },
-        ],
       });
 
       const diagnosticReport = makeDiagnosticReport({
@@ -143,7 +130,6 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         effectiveDateTime: matchingDate,
-        identifier: defaultIdentifier,
       });
 
       const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
@@ -167,7 +153,6 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         performedDateTime: DATE_TO_MATCH,
-        identifier: defaultIdentifier,
       });
 
       const diagnosticReport = makeDiagnosticReport({
@@ -180,7 +165,6 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         effectiveDateTime: notMatchingDate,
-        identifier: defaultIdentifier,
       });
 
       const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
@@ -218,35 +202,6 @@ describe("linkProceduresToDiagnosticReports", () => {
 
       expect(result[0]?.report).toBeDefined();
       expect(result[0]?.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport.id}`);
-    });
-
-    it("should filter out bad identifier values", () => {
-      const matchingDate = buildDayjs(baseMs + THRESHOLD.asMilliseconds() / 2).toISOString();
-
-      const procedure = makeProcedure({
-        identifier: [
-          {
-            value: "UNK",
-            system: "http://example.com/ids",
-          },
-        ],
-        performedDateTime: DATE_TO_MATCH,
-      });
-
-      const diagnosticReport = makeDiagnosticReport({
-        identifier: [
-          {
-            value: "UNK",
-            system: "http://example.com/ids",
-          },
-        ],
-        effectiveDateTime: matchingDate,
-      });
-
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
-
-      expect(result).toBeDefined();
-      expect(result[0]?.report).toBeUndefined();
     });
 
     it("should filter out all known useless display values", () => {
@@ -325,7 +280,6 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         performedDateTime: DATE_TO_MATCH,
-        identifier: defaultIdentifier,
       });
 
       const diagnosticReport1 = makeDiagnosticReport({
@@ -338,7 +292,6 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         effectiveDateTime: matchingDate,
-        identifier: defaultIdentifier,
       });
 
       const diagnosticReport2 = makeDiagnosticReport({
@@ -351,7 +304,6 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         effectiveDateTime: matchingDate,
-        identifier: defaultIdentifier,
       });
 
       const result = linkProceduresToDiagnosticReports(
@@ -376,12 +328,6 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         performedDateTime: DATE_TO_MATCH,
-        identifier: [
-          {
-            value: "PROC123",
-            system: "http://example.com/ids",
-          },
-        ],
       });
 
       const diagnosticReport = makeDiagnosticReport({
@@ -394,12 +340,6 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         effectiveDateTime: DATE_TO_MATCH,
-        identifier: [
-          {
-            value: "DR123",
-            system: "http://example.com/ids",
-          },
-        ],
       });
 
       const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
@@ -421,13 +361,8 @@ describe("linkProceduresToDiagnosticReports", () => {
             },
           ],
         },
+        identifier: defaultIdentifier,
         performedDateTime: DATE_TO_MATCH,
-        identifier: [
-          {
-            value: "PROC001",
-            system: "http://example.com/ids",
-          },
-        ],
       });
 
       const procedure2 = makeProcedure({
@@ -440,12 +375,6 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         performedDateTime: withinWindow,
-        identifier: [
-          {
-            value: "PROC002",
-            system: "http://example.com/ids",
-          },
-        ],
       });
 
       const procedure3 = makeProcedure({
@@ -458,15 +387,9 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         performedDateTime: DATE_TO_MATCH,
-        identifier: [
-          {
-            value: "PROC003",
-            system: "http://example.com/ids",
-          },
-        ],
       });
 
-      const report1 = makeDiagnosticReport({
+      const reportMatchingProcedure1 = makeDiagnosticReport({
         code: {
           coding: [
             {
@@ -476,15 +399,9 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         effectiveDateTime: withinWindow,
-        identifier: [
-          {
-            value: "DR001",
-            system: "http://example.com/ids",
-          },
-        ],
       });
 
-      const report2 = makeDiagnosticReport({
+      const reportMatchingProcedure2 = makeDiagnosticReport({
         code: {
           coding: [
             {
@@ -494,15 +411,9 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         effectiveDateTime: DATE_TO_MATCH,
-        identifier: [
-          {
-            value: "DR002",
-            system: "http://example.com/ids",
-          },
-        ],
       });
 
-      const report3 = makeDiagnosticReport({
+      const reportNotMatchingAnyProcedureDate = makeDiagnosticReport({
         code: {
           coding: [
             {
@@ -512,15 +423,9 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         effectiveDateTime: outsideWindow,
-        identifier: [
-          {
-            value: "DR003_DIFFERENT",
-            system: "http://example.com/ids",
-          },
-        ],
       });
 
-      const report4 = makeDiagnosticReport({
+      const reportNotMatchingAnyProcedureCode = makeDiagnosticReport({
         code: {
           coding: [
             {
@@ -530,28 +435,41 @@ describe("linkProceduresToDiagnosticReports", () => {
           ],
         },
         effectiveDateTime: withinWindow,
-        identifier: [
-          {
-            value: "DR004",
-            system: "http://example.com/ids",
-          },
-        ],
+      });
+
+      const reportMatchingProcedure1ThroughIdentifier = makeDiagnosticReport({
+        effectiveDateTime: withinWindow,
+        identifier: defaultIdentifier,
       });
 
       const procedures = [procedure1, procedure2, procedure3];
-      const reports = [report1, report2, report3, report4];
+      const reports = [
+        reportMatchingProcedure1,
+        reportMatchingProcedure2,
+        reportNotMatchingAnyProcedureDate,
+        reportNotMatchingAnyProcedureCode,
+        reportMatchingProcedure1ThroughIdentifier,
+      ];
 
       const result = linkProceduresToDiagnosticReports(procedures, reports);
 
       expect(result).toHaveLength(3);
 
       expect(result[0]?.report).toBeDefined();
-      expect(result[0]?.report).toHaveLength(1);
-      expect(result[0]?.report?.[0]?.reference).toBe(`DiagnosticReport/${report1.id}`);
+      expect(result[0]?.report).toHaveLength(2);
+
+      const reportReferences = result[0]?.report?.map(r => r.reference) ?? [];
+      expect(reportReferences).toContain(`DiagnosticReport/${reportMatchingProcedure1.id}`);
+      expect(reportReferences).toContain(
+        `DiagnosticReport/${reportMatchingProcedure1ThroughIdentifier.id}`
+      );
 
       expect(result[1]?.report).toBeDefined();
       expect(result[1]?.report).toHaveLength(1);
-      expect(result[1]?.report?.[0]?.reference).toBe(`DiagnosticReport/${report2.id}`);
+      expect(result[1]?.report?.[0]?.reference).toBe(
+        `DiagnosticReport/${reportMatchingProcedure2.id}`
+      );
+
       expect(result[2]?.report).toBeUndefined();
     });
   });

--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
@@ -1,0 +1,638 @@
+import { buildDayjs } from "@metriport/shared/common/date";
+import {
+  linkProceduresToDiagnosticReports,
+  matchDates,
+  SIZE_OF_WINDOW,
+} from "../link-procedures-to-reports";
+import { makeProcedure } from "../../../../fhir-to-cda/cda-templates/components/__tests__/make-procedure";
+import { makeDiagnosticReport } from "../../../../fhir-to-cda/cda-templates/components/__tests__/make-diagnostic-report";
+
+describe("linkProceduresToDiagnosticReports", () => {
+  const baseMs = Date.now();
+  const DATE_TO_MATCH = buildDayjs(baseMs).toISOString();
+
+  const defaultIdentifier = [
+    {
+      value: "TEST123",
+      system: "http://example.com/ids",
+    },
+  ];
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-01-02T12:00:00.000Z"));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe("matchDates", () => {
+    it("should match based off dates", () => {
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const notMatchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW * 2).toISOString();
+      const barelyNotMatchingDate = buildDayjs(baseMs + (SIZE_OF_WINDOW + 1)).toISOString();
+
+      const shouldMatch = matchDates([DATE_TO_MATCH], [matchingDate]);
+      const shouldNotMatch = matchDates([DATE_TO_MATCH], [notMatchingDate]);
+      const barelyNotMatch = matchDates([DATE_TO_MATCH], [barelyNotMatchingDate]);
+
+      expect(shouldMatch).toBe(true);
+      expect(shouldNotMatch).toBe(false);
+      expect(barelyNotMatch).toBe(false);
+    });
+
+    it("should return false when either array is empty", () => {
+      expect(matchDates([], [DATE_TO_MATCH])).toBe(false);
+      expect(matchDates([DATE_TO_MATCH], [])).toBe(false);
+      expect(matchDates([], [])).toBe(false);
+    });
+
+    it("should return false when no valid dates are found", () => {
+      expect(matchDates(["invalid-date"], ["another-invalid-date"])).toBe(false);
+    });
+
+    it("should handle multiple dates in arrays", () => {
+      const matchingDate1 = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const matchingDate2 = buildDayjs(baseMs + SIZE_OF_WINDOW / 3).toISOString();
+      const notMatchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW * 2).toISOString();
+
+      expect(matchDates([DATE_TO_MATCH], [matchingDate1, notMatchingDate])).toBe(true);
+      expect(matchDates([DATE_TO_MATCH], [notMatchingDate, matchingDate2])).toBe(true);
+    });
+  });
+
+  describe("linkProceduresToDiagnosticReports", () => {
+    it("should link procedure to diagnostic report when codes match and dates are within window", () => {
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const sharedCode = "55555";
+
+      const procedure = makeProcedure({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        performedDateTime: DATE_TO_MATCH,
+        identifier: [
+          {
+            value: "PROC123",
+            system: "http://example.com/ids",
+          },
+        ],
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        effectiveDateTime: matchingDate,
+        identifier: [
+          {
+            value: "DR123",
+            system: "http://example.com/ids",
+          },
+        ],
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]).toBeDefined();
+      expect(result.procedures[0]?.report).toBeDefined();
+      expect(result.procedures[0]?.report).toHaveLength(1);
+      expect(result.procedures[0]?.report?.[0]?.reference).toBe(
+        `DiagnosticReport/${diagnosticReport.id}`
+      );
+    });
+
+    it("should not link when codes don't match", () => {
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+
+      const procedure = makeProcedure({
+        code: {
+          coding: [
+            {
+              code: "55555",
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        performedDateTime: DATE_TO_MATCH,
+        identifier: [
+          {
+            value: "PROC123",
+            system: "http://example.com/ids",
+          },
+        ],
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        code: {
+          coding: [
+            {
+              code: "66666",
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        effectiveDateTime: matchingDate,
+        identifier: [
+          {
+            value: "DR123",
+            system: "http://example.com/ids",
+          },
+        ],
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]).toBeDefined();
+      expect(result.procedures[0]?.report).toBeUndefined();
+    });
+
+    it("should not link when dates are outside the window", () => {
+      const notMatchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW * 2).toISOString();
+      const sharedCode = "55555";
+
+      const procedure = makeProcedure({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        performedDateTime: DATE_TO_MATCH,
+        identifier: defaultIdentifier,
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        effectiveDateTime: notMatchingDate,
+        identifier: defaultIdentifier,
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]).toBeDefined();
+      expect(result.procedures[0]?.report).toBeUndefined();
+    });
+
+    it("should link based on identifier values", () => {
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const sharedIdentifier = "TEST123";
+
+      const procedure = makeProcedure({
+        identifier: [
+          {
+            value: sharedIdentifier,
+            system: "http://example.com/ids",
+          },
+        ],
+        performedDateTime: DATE_TO_MATCH,
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        identifier: [
+          {
+            value: sharedIdentifier,
+            system: "http://example.com/ids",
+          },
+        ],
+        effectiveDateTime: matchingDate,
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]?.report).toBeDefined();
+      expect(result.procedures[0]?.report?.[0]?.reference).toBe(
+        `DiagnosticReport/${diagnosticReport.id}`
+      );
+    });
+
+    it("should handle identifier values with pipe separators", () => {
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const sharedIdentifier = "TEST123";
+
+      const procedure = makeProcedure({
+        identifier: [
+          {
+            value: `system1|${sharedIdentifier}`,
+            system: "http://example.com/ids",
+          },
+        ],
+        performedDateTime: DATE_TO_MATCH,
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        identifier: [
+          {
+            value: `system2|${sharedIdentifier}`,
+            system: "http://example.com/ids",
+          },
+        ],
+        effectiveDateTime: matchingDate,
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]?.report).toBeDefined();
+      expect(result.procedures[0]?.report?.[0]?.reference).toBe(
+        `DiagnosticReport/${diagnosticReport.id}`
+      );
+    });
+
+    it("should handle identifier values with dash separators", () => {
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+
+      const procedure = makeProcedure({
+        identifier: [
+          {
+            value: `123-456`,
+            system: "http://example.com/ids",
+          },
+        ],
+        performedDateTime: DATE_TO_MATCH,
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        identifier: [
+          {
+            value: `123-456`,
+            system: "http://example.com/ids",
+          },
+        ],
+        effectiveDateTime: matchingDate,
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]?.report).toBeDefined();
+      expect(result.procedures[0]?.report?.[0]?.reference).toBe(
+        `DiagnosticReport/${diagnosticReport.id}`
+      );
+    });
+
+    it("should filter out bad identifier values", () => {
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+
+      const procedure = makeProcedure({
+        identifier: [
+          {
+            value: "UNK",
+            system: "http://example.com/ids",
+          },
+        ],
+        performedDateTime: DATE_TO_MATCH,
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        identifier: [
+          {
+            value: "UNK",
+            system: "http://example.com/ids",
+          },
+        ],
+        effectiveDateTime: matchingDate,
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]).toBeDefined();
+      expect(result.procedures[0]?.report).toBeUndefined();
+    });
+
+    it("should filter out identifier values with URIs", () => {
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+
+      const procedure = makeProcedure({
+        identifier: [
+          {
+            value: "urn:uuid:12345",
+            system: "http://example.com/ids",
+          },
+        ],
+        performedDateTime: DATE_TO_MATCH,
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        identifier: [
+          {
+            value: "urn:uuid:12345",
+            system: "http://example.com/ids",
+          },
+        ],
+        effectiveDateTime: matchingDate,
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]?.report).toBeUndefined();
+    });
+
+    it("should remove trailing carets from identifier values", () => {
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const sharedIdentifier = "TEST123";
+
+      const procedure = makeProcedure({
+        identifier: [
+          {
+            value: `${sharedIdentifier}^`,
+            system: "http://example.com/ids",
+          },
+        ],
+        performedDateTime: DATE_TO_MATCH,
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        identifier: [
+          {
+            value: sharedIdentifier,
+            system: "http://example.com/ids",
+          },
+        ],
+        effectiveDateTime: matchingDate,
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]?.report).toBeDefined();
+      expect(result.procedures[0]?.report?.[0]?.reference).toBe(
+        `DiagnosticReport/${diagnosticReport.id}`
+      );
+    });
+
+    it("should handle multiple matching diagnostic reports and link to the first one", () => {
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const sharedCode = "55555";
+
+      const procedure = makeProcedure({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        performedDateTime: DATE_TO_MATCH,
+        identifier: defaultIdentifier,
+      });
+
+      const diagnosticReport1 = makeDiagnosticReport({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        effectiveDateTime: matchingDate,
+        identifier: defaultIdentifier,
+      });
+
+      const diagnosticReport2 = makeDiagnosticReport({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        effectiveDateTime: matchingDate,
+        identifier: defaultIdentifier,
+      });
+
+      const result = linkProceduresToDiagnosticReports(
+        [procedure],
+        [diagnosticReport1, diagnosticReport2]
+      );
+
+      expect(result.procedures[0]?.report).toBeDefined();
+      expect(result.procedures[0]?.report).toHaveLength(1);
+      // Should link to the first matching report
+      expect(result.procedures[0]?.report?.[0]?.reference).toBe(
+        `DiagnosticReport/${diagnosticReport1.id}`
+      );
+    });
+
+    it("should not add duplicate references", () => {
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const sharedCode = "55555";
+
+      const procedure = makeProcedure({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        performedDateTime: DATE_TO_MATCH,
+        report: [{ reference: `DiagnosticReport/existing-id` }],
+        identifier: defaultIdentifier,
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        effectiveDateTime: matchingDate,
+        identifier: defaultIdentifier,
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]?.report).toBeDefined();
+      expect(result.procedures[0]?.report).toHaveLength(2);
+      expect(result.procedures[0]?.report?.[0]?.reference).toBe(`DiagnosticReport/existing-id`);
+      expect(result.procedures[0]?.report?.[1]?.reference).toBe(
+        `DiagnosticReport/${diagnosticReport.id}`
+      );
+    });
+
+    it("should handle procedures without dates", () => {
+      const sharedCode = "55555";
+
+      const procedure = makeProcedure({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        // No performedDateTime
+        identifier: defaultIdentifier,
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        effectiveDateTime: DATE_TO_MATCH,
+        identifier: defaultIdentifier,
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]?.report).toBeUndefined();
+    });
+
+    it("should handle diagnostic reports without dates", () => {
+      const sharedCode = "55555";
+
+      const procedure = makeProcedure({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        performedDateTime: DATE_TO_MATCH,
+        identifier: defaultIdentifier,
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        code: {
+          coding: [
+            {
+              code: sharedCode,
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        // No effectiveDateTime
+        identifier: defaultIdentifier,
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]?.report).toBeUndefined();
+    });
+
+    it("should handle empty arrays", () => {
+      const result = linkProceduresToDiagnosticReports([], []);
+
+      expect(result.procedures).toEqual([]);
+      expect(result.reports).toEqual([]);
+    });
+
+    it("should handle procedures with no matching reports", () => {
+      const procedure = makeProcedure({
+        code: {
+          coding: [
+            {
+              code: "55555",
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        performedDateTime: DATE_TO_MATCH,
+        identifier: [
+          {
+            value: "PROC123",
+            system: "http://example.com/ids",
+          },
+        ],
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        code: {
+          coding: [
+            {
+              code: "66666",
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        effectiveDateTime: DATE_TO_MATCH,
+        identifier: [
+          {
+            value: "DR123",
+            system: "http://example.com/ids",
+          },
+        ],
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.procedures[0]?.report).toBeUndefined();
+    });
+
+    it("should handle diagnostic reports with no matching procedures", () => {
+      const procedure = makeProcedure({
+        code: {
+          coding: [
+            {
+              code: "55555",
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        performedDateTime: DATE_TO_MATCH,
+        identifier: [
+          {
+            value: "PROC123",
+            system: "http://example.com/ids",
+          },
+        ],
+      });
+
+      const diagnosticReport = makeDiagnosticReport({
+        code: {
+          coding: [
+            {
+              code: "66666",
+              system: "http://www.ama-assn.org/go/cpt",
+            },
+          ],
+        },
+        effectiveDateTime: DATE_TO_MATCH,
+        identifier: [
+          {
+            value: "DR123",
+            system: "http://example.com/ids",
+          },
+        ],
+      });
+
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+      expect(result.reports).toEqual([diagnosticReport]);
+    });
+  });
+});

--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
@@ -231,38 +231,6 @@ describe("linkProceduresToDiagnosticReports", () => {
       );
     });
 
-    it("should handle identifier values with pipe separators", () => {
-      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
-      const sharedIdentifier = "TEST123";
-
-      const procedure = makeProcedure({
-        identifier: [
-          {
-            value: `system1|${sharedIdentifier}`,
-            system: "http://example.com/ids",
-          },
-        ],
-        performedDateTime: DATE_TO_MATCH,
-      });
-
-      const diagnosticReport = makeDiagnosticReport({
-        identifier: [
-          {
-            value: `system2|${sharedIdentifier}`,
-            system: "http://example.com/ids",
-          },
-        ],
-        effectiveDateTime: matchingDate,
-      });
-
-      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
-
-      expect(result.procedures[0]?.report).toBeDefined();
-      expect(result.procedures[0]?.report?.[0]?.reference).toBe(
-        `DiagnosticReport/${diagnosticReport.id}`
-      );
-    });
-
     it("should match identifier values", () => {
       const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
 

--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
@@ -9,8 +9,8 @@ import { makeProcedure } from "../../../../fhir-to-cda/cda-templates/components/
 import { makeDiagnosticReport } from "../../../../fhir-to-cda/cda-templates/components/__tests__/make-diagnostic-report";
 
 describe("linkProceduresToDiagnosticReports", () => {
-  const baseMs = Date.now();
-  const DATE_TO_MATCH = buildDayjs(baseMs).toISOString();
+  let baseMs: number;
+  let DATE_TO_MATCH: string;
 
   const defaultIdentifier = [
     {
@@ -22,6 +22,8 @@ describe("linkProceduresToDiagnosticReports", () => {
   beforeAll(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date("2025-01-02T12:00:00.000Z"));
+    baseMs = Date.now();
+    DATE_TO_MATCH = buildDayjs(baseMs).toISOString();
   });
 
   afterAll(() => {
@@ -31,9 +33,13 @@ describe("linkProceduresToDiagnosticReports", () => {
 
   describe("matchDates", () => {
     it("should match based off dates", () => {
-      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
-      const notMatchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW * 2).toISOString();
-      const barelyNotMatchingDate = buildDayjs(baseMs + (SIZE_OF_WINDOW + 1)).toISOString();
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 2).toISOString();
+      const notMatchingDate = buildDayjs(
+        baseMs + SIZE_OF_WINDOW.asMilliseconds() * 2
+      ).toISOString();
+      const barelyNotMatchingDate = buildDayjs(
+        baseMs + (SIZE_OF_WINDOW.asMilliseconds() + 1)
+      ).toISOString();
 
       const shouldMatch = doAnyDatesMatchThroughWindow([DATE_TO_MATCH], [matchingDate]);
       const shouldNotMatch = doAnyDatesMatchThroughWindow([DATE_TO_MATCH], [notMatchingDate]);
@@ -55,9 +61,11 @@ describe("linkProceduresToDiagnosticReports", () => {
     });
 
     it("should handle multiple dates in arrays", () => {
-      const matchingDate1 = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
-      const matchingDate2 = buildDayjs(baseMs + SIZE_OF_WINDOW / 3).toISOString();
-      const notMatchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW * 2).toISOString();
+      const matchingDate1 = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 2).toISOString();
+      const matchingDate2 = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 3).toISOString();
+      const notMatchingDate = buildDayjs(
+        baseMs + SIZE_OF_WINDOW.asMilliseconds() * 2
+      ).toISOString();
 
       expect(doAnyDatesMatchThroughWindow([DATE_TO_MATCH], [matchingDate1, notMatchingDate])).toBe(
         true
@@ -70,7 +78,7 @@ describe("linkProceduresToDiagnosticReports", () => {
 
   describe("linkProceduresToDiagnosticReports", () => {
     it("should link procedure to diagnostic report when codes match and dates are within window", () => {
-      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 2).toISOString();
       const sharedCode = "55555";
 
       const procedure = makeProcedure({
@@ -119,7 +127,7 @@ describe("linkProceduresToDiagnosticReports", () => {
     });
 
     it("should not link when codes don't match", () => {
-      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 2).toISOString();
 
       const procedure = makeProcedure({
         code: {
@@ -165,7 +173,9 @@ describe("linkProceduresToDiagnosticReports", () => {
     });
 
     it("should not link when dates are outside the window", () => {
-      const notMatchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW * 2).toISOString();
+      const notMatchingDate = buildDayjs(
+        baseMs + SIZE_OF_WINDOW.asMilliseconds() * 2
+      ).toISOString();
       const sharedCode = "55555";
 
       const procedure = makeProcedure({
@@ -202,7 +212,7 @@ describe("linkProceduresToDiagnosticReports", () => {
     });
 
     it("should link based on identifier values", () => {
-      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 2).toISOString();
       const sharedIdentifier = "TEST123";
 
       const procedure = makeProcedure({
@@ -232,7 +242,7 @@ describe("linkProceduresToDiagnosticReports", () => {
     });
 
     it("should match identifier values", () => {
-      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 2).toISOString();
 
       const procedure = makeProcedure({
         identifier: [
@@ -261,7 +271,7 @@ describe("linkProceduresToDiagnosticReports", () => {
     });
 
     it("should filter out bad identifier values", () => {
-      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 2).toISOString();
 
       const procedure = makeProcedure({
         identifier: [
@@ -290,7 +300,7 @@ describe("linkProceduresToDiagnosticReports", () => {
     });
 
     it("should filter out all known useless display values", () => {
-      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 2).toISOString();
       const uselessValues = ["unknown", "unk", "no known", "no data available"];
 
       for (const uselessValue of uselessValues) {
@@ -322,7 +332,7 @@ describe("linkProceduresToDiagnosticReports", () => {
     });
 
     it("should filter out identifier values with URIs", () => {
-      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 2).toISOString();
 
       const procedure = makeProcedure({
         identifier: [
@@ -350,7 +360,7 @@ describe("linkProceduresToDiagnosticReports", () => {
     });
 
     it("should remove trailing carets from identifier values", () => {
-      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 2).toISOString();
       const sharedIdentifier = "TEST123";
 
       const procedure = makeProcedure({
@@ -380,7 +390,7 @@ describe("linkProceduresToDiagnosticReports", () => {
     });
 
     it("should handle multiple matching diagnostic reports and link to all of them", () => {
-      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 2).toISOString();
       const sharedCode = "55555";
 
       const procedure = makeProcedure({
@@ -434,7 +444,7 @@ describe("linkProceduresToDiagnosticReports", () => {
     });
 
     it("should not add duplicate references", () => {
-      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW.asMilliseconds() / 2).toISOString();
       const sharedCode = "55555";
 
       const procedure = makeProcedure({

--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../link-procedures-to-reports";
 import { makeProcedure } from "../../../../fhir-to-cda/cda-templates/components/__tests__/make-procedure";
 import { makeDiagnosticReport } from "../../../../fhir-to-cda/cda-templates/components/__tests__/make-diagnostic-report";
+import { LOINC_URL } from "@metriport/shared/medical";
 
 describe("linkProceduresToDiagnosticReports", () => {
   let baseMs: number;
@@ -77,7 +78,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: sharedCode,
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -89,7 +90,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: sharedCode,
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -113,7 +114,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: "55555",
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -125,7 +126,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: "66666",
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -148,7 +149,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: sharedCode,
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -160,7 +161,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: sharedCode,
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -206,37 +207,34 @@ describe("linkProceduresToDiagnosticReports", () => {
 
     it("should filter out all known useless display values", () => {
       const matchingDate = buildDayjs(baseMs + THRESHOLD.asMilliseconds() / 2).toISOString();
-      const uselessValues = ["unknown", "unk", "no known", "no data available"];
+      const uselessValue = "unknown";
+      const procedure = makeProcedure({
+        identifier: [
+          {
+            value: uselessValue,
+            system: "http://example.com/ids",
+          },
+        ],
+        performedDateTime: DATE_TO_MATCH,
+      });
 
-      for (const uselessValue of uselessValues) {
-        const procedure = makeProcedure({
-          identifier: [
-            {
-              value: uselessValue,
-              system: "http://example.com/ids",
-            },
-          ],
-          performedDateTime: DATE_TO_MATCH,
-        });
+      const diagnosticReport = makeDiagnosticReport({
+        identifier: [
+          {
+            value: uselessValue,
+            system: "http://example.com/ids",
+          },
+        ],
+        effectiveDateTime: matchingDate,
+      });
 
-        const diagnosticReport = makeDiagnosticReport({
-          identifier: [
-            {
-              value: uselessValue,
-              system: "http://example.com/ids",
-            },
-          ],
-          effectiveDateTime: matchingDate,
-        });
+      const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
 
-        const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
-
-        expect(result).toBeDefined();
-        expect(result[0]?.report).toBeUndefined();
-      }
+      expect(result).toBeDefined();
+      expect(result[0]?.report).toBeUndefined();
     });
 
-    it("should remove trailing carets from identifier values", () => {
+    it("should match despite trailing caret in identifier value", () => {
       const matchingDate = buildDayjs(baseMs + THRESHOLD.asMilliseconds() / 2).toISOString();
       const sharedIdentifier = "TEST123";
 
@@ -275,7 +273,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: sharedCode,
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -287,7 +285,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: sharedCode,
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -299,7 +297,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: sharedCode,
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -323,7 +321,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: "55555",
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -335,7 +333,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: "66666",
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -357,7 +355,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: "12345",
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -370,7 +368,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: "67890",
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -382,7 +380,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: "11111",
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -394,7 +392,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: "12345",
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -406,7 +404,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: "67890",
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -418,7 +416,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: "11111",
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },
@@ -430,7 +428,7 @@ describe("linkProceduresToDiagnosticReports", () => {
           coding: [
             {
               code: "99999",
-              system: "http://www.ama-assn.org/go/cpt",
+              system: LOINC_URL,
             },
           ],
         },

--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
@@ -426,7 +426,6 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
 
       expect(procedure.report).toBeDefined();
       expect(procedure.report).toHaveLength(2);
-      // Should link to both matching reports
       expect(procedure.report?.[0]?.reference).toBe(`DiagnosticReport/${diagnosticReport1.id}`);
       expect(procedure.report?.[1]?.reference).toBe(`DiagnosticReport/${diagnosticReport2.id}`);
     });
@@ -482,7 +481,6 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
             },
           ],
         },
-        // No performedDateTime
         identifier: defaultIdentifier,
       });
 
@@ -529,7 +527,6 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
             },
           ],
         },
-        // No effectiveDateTime
         identifier: defaultIdentifier,
       });
 
@@ -625,8 +622,6 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
       });
 
       dangerouslyLinkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
-
-      // Reports are not returned since they're not modified
     });
 
     it("should comprehensively link multiple procedures to multiple diagnostic reports", () => {
@@ -634,7 +629,6 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
       const withinWindow = baseTime.add(1, "hour").toISOString();
       const outsideWindow = baseTime.add(3, "hours").toISOString();
 
-      // Create procedures
       const procedure1 = makeProcedure({
         code: {
           coding: [
@@ -689,7 +683,6 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
         ],
       });
 
-      // Create diagnostic reports
       const report1 = makeDiagnosticReport({
         code: {
           coding: [
@@ -767,24 +760,16 @@ describe("dangerouslyLinkProceduresToDiagnosticReports", () => {
 
       dangerouslyLinkProceduresToDiagnosticReports(procedures, reports);
 
-      // Verify all procedures are still there
       expect(procedures).toHaveLength(3);
 
-      // Procedure1 should link to Report1 (same code, dates within window)
       expect(procedure1.report).toBeDefined();
       expect(procedure1.report).toHaveLength(1);
       expect(procedure1.report?.[0]?.reference).toBe(`DiagnosticReport/${report1.id}`);
 
-      // Procedure2 should link to Report2 (same code, dates within window)
       expect(procedure2.report).toBeDefined();
       expect(procedure2.report).toHaveLength(1);
       expect(procedure2.report?.[0]?.reference).toBe(`DiagnosticReport/${report2.id}`);
-
-      // Procedure3 should NOT link to Report3 (same code but dates outside window)
       expect(procedure3.report).toBeUndefined();
-
-      // Report4 should remain unlinked (different code)
-      // This is verified by the fact that no procedure links to it
     });
   });
 });

--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
@@ -259,7 +259,7 @@ describe("linkProceduresToDiagnosticReports", () => {
       );
     });
 
-    it("should handle identifier values with dash separators", () => {
+    it("should match identifier values with dash separators using head-only matching", () => {
       const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
 
       const procedure = makeProcedure({
@@ -275,7 +275,7 @@ describe("linkProceduresToDiagnosticReports", () => {
       const diagnosticReport = makeDiagnosticReport({
         identifier: [
           {
-            value: `123-456`,
+            value: `123-789`,
             system: "http://example.com/ids",
           },
         ],

--- a/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
+++ b/packages/core/src/external/fhir/normalization/__tests__/normalize-matching.test.ts
@@ -323,6 +323,38 @@ describe("linkProceduresToDiagnosticReports", () => {
       expect(result.procedures[0]?.report).toBeUndefined();
     });
 
+    it("should filter out all known useless display values", () => {
+      const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
+      const uselessValues = ["unknown", "unk", "no known", "no data available"];
+
+      for (const uselessValue of uselessValues) {
+        const procedure = makeProcedure({
+          identifier: [
+            {
+              value: uselessValue,
+              system: "http://example.com/ids",
+            },
+          ],
+          performedDateTime: DATE_TO_MATCH,
+        });
+
+        const diagnosticReport = makeDiagnosticReport({
+          identifier: [
+            {
+              value: uselessValue,
+              system: "http://example.com/ids",
+            },
+          ],
+          effectiveDateTime: matchingDate,
+        });
+
+        const result = linkProceduresToDiagnosticReports([procedure], [diagnosticReport]);
+
+        expect(result.procedures[0]).toBeDefined();
+        expect(result.procedures[0]?.report).toBeUndefined();
+      }
+    });
+
     it("should filter out identifier values with URIs", () => {
       const matchingDate = buildDayjs(baseMs + SIZE_OF_WINDOW / 2).toISOString();
 

--- a/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
+++ b/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
@@ -48,8 +48,8 @@ export function linkProceduresToDiagnosticReports(
       if (!drs) continue;
       for (const dr of drs) {
         if (!dr?.id) continue;
-        const hitDates = getDateFromDiagnosticReport(dr);
-        if (!doAnyDatesMatchThroughWindow(dates, hitDates)) {
+        const drDates = getDateFromDiagnosticReport(dr);
+        if (!doAnyDatesMatchThroughWindow(dates, drDates)) {
           continue;
         }
         const ref: Reference<DiagnosticReport> = createReference(dr);

--- a/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
+++ b/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
@@ -1,0 +1,203 @@
+import {
+  CodeableConcept,
+  Coding,
+  DiagnosticReport,
+  Procedure,
+  Reference,
+  Resource,
+} from "@medplum/fhirtypes";
+
+const HOURS_FOR_WINDOW = 2;
+const SIZE_OF_WINDOW = HOURS_FOR_WINDOW * 60 * 60 * 1000;
+
+export function linkProceduresToDiagnosticReports(
+  procedures: Procedure[],
+  reports: DiagnosticReport[]
+): { procedures: Procedure[]; reports: DiagnosticReport[] } {
+  const drByKey = new Map<string, DiagnosticReport[]>();
+
+  for (const dr of reports) {
+    const keys = keysForDiagnosticReport(dr);
+    for (const k of keys) {
+      if (!k) continue;
+      const prior = drByKey.get(k) ?? [];
+      prior.push(dr);
+      drByKey.set(k, prior);
+    }
+  }
+
+  for (const proc of procedures) {
+    const { dates, pKeys } = keysForProcedure(proc);
+    for (const key of pKeys) {
+      const hits = key ? drByKey.get(key) : undefined;
+      if (!hits) continue;
+      for (const hit of hits) {
+        if (!hit?.id) continue;
+        if (!matchDates(dates, getDate(hit))) {
+          continue;
+        }
+        const ref: Reference<DiagnosticReport> = { reference: `DiagnosticReport/${hit.id}` };
+        const existing: Reference<DiagnosticReport>[] = (proc.report ??
+          []) as Reference<DiagnosticReport>[];
+
+        if (!existing.some(r => r.reference === ref.reference)) {
+          proc.report = [...existing, ref];
+        }
+        break;
+      }
+    }
+  }
+
+  return { procedures, reports };
+}
+
+function matchDates(a: string[] = [], b: string[] = []): boolean {
+  if (a.length === 0 || b.length === 0) return false;
+
+  const aTimes = a
+    .map(a => {
+      return parseDateIntoNumber(a);
+    })
+    .filter((t): t is number => t !== undefined);
+
+  const bTimes = b
+    .map(b => {
+      return parseDateIntoNumber(b);
+    })
+    .filter((t): t is number => t !== undefined);
+
+  if (aTimes.length === 0 || bTimes.length === 0) return false;
+
+  for (const ta of aTimes) {
+    for (const tb of bTimes) {
+      if (Math.abs(ta - tb) <= SIZE_OF_WINDOW) return true;
+    }
+  }
+
+  return false;
+}
+
+function parseDateIntoNumber(iso?: string): number | undefined {
+  if (!iso) return undefined;
+  const d = new Date(iso);
+  if (Number.isFinite(d.getTime())) return d.getTime();
+
+  const mFull = iso.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  if (mFull) {
+    const dd = new Date(`${mFull[0]}.000Z`);
+    if (Number.isFinite(dd.getTime())) return dd.getTime();
+  }
+  const mDate = iso.match(/^\d{4}-\d{2}-\d{2}/);
+  if (mDate) {
+    const dd = new Date(`${mDate[0]}T00:00:00.000Z`);
+    if (Number.isFinite(dd.getTime())) return dd.getTime();
+  }
+  return undefined;
+}
+
+function getDate(dr: DiagnosticReport): string[] {
+  const raw = [
+    dr.effectiveDateTime,
+    dr.effectivePeriod?.start,
+    dr.effectivePeriod?.end,
+    dr.issued,
+  ].filter(Boolean) as string[];
+  return [...new Set(raw)];
+}
+
+function keysForDiagnosticReport(dr: DiagnosticReport): string[] {
+  const idVals = identifierValueTokens(dr);
+  const codes = codeTokensFromCode(dr.code);
+
+  const out: string[] = [];
+  for (const v of idVals) out.push(`${v}`);
+  for (const c of codes) out.push(`${c}`);
+  return dedupe(out);
+}
+
+function keysForProcedure(p: Procedure): { dates: string[]; pKeys: string[] } {
+  const dates = dateCandidatesFromProcedure(p);
+  const idVals = identifierValueTokens(p);
+  const codes = codeTokensFromCode(p.code);
+
+  const out: string[] = [];
+
+  for (const v of idVals) out.push(`${v}`);
+  for (const c of codes) out.push(`${c}`);
+  const dedupedOut = dedupe(out);
+  const dedupedDates = dedupe(dates);
+  return { dates: dedupedDates, pKeys: dedupedOut };
+}
+
+function dateCandidatesFromProcedure(p: Procedure): string[] {
+  const raw = [p.performedDateTime, p.performedPeriod?.start, p.performedPeriod?.end].filter(
+    Boolean
+  ) as string[];
+  return dedupe(raw);
+}
+
+function identifierValueTokens(dr: Resource): string[] {
+  const BAD = new Set(["UNK", "UNKNOWN", "UNSPECIFIED", "NA", "N/A", "NONE", "NO_CODE"]);
+  const out: string[] = [];
+  if (!("identifier" in dr)) {
+    throw new Error("No identifier in this resource");
+  }
+
+  const identifiers = Array.isArray(dr.identifier) ? dr.identifier : [dr.identifier];
+
+  for (const id of identifiers) {
+    if (!id) continue;
+    const value = (id.value ?? "").toString().trim();
+    if (!value) continue;
+
+    const valueByPipe = splitValueByPipe(value);
+    if (!valueByPipe) continue;
+
+    const valueByDash = splitValueByDash(valueByPipe);
+
+    if (BAD.has(valueByDash.toUpperCase())) continue;
+    if (/^(?:urn:|oid:|https?:\/\/)/i.test(valueByDash)) continue;
+    const noTrailingCaret = removeTrailingCaret(valueByDash);
+    out.push(noTrailingCaret);
+  }
+  return dedupe(out);
+}
+
+function splitValueByPipe(value: string): string {
+  if (!value.includes("|")) return value;
+  const parts = value
+    .split("|")
+    .map(s => s.trim())
+    .filter(Boolean);
+  return parts[parts.length - 1] ?? "";
+}
+
+function splitValueByDash(value: string): string {
+  const [head = "", tail = ""] = (value ?? "").split("-", 2);
+  return head && tail && /^\d+$/.test(head) && /^\d+$/.test(tail) ? head : value ?? "";
+}
+
+function codeTokensFromCode(code?: CodeableConcept): string[] {
+  const BAD = new Set(["UNK", "UNKNOWN", "UNSPECIFIED", "NA", "N/A", "NONE", "NO_CODE"]);
+  const codings = (code?.coding ?? []).filter((c): c is Coding => !!c?.code);
+
+  const out: string[] = [];
+  for (const c of codings) {
+    const token = (c.code ?? "").toString().trim().toUpperCase();
+    if (!token || BAD.has(token)) continue;
+    if (/^(?:urn:|oid:|https?:\/\/)/i.test(token)) continue;
+    out.push(token);
+  }
+  return dedupe(out);
+}
+
+function dedupe<T>(arr: T[]): T[] {
+  return [...new Set(arr)];
+}
+
+function removeTrailingCaret(s: string): string {
+  if (s.charAt(s.length - 1) === "^") {
+    return s.slice(0, s.length - 1);
+  }
+  return s;
+}

--- a/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
+++ b/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
@@ -15,7 +15,7 @@ import {
   isUselessDisplay,
 } from "../../../fhir-deduplication/shared";
 import { toArray } from "@metriport/shared/common/array";
-import { createReference } from "@medplum/core";
+import { createReference, deepClone } from "@medplum/core";
 
 dayjs.extend(duration);
 
@@ -24,10 +24,11 @@ export const SIZE_OF_WINDOW = dayjs.duration(2, "hours").asMilliseconds();
 // Regex patterns for filtering identifier and code values
 const URI_PATTERN = /^(?:urn:|oid:|https?:\/\/)/i; // Matches URIs, OIDs, and HTTP/HTTPS URLs
 
-export function dangerouslyLinkProceduresToDiagnosticReports(
+export function linkProceduresToDiagnosticReports(
   procedures: Procedure[],
   reports: DiagnosticReport[]
-): void {
+): Procedure[] {
+  const clonedProcedures = deepClone(procedures);
   const drMap = new Map<string, DiagnosticReport[]>();
 
   for (const dr of reports) {
@@ -40,7 +41,7 @@ export function dangerouslyLinkProceduresToDiagnosticReports(
     }
   }
 
-  for (const proc of procedures) {
+  for (const proc of clonedProcedures) {
     const { dates, procedureKeys } = getKeysAndDatesForProcedure(proc);
     for (const key of procedureKeys) {
       const drs = drMap.get(key);
@@ -61,6 +62,8 @@ export function dangerouslyLinkProceduresToDiagnosticReports(
       }
     }
   }
+
+  return clonedProcedures;
 }
 
 function getKeysForDiagnosticReport(dr: DiagnosticReport): string[] {

--- a/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
+++ b/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
@@ -34,7 +34,6 @@ export function linkProceduresToDiagnosticReports(
   for (const dr of reports) {
     const keys = getKeysForDiagnosticReport(dr);
     for (const k of keys) {
-      if (!k) continue;
       const prior = drMap.get(k) ?? [];
       prior.push(dr);
       drMap.set(k, prior);

--- a/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
+++ b/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
@@ -46,7 +46,6 @@ export function linkProceduresToDiagnosticReports(
       const drs = drMap.get(key);
       if (!drs) continue;
       for (const dr of drs) {
-        if (!dr?.id) continue;
         const drDates = getDateFromDiagnosticReport(dr);
         if (!doAnyDatesMatchThroughWindow(dates, drDates)) {
           continue;

--- a/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
+++ b/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
@@ -22,22 +22,22 @@ export function linkProceduresToDiagnosticReports(
   procedures: Procedure[],
   reports: DiagnosticReport[]
 ): { procedures: Procedure[]; reports: DiagnosticReport[] } {
-  const drByKey = new Map<string, DiagnosticReport[]>();
+  const drMap = new Map<string, DiagnosticReport[]>();
 
   for (const dr of reports) {
     const keys = getKeysForDiagnosticReport(dr);
     for (const k of keys) {
       if (!k) continue;
-      const prior = drByKey.get(k) ?? [];
+      const prior = drMap.get(k) ?? [];
       prior.push(dr);
-      drByKey.set(k, prior);
+      drMap.set(k, prior);
     }
   }
 
   for (const proc of procedures) {
     const { dates, pKeys } = getKeysAndDatesForProcedure(proc);
     for (const key of pKeys) {
-      const hits = key ? drByKey.get(key) : undefined;
+      const hits = key ? drMap.get(key) : undefined;
       if (!hits) continue;
       for (const hit of hits) {
         if (!hit?.id) continue;

--- a/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
+++ b/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
@@ -13,6 +13,7 @@ import {
   getPerformedDateFromResource,
   getDateFromResource,
 } from "../../../fhir-deduplication/shared";
+import { toArray } from "@metriport/shared/common/array";
 
 dayjs.extend(duration);
 
@@ -128,7 +129,7 @@ function getIdentifierValueTokens(dr: Resource): string[] {
     return [];
   }
 
-  const identifiers = Array.isArray(dr.identifier) ? dr.identifier : [dr.identifier];
+  const identifiers = toArray(dr.identifier);
 
   for (const id of identifiers) {
     if (!id) continue;

--- a/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
+++ b/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
@@ -140,7 +140,7 @@ function identifierValueTokens(dr: Resource): string[] {
   const BAD = new Set(["UNK", "UNKNOWN", "UNSPECIFIED", "NA", "N/A", "NONE", "NO_CODE"]);
   const out: string[] = [];
   if (!("identifier" in dr)) {
-    throw new Error("No identifier in this resource");
+    return [];
   }
 
   const identifiers = Array.isArray(dr.identifier) ? dr.identifier : [dr.identifier];

--- a/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
+++ b/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
@@ -100,7 +100,7 @@ export function doDatesMatch(a: string[] = [], b: string[] = []): boolean {
 
   for (const dateA of aDates) {
     for (const dateB of bDates) {
-      const diffInMs = Math.abs(dateA.diff(dateB, "milliseconds"));
+      const diffInMs = Math.abs(dateA.diff(dateB));
       if (diffInMs <= THRESHOLD.asMilliseconds()) return true;
     }
   }

--- a/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
+++ b/packages/core/src/external/fhir/normalization/link-procedures-to-reports.ts
@@ -138,31 +138,12 @@ function getIdentifierValueTokens(dr: Resource): string[] {
     const value = id.value?.trim();
     if (!value) continue;
 
-    const valueByPipe = getSplitValueByPipe(value);
-    if (!valueByPipe) continue;
-
-    if (isUselessDisplay(valueByPipe)) continue;
-    if (URI_PATTERN.test(valueByPipe)) continue;
-    const noTrailingCaret = removeTrailingCaret(valueByPipe);
+    if (isUselessDisplay(value)) continue;
+    if (URI_PATTERN.test(value)) continue;
+    const noTrailingCaret = removeTrailingCaret(value);
     out.push(noTrailingCaret);
   }
   return dedupe(out);
-}
-
-/**
- * Splits a value by pipe and returns the last part.
- * This is needed because the Procedures identifier values sometimes are stored as the system and the value separated by a pipe.
- * But the DiagnosticReport identifier values are not stored as the system and the value separated by a pipe. Resulting in a mismatch.
- * @param value The value to split by pipe
- * @returns The last part of the value split by pipe
- */
-function getSplitValueByPipe(value: string): string {
-  if (!value.includes("|")) return value;
-  const parts = value
-    .split("|")
-    .map(s => s.trim())
-    .filter(Boolean);
-  return parts[parts.length - 1] ?? "";
 }
 
 function getCodeTokensFromCode(code?: CodeableConcept): string[] {

--- a/packages/core/src/external/fhir/normalization/normalize-fhir.ts
+++ b/packages/core/src/external/fhir/normalization/normalize-fhir.ts
@@ -6,7 +6,7 @@ import { normalizeConditions } from "./resources/condition";
 import { normalizeCoverages } from "./resources/coverage";
 import { filterInvalidEncounters } from "./resources/encounter";
 import { normalizeObservations } from "./resources/observation";
-import { linkProceduresToDiagnosticReports } from "./link-procedures-to-reports";
+import { dangerouslyLinkProceduresToDiagnosticReports } from "./link-procedures-to-reports";
 
 /**
  * Normalizes a FHIR Bundle by standardizing and cleaning up its resources.
@@ -40,13 +40,10 @@ export function normalizeFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> {
   );
   resourceArrays.encounters = validEncounters;
 
-  const { procedures: linkedProcs, reports: linkedDRs } = linkProceduresToDiagnosticReports(
+  dangerouslyLinkProceduresToDiagnosticReports(
     resourceArrays.procedures,
     resourceArrays.diagnosticReports
   );
-
-  resourceArrays.procedures = linkedProcs;
-  resourceArrays.diagnosticReports = linkedDRs;
 
   normalizedBundle.entry = Object.entries(resourceArrays).flatMap(([, resources]) => {
     const entriesArray = Array.isArray(resources) ? resources : [resources];

--- a/packages/core/src/external/fhir/normalization/normalize-fhir.ts
+++ b/packages/core/src/external/fhir/normalization/normalize-fhir.ts
@@ -6,6 +6,7 @@ import { normalizeConditions } from "./resources/condition";
 import { normalizeCoverages } from "./resources/coverage";
 import { filterInvalidEncounters } from "./resources/encounter";
 import { normalizeObservations } from "./resources/observation";
+import { linkProceduresToDiagnosticReports } from "./link-procedures-to-reports";
 
 /**
  * Normalizes a FHIR Bundle by standardizing and cleaning up its resources.
@@ -38,6 +39,14 @@ export function normalizeFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> {
     resourceArrays.locations
   );
   resourceArrays.encounters = validEncounters;
+
+  const { procedures: linkedProcs, reports: linkedDRs } = linkProceduresToDiagnosticReports(
+    resourceArrays.procedures,
+    resourceArrays.diagnosticReports
+  );
+
+  resourceArrays.procedures = linkedProcs;
+  resourceArrays.diagnosticReports = linkedDRs;
 
   normalizedBundle.entry = Object.entries(resourceArrays).flatMap(([, resources]) => {
     const entriesArray = Array.isArray(resources) ? resources : [resources];

--- a/packages/core/src/external/fhir/normalization/normalize-fhir.ts
+++ b/packages/core/src/external/fhir/normalization/normalize-fhir.ts
@@ -6,7 +6,7 @@ import { normalizeConditions } from "./resources/condition";
 import { normalizeCoverages } from "./resources/coverage";
 import { filterInvalidEncounters } from "./resources/encounter";
 import { normalizeObservations } from "./resources/observation";
-import { dangerouslyLinkProceduresToDiagnosticReports } from "./link-procedures-to-reports";
+import { linkProceduresToDiagnosticReports } from "./link-procedures-to-reports";
 
 /**
  * Normalizes a FHIR Bundle by standardizing and cleaning up its resources.
@@ -40,10 +40,12 @@ export function normalizeFhir(fhirBundle: Bundle<Resource>): Bundle<Resource> {
   );
   resourceArrays.encounters = validEncounters;
 
-  dangerouslyLinkProceduresToDiagnosticReports(
+  const proceduresWithDiagnosticReports = linkProceduresToDiagnosticReports(
     resourceArrays.procedures,
     resourceArrays.diagnosticReports
   );
+
+  resourceArrays.procedures = proceduresWithDiagnosticReports;
 
   normalizedBundle.entry = Object.entries(resourceArrays).flatMap(([, resources]) => {
     const entriesArray = Array.isArray(resources) ? resources : [resources];


### PR DESCRIPTION
_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1006

### Dependencies
None

### Description
Add a matching algorithm that matches reports and procedures based off of:
1.  Date
2. Codes
3. Identifier Values

### Testing
- Local
  - [x] Test on different XMLs to make sure imaging reports are linked [(IMG IN THREAD)](https://metriport.slack.com/archives/C0616FCPAKZ/p1757449808189129?thread_ts=1756944508.559769&cid=C0616FCPAKZ)
  - [x] Run Unit tests
- Production
  - [ ] Reconvert single patient to make sure Alexey's changes are working with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Procedures are now automatically linked to related Diagnostic Reports during normalization using identifier/code token matching and near-time (2‑hour) date alignment. Existing references are preserved, duplicates avoided, and the first suitable match is preferred; final bundles include these relationships.

- **Tests**
  - Added comprehensive tests for date matching and procedure–report linking, covering identifier normalization, multiple-match scenarios, invalid inputs, edge cases, identifier formats, trailing-carets, and window-based comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->