### PR TITLE
ENG-1022: feat(infra): allow multiple internal cidr blocks instead of just one per hie config

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -49,7 +49,7 @@ export type HiePatientRosterMapping = {
 export type HieConfig = {
   name: string;
   gatewayPublicIp: string;
-  internalCidrBlock: string;
+  internalCidrBlocks: string[];
   timezone: HieIanaTimezone;
   states: USState[];
   subscriptions: Hl7v2Subscription[];
@@ -58,7 +58,7 @@ export type HieConfig = {
   mapping: HiePatientRosterMapping;
 };
 
-export type VpnlessHieConfig = Omit<HieConfig, "gatewayPublicIp" | "internalCidrBlock">;
+export type VpnlessHieConfig = Omit<HieConfig, "gatewayPublicIp" | "internalCidrBlocks">;
 
 export type Hl7v2SubscriberParams = {
   hieName: string;
@@ -83,5 +83,5 @@ export type Hl7v2SubscriberApiResponse = {
  * @returns true if config is HieConfig, false if config is VpnlessHieConfig
  */
 export function doesHieUseVpn(config: HieConfig | VpnlessHieConfig): config is HieConfig {
-  return "gatewayPublicIp" in config && "internalCidrBlock" in config;
+  return "gatewayPublicIp" in config && "internalCidrBlocks" in config;
 }

--- a/packages/core/src/external/hl7-notification/hie-config-dictionary.ts
+++ b/packages/core/src/external/hl7-notification/hie-config-dictionary.ts
@@ -24,9 +24,11 @@ export const hieConfigDictionarySchema = z.record(
   z.union([
     // Schema for a normal Vpn based HIE config
     z.object({
-      cidrBlock: z.string().regex(cidrBlockRegex, {
-        message: "Must be a valid CIDR block (e.g., '10.0.0.0/16')",
-      }),
+      cidrBlocks: z.array(
+        z.string().regex(cidrBlockRegex, {
+          message: "Must be a valid CIDR block (e.g., '10.0.0.0/16')",
+        })
+      ),
       timezone: hieIanaTimezoneSchema,
     }),
     // Schema for a HIE config that doesn't have a VPN

--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -185,7 +185,7 @@ export const config: EnvConfigNonSandbox = {
         states: [USState.TX],
         timezone: "America/Chicago",
         gatewayPublicIp: "200.1.1.1",
-        internalCidrBlock: "10.10.0.0/16",
+        internalCidrBlocks: ["10.10.0.0/16"],
         subscriptions: ["adt"],
         mapping: {
           ID: "scrambledId",

--- a/packages/infra/lib/shared/hie-config-dictionary.ts
+++ b/packages/infra/lib/shared/hie-config-dictionary.ts
@@ -15,7 +15,7 @@ export const createHieConfigDictionary = (
 ) => {
   return Object.values(hieConfigs).reduce((acc, item) => {
     acc[item.name] = {
-      ...(doesHieUseVpn(item) ? { cidrBlock: item.internalCidrBlock } : {}),
+      ...(doesHieUseVpn(item) ? { cidrBlocks: item.internalCidrBlock } : {}),
       timezone: item.timezone,
     };
 

--- a/packages/infra/lib/shared/hie-config-dictionary.ts
+++ b/packages/infra/lib/shared/hie-config-dictionary.ts
@@ -15,7 +15,7 @@ export const createHieConfigDictionary = (
 ) => {
   return Object.values(hieConfigs).reduce((acc, item) => {
     acc[item.name] = {
-      ...(doesHieUseVpn(item) ? { cidrBlocks: item.internalCidrBlock } : {}),
+      ...(doesHieUseVpn(item) ? { cidrBlocks: item.internalCidrBlocks } : {}),
       timezone: item.timezone,
     };
 

--- a/packages/mllp-server/.env.example
+++ b/packages/mllp-server/.env.example
@@ -6,7 +6,7 @@ HL7_INCOMING_MESSAGE_BUCKET_NAME=your-incoming-bucket-name
 HL7_OUTGOING_MESSAGE_BUCKET_NAME=your-outgoing-bucket-name
 HL7_CONVERSION_BUCKET_NAME=metriport-hl7-conversion-staging
 HL7_NOTIFICATION_QUEUE_URL=your-queue-url
-HIE_CONFIG_DICTIONARY='{"myHie":{"timezone":"America/New_York","cidrBlock":"1.1.1.1/32"}}'
+HIE_CONFIG_DICTIONARY='{"myHie":{"timezone":"America/New_York","cidrBlocks":["1.1.1.1/32", "1.1.1.2/32"]}}'
 
 AWS_REGION=your-aws-region
 HL7_BASE64_SCRAMBLER_SEED=your-seed

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -90,7 +90,9 @@ export function getCleanIpAddress(address: string | undefined): string {
  */
 export function lookupHieTzEntryForIp(hieConfigDictionary: HieConfigDictionary, ip: string) {
   const hieVpnConfigRows = Object.entries(hieConfigDictionary).flatMap(keepOnlyVpnConfigs);
-  const match = hieVpnConfigRows.find(({ cidrBlock }) => isIpInRange(cidrBlock, ip));
+  const match = hieVpnConfigRows.find(({ cidrBlocks }) =>
+    cidrBlocks.some(cidrBlock => isIpInRange(cidrBlock, ip))
+  );
   if (!match) {
     console.log("[mllp-server.lookupHieTzEntryForIp] Sender IP not found in any CIDR block", ip);
     throw new MetriportError(`Sender IP not found in any CIDR block`, {
@@ -107,7 +109,7 @@ function isIpInRange(cidrBlock: string, ip: string): boolean {
 }
 
 function keepOnlyVpnConfigs([hieName, config]: [string, HieConfigDictionary[string]]) {
-  return "cidrBlock" in config
-    ? [{ hieName, cidrBlock: config.cidrBlock, timezone: config.timezone }]
+  return "cidrBlocks" in config
+    ? [{ hieName, cidrBlocks: config.cidrBlocks, timezone: config.timezone }]
     : [];
 }


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/3235

### Description

Konza integration required a slightly more complex configuration. Can support it by allowing multiple internal cidr blocks to be routable through our tunnels + nacls.

### Testing

- Local
  - [x] Send message over connection, using an ip from the internalCidrBlocks config field and decode and identify source HIE.
- Production
  - [ ] Have Konza verify connectivity tomorrow (Wednesday)

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support multiple CIDR blocks per HIE VPN configuration.
  - Network ACLs and VPN routes are now created per CIDR block for improved flexibility.
  - IP-to-timezone lookup now checks multiple CIDRs.

- Documentation
  - Updated sample configuration and environment examples to use cidrBlocks arrays.
  - Migration: rename cidrBlock/internalCidrBlock (single string) to cidrBlocks/internalCidrBlocks (array of strings) in your configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->