### PR TITLE
Add roster analytics by customer name and ids.

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-analytics.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-analytics.ts
@@ -46,9 +46,8 @@ export async function trackRosterSizePerCustomer(
     }
   }
 
-  // Maybe throw error here?
   if (totalRosterSize !== rosterSize) {
-    log(
+    throw new Error(
       `WARNING: Total roster size sent partitioned by cxs (${totalRosterSize}) does not match the actual roster size sent to the HIE (${rosterSize})!!`
     );
   }

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-analytics.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-analytics.ts
@@ -1,0 +1,93 @@
+import { InternalOrganizationDTO } from "@metriport/shared/domain/organization";
+import { Patient } from "../../domain/patient";
+import { analyticsAsync, EventTypes } from "../../external/analytics/posthog";
+import { reportMetric } from "../../external/aws/cloudwatch";
+import { Config } from "../../util/config";
+import _ from "lodash";
+import { getSecretValueOrFail } from "../../external/aws/secret-manager";
+
+export async function trackRosterSizePerCustomer(
+  patients: Patient[],
+  hieName: string,
+  orgsByCxId: Record<string, InternalOrganizationDTO>,
+  rosterSize: number,
+  log: typeof console.log
+): Promise<void> {
+  log("Tracking roster size per customer per HIE");
+
+  const posthogSecretArn = Config.getPostHogApiKey();
+  if (!posthogSecretArn) {
+    throw new Error("Failed to get posthog secret");
+  }
+  const posthogSecret = await getSecretValueOrFail(posthogSecretArn, Config.getAWSRegion());
+
+  const patientsByCustomer = _.groupBy(patients, "cxId");
+  let totalRosterSize = 0;
+  for (const [cxId, customerPatients] of Object.entries(patientsByCustomer)) {
+    const cx = orgsByCxId[cxId];
+    if (!cx) {
+      log(`Customer ${cxId} has no name, skipping`);
+      continue;
+    }
+
+    const cxName = cx.name;
+
+    totalRosterSize += customerPatients.length;
+    const customerRosterSize = customerPatients.length;
+
+    try {
+      await Promise.all([
+        notifyPostHogPerCustomer(cxId, cxName, customerRosterSize, hieName, posthogSecret),
+        notifyCloudWatchPerCustomer(cxId, cxName, customerRosterSize, hieName),
+      ]);
+      log(`Sent analytics for customer ${cxId}: ${customerRosterSize} patients in ${hieName}`);
+    } catch (error) {
+      log(`Failed to send analytics for customer ${cxId}: ${error}`);
+    }
+  }
+
+  // Maybe throw error here?
+  if (totalRosterSize !== rosterSize) {
+    log(
+      `WARNING: Total roster size sent partitioned by cxs (${totalRosterSize}) does not match the actual roster size sent to the HIE (${rosterSize})!!`
+    );
+  }
+}
+
+async function notifyPostHogPerCustomer(
+  cxId: string,
+  cxName: string,
+  rosterSize: number,
+  hieName: string,
+  posthogSecret: string
+): Promise<void> {
+  await analyticsAsync(
+    {
+      event: EventTypes.rosterUploadPerCustomer,
+      distinctId: cxId,
+      properties: {
+        customerId: cxId,
+        customerName: cxName,
+        stateHie: hieName,
+        rosterSize: rosterSize,
+      },
+    },
+    posthogSecret
+  );
+}
+
+async function notifyCloudWatchPerCustomer(
+  cxId: string,
+  cxName: string,
+  rosterSize: number,
+  hieName: string
+): Promise<void> {
+  const additional = `Hie=${hieName},Customer=${cxId},CustomerName=${cxName}`;
+
+  await reportMetric({
+    name: "ADT.RosterUpload.CustomerRosterSize",
+    unit: "Count",
+    value: rosterSize,
+    additionalDimension: additional,
+  });
+}

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -20,7 +20,10 @@ import { Config } from "../../util/config";
 import { CSV_FILE_EXTENSION, CSV_MIME_TYPE } from "../../util/mime";
 import { METRIPORT_ASSIGNING_AUTHORITY_IDENTIFIER } from "./constants";
 import { uploadToRemoteSftp } from "./hl7v2-roster-uploader";
-import { trackRosterSizePerCustomer } from "./hl7v2-roster-analytics";
+import {
+  trackRosterSizePerCustomer,
+  TrackRosterSizePerCustomerParams,
+} from "./hl7v2-roster-analytics";
 import {
   HieConfig,
   HiePatientRosterMapping,
@@ -126,7 +129,14 @@ export class Hl7v2RosterGenerator {
     log(`Saved in S3: ${this.bucketName}/${s3Key}`);
 
     const rosterSize = rosterRows.length;
-    await trackRosterSizePerCustomer(patients, hieName, orgsByCxId, rosterSize, log);
+    const trackRosterSizePerCustomerParams: TrackRosterSizePerCustomerParams = {
+      patients,
+      hieName,
+      orgsByCxId,
+      rosterSize,
+      log,
+    };
+    await trackRosterSizePerCustomer(trackRosterSizePerCustomerParams);
 
     return rosterCsv;
   }

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -14,15 +14,13 @@ import axios, { AxiosResponse } from "axios";
 import { stringify } from "csv-stringify/sync";
 import _ from "lodash";
 import { getFirstNameAndMiddleInitial, Patient } from "../../domain/patient";
-import { analyticsAsync, EventTypes } from "../../external/analytics/posthog";
-import { reportMetric } from "../../external/aws/cloudwatch";
 import { S3Utils, storeInS3WithRetries } from "../../external/aws/s3";
-import { getSecretValueOrFail } from "../../external/aws/secret-manager";
 import { out } from "../../util";
 import { Config } from "../../util/config";
 import { CSV_FILE_EXTENSION, CSV_MIME_TYPE } from "../../util/mime";
 import { METRIPORT_ASSIGNING_AUTHORITY_IDENTIFIER } from "./constants";
 import { uploadToRemoteSftp } from "./hl7v2-roster-uploader";
+import { trackRosterSizePerCustomer } from "./roster-analytics";
 import {
   HieConfig,
   HiePatientRosterMapping,
@@ -128,52 +126,9 @@ export class Hl7v2RosterGenerator {
     log(`Saved in S3: ${this.bucketName}/${s3Key}`);
 
     const rosterSize = rosterRows.length;
-    await this.logResults(rosterSize, hieName, log);
+    await trackRosterSizePerCustomer(patients, hieName, orgsByCxId, rosterSize, log);
 
     return rosterCsv;
-  }
-
-  private async logResults(
-    rosterSize: number,
-    hieName: string,
-    log: typeof console.log
-  ): Promise<void> {
-    log("Sending analytics to posthog");
-    await this.notifyPostHog(rosterSize, hieName);
-
-    log("Sending metrics to cloudwatch");
-    await this.notifyCloudWatch(rosterSize, hieName);
-  }
-
-  private async notifyPostHog(rosterSize: number, hieName: string) {
-    const posthogSecretName = Config.getPostHogApiKey();
-    if (!posthogSecretName) {
-      throw new Error("Failed to get posthog secret name");
-    }
-
-    const posthogSecret = await getSecretValueOrFail(posthogSecretName, region);
-    await analyticsAsync(
-      {
-        event: EventTypes.rosterUploadSummary,
-        distinctId: `cx:${hieName}`,
-        properties: {
-          stateHie: hieName,
-          rosterSize: rosterSize,
-        },
-      },
-      posthogSecret
-    );
-  }
-
-  private async notifyCloudWatch(rosterSize: number, hieName: string): Promise<void> {
-    const additional = `Hie=${hieName}`;
-
-    await reportMetric({
-      name: "ADT.RosterUpload.RosterSize",
-      unit: "Count",
-      value: rosterSize,
-      additionalDimension: additional,
-    });
   }
 
   private async getAllSubscribedPatients(hieName: string): Promise<Patient[]> {

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -20,7 +20,7 @@ import { Config } from "../../util/config";
 import { CSV_FILE_EXTENSION, CSV_MIME_TYPE } from "../../util/mime";
 import { METRIPORT_ASSIGNING_AUTHORITY_IDENTIFIER } from "./constants";
 import { uploadToRemoteSftp } from "./hl7v2-roster-uploader";
-import { trackRosterSizePerCustomer } from "./roster-analytics";
+import { trackRosterSizePerCustomer } from "./hl7v2-roster-analytics";
 import {
   HieConfig,
   HiePatientRosterMapping,

--- a/packages/core/src/external/analytics/posthog.ts
+++ b/packages/core/src/external/analytics/posthog.ts
@@ -70,7 +70,6 @@ export enum EventTypes {
   inboundDocumentQuery = "inbound.documentQuery",
   inboundDocumentRetrieval = "inbound.documentRetrieval",
   dischargeRequery = "dischargeRequery",
-  rosterUploadSummary = "rosterUploadSummary",
   rosterUploadPerCustomer = "rosterUploadPerCustomer",
 }
 

--- a/packages/core/src/external/analytics/posthog.ts
+++ b/packages/core/src/external/analytics/posthog.ts
@@ -71,6 +71,7 @@ export enum EventTypes {
   inboundDocumentRetrieval = "inbound.documentRetrieval",
   dischargeRequery = "dischargeRequery",
   rosterUploadSummary = "rosterUploadSummary",
+  rosterUploadPerCustomer = "rosterUploadPerCustomer",
 }
 
 export enum EventErrMessage {


### PR DESCRIPTION
_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-714

### Dependencies
None

### Description
Partition roster analytics by customer name/id instead of only HIE name.

### Testing
- Local
  - [x] Run create roster upload locally 
- Staging
  - [ ] Run create roster upload 

<img width="915" height="460" alt="Screenshot 2025-09-10 at 10 08 41 AM" src="https://github.com/user-attachments/assets/3a2a5db9-15b7-4a13-92f8-ea4d373fcbc2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-customer analytics for HL7 v2 roster uploads, reporting roster sizes to analytics and monitoring systems.
  * Added event type for per-customer roster uploads.
  * Consistency checks compare calculated vs reported roster sizes and emit warnings on mismatch.

* **Refactor**
  * Centralized roster analytics into a dedicated tracker and removed inline analytics from the roster generation flow for improved clarity and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->