### PR TITLE
PATCH RELEASE: Remove CW v2 FF check based on facility/org ID

### DIFF
--- a/packages/api/src/external/commonwell/document/document-query.ts
+++ b/packages/api/src/external/commonwell/document/document-query.ts
@@ -26,11 +26,7 @@ export async function queryAndProcessDocuments({
   getOrgIdExcludeList: () => Promise<string[]>;
   triggerConsolidated?: boolean;
 }): Promise<void> {
-  const [isCwV2EnabledCx, isCwV2EnabledFacility] = await Promise.all([
-    isCommonwellV2EnabledForCx(patientParam.cxId),
-    isCommonwellV2EnabledForCx(facilityId ?? "NA"),
-  ]);
-  const isCwV2Enabled = isCwV2EnabledCx && isCwV2EnabledFacility;
+  const isCwV2Enabled = await isCommonwellV2EnabledForCx(patientParam.cxId);
 
   // TODO ENG-554 Remove FF and v1 code
   if (!isCwV2Enabled) {

--- a/packages/api/src/external/commonwell/patient/patient.ts
+++ b/packages/api/src/external/commonwell/patient/patient.ts
@@ -69,12 +69,7 @@ export async function create({
 }): Promise<{ commonwellPatientId: string } | void> {
   const { log, debug } = out(`CW create - M patientId ${patient.id}`);
 
-  const [isCwV2EnabledCx, isCwV2EnabledFacility] = await Promise.all([
-    isCommonwellV2EnabledForCx(patient.cxId),
-    isCommonwellV2EnabledForCx(facilityId),
-  ]);
-  const isCwV2Enabled = isCwV2EnabledCx && isCwV2EnabledFacility;
-
+  const isCwV2Enabled = await isCommonwellV2EnabledForCx(patient.cxId);
   const isCwEnabled = await validateCWEnabled({
     patient,
     facilityId,
@@ -151,12 +146,7 @@ export async function update({
 }: UpdatePatientCmd): Promise<void> {
   const { log, debug } = out(`CW update - M patientId ${patient.id}`);
 
-  const [isCwV2EnabledCx, isCwV2EnabledFacility] = await Promise.all([
-    isCommonwellV2EnabledForCx(patient.cxId),
-    isCommonwellV2EnabledForCx(facilityId),
-  ]);
-  const isCwV2Enabled = isCwV2EnabledCx && isCwV2EnabledFacility;
-
+  const isCwV2Enabled = await isCommonwellV2EnabledForCx(patient.cxId);
   const isCwEnabled = await validateCWEnabled({
     patient,
     facilityId,
@@ -164,7 +154,6 @@ export async function update({
     log,
     isCwV2Enabled,
   });
-
   if (!isCwEnabled) return;
 
   const demoAugEnabled = await isDemoAugEnabledForCx(patient.cxId);
@@ -224,11 +213,7 @@ export async function update({
 export async function remove({ patient, facilityId }: UpdatePatientCmd): Promise<void> {
   const { log } = out(`CW remove - patientId ${patient.id}`);
 
-  const [isCwV2EnabledCx, isCwV2EnabledFacility] = await Promise.all([
-    isCommonwellV2EnabledForCx(patient.cxId),
-    isCommonwellV2EnabledForCx(facilityId),
-  ]);
-  const isCwV2Enabled = isCwV2EnabledCx && isCwV2EnabledFacility;
+  const isCwV2Enabled = await isCommonwellV2EnabledForCx(patient.cxId);
   if (!isCwV2Enabled) {
     await removeInCwV1(patient, facilityId);
     log(`Removed patient from CW v1`);

--- a/packages/lambdas/src/document-downloader.ts
+++ b/packages/lambdas/src/document-downloader.ts
@@ -74,15 +74,11 @@ export const handler = capture.wrapHandler(
         `sourceDocument: ${JSON.stringify(sourceDocument)}`
     );
 
-    // TODO REVERT THE CHECK FOR OID
-    const [cwOrgCertificate, cwOrgPrivateKey, isV2EnabledCx, isV2EnabledFacility] =
-      await Promise.all([
-        getSecret(cwOrgCertificateSecret) as Promise<string>,
-        getSecret(cwOrgPrivateKeySecret) as Promise<string>,
-        isCommonwellV2EnabledForCx(cxId),
-        isCommonwellV2EnabledForCx(orgOid),
-      ]);
-    const isV2Enabled = isV2EnabledCx && isV2EnabledFacility;
+    const [cwOrgCertificate, cwOrgPrivateKey, isV2Enabled] = await Promise.all([
+      getSecret(cwOrgCertificateSecret) as Promise<string>,
+      getSecret(cwOrgPrivateKeySecret) as Promise<string>,
+      isCommonwellV2EnabledForCx(cxId),
+    ]);
 
     if (!cwOrgCertificate) {
       throw new Error(`Config error - CW_ORG_CERTIFICATE doesn't exist`);
@@ -120,8 +116,6 @@ export const handler = capture.wrapHandler(
     }
 
     // V2
-
-    console.log("Using CW v2");
     const commonWell = new CommonWell({
       orgCert: cwOrgCertificate,
       rsaPrivateKey: cwOrgPrivateKey,


### PR DESCRIPTION
Part of ENG-1002

Signed-off-by: RamilGaripov <ramil@metriport.com>

### Description

- This PR covers part 1 of the ticket:
  - Remove CW v2 FF check based on facility/org ID. This means that we will rely solely on `cxId` to see if CW v2 is enabled

### Testing

- Production
  - [ ] Make sure CW v2-enabled orgs do not use CW v1 flow

### Release Plan

- Points to master ⚠️ 
- [ ] Merge this
- [ ] FFs have been set in Staging, Production, and Sandbox


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CommonWell v2 now enables based solely on the customer setting, ensuring consistent behavior across facilities for patient create/update/remove and document downloads.

* **Refactor**
  * Simplified v1/v2 gating logic and removed redundant facility/org checks, reducing calls and improving reliability.
  * Cleaned up logging in document downloads.
  * No changes to public APIs or function signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->