### PR TITLE
ENG-1021: Relaxing CW v2 schemas slightly

### DIFF
--- a/packages/commonwell-sdk/src/models/document.ts
+++ b/packages/commonwell-sdk/src/models/document.ts
@@ -68,7 +68,7 @@ export const documentReferenceSchema = z.object({
   id: z.string().nullish(),
   masterIdentifier: identifierSchema.nullish(),
   identifier: z.array(identifierSchema).nullish(),
-  status: statusSchema,
+  status: statusSchema.default("current"),
   docStatus: docStatusSchema.nullish(),
   type: codeableConceptSchema.nullish(),
   category: z.array(codeableConceptSchema).nullish(),

--- a/packages/commonwell-sdk/src/models/identifier.ts
+++ b/packages/commonwell-sdk/src/models/identifier.ts
@@ -56,8 +56,8 @@ export const patientIdentifierSchema = z.object({
   value: z.string(),
   /** Assigning Authority ID for the unique Patient ID */
   system: z.string(),
-  use: emptyStringToUndefinedSchema.pipe(identifierUseCodesSchema.nullish()),
-  type: emptyStringToUndefinedSchema.pipe(identifierTypeCodesSchema.nullish()),
+  use: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
+  type: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
   assigner: emptyStringToUndefinedSchema,
   period: periodSchema.nullish(),
 });


### PR DESCRIPTION
Part of ENG-1021

### Description
- Relaxed Patient identifiers schema: `use` and `type` 
- Relaxed DocRef schema to accept `undefined` for status, but since it's a required field, we'll just default to `current`

### Testing

- Local
  - [ ] Run a script to retrieve problematic patients to make sure they don't cause errors anymore

### Release Plan
- [ ] Release NPM packages 
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document references now default to a “current” status when none is provided.
  * Patient identifier fields for “use” and “type” accept any string or can be left empty, improving compatibility with varied data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->