### PR TITLE
ENG-1041: feat(api): fix broken adt enrollment endpoint. +remove dangerous endpoint

### DIFF
--- a/packages/api/src/routes/internal/medical/patient-settings.ts
+++ b/packages/api/src/routes/internal/medical/patient-settings.ts
@@ -1,18 +1,14 @@
 import {
   parseAdtSubscriptionRequest,
-  parseBulkPatientSettingsRequest,
-  parseQuestMonitoringRequest,
   parsePatientSettingsRequest,
+  parseQuestMonitoringRequest,
 } from "@metriport/core/domain/patient-settings";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import { Request, Response } from "express";
 import Router from "express-promise-router";
 import status from "http-status";
-import {
-  upsertPatientSettingsForCx,
-  upsertPatientSettingsForPatientList,
-} from "../../../command/medical/patient/settings/create-patient-settings";
+import { upsertPatientSettingsForPatientList } from "../../../command/medical/patient/settings/create-patient-settings";
 import {
   addHieSubscriptionToPatients,
   removeHieSubscriptionFromPatients,
@@ -158,34 +154,6 @@ router.delete(
     const result = await removeQuestSubscriptionFromPatients({
       cxId,
       patientIds,
-    });
-
-    return res.status(status.OK).json(result);
-  })
-);
-
-/** ---------------------------------------------------------------------------
- * POST /internal/patient/settings/bulk
- *
- * Creates or updates patient settings across all patients for a CX.
- *
- * @param req.query.cxId The customer ID.
- * @param req.query.facilityId The facility ID. Optional.
- * @param req.body The patient settings to apply. Optional, defaults to empty object.
- * @returns 200 with the results of the operation.
- */
-router.post(
-  "/bulk",
-  requestLogger,
-  asyncHandler(async (req: Request, res: Response) => {
-    const cxId = getUUIDFrom("query", req, "cxId").orFail();
-    const facilityId = getUUIDFrom("query", req, "facilityId").optional();
-    const { settings } = parseBulkPatientSettingsRequest(req.body);
-
-    const result = await upsertPatientSettingsForCx({
-      cxId,
-      facilityId,
-      settings,
     });
 
     return res.status(status.OK).json(result);

--- a/packages/core/src/domain/patient-settings.ts
+++ b/packages/core/src/domain/patient-settings.ts
@@ -1,8 +1,6 @@
 import {
   AdtSubscriptionRequest,
   adtSubscriptionRequestSchema,
-  BulkPatientSettingsRequest,
-  bulkPatientSettingsRequestSchema,
   createQueryMetaSchema,
   PatientSettingsRequest,
   patientSettingsRequestSchema,
@@ -57,21 +55,6 @@ export function parsePatientSettingsRequest(data: unknown): PatientSettingsReque
   }
 
   const result = patientSettingsRequestSchema.parse(data);
-  result.settings.subscriptions?.adt?.forEach(throwOnInvalidHieName);
-  return result;
-}
-
-export function parseBulkPatientSettingsRequest(data: unknown): BulkPatientSettingsRequest {
-  try {
-    getHieConfigDictionary();
-  } catch (error) {
-    log(
-      "parseBulkPatientSettingsRequest - No HIE config dictionary found, skipping HIE name validation"
-    );
-    return bulkPatientSettingsRequestSchema.parse(data);
-  }
-
-  const result = bulkPatientSettingsRequestSchema.parse(data);
   result.settings.subscriptions?.adt?.forEach(throwOnInvalidHieName);
   return result;
 }


### PR DESCRIPTION
### Dependencies

None

### Description

Patient enrollment endpoint queries were failing based if the subscriptions column was null, needed some tweaking. I'm not sure why / how this broke.

This also removes the dangerous bulk endpoint that makes it easy to accidentally overwrite settings.

### Testing

- Local
  - [x] Repro silent failure
  - [x] Verify fixed by running query w some sample patient ids on local
  - [x] Test Case: Add when already exists: no change in adt array, no error thrown
  - [x] Test Case: Add when does not exist: element is added to adt array
  - [x] Test Case: Remove when already exists: element is removed from adt array
  - [x] Test Case: Remove when does not exist: no change in adt array
  - [x] Test Case: Operation taken on null column: behaves as though it had an empty adt array (for add + remove)
- Production
  - [ ] re-enable cx patients
 
### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents duplicate ADT HIE subscriptions and ensures updates work reliably even when existing settings are empty; timestamps preserved.

- Chores
  - Removed the CX-wide bulk patient-settings update and its bulk parsing path; only per-patient-list updates remain, so bulk "apply to all patients" workflow is no longer available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->