### PR TITLE
feat(utils): updated email verification with more RFC 5322-compliant …

### DIFF
--- a/packages/api-sdk/src/medical/models/__tests__/demographics.test.ts
+++ b/packages/api-sdk/src/medical/models/__tests__/demographics.test.ts
@@ -31,6 +31,12 @@ describe("demographicsSchema", () => {
       "user123@metriport.com",
       "123user@metriport.com",
       "user@metriport.com.br",
+      "test!user@example.com",
+      "test+user@example.com",
+      "test_user@example.com",
+      "test-user@example.com",
+      "test.user@example.com",
+      "test_user+test@example.com",
     ];
     const casesToFail: (string | null | undefined)[] = [
       null,

--- a/packages/api-sdk/src/medical/models/demographics.ts
+++ b/packages/api-sdk/src/medical/models/demographics.ts
@@ -5,6 +5,7 @@ import {
   normalizeUsPhoneWithPlusOne,
   phoneLength,
   validDateOfBirthStringSchema,
+  isEmailValid,
 } from "@metriport/shared";
 import { z } from "zod";
 import { addressSchema } from "./common/address";
@@ -56,7 +57,9 @@ export type PersonalIdentifier = z.infer<typeof personalIdentifierSchema>;
 
 export const genderAtBirthSchema = z.enum(["F", "M", "O", "U"]);
 
-export const emailSchema = z.string().email();
+export const emailSchema = z.string().refine(isEmailValid, {
+  message: "Invalid email address",
+});
 
 export const contactSchema = z
   .object({

--- a/packages/shared/src/domain/contact/__tests__/email.test.ts
+++ b/packages/shared/src/domain/contact/__tests__/email.test.ts
@@ -1,5 +1,6 @@
 import {
   isEmailValid,
+  isPhoneNumberFormat,
   normalizeEmail,
   normalizeEmailStrict,
   normalizeEmailNewSafe,
@@ -23,6 +24,54 @@ describe("Email Utility Functions", () => {
     it('should return false for email with "mailto:" prefix', () => {
       expect(isEmailValid("mailto:test@example.com")).toBe(false);
     });
+
+    it("should return true for email with exclamation mark", () => {
+      expect(isEmailValid("test!user@example.com")).toBe(true);
+    });
+
+    it("should return true for email with other valid special characters", () => {
+      expect(isEmailValid("test#user@example.com")).toBe(true);
+      expect(isEmailValid("test$user@example.com")).toBe(true);
+      expect(isEmailValid("test%user@example.com")).toBe(true);
+      expect(isEmailValid("test&user@example.com")).toBe(true);
+      expect(isEmailValid("test'user@example.com")).toBe(true);
+      expect(isEmailValid("test*user@example.com")).toBe(true);
+      expect(isEmailValid("test+user@example.com")).toBe(true);
+      expect(isEmailValid("test-user@example.com")).toBe(true);
+      expect(isEmailValid("test/user@example.com")).toBe(true);
+      expect(isEmailValid("test=user@example.com")).toBe(true);
+      expect(isEmailValid("test?user@example.com")).toBe(true);
+      expect(isEmailValid("test^user@example.com")).toBe(true);
+      expect(isEmailValid("test_user@example.com")).toBe(true);
+      expect(isEmailValid("test`user@example.com")).toBe(true);
+      expect(isEmailValid("test{user@example.com")).toBe(true);
+      expect(isEmailValid("test|user@example.com")).toBe(true);
+      expect(isEmailValid("test}user@example.com")).toBe(true);
+      expect(isEmailValid("test~user@example.com")).toBe(true);
+    });
+
+    it("should return false for phone number format (+1 prefix)", () => {
+      expect(isEmailValid("+1234567890@example.com")).toBe(false);
+      expect(isEmailValid("+1-234-567-8900@example.com")).toBe(false);
+    });
+  });
+
+  describe("isPhoneNumberFormat", () => {
+    it("should return true for phone number format", () => {
+      expect(isPhoneNumberFormat("+1234567890")).toBe(true);
+      expect(isPhoneNumberFormat("+1-234-567-8900")).toBe(true);
+      expect(isPhoneNumberFormat("+1 (234) 567-8900")).toBe(true);
+    });
+
+    it("should return false for regular email", () => {
+      expect(isPhoneNumberFormat("test@example.com")).toBe(false);
+      expect(isPhoneNumberFormat("user+tag@example.com")).toBe(false);
+    });
+
+    it("should handle whitespace", () => {
+      expect(isPhoneNumberFormat(" +1234567890")).toBe(true);
+      expect(isPhoneNumberFormat(" +1-234-567-8900")).toBe(true);
+    });
   });
 
   describe("normalizeEmail", () => {
@@ -40,12 +89,22 @@ describe("Email Utility Functions", () => {
       expect(normalizeEmailStrict("  Test@Example.COM  ")).toBe("test@example.com");
     });
 
+    it("should return normalized email with special characters", () => {
+      expect(normalizeEmailStrict("  Test!User@Example.COM  ")).toBe("test!user@example.com");
+    });
+
     it("should throw an error for invalid email format", () => {
       expect(() => normalizeEmailStrict("invalid-email")).toThrow("Invalid email.");
     });
 
     it('should throw an error for email with "mailto:" prefix', () => {
       expect(() => normalizeEmailStrict("mailto:test@example.com")).toThrow("Invalid email.");
+    });
+
+    it("should throw specific error for phone number format", () => {
+      expect(() => normalizeEmailStrict("+1234567890@example.com")).toThrow(
+        "Invalid email: appears to be a phone number (starts with +1). Please enter a valid email address."
+      );
     });
   });
 });
@@ -86,14 +145,24 @@ describe("email", () => {
       expect(normalizeEmailNewSafe(input)).toBe(expectedOutput);
     });
 
-    it("should relace mailto: prefix", () => {
+    it("should replace mailto: prefix", () => {
       const expectedOutput = exampleEmail;
       const input = "mailto:" + expectedOutput;
       expect(normalizeEmailNewSafe(input)).toBe(expectedOutput);
     });
 
-    it("should return undefined for emails that invalid", () => {
+    it("should return undefined for emails that are invalid", () => {
       const input = "this.is.not.an.email";
+      expect(normalizeEmailNewSafe(input)).toBeUndefined();
+    });
+
+    it("should handle emails with special characters", () => {
+      const input = "test!user@example.com";
+      expect(normalizeEmailNewSafe(input)).toBe("test!user@example.com");
+    });
+
+    it("should return undefined for phone number format", () => {
+      const input = "+1234567890@example.com";
       expect(normalizeEmailNewSafe(input)).toBeUndefined();
     });
   });

--- a/packages/shared/src/domain/contact/email.ts
+++ b/packages/shared/src/domain/contact/email.ts
@@ -1,8 +1,11 @@
-import { z } from "zod";
 import { BadRequestError } from "../../error/bad-request";
 
 export const exampleEmail = "test@test.com";
 const mailtoPrefix = "mailto:";
+
+// Enhanced email validation that properly handles RFC 5322 characters
+const EMAIL_REGEX =
+  /^(?=.{1,254}$)(?=.{1,64}@)[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$/;
 
 export function isEmail(email: string): boolean {
   return email.includes("@");
@@ -11,9 +14,21 @@ export function isEmail(email: string): boolean {
 export function isEmailValid(email: string): boolean {
   if (!email) return false;
   if (email.length === 0) return false;
-  const safeParseEmail = z.string().email().safeParse(email);
-  if (!safeParseEmail.success) return false;
-  return true;
+
+  // Check for phone number format (+1 prefix)
+  if (email.startsWith("+1")) {
+    return false;
+  }
+
+  // Use our enhanced regex instead of Zod's potentially too-strict validation
+  return EMAIL_REGEX.test(email);
+}
+
+/**
+ * Checks if an email appears to be a phone number (starts with +1)
+ */
+export function isPhoneNumberFormat(email: string): boolean {
+  return email.trim().startsWith("+1");
 }
 
 /**
@@ -29,7 +44,14 @@ export function normalizeEmail(email: string): string {
  */
 export function normalizeEmailStrict(email: string): string {
   const normalEmail = normalizeEmail(email);
-  if (!isEmailValid(normalEmail)) throw new Error("Invalid email.");
+  if (!isEmailValid(normalEmail)) {
+    if (isPhoneNumberFormat(email)) {
+      throw new Error(
+        "Invalid email: appears to be a phone number (starts with +1). Please enter a valid email address."
+      );
+    }
+    throw new Error("Invalid email.");
+  }
   return normalEmail;
 }
 
@@ -67,6 +89,13 @@ export function normalizeEmailNewSafe(
 export function normalizeEmailNew(email: string): string {
   const emailOrUndefined = normalizeEmailNewSafe(email);
   if (!emailOrUndefined) {
+    if (isPhoneNumberFormat(email)) {
+      throw new BadRequestError(
+        "Invalid email: appears to be a phone number (starts with +1). Please enter a valid email address.",
+        undefined,
+        { email }
+      );
+    }
     throw new BadRequestError("Invalid email", undefined, { email });
   }
   return emailOrUndefined;

--- a/packages/utils/src/bulk-insert-patients.ts
+++ b/packages/utils/src/bulk-insert-patients.ts
@@ -8,6 +8,7 @@ import { sleep } from "@metriport/core/util/sleep";
 import {
   getEnvVar,
   isEmailValid,
+  isPhoneNumber,
   isPhoneValid,
   normalizeDob,
   normalizeEmail,
@@ -285,7 +286,14 @@ export function normalizeEmailUtils(email: string | undefined): string | undefin
   if (email == undefined) return undefined;
   const normalEmail = normalizeEmail(email);
   if (normalEmail.length === 0) return undefined;
-  if (!isEmailValid(normalEmail)) throw new Error("Invalid Email");
+  if (!isEmailValid(normalEmail)) {
+    if (isPhoneNumber(email)) {
+      throw new Error(
+        "Invalid Email: appears to be a phone number (starts with +1). Please enter a valid email address."
+      );
+    }
+    throw new Error("Invalid Email");
+  }
   return normalEmail;
 }
 


### PR DESCRIPTION
…check, added phone number check

Issues:

- https://linear.app/metriport/issue/ENG-1036

### Dependencies

- Upstream: None
- Downstream: https://github.com/metriport/metriport-internal/pull/3246

### Description

Zod's email check isn't a fully comprehensive check (article from Zod's maintainer [here](https://colinhacks.com/essays/reasonable-email-regex)), so replacing it with a more comprehensive custom regex catches more valid emails. Being fully RFC5322 compliant is unreasonable, but this is an improvement.

- Remove zod's `string().email().safeParse`
- Replaced with upgraded regex to match more valid emails
  - Handles `!` in email edge case
  - Handles phone numbers being sent as emails (starting with `+1`) 
- Added more comprehensive testing 

### Testing

- Local
  - [x] Ran updated test suite

Check each PR.

### Release Plan

This update (given existing unit tests) should be backwards compatible with what we currently have, and if we are notified of new errors we can roll back the change

- [x] No dependencies between API and Infra that will cause errors during deployment
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public phone-number detection utility and applied broader email normalization/validation across the SDK (custom email validation used in schema).

* **Bug Fixes**
  * Prevented phone-number-like inputs (e.g., +1-prefixed) from being accepted as emails and added clearer, phone-specific error messages.
  * Improved handling of whitespace, mailto: prefixes, special characters, and other edge cases.

* **Tests**
  * Expanded coverage for email formats, phone-number detection, normalization behavior, and fixed test descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->