### PR TITLE
ENG-1046: feat(core): tweak backoff settings for consolidated ingest

### DIFF
--- a/packages/core/src/command/consolidated/search/fhir-resource/ingest-lexical.ts
+++ b/packages/core/src/command/consolidated/search/fhir-resource/ingest-lexical.ts
@@ -113,7 +113,8 @@ async function getConsolidatedBundle({
       return true;
     },
     initialDelay: 1_000,
-    maxAttempts: 5,
+    maxAttempts: 10,
+    backoffMultiplier: 1.6,
     log,
   });
 


### PR DESCRIPTION
### Dependencies

None

### Description

Consolidated ingestion can fail due to DQ deleting the consolidated bundle. The bundle can be deleted for up to 30+ seconds at a time. This bandaid ensures that consolidated ingest's retry policy will go for long enough to bridge that gap.

### Testing

None

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Increased retry attempts for ingestion/search from 5 to 10 and enabled exponential backoff (multiplier 1.6); initial delay unchanged.
  - Users should see fewer intermittent failures and more successful consolidated bundle loads, with a slightly longer wait before a final error if issues persist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->