### PR TITLE
ENG-1048 Stop storing raw XCPD responses to S3

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests.ts
@@ -1,10 +1,9 @@
-import { XCPDGateway, OutboundPatientDiscoveryReq } from "@metriport/ihe-gateway-sdk";
+import { OutboundPatientDiscoveryReq, XCPDGateway } from "@metriport/ihe-gateway-sdk";
 import { errorToString } from "../../../../../../util/error/shared";
-import { SamlCertsAndKeys } from "../../../saml/security/types";
-import { SamlClientResponse, sendSignedXml } from "../../../saml/saml-client";
-import { SignedXcpdRequest } from "../create/iti55-envelope";
 import { out } from "../../../../../../util/log";
-import { storeXcpdResponses } from "../../../monitor/store";
+import { SamlClientResponse, sendSignedXml } from "../../../saml/saml-client";
+import { SamlCertsAndKeys } from "../../../saml/security/types";
+import { SignedXcpdRequest } from "../create/iti55-envelope";
 
 const { log } = out("Sending XCPD Requests");
 
@@ -38,11 +37,12 @@ export async function sendSignedXcpdRequest({
         request.gateway.oid
       }`
     );
-    await storeXcpdResponses({
-      response,
-      outboundRequest: request.outboundRequest,
-      gateway: request.gateway,
-    });
+    // ENG-1048 Disable S3 storage for IHE raw requests/responses
+    // await storeXcpdResponses({
+    //   response,
+    //   outboundRequest: request.outboundRequest,
+    //   gateway: request.gateway,
+    // });
     return {
       gateway: request.gateway,
       response,


### PR DESCRIPTION
### Dependencies

none

### Description

Stop storing raw XCPD responses to S3.

### Testing

- Local
  - none
- Staging
  - [x] XCPD is not stored on S3 on a new PD
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this
