### PR TITLE
PATCH RELEASE CW Patient Update Fix

### DIFF
--- a/packages/api/src/external/commonwell-v2/patient/patient.ts
+++ b/packages/api/src/external/commonwell-v2/patient/patient.ts
@@ -538,7 +538,7 @@ export async function removeInCwV2(patient: Patient, facilityId: string): Promis
 
 async function getCommonwellPatientId(patient: Patient): Promise<string | undefined> {
   const commonwellData = getCWData(patient.data.externalData);
-  if (!commonwellData) return undefined;
+  if (!commonwellData || !commonwellData.patientId) return undefined;
   return getCwV2PatientId(commonwellData.patientId);
 }
 


### PR DESCRIPTION
Part of ENG-000

Signed-off-by: RamilGaripov <ramil@metriport.com>

Issues:

- https://linear.app/metriport/issue/ENG-000

### Description

- The code was erroneously assuming that the CW patient ID always existed if we're trying to update the patient on CW. This patch fixes it

### Testing

- [ ] Rerun the problematic patient on prod

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation before CommonWell v2 patient lookup to ensure a valid patient ID is present. Prevents intermittent errors, reduces failed requests, and improves reliability of patient matching and data retrieval within the integration. Users should experience fewer sync interruptions and more predictable behavior when patient identifiers are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->