### PR TITLE
feat(api): fix e2e consolidated html fail

### DIFF
--- a/packages/api/src/__tests__/e2e/mapi/parts/consolidated.test.part.ts
+++ b/packages/api/src/__tests__/e2e/mapi/parts/consolidated.test.part.ts
@@ -36,6 +36,12 @@ dayjs.extend(duration);
 const conversionCheckStatusMaxRetries = 12;
 const conversionCheckStatusWaitTime = dayjs.duration({ seconds: 10 });
 
+const REQUESTED_MIME_TYPE: Record<string, string> = {
+  json: "application/json",
+  pdf: "application/pdf",
+  html: "text/html",
+};
+
 export function runConsolidatedTests(e2e: E2eContext) {
   it("prepares consolidated", async () => {
     await prepareConsolidatedTests(e2e);
@@ -118,6 +124,7 @@ export function runConsolidatedTests(e2e: E2eContext) {
       if (!e2e.patient) throw new Error("Missing patient");
       const whRequest = getConsolidatedWebhookRequest();
       const consolidatedData = whRequest?.patients;
+      const contentType = REQUESTED_MIME_TYPE[format];
       expect(consolidatedData).toBeTruthy();
       if (!consolidatedData) throw new Error("Missing consolidated data");
       expect(consolidatedData.length).toEqual(1);
@@ -135,9 +142,7 @@ export function runConsolidatedTests(e2e: E2eContext) {
               resourceType: "DocumentReference",
               content: expect.arrayContaining([
                 expect.objectContaining({
-                  attachment: expect.objectContaining({
-                    contentType: `application/${format}`,
-                  }),
+                  attachment: expect.objectContaining({ contentType }),
                 }),
               ]),
             }),


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-000

### Dependencies

- none

### Description

- e2e test fail for staging will be joining this release: https://github.com/metriport/metriport/pull/4623

### Testing


- Local
  - [x] pass e2e 
- Staging
  - [ ] monitor should pass
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened end-to-end validation to ensure consolidated reports are returned with the correct MIME type for each requested format (JSON, PDF, HTML).
  * Improves confidence in format-specific responses and reduces the risk of incorrect content-type headers reaching users.
  * No changes to user-facing functionality; behavior remains the same with increased test coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->