### PR TITLE
ENG-1021: Relax Contact schema on CW

### DIFF
--- a/packages/api/src/external/commonwell-v2/patient/patient-conversion.ts
+++ b/packages/api/src/external/commonwell-v2/patient/patient-conversion.ts
@@ -63,7 +63,7 @@ export function patientToCommonwell({
       if (address.addressLine2) line.push(address.addressLine2);
       return {
         line,
-        postalCode: normalizePostalCode(address.zip),
+        postalCode: address.zip,
         city: address.city,
         state: address.state,
         use: AddressUseCodes.home,
@@ -87,11 +87,6 @@ export function patientToCommonwell({
         return contacts;
       }) ?? [],
   };
-}
-
-function normalizePostalCode(zip: string): string | undefined {
-  if (zip === "00000") return undefined;
-  return zip;
 }
 
 function mapGenderAtBirthToCw(k: GenderAtBirth): GenderCodes | undefined {

--- a/packages/api/src/external/commonwell-v2/patient/patient-conversion.ts
+++ b/packages/api/src/external/commonwell-v2/patient/patient-conversion.ts
@@ -63,7 +63,7 @@ export function patientToCommonwell({
       if (address.addressLine2) line.push(address.addressLine2);
       return {
         line,
-        postalCode: address.zip,
+        postalCode: normalizePostalCode(address.zip),
         city: address.city,
         state: address.state,
         use: AddressUseCodes.home,
@@ -87,6 +87,11 @@ export function patientToCommonwell({
         return contacts;
       }) ?? [],
   };
+}
+
+function normalizePostalCode(zip: string): string | undefined {
+  if (zip === "00000") return undefined;
+  return zip;
 }
 
 function mapGenderAtBirthToCw(k: GenderAtBirth): GenderCodes | undefined {

--- a/packages/commonwell-sdk/src/models/contact.ts
+++ b/packages/commonwell-sdk/src/models/contact.ts
@@ -2,6 +2,20 @@ import { z } from "zod";
 import { emptyStringToUndefinedSchema } from "../common/zod";
 import { periodSchema } from "./period";
 
+/**
+ * Describes the kind of contact.
+ * @see: https://hl7.org/fhir/R4/valueset-contact-point-system.html
+ */
+export enum ContactSystemCodes {
+  phone = "phone",
+  fax = "fax",
+  email = "email",
+  pager = "pager",
+  url = "url",
+  sms = "sms",
+  other = "other",
+}
+
 // A variety of technology-mediated contact details for a person or organization, including
 // telephone, email, etc.
 // See: https://specification.commonwellalliance.org/services/rest-api-reference (8.4.7 Contact)

--- a/packages/commonwell-sdk/src/models/contact.ts
+++ b/packages/commonwell-sdk/src/models/contact.ts
@@ -1,42 +1,13 @@
-import { zodToLowerCase } from "@metriport/shared";
 import { z } from "zod";
 import { emptyStringToUndefinedSchema } from "../common/zod";
 import { periodSchema } from "./period";
-
-/**
- * Describes the kind of contact.
- * @see: https://hl7.org/fhir/R4/valueset-contact-point-system.html
- */
-export enum ContactSystemCodes {
-  phone = "phone",
-  fax = "fax",
-  email = "email",
-  pager = "pager",
-  url = "url",
-  sms = "sms",
-  other = "other",
-}
-export const contactSystemCodesSchema = z
-  .string()
-  .transform(zodToLowerCase)
-  .transform(normalizeContactSystem)
-  .pipe(z.nativeEnum(ContactSystemCodes));
-
-function normalizeContactSystem(system: unknown): unknown {
-  if (typeof system !== "string") return system;
-  switch (system.toLowerCase()) {
-    case "mobile":
-      return "phone";
-  }
-  return system;
-}
 
 // A variety of technology-mediated contact details for a person or organization, including
 // telephone, email, etc.
 // See: https://specification.commonwellalliance.org/services/rest-api-reference (8.4.7 Contact)
 export const contactSchema = z.object({
   value: z.string().nullish(),
-  system: emptyStringToUndefinedSchema.pipe(contactSystemCodesSchema.nullish()),
+  system: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
   use: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
   period: periodSchema.nullish(),
 });


### PR DESCRIPTION
### Description
- Relaxed the schema for the contact.system on CW-SDK

### Testing

- Local
  - [x] Try to get the links for the patient that had issues locally using the new relaxed schemas
- Production
  - [ ] Update the problematic patient

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Contact “system” now accepts any string (including null/undefined), allowing custom values beyond the previous predefined set.

- Refactor
  - Validation for the contact “system” field was relaxed; automatic lower-casing/normalization was removed.

- Documentation
  - Updated type and validation guidance for the contact “system” field to reflect broader input support and nullable values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->