### PR TITLE
ENG-1021: Relax CW schema for contact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31132,7 +31132,7 @@
       }
     },
     "packages/api": {
-      "version": "1.29.4",
+      "version": "1.29.5-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.800.0",
@@ -31218,11 +31218,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "18.0.4",
+      "version": "18.0.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/shared": "^0.26.4",
+        "@metriport/shared": "^0.26.5-alpha.0",
         "axios": "^1.8.2",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -31311,11 +31311,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.20.4",
+      "version": "1.20.5-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.21.4",
-        "@metriport/shared": "^0.26.4"
+        "@metriport/ihe-gateway-sdk": "^0.21.5-alpha.0",
+        "@metriport/shared": "^0.26.5-alpha.0"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -31323,7 +31323,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.9.4",
+      "version": "1.9.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -31347,7 +31347,7 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "2.1.4",
+      "version": "2.1.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "file:packages/commonwell-sdk",
@@ -31444,7 +31444,7 @@
     "packages/commonwell-cert-runner/packages/shared": {},
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.27.4",
+      "version": "1.27.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^5.9.20",
@@ -31555,10 +31555,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "7.0.2",
+      "version": "7.0.3-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.26.4",
+        "@metriport/shared": "^0.26.5-alpha.0",
         "axios": "^1.8.2",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -31606,7 +31606,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.26.4",
+      "version": "1.26.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -32060,7 +32060,7 @@
     "packages/core/packages/shared": {},
     "packages/eslint-rules": {
       "name": "@metriport/eslint-plugin-eslint-rules",
-      "version": "1.2.4",
+      "version": "1.2.5-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/rule-tester": "^6.0.0",
@@ -32076,7 +32076,7 @@
     },
     "packages/fhir-sdk": {
       "name": "@metriport/fhir-sdk",
-      "version": "1.2.4",
+      "version": "1.2.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.2.10",
@@ -32200,17 +32200,17 @@
     "packages/fhir-sdk/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.21.4",
+      "version": "0.21.5-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.26.4",
+        "@metriport/shared": "^0.26.5-alpha.0",
         "axios": "^1.8.2",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.24.4",
+      "version": "1.24.5-alpha.0",
       "dependencies": {
         "@metriport/core": "file:packages/core",
         "@metriport/shared": "file:packages/shared",
@@ -32273,7 +32273,7 @@
     "packages/infra/packages/core": {},
     "packages/infra/packages/shared": {},
     "packages/mllp-server": {
-      "version": "0.5.4",
+      "version": "0.5.5-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@medplum/core": "^3.2.33",
@@ -32474,7 +32474,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.26.4",
+      "version": "0.26.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -32527,7 +32527,7 @@
       "dev": true
     },
     "packages/utils": {
-      "version": "1.27.4",
+      "version": "1.27.5-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.800.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "18.0.4",
+  "version": "18.0.5-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/shared": "^0.26.4",
+    "@metriport/shared": "^0.26.5-alpha.0",
     "axios": "^1.8.2",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.29.4",
+  "version": "1.29.5-alpha.0",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/src/external/commonwell-v2/document/cw-to-fhir.ts
+++ b/packages/api/src/external/commonwell-v2/document/cw-to-fhir.ts
@@ -71,11 +71,12 @@ export function cwToFHIR(
       system: doc.masterIdentifier?.system ?? undefined,
       value: doc.masterIdentifier?.value ?? docId,
     },
-    identifier: (doc.identifier?.map(id => ({
-      system: id.system ?? undefined,
-      value: id.value,
-      use: id.use ?? undefined,
-    })) ?? []) as Identifier[],
+    identifier:
+      doc.identifier?.map(id => ({
+        system: id.system ?? undefined,
+        value: id.value,
+        use: (id.use as Identifier["use"]) ?? undefined,
+      })) ?? [],
     date,
     status: doc.status,
     type: doc.type ?? undefined,

--- a/packages/api/src/external/commonwell-v2/document/cw-to-fhir.ts
+++ b/packages/api/src/external/commonwell-v2/document/cw-to-fhir.ts
@@ -1,4 +1,4 @@
-import { DocumentReference, DocumentReferenceContext } from "@medplum/fhirtypes";
+import { DocumentReference, DocumentReferenceContext, Identifier } from "@medplum/fhirtypes";
 import { DocumentReference as CwDocumentReference } from "@metriport/commonwell-sdk";
 import { Patient } from "@metriport/core/domain/patient";
 import { cwExtension } from "@metriport/core/external/commonwell/extension";
@@ -71,12 +71,11 @@ export function cwToFHIR(
       system: doc.masterIdentifier?.system ?? undefined,
       value: doc.masterIdentifier?.value ?? docId,
     },
-    identifier:
-      doc.identifier?.map(id => ({
-        system: id.system ?? undefined,
-        value: id.value,
-        use: id.use ?? undefined,
-      })) ?? [],
+    identifier: (doc.identifier?.map(id => ({
+      system: id.system ?? undefined,
+      value: id.value,
+      use: id.use ?? undefined,
+    })) ?? []) as Identifier[],
     date,
     status: doc.status,
     type: doc.type ?? undefined,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.20.4",
+  "version": "1.20.5-alpha.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.21.4",
-    "@metriport/shared": "^0.26.4"
+    "@metriport/ihe-gateway-sdk": "^0.21.5-alpha.0",
+    "@metriport/shared": "^0.26.5-alpha.0"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.9.4",
+  "version": "1.9.5-alpha.0",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "2.1.4",
+  "version": "2.1.5-alpha.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.27.4",
+  "version": "1.27.5-alpha.0",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "7.0.2",
+  "version": "7.0.3-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.26.4",
+    "@metriport/shared": "^0.26.5-alpha.0",
     "axios": "^1.8.2",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/commonwell-sdk/src/models/address.ts
+++ b/packages/commonwell-sdk/src/models/address.ts
@@ -1,4 +1,4 @@
-import { normalizeState, zodToLowerCase } from "@metriport/shared";
+import { normalizeState } from "@metriport/shared";
 import { z } from "zod";
 import { emptyStringToUndefinedSchema } from "../common/zod";
 import { periodSchema } from "./period";
@@ -14,14 +14,12 @@ export enum AddressUseCodes {
   old = "old",
   billing = "billing",
 }
-export const addressUseCodesSchema = z.preprocess(zodToLowerCase, z.nativeEnum(AddressUseCodes));
 
 export enum AddressTypeCodes {
   postal = "postal",
   physical = "physical",
   both = "both",
 }
-export const addressTypeCodesSchema = z.preprocess(zodToLowerCase, z.nativeEnum(AddressTypeCodes));
 
 // A postal address.
 // See: https://specification.commonwellalliance.org/services/rest-api-reference (8.4.3 Address)
@@ -31,8 +29,8 @@ export const addressSchema = z.object({
   state: z.preprocess(normalizeStatePreprocess, z.string().nullish()),
   country: emptyStringToUndefinedSchema,
   postalCode: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
-  use: emptyStringToUndefinedSchema.pipe(addressUseCodesSchema.nullish()),
-  type: emptyStringToUndefinedSchema.pipe(addressTypeCodesSchema.nullish()),
+  use: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
+  type: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
   period: periodSchema.nullish(),
 });
 export type Address = z.infer<typeof addressSchema>;

--- a/packages/commonwell-sdk/src/models/contact.ts
+++ b/packages/commonwell-sdk/src/models/contact.ts
@@ -1,4 +1,3 @@
-import { zodToLowerCase } from "@metriport/shared";
 import { z } from "zod";
 import { emptyStringToUndefinedSchema } from "../common/zod";
 import { periodSchema } from "./period";
@@ -16,27 +15,13 @@ export enum ContactSystemCodes {
   sms = "sms",
   other = "other",
 }
-export const contactSystemCodesSchema = z
-  .string()
-  .transform(zodToLowerCase)
-  .transform(normalizeContactSystem)
-  .pipe(z.nativeEnum(ContactSystemCodes));
-
-function normalizeContactSystem(system: unknown): unknown {
-  if (typeof system !== "string") return system;
-  switch (system.toLowerCase()) {
-    case "mobile":
-      return "phone";
-  }
-  return system;
-}
 
 // A variety of technology-mediated contact details for a person or organization, including
 // telephone, email, etc.
 // See: https://specification.commonwellalliance.org/services/rest-api-reference (8.4.7 Contact)
 export const contactSchema = z.object({
   value: z.string().nullish(),
-  system: emptyStringToUndefinedSchema.pipe(contactSystemCodesSchema.nullish()),
+  system: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
   use: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
   period: periodSchema.nullish(),
 });

--- a/packages/commonwell-sdk/src/models/human-name.ts
+++ b/packages/commonwell-sdk/src/models/human-name.ts
@@ -1,10 +1,5 @@
-import { zodToLowerCase } from "@metriport/shared";
 import { z } from "zod";
-import {
-  emptyStringToUndefined,
-  emptyStringToUndefinedSchema,
-  literalStringToUndefined,
-} from "../common/zod";
+import { emptyStringToUndefined, emptyStringToUndefinedSchema } from "../common/zod";
 import { periodSchema } from "./period";
 
 /**
@@ -20,7 +15,6 @@ export enum NameUseCodes {
   old = "old",
   maiden = "maiden",
 }
-export const nameUseCodesSchema = z.preprocess(zodToLowerCase, z.nativeEnum(NameUseCodes));
 
 // A name of a Person with text, parts and usage information.
 // Names may be changed or repudiated. People may have different names in different contexts.
@@ -42,9 +36,7 @@ export const humanNameSchema = z.object({
     emptyStringToUndefined,
     z.string().or(z.array(z.string().nullish())).nullish()
   ),
-  use: emptyStringToUndefinedSchema.pipe(
-    z.preprocess(literalStringToUndefined, nameUseCodesSchema.nullish())
-  ),
+  use: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
   period: periodSchema.nullish(),
   text: z.string().nullish(),
 });

--- a/packages/commonwell-sdk/src/models/identifier.ts
+++ b/packages/commonwell-sdk/src/models/identifier.ts
@@ -2,42 +2,6 @@ import { z } from "zod";
 import { emptyStringToUndefinedSchema } from "../common/zod";
 import { periodSchema } from "./period";
 
-// See: https://hl7.org/fhir/R4/valueset-identifier-use.html
-export const identifierUseCodesSchema = z.enum(["usual", "official", "temp", "secondary", "old"]);
-export type IdentifierUseCodes = z.infer<typeof identifierUseCodesSchema>;
-
-export const strongIdentifierTypeCodesSchema = z.enum([
-  "SS", // Social Security Number
-  "DL", // Driver's license number
-  "PPN", // Passport number
-]);
-export type StrongIdentifierTypeCodes = z.infer<typeof strongIdentifierTypeCodesSchema>;
-
-export const regularIdentifierTypeCodesSchema = z.enum([
-  "BRN", // Breed Registry Number
-  "MR", // Medical record number
-  "MCN", // Microchip Number
-  "EN", // Employer number
-  "TAX", // Tax ID number
-  "NIIP", // National Insurance Payor Identifier (Payor)
-  "PRN", // Provider number
-  "MD", // Medical License number
-  "DR", // Donor Registration Number
-  "ACSN", // Accession ID
-  "UDI", // Universal Device Identifier
-  "SNO", // Serial Number
-  "SB", // Social Beneficiary Identifier
-  "PLAC", // Placer Identifier
-  "FILL", // Filler Identifier
-  "IAL2", // Identify proofing - see 11.1 on https://www.commonwellalliance.org/specification/
-  "IAL3", // Identify proofing - see 11.1 on https://www.commonwellalliance.org/specification/
-]);
-const identifierTypeCodesSchema = z.enum([
-  ...strongIdentifierTypeCodesSchema.options,
-  ...regularIdentifierTypeCodesSchema.options,
-] as const);
-export type IdentifierTypeCodes = z.infer<typeof identifierTypeCodesSchema>;
-
 export enum KnownIdentifierSystems {
   SSN = "http://hl7.org/fhir/sid/us-ssn",
   NPI = "http://hl7.org/fhir/sid/us-npi",
@@ -66,8 +30,8 @@ export type PatientIdentifier = z.infer<typeof patientIdentifierSchema>;
 export const identifierSchema = z.object({
   value: z.string(),
   system: z.string().nullish(),
-  use: emptyStringToUndefinedSchema.pipe(identifierUseCodesSchema.nullish()),
-  type: emptyStringToUndefinedSchema.pipe(identifierTypeCodesSchema.nullish()),
+  use: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
+  type: emptyStringToUndefinedSchema.pipe(z.string().nullish()),
   assigner: referenceInIdentifierSchema.nullish(),
   period: periodSchema.nullish(),
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.26.4",
+  "version": "1.26.5-alpha.0",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/eslint-rules/package.json
+++ b/packages/eslint-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/eslint-plugin-eslint-rules",
-  "version": "1.2.4",
+  "version": "1.2.5-alpha.0",
   "description": "Custom ESLint rules for Metriport's monorepo",
   "main": "index.js",
   "keywords": [

--- a/packages/fhir-sdk/package.json
+++ b/packages/fhir-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/fhir-sdk",
-  "version": "1.2.4",
+  "version": "1.2.5-alpha.0",
   "private": true,
   "description": "FHIR Bundle SDK for parsing, querying, and manipulating FHIR bundles with reference resolution",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.21.4",
+  "version": "0.21.5-alpha.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.26.4",
+    "@metriport/shared": "^0.26.5-alpha.0",
     "axios": "^1.8.2",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.24.4",
+  "version": "1.24.5-alpha.0",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mllp-server",
-  "version": "0.5.4",
+  "version": "0.5.5-alpha.0",
   "description": "MLLP server that reads HL7 messages off of a raw tcp connection",
   "main": "app.js",
   "private": true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.26.4",
+  "version": "0.26.5-alpha.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.27.4",
+  "version": "1.27.5-alpha.0",
   "description": "",
   "private": true,
   "scripts": {


### PR DESCRIPTION
### Description
- Relaxed the schema for the contact.system on CW-SDK

### Testing

- Local
  - [x] Try to get the links for the patient that had issues locally using the new relaxed schemas
  - [x] Run the cert-runner flow 
- Production
  - [ ] Update the problematic patient

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Relaxed validation for contact, address, name, and identifier fields so they accept free-form strings instead of restricted code sets or normalized values.
* **Chores**
  * Removed automatic normalization and enum-based validation for those fields.
  * Clarified a type annotation for document identifiers (no runtime change).
  * Bumped multiple package versions to alpha releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->