### PR TITLE
chore(release): publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31132,7 +31132,7 @@
       }
     },
     "packages/api": {
-      "version": "1.29.5-alpha.0",
+      "version": "1.29.5",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.800.0",
@@ -31218,11 +31218,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "18.0.5-alpha.0",
+      "version": "18.0.5",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/shared": "^0.26.5-alpha.0",
+        "@metriport/shared": "^0.26.5",
         "axios": "^1.8.2",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -31311,11 +31311,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.20.5-alpha.0",
+      "version": "1.20.5",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.21.5-alpha.0",
-        "@metriport/shared": "^0.26.5-alpha.0"
+        "@metriport/ihe-gateway-sdk": "^0.21.5",
+        "@metriport/shared": "^0.26.5"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -31323,7 +31323,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.9.5-alpha.0",
+      "version": "1.9.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -31347,7 +31347,7 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "2.1.5-alpha.0",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "file:packages/commonwell-sdk",
@@ -31444,7 +31444,7 @@
     "packages/commonwell-cert-runner/packages/shared": {},
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.27.5-alpha.0",
+      "version": "1.27.5",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^5.9.20",
@@ -31555,10 +31555,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "7.0.3-alpha.0",
+      "version": "7.0.3",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.26.5-alpha.0",
+        "@metriport/shared": "^0.26.5",
         "axios": "^1.8.2",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -31606,7 +31606,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.26.5-alpha.0",
+      "version": "1.26.5",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -32060,7 +32060,7 @@
     "packages/core/packages/shared": {},
     "packages/eslint-rules": {
       "name": "@metriport/eslint-plugin-eslint-rules",
-      "version": "1.2.5-alpha.0",
+      "version": "1.2.5",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/rule-tester": "^6.0.0",
@@ -32076,7 +32076,7 @@
     },
     "packages/fhir-sdk": {
       "name": "@metriport/fhir-sdk",
-      "version": "1.2.5-alpha.0",
+      "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.2.10",
@@ -32200,17 +32200,17 @@
     "packages/fhir-sdk/packages/shared": {},
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.21.5-alpha.0",
+      "version": "0.21.5",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.26.5-alpha.0",
+        "@metriport/shared": "^0.26.5",
         "axios": "^1.8.2",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.24.5-alpha.0",
+      "version": "1.24.5",
       "dependencies": {
         "@metriport/core": "file:packages/core",
         "@metriport/shared": "file:packages/shared",
@@ -32273,7 +32273,7 @@
     "packages/infra/packages/core": {},
     "packages/infra/packages/shared": {},
     "packages/mllp-server": {
-      "version": "0.5.5-alpha.0",
+      "version": "0.5.5",
       "license": "ISC",
       "dependencies": {
         "@medplum/core": "^3.2.33",
@@ -32474,7 +32474,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.26.5-alpha.0",
+      "version": "0.26.5",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -32527,7 +32527,7 @@
       "dev": true
     },
     "packages/utils": {
-      "version": "1.27.5-alpha.0",
+      "version": "1.27.5",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.800.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "18.0.5-alpha.0",
+  "version": "18.0.5",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/shared": "^0.26.5-alpha.0",
+    "@metriport/shared": "^0.26.5",
     "axios": "^1.8.2",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.29.5-alpha.0",
+  "version": "1.29.5",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.20.5-alpha.0",
+  "version": "1.20.5",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.21.5-alpha.0",
-    "@metriport/shared": "^0.26.5-alpha.0"
+    "@metriport/ihe-gateway-sdk": "^0.21.5",
+    "@metriport/shared": "^0.26.5"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.9.5-alpha.0",
+  "version": "1.9.5",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "2.1.5-alpha.0",
+  "version": "2.1.5",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.27.5-alpha.0",
+  "version": "1.27.5",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "7.0.3-alpha.0",
+  "version": "7.0.3",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.26.5-alpha.0",
+    "@metriport/shared": "^0.26.5",
     "axios": "^1.8.2",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.26.5-alpha.0",
+  "version": "1.26.5",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/eslint-rules/package.json
+++ b/packages/eslint-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/eslint-plugin-eslint-rules",
-  "version": "1.2.5-alpha.0",
+  "version": "1.2.5",
   "description": "Custom ESLint rules for Metriport's monorepo",
   "main": "index.js",
   "keywords": [

--- a/packages/fhir-sdk/package.json
+++ b/packages/fhir-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/fhir-sdk",
-  "version": "1.2.5-alpha.0",
+  "version": "1.2.5",
   "private": true,
   "description": "FHIR Bundle SDK for parsing, querying, and manipulating FHIR bundles with reference resolution",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.21.5-alpha.0",
+  "version": "0.21.5",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.26.5-alpha.0",
+    "@metriport/shared": "^0.26.5",
     "axios": "^1.8.2",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.24.5-alpha.0",
+  "version": "1.24.5",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mllp-server",
-  "version": "0.5.5-alpha.0",
+  "version": "0.5.5",
   "description": "MLLP server that reads HL7 messages off of a raw tcp connection",
   "main": "app.js",
   "private": true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.26.5-alpha.0",
+  "version": "0.26.5",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.27.5-alpha.0",
+  "version": "1.27.5",
   "description": "",
   "private": true,
   "scripts": {


### PR DESCRIPTION
### Description

- Package release for 
- https://github.com/metriport/metriport/pull/4626

Ref: #000

 - api@1.29.5
 - @metriport/api-sdk@18.0.5
 - @metriport/carequality-cert-runner@1.20.5
 - @metriport/carequality-sdk@1.9.5
 - @metriport/commonwell-cert-runner@2.1.5
 - @metriport/commonwell-jwt-maker@1.27.5
 - @metriport/commonwell-sdk@7.0.3
 - @metriport/core@1.26.5
 - @metriport/eslint-plugin-eslint-rules@1.2.5
 - @metriport/fhir-sdk@1.2.5
 - @metriport/ihe-gateway-sdk@0.21.5
 - infrastructure@1.24.5
 - mllp-server@0.5.5
 - @metriport/shared@0.26.5
 - utils@1.27.5

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1021

### Description
- NPM prod release

### Testing
- n/a

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Promoted multiple packages from pre-release (alpha) to stable versions across SDKs, services, and tooling.
  - Updated shared dependencies to stable releases for consistency across the stack.
  - No functional changes; existing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->