### PR TITLE
ENG-1059 Improved retry logic on CW

### DIFF
--- a/packages/api/src/external/commonwell-v2/command/organization/organization.ts
+++ b/packages/api/src/external/commonwell-v2/command/organization/organization.ts
@@ -10,6 +10,7 @@ import { OrganizationData } from "@metriport/core/domain/organization";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import {
+  defaultOptionsRequestNotAccepted,
   errorToString,
   executeWithNetworkRetries,
   getEnvVarOrFail,
@@ -18,6 +19,7 @@ import {
   TreatmentType,
   USState,
 } from "@metriport/shared";
+import { AxiosError } from "axios";
 import { Config } from "../../../../shared/config";
 import { getCertificate, makeCommonWellMemberAPI } from "../../api";
 
@@ -152,7 +154,12 @@ export async function get(orgOid: string): Promise<CwSdkOrganization | undefined
   const { log, debug } = out(`CW.v2.org get - CW Org OID ${orgOid}`);
   const commonWell = makeCommonWellMemberAPI();
   try {
-    const resp = await executeWithNetworkRetries(() => commonWell.getOneOrg(orgOid));
+    const resp = await executeWithNetworkRetries(() => commonWell.getOneOrg(orgOid), {
+      httpCodesToRetry: [
+        ...defaultOptionsRequestNotAccepted.httpCodesToRetry,
+        AxiosError.ECONNABORTED,
+      ],
+    });
     debug(`resp getOneOrg: `, JSON.stringify(resp));
     return resp;
   } catch (error) {


### PR DESCRIPTION
Ref eng-1059

Signed-off-by: Rafael Leite <2132564+leite08@users.noreply.github.com>

### Description
- Improved the get org on CW to retry on certain error statuses

### Testing
- Local
  - [x] Get org from CW
  - [x] Update org thru ops dash

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of organization data retrieval in the CommonWell integration by adding retries for certain network timeouts.
  * Reduces intermittent request failures and transient error messages during periods of network instability, resulting in a smoother, more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->