### PR TITLE
Eng 1036 improve email validation

### DIFF
--- a/docs/_snippets/demographics.mdx
+++ b/docs/_snippets/demographics.mdx
@@ -1,7 +1,9 @@
 <Info>
-  You may provide a comma/space delimited string to specify multiple first and last names. For
-  example, the following inputs would be equivalent: `"John,Jonathan"` & `"John Jonathan"` - these
-  would translate to `["John", "Jonathan"]`.
+  You may provide a comma/space delimited string to specify
+  multiple first and last names. For example, the following
+  inputs would be equivalent: `"John,Jonathan"` & `"John
+  Jonathan"` - these would translate to `["John",
+  "Jonathan"]`.
 </Info>
 
 <ParamField body="firstName" type="string" required>
@@ -13,12 +15,16 @@
 </ParamField>
 
 <ParamField body="dob" type="string" required>
-  The Patient's date of birth (DOB), formatted `YYYY-MM-DD` as per [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601).
+  The Patient's date of birth (DOB), formatted `YYYY-MM-DD`
+  as per [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601).
 </ParamField>
 
 <ParamField body="genderAtBirth" type="string" required>
-  The Patient's gender at birth, can be one of `M` or `F` or `O` or `U`. Use `O` (other) when the patient's gender is known but it is not `M` or `F`, i.e intersex or hermaphroditic. 
-  Use U (unknown) when the patient's gender is not known.
+  The Patient's gender at birth, can be one of `M` or `F` or
+  `O` or `U`. Use `O` (other) when the patient's gender is
+  known but it is not `M` or `F`, i.e intersex or
+  hermaphroditic. Use U (unknown) when the patient's gender
+  is not known.
 </ParamField>
 
 <ParamField body="personalIdentifiers" type="PersonalIdentifier[]" optional>
@@ -54,7 +60,22 @@
     </ParamField>
 
     <ParamField body="email" type="string">
-      The Patient's email address.
+      The Patient's email address. Supports a wide range of valid email formats including special characters.
+
+      **Valid email examples:**
+      - `user@example.com`
+      - `test!user@example.com`
+      - `user+tag@example.com`
+      - `user_name@example.com`
+      - `user-name@example.com`
+      - `user.name@example.com`
+
+      **Invalid email examples:**
+      - `invalid-email` (missing @ and domain)
+      - `user@` (missing domain)
+      - `@example.com` (missing local part)
+      - `+1234567890@example.com` (phone number format)
+      - `mailto:user@example.com` (mailto: prefix not allowed)
     </ParamField>
 
   </Expandable>

--- a/package-lock.json
+++ b/package-lock.json
@@ -30492,8 +30492,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.9.0",
-      "license": "MIT",
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -31227,6 +31228,7 @@
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
         "semver": ">=5.7.2",
+        "validator": "^13.15.15",
         "zod": "^3.22.1"
       },
       "devDependencies": {
@@ -32484,6 +32486,7 @@
         "http-status": "~1.7.0",
         "lodash": "^4.17.21",
         "semver": ">=5.7.2",
+        "validator": "^13.15.15",
         "zod": "^3.22.1"
       },
       "devDependencies": {

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -63,6 +63,7 @@
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",
     "semver": ">=5.7.2",
+    "validator": "^13.15.15",
     "zod": "^3.22.1"
   },
   "devDependencies": {

--- a/packages/api-sdk/src/medical/models/__tests__/demographics.test.ts
+++ b/packages/api-sdk/src/medical/models/__tests__/demographics.test.ts
@@ -31,6 +31,12 @@ describe("demographicsSchema", () => {
       "user123@metriport.com",
       "123user@metriport.com",
       "user@metriport.com.br",
+      "test!user@example.com",
+      "test+user@example.com",
+      "test_user@example.com",
+      "test-user@example.com",
+      "test.user@example.com",
+      "test_user+test@example.com",
     ];
     const casesToFail: (string | null | undefined)[] = [
       null,

--- a/packages/api-sdk/src/medical/models/demographics.ts
+++ b/packages/api-sdk/src/medical/models/demographics.ts
@@ -5,6 +5,7 @@ import {
   normalizeUsPhoneWithPlusOne,
   phoneLength,
   validDateOfBirthStringSchema,
+  isEmailValid,
 } from "@metriport/shared";
 import { z } from "zod";
 import { addressSchema } from "./common/address";
@@ -56,7 +57,9 @@ export type PersonalIdentifier = z.infer<typeof personalIdentifierSchema>;
 
 export const genderAtBirthSchema = z.enum(["F", "M", "O", "U"]);
 
-export const emailSchema = z.string().email();
+export const emailSchema = z.string().refine(isEmailValid, {
+  message: "Invalid email address",
+});
 
 export const contactSchema = z
   .object({

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -98,6 +98,7 @@
     "http-status": "~1.7.0",
     "lodash": "^4.17.21",
     "semver": ">=5.7.2",
+    "validator": "^13.15.15",
     "zod": "^3.22.1"
   },
   "devDependencies": {

--- a/packages/shared/src/domain/contact/__tests__/email.test.ts
+++ b/packages/shared/src/domain/contact/__tests__/email.test.ts
@@ -1,6 +1,6 @@
 import {
   isEmailValid,
-  isPhoneNumberFormat,
+  isEmailAPhoneNumber,
   normalizeEmail,
   normalizeEmailStrict,
   normalizeEmailNewSafe,
@@ -56,21 +56,21 @@ describe("Email Utility Functions", () => {
     });
   });
 
-  describe("isPhoneNumberFormat", () => {
+  describe("isEmailAPhoneNumber", () => {
     it("should return true for phone number format", () => {
-      expect(isPhoneNumberFormat("+1234567890")).toBe(true);
-      expect(isPhoneNumberFormat("+1-234-567-8900")).toBe(true);
-      expect(isPhoneNumberFormat("+1 (234) 567-8900")).toBe(true);
+      expect(isEmailAPhoneNumber("+1234567890")).toBe(true);
+      expect(isEmailAPhoneNumber("+1-234-567-8900")).toBe(true);
+      expect(isEmailAPhoneNumber("+1 (234) 567-8900")).toBe(true);
     });
 
     it("should return false for regular email", () => {
-      expect(isPhoneNumberFormat("test@example.com")).toBe(false);
-      expect(isPhoneNumberFormat("user+tag@example.com")).toBe(false);
+      expect(isEmailAPhoneNumber("test@example.com")).toBe(false);
+      expect(isEmailAPhoneNumber("user+tag@example.com")).toBe(false);
     });
 
     it("should handle whitespace", () => {
-      expect(isPhoneNumberFormat(" +1234567890")).toBe(true);
-      expect(isPhoneNumberFormat(" +1-234-567-8900")).toBe(true);
+      expect(isEmailAPhoneNumber(" +1234567890")).toBe(true);
+      expect(isEmailAPhoneNumber(" +1-234-567-8900")).toBe(true);
     });
   });
 

--- a/packages/shared/src/domain/contact/__tests__/email.test.ts
+++ b/packages/shared/src/domain/contact/__tests__/email.test.ts
@@ -1,5 +1,6 @@
 import {
   isEmailValid,
+  isPhoneNumberFormat,
   normalizeEmail,
   normalizeEmailStrict,
   normalizeEmailNewSafe,
@@ -23,6 +24,54 @@ describe("Email Utility Functions", () => {
     it('should return false for email with "mailto:" prefix', () => {
       expect(isEmailValid("mailto:test@example.com")).toBe(false);
     });
+
+    it("should return true for email with exclamation mark", () => {
+      expect(isEmailValid("test!user@example.com")).toBe(true);
+    });
+
+    it("should return true for email with other valid special characters", () => {
+      expect(isEmailValid("test#user@example.com")).toBe(true);
+      expect(isEmailValid("test$user@example.com")).toBe(true);
+      expect(isEmailValid("test%user@example.com")).toBe(true);
+      expect(isEmailValid("test&user@example.com")).toBe(true);
+      expect(isEmailValid("test'user@example.com")).toBe(true);
+      expect(isEmailValid("test*user@example.com")).toBe(true);
+      expect(isEmailValid("test+user@example.com")).toBe(true);
+      expect(isEmailValid("test-user@example.com")).toBe(true);
+      expect(isEmailValid("test/user@example.com")).toBe(true);
+      expect(isEmailValid("test=user@example.com")).toBe(true);
+      expect(isEmailValid("test?user@example.com")).toBe(true);
+      expect(isEmailValid("test^user@example.com")).toBe(true);
+      expect(isEmailValid("test_user@example.com")).toBe(true);
+      expect(isEmailValid("test`user@example.com")).toBe(true);
+      expect(isEmailValid("test{user@example.com")).toBe(true);
+      expect(isEmailValid("test|user@example.com")).toBe(true);
+      expect(isEmailValid("test}user@example.com")).toBe(true);
+      expect(isEmailValid("test~user@example.com")).toBe(true);
+    });
+
+    it("should return false for phone number format (+1 prefix)", () => {
+      expect(isEmailValid("+1234567890@example.com")).toBe(false);
+      expect(isEmailValid("+1-234-567-8900@example.com")).toBe(false);
+    });
+  });
+
+  describe("isPhoneNumberFormat", () => {
+    it("should return true for phone number format", () => {
+      expect(isPhoneNumberFormat("+1234567890")).toBe(true);
+      expect(isPhoneNumberFormat("+1-234-567-8900")).toBe(true);
+      expect(isPhoneNumberFormat("+1 (234) 567-8900")).toBe(true);
+    });
+
+    it("should return false for regular email", () => {
+      expect(isPhoneNumberFormat("test@example.com")).toBe(false);
+      expect(isPhoneNumberFormat("user+tag@example.com")).toBe(false);
+    });
+
+    it("should handle whitespace", () => {
+      expect(isPhoneNumberFormat(" +1234567890")).toBe(true);
+      expect(isPhoneNumberFormat(" +1-234-567-8900")).toBe(true);
+    });
   });
 
   describe("normalizeEmail", () => {
@@ -40,12 +89,22 @@ describe("Email Utility Functions", () => {
       expect(normalizeEmailStrict("  Test@Example.COM  ")).toBe("test@example.com");
     });
 
+    it("should return normalized email with special characters", () => {
+      expect(normalizeEmailStrict("  Test!User@Example.COM  ")).toBe("test!user@example.com");
+    });
+
     it("should throw an error for invalid email format", () => {
       expect(() => normalizeEmailStrict("invalid-email")).toThrow("Invalid email.");
     });
 
     it('should throw an error for email with "mailto:" prefix', () => {
       expect(() => normalizeEmailStrict("mailto:test@example.com")).toThrow("Invalid email.");
+    });
+
+    it("should throw specific error for phone number format", () => {
+      expect(() => normalizeEmailStrict("+1234567890@example.com")).toThrow(
+        "Invalid email: appears to be a phone number (starts with +1). Please enter a valid email address."
+      );
     });
   });
 });
@@ -86,14 +145,24 @@ describe("email", () => {
       expect(normalizeEmailNewSafe(input)).toBe(expectedOutput);
     });
 
-    it("should relace mailto: prefix", () => {
+    it("should replace mailto: prefix", () => {
       const expectedOutput = exampleEmail;
       const input = "mailto:" + expectedOutput;
       expect(normalizeEmailNewSafe(input)).toBe(expectedOutput);
     });
 
-    it("should return undefined for emails that invalid", () => {
+    it("should return undefined for emails that are invalid", () => {
       const input = "this.is.not.an.email";
+      expect(normalizeEmailNewSafe(input)).toBeUndefined();
+    });
+
+    it("should handle emails with special characters", () => {
+      const input = "test!user@example.com";
+      expect(normalizeEmailNewSafe(input)).toBe("test!user@example.com");
+    });
+
+    it("should return undefined for phone number format", () => {
+      const input = "+1234567890@example.com";
       expect(normalizeEmailNewSafe(input)).toBeUndefined();
     });
   });

--- a/packages/shared/src/domain/contact/email.ts
+++ b/packages/shared/src/domain/contact/email.ts
@@ -1,8 +1,11 @@
-import { z } from "zod";
 import { BadRequestError } from "../../error/bad-request";
 
 export const exampleEmail = "test@test.com";
 const mailtoPrefix = "mailto:";
+
+// Enhanced email validation that properly handles RFC 5322 characters
+const EMAIL_REGEX =
+  /^(?=.{1,254}$)(?=.{1,64}@)[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$/;
 
 export function isEmail(email: string): boolean {
   return email.includes("@");
@@ -11,9 +14,21 @@ export function isEmail(email: string): boolean {
 export function isEmailValid(email: string): boolean {
   if (!email) return false;
   if (email.length === 0) return false;
-  const safeParseEmail = z.string().email().safeParse(email);
-  if (!safeParseEmail.success) return false;
-  return true;
+
+  // Check for phone number format (+1 prefix)
+  if (email.startsWith("+1")) {
+    return false;
+  }
+
+  // Use our enhanced regex instead of Zod's potentially too-strict validation
+  return EMAIL_REGEX.test(email);
+}
+
+/**
+ * Checks if an email appears to be a phone number (starts with +1)
+ */
+export function isPhoneNumberFormat(email: string): boolean {
+  return email.trim().startsWith("+1");
 }
 
 /**
@@ -29,7 +44,14 @@ export function normalizeEmail(email: string): string {
  */
 export function normalizeEmailStrict(email: string): string {
   const normalEmail = normalizeEmail(email);
-  if (!isEmailValid(normalEmail)) throw new Error("Invalid email.");
+  if (!isEmailValid(normalEmail)) {
+    if (isPhoneNumberFormat(email)) {
+      throw new Error(
+        "Invalid email: appears to be a phone number (starts with +1). Please enter a valid email address."
+      );
+    }
+    throw new Error("Invalid email.");
+  }
   return normalEmail;
 }
 
@@ -67,6 +89,13 @@ export function normalizeEmailNewSafe(
 export function normalizeEmailNew(email: string): string {
   const emailOrUndefined = normalizeEmailNewSafe(email);
   if (!emailOrUndefined) {
+    if (isPhoneNumberFormat(email)) {
+      throw new BadRequestError(
+        "Invalid email: appears to be a phone number (starts with +1). Please enter a valid email address.",
+        undefined,
+        { email }
+      );
+    }
     throw new BadRequestError("Invalid email", undefined, { email });
   }
   return emailOrUndefined;

--- a/packages/shared/src/domain/contact/email.ts
+++ b/packages/shared/src/domain/contact/email.ts
@@ -25,6 +25,8 @@ export function isEmailValid(email: string): boolean {
 
 /**
  * Checks if an email appears to be a phone number (starts with +1)
+ * This has been decided by the team to be an invalid email, and we should not allow it.
+ * This means the +1iamarealuser@example.com is an invalid email to us, even though it is technically a valid email.
  */
 export function isEmailAPhoneNumber(email: string): boolean {
   return email.trim().startsWith("+1");
@@ -45,8 +47,10 @@ export function normalizeEmailStrict(email: string): string {
   const normalEmail = normalizeEmail(email);
   if (!isEmailValid(normalEmail)) {
     if (isEmailAPhoneNumber(email)) {
-      throw new Error(
-        "Invalid email: appears to be a phone number (starts with +1). Please enter a valid email address."
+      throw new BadRequestError(
+        "Invalid email: appears to be a phone number (starts with +1). Please enter a valid email address.",
+        undefined,
+        { email }
       );
     }
     throw new Error("Invalid email.");

--- a/packages/utils/src/bulk-insert-patients.ts
+++ b/packages/utils/src/bulk-insert-patients.ts
@@ -8,6 +8,7 @@ import { sleep } from "@metriport/core/util/sleep";
 import {
   getEnvVar,
   isEmailValid,
+  isPhoneNumber,
   isPhoneValid,
   normalizeDob,
   normalizeEmail,
@@ -292,7 +293,14 @@ export function normalizeEmailUtils(email: string | undefined): string | undefin
   if (email == undefined) return undefined;
   const normalEmail = normalizeEmail(email);
   if (normalEmail.length === 0) return undefined;
-  if (!isEmailValid(normalEmail)) throw new Error("Invalid Email");
+  if (!isEmailValid(normalEmail)) {
+    if (isPhoneNumber(email)) {
+      throw new Error(
+        "Invalid Email: appears to be a phone number (starts with +1). Please enter a valid email address."
+      );
+    }
+    throw new Error("Invalid Email");
+  }
   return normalEmail;
 }
 

--- a/packages/utils/src/bulk-insert-patients.ts
+++ b/packages/utils/src/bulk-insert-patients.ts
@@ -8,7 +8,7 @@ import { sleep } from "@metriport/core/util/sleep";
 import {
   getEnvVar,
   isEmailValid,
-  isPhoneNumber,
+  isEmailAPhoneNumber,
   isPhoneValid,
   normalizeDob,
   normalizeEmail,
@@ -294,7 +294,7 @@ export function normalizeEmailUtils(email: string | undefined): string | undefin
   const normalEmail = normalizeEmail(email);
   if (normalEmail.length === 0) return undefined;
   if (!isEmailValid(normalEmail)) {
-    if (isPhoneNumber(email)) {
+    if (isEmailAPhoneNumber(email)) {
       throw new Error(
         "Invalid Email: appears to be a phone number (starts with +1). Please enter a valid email address."
       );


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-1036

### Dependencies

- Upstream: None
- Downstream: https://github.com/metriport/metriport-internal/pull/3255

### Description

Zod's email check isn't a fully comprehensive check (article from Zod's maintainer [here](https://colinhacks.com/essays/reasonable-email-regex)), so adding the validator package's isEmail accounts for more edge cases.

- Augmented zod's `string().email().safeParse` with validator package
  - Handles `!` in email edge case
  - Handles phone numbers being sent as emails (starting with `+1`) 
- Added more comprehensive testing 

### Testing

- Local
  - [x] Ran updated test suite
- Staging
  - [x] Updated email for test account

Check each PR.

### Release Plan

This update (given existing unit tests) should be backwards compatible with what we currently have, and if we are notified of new errors we can roll back the change

- [x] No dependencies between API and Infra that will cause errors during deployment
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader email acceptance supporting many special characters in the local part and improved normalization.
  * New detection that treats phone-number-like inputs specially and returns a clear, specific error message.

* **Bug Fixes**
  * Prevents valid emails with special characters from being rejected or altered.

* **Documentation**
  * Expanded email docs with supported formats and explicit valid/invalid examples.

* **Chores**
  * Added a validated email library dependency to strengthen checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->