### PR TITLE
PATCH: find doc ref by master id

### DIFF
--- a/packages/api/src/command/hie/unlink-patient-from-organization.ts
+++ b/packages/api/src/command/hie/unlink-patient-from-organization.ts
@@ -227,9 +227,9 @@ function getDocumentsWithOid(
       continue;
     }
 
-    const masterIdentifier = document.masterIdentifier?.value === oid;
+    const masterIdentifier = document.masterIdentifier?.system === oid;
     const potentialMasterIdentifier =
-      document.masterIdentifier?.value?.includes(oid) && !masterIdentifier;
+      document.masterIdentifier?.system?.includes(oid) && !masterIdentifier;
 
     if (masterIdentifier) {
       matchingDocumentRefs.push(document);


### PR DESCRIPTION
Part of cs-980

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/CS-980

### Dependencies

- Upstream: NONE
- Downstream: NONE

### Description

- The system has the OID not the value in the master identifier

### Testing

- Production
  - [ ] removes correct doc refs


### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected identifier matching for documents sourced via the Carequality network, improving accuracy and reducing missed or misclassified records during retrieval.
  * Retrieval from other networks remains unchanged.
  * Enhances reliability when viewing or consolidating external patient documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->