### PR TITLE
ENG-1059: Small fix on CW get org

### DIFF
--- a/packages/api/src/external/commonwell-v2/command/organization/organization.ts
+++ b/packages/api/src/external/commonwell-v2/command/organization/organization.ts
@@ -1,7 +1,7 @@
 import {
+  Organization as CwSdkOrganization,
   CwTreatmentType,
   isOrgInitiatorAndResponder,
-  Organization as CwSdkOrganization,
   OrganizationBase,
   OrganizationWithNetworkInfo,
 } from "@metriport/commonwell-sdk";
@@ -10,7 +10,6 @@ import { OrganizationData } from "@metriport/core/domain/organization";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import {
-  defaultOptionsRequestNotAccepted,
   errorToString,
   executeWithNetworkRetries,
   getEnvVarOrFail,
@@ -19,7 +18,6 @@ import {
   TreatmentType,
   USState,
 } from "@metriport/shared";
-import { AxiosError } from "axios";
 import { Config } from "../../../../shared/config";
 import { getCertificate, makeCommonWellMemberAPI } from "../../api";
 
@@ -155,10 +153,6 @@ export async function get(orgOid: string): Promise<CwSdkOrganization | undefined
   const commonWell = makeCommonWellMemberAPI();
   try {
     const resp = await executeWithNetworkRetries(() => commonWell.getOneOrg(orgOid), {
-      httpCodesToRetry: [
-        ...defaultOptionsRequestNotAccepted.httpCodesToRetry,
-        AxiosError.ECONNABORTED,
-      ],
       retryOnTimeout: true,
     });
     debug(`resp getOneOrg: `, JSON.stringify(resp));

--- a/packages/api/src/external/commonwell-v2/command/organization/organization.ts
+++ b/packages/api/src/external/commonwell-v2/command/organization/organization.ts
@@ -159,6 +159,7 @@ export async function get(orgOid: string): Promise<CwSdkOrganization | undefined
         ...defaultOptionsRequestNotAccepted.httpCodesToRetry,
         AxiosError.ECONNABORTED,
       ],
+      retryOnTimeout: true,
     });
     debug(`resp getOneOrg: `, JSON.stringify(resp));
     return resp;


### PR DESCRIPTION
Part of ENG-1059

### Description

- Added `retryOnTimeout`

### Testing

- N/A

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving organization information from the external health network by automatically retrying requests that time out. This reduces intermittent failures, error messages, and stalled loads during periods of network instability.
  * No action required; existing workflows continue to function as before, with more resilient behavior under poor connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->