### PR TITLE
ENG-324 ENG-1026 Better CSV parsing on bulk import

### DIFF
--- a/packages/api/src/command/medical/patient/patient-import/update-tracking.ts
+++ b/packages/api/src/command/medical/patient/patient-import/update-tracking.ts
@@ -71,6 +71,9 @@ export async function updatePatientImportTracking({
   if (!dryRunCx && !dryRunOps && successful != undefined) {
     throw new BadRequestError("Setting successful count is only allowed on dry-run mode");
   }
+  if (reason && status !== "failed") {
+    throw new BadRequestError("Setting reason is only allowed on failed status");
+  }
 
   const oldStatus = job.status;
   const newStatus = status
@@ -84,6 +87,7 @@ export async function updatePatientImportTracking({
   const jobToUpdate: PatientImportJob = {
     ...job.dataValues,
     status: newStatus ?? oldStatus,
+    reason,
   };
   if (total != undefined) {
     jobToUpdate.total = total;
@@ -95,7 +99,6 @@ export async function updatePatientImportTracking({
   }
   if (failed != undefined) {
     jobToUpdate.failed = failed;
-    jobToUpdate.reason = reason;
   }
   if (justTurnedProcessing) {
     jobToUpdate.startedAt = now;

--- a/packages/api/src/command/medical/patient/patient-import/update-tracking.ts
+++ b/packages/api/src/command/medical/patient/patient-import/update-tracking.ts
@@ -27,7 +27,7 @@ export type PatientImportUpdateStatusCmd = {
       reason?: never;
     }
   | {
-      status?: "failed";
+      status: "failed";
       reason?: string | undefined;
     }
 );

--- a/packages/api/src/routes/internal/medical/patient-import.ts
+++ b/packages/api/src/routes/internal/medical/patient-import.ts
@@ -216,23 +216,16 @@ router.post(
     const updateParams = updateJobSchema.parse(req.body);
     capture.setExtra({ cxId, jobId });
 
-    const { status: jobStatus, reason } = updateParams;
-    if (reason && jobStatus !== "failed") {
-      throw new BadRequestError("Reason is only allowed when status is failed");
-    }
-
-    const baseParams = {
+    const params: PatientImportUpdateStatusCmd = {
       jobId,
       cxId,
+      status: updateParams.status,
+      reason: updateParams.reason,
       total: updateParams.total,
       failed: updateParams.failed,
       successful: updateParams.successful,
       forceStatusUpdate: updateParams.forceStatusUpdate,
     };
-    const params: PatientImportUpdateStatusCmd =
-      jobStatus && jobStatus === "failed"
-        ? { ...baseParams, status: jobStatus, reason }
-        : { ...baseParams, status: jobStatus };
 
     const patientImport = await updatePatientImportTracking(params);
 

--- a/packages/api/src/routes/internal/medical/patient-import.ts
+++ b/packages/api/src/routes/internal/medical/patient-import.ts
@@ -216,9 +216,6 @@ router.post(
     const updateParams = updateJobSchema.parse(req.body);
     capture.setExtra({ cxId, jobId });
 
-    if (updateParams.status === "waiting") {
-      throw new BadRequestError("Waiting status is not allowed on this endpoint");
-    }
     const { status: jobStatus, reason } = updateParams;
     if (reason && jobStatus !== "failed") {
       throw new BadRequestError("Reason is only allowed when status is failed");

--- a/packages/api/src/routes/internal/medical/patient-import.ts
+++ b/packages/api/src/routes/internal/medical/patient-import.ts
@@ -220,7 +220,7 @@ router.post(
       throw new BadRequestError("Waiting status is not allowed on this endpoint");
     }
     const { status: jobStatus, reason } = updateParams;
-    if (jobStatus && jobStatus !== "failed" && reason) {
+    if (reason && jobStatus !== "failed") {
       throw new BadRequestError("Reason is only allowed when status is failed");
     }
 

--- a/packages/core/src/command/patient-import/api/update-job-status.ts
+++ b/packages/core/src/command/patient-import/api/update-job-status.ts
@@ -18,6 +18,7 @@ export type UpdateJobAtApiParams = {
    */
   successful?: number | undefined;
   failed?: number | undefined;
+  reason?: string | undefined;
   forceStatusUpdate?: boolean | undefined;
 };
 
@@ -36,11 +37,11 @@ export type UpdateJobAtApiParams = {
  * @throws MetriportError if the update fails.
  */
 export async function updateJobAtApi(params: UpdateJobAtApiParams): Promise<PatientImportJob> {
-  const { cxId, jobId, status, total, successful, failed, forceStatusUpdate } = params;
+  const { cxId, jobId, status, total, successful, failed, reason, forceStatusUpdate } = params;
   const { log } = out(`PatientImport updateJobAtApi - cxId ${cxId} jobId ${jobId}`);
   const api = axios.create({ baseURL: Config.getApiUrl() });
   const url = buildUrl(cxId, jobId);
-  const payload: UpdateJobSchema = { status, total, successful, failed, forceStatusUpdate };
+  const payload: UpdateJobSchema = { status, total, successful, failed, reason, forceStatusUpdate };
 
   if (status == undefined && total == undefined && failed == undefined && successful == undefined) {
     throw new Error("updateJobAtApi requires at least one of {status,total,failed} to be defined");

--- a/packages/core/src/command/patient-import/api/update-job-status.ts
+++ b/packages/core/src/command/patient-import/api/update-job-status.ts
@@ -1,6 +1,6 @@
 import { errorToString, MetriportError } from "@metriport/shared";
 import { UpdateJobSchema } from "@metriport/shared/domain/patient/patient-import/schemas";
-import { PatientImportJobStatus } from "@metriport/shared/domain/patient/patient-import/status";
+import { PatientImportJobUpdatableStatus } from "@metriport/shared/domain/patient/patient-import/status";
 import { PatientImportJob } from "@metriport/shared/domain/patient/patient-import/types";
 import axios from "axios";
 import { Config } from "../../../util/config";
@@ -10,7 +10,7 @@ import { withDefaultApiErrorHandling } from "../../shared/api/shared";
 export type UpdateJobAtApiParams = {
   cxId: string;
   jobId: string;
-  status?: PatientImportJobStatus;
+  status?: PatientImportJobUpdatableStatus;
   total?: number | undefined;
   /**
    * Only to be set on dry run mode - on regular mode, the successful count is incremented

--- a/packages/core/src/command/patient-import/csv/validate-and-parse-import.ts
+++ b/packages/core/src/command/patient-import/csv/validate-and-parse-import.ts
@@ -46,16 +46,18 @@ export async function validateAndParsePatientImportCsvFromS3({
       contents: csvAsString,
     });
 
-    const createHeadersFilePromise = async () => {
+    // eslint-disable-next-line no-inner-declarations
+    async function createHeadersFilePromise() {
       await createHeadersFile({ cxId, jobId, headers, s3BucketName });
-    };
+    }
 
     const result: {
       rowNumber: number;
       status: PatientImportEntryStatus;
     }[] = [];
 
-    const getCreatePatientRecordPromises = () => {
+    // eslint-disable-next-line no-inner-declarations
+    function getCreatePatientRecordPromises() {
       return patients.map(p => {
         return async () => {
           const base = {
@@ -91,7 +93,7 @@ export async function validateAndParsePatientImportCsvFromS3({
           }
         };
       });
-    };
+    }
 
     await executeAsynchronously(
       [createHeadersFilePromise, ...getCreatePatientRecordPromises()],
@@ -154,6 +156,8 @@ export async function validateAndParsePatientImportCsv({
         headers.push(...parsedHeaders);
       })
       .on("data", async data => {
+        // Skip empty lines
+        if (Object.keys(data).length < 1) return;
         try {
           if (++numberOfRows > MAX_NUMBER_ROWS) {
             throw new MetriportError(`CSV has more rows than max (${MAX_NUMBER_ROWS})`);

--- a/packages/core/src/command/patient-import/csv/validate-and-parse-import.ts
+++ b/packages/core/src/command/patient-import/csv/validate-and-parse-import.ts
@@ -203,7 +203,10 @@ function normalizeData(data: Record<string, string>) {
 }
 
 function normalizeProperty(record: string) {
-  return record.replace(charsToRemove, "").replace(charsToReplaceWithSpace, " ");
+  // Replace chars to remove with space so new lines without any space on either side wouldn't
+  // result in merged words. Duplicate spaces are replaced with a single space on the second
+  // replace anyways.
+  return record.replace(charsToRemove, " ").replace(charsToReplaceWithSpace, " ");
 }
 
 function normalizeCsvRecord(record: string) {

--- a/packages/core/src/command/patient-import/csv/validate-and-parse-import.ts
+++ b/packages/core/src/command/patient-import/csv/validate-and-parse-import.ts
@@ -15,6 +15,7 @@ const numberOfParallelExecutions = 20;
 
 const columnSeparator = ",";
 const commaRegex = new RegExp(/,/g);
+const charsThatRequireQuotes = [columnSeparator, "\n", "\r", "\t"];
 
 /**
  * Validates and parses a CSV file from S3 for bulk patient import.
@@ -181,7 +182,7 @@ export function csvRecordToParsedPatient(
   rowNumber: number
 ): ParsedPatient {
   const raw = Object.values(data) as string[];
-  const rawNormalized = raw.map(r => (r.includes(columnSeparator) ? `"${r}"` : r));
+  const rawNormalized = raw.map(normalizeRecord);
   const result = mapCsvPatientToMetriportPatient(data);
   const baseParsedPatient = { rowNumber, raw: rawNormalized.join(",") };
   if (Array.isArray(result)) {
@@ -189,6 +190,10 @@ export function csvRecordToParsedPatient(
   } else {
     return { ...baseParsedPatient, parsed: result };
   }
+}
+
+function normalizeRecord(record: string) {
+  return charsThatRequireQuotes.some(char => record.includes(char)) ? `"${record}"` : record;
 }
 
 function stripCommas(input: string, replacement = "") {

--- a/packages/core/src/command/patient-import/steps/parse/patient-import-parse-command.ts
+++ b/packages/core/src/command/patient-import/steps/parse/patient-import-parse-command.ts
@@ -60,6 +60,7 @@ export async function processJobParse({
         status: "failed",
         total: failed.length,
         failed: failed.length,
+        reason: "Empty or invalid file",
       });
       return;
     }
@@ -145,7 +146,12 @@ export async function processJobParse({
   } catch (error) {
     const msg = `Failure while parsing the job of patient import @ PatientImport`;
     log(`${msg}. Cause: ${errorToString(error)}`);
-    await updateJobAtApi({ cxId, jobId, status: "failed" });
+    await updateJobAtApi({
+      cxId,
+      jobId,
+      status: "failed",
+      reason: "Unknown error while parsing the inputfile",
+    });
     capture.setExtra({
       cxId,
       jobId,

--- a/packages/shared/src/domain/patient/patient-import/schemas.ts
+++ b/packages/shared/src/domain/patient/patient-import/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { patientImportJobStatus } from "./status";
+import { patientImportJobStatus, PatientImportJobUpdatableStatus } from "./status";
 
 // TODO 2330 Review this as part of POST /internal/patient/bulk/coverage-assessment
 // export const patientImportPatientSchema = z.object({
@@ -28,7 +28,12 @@ import { patientImportJobStatus } from "./status";
 
 export const updateJobSchema = z.object({
   status: z
-    .enum(patientImportJobStatus.filter(s => s !== "waiting") as [string, ...string[]])
+    .enum(
+      patientImportJobStatus.filter(s => s !== "waiting") as [
+        PatientImportJobUpdatableStatus,
+        ...PatientImportJobUpdatableStatus[]
+      ]
+    )
     .optional(),
   total: z.number().optional(),
   /**

--- a/packages/shared/src/domain/patient/patient-import/schemas.ts
+++ b/packages/shared/src/domain/patient/patient-import/schemas.ts
@@ -27,7 +27,9 @@ import { patientImportJobStatus } from "./status";
 // });
 
 export const updateJobSchema = z.object({
-  status: z.enum(patientImportJobStatus).optional(),
+  status: z
+    .enum(patientImportJobStatus.filter(s => s !== "waiting") as [string, ...string[]])
+    .optional(),
   total: z.number().optional(),
   /**
    * Only to be set on dry run mode - on regular mode, the successful count is incremented

--- a/packages/shared/src/domain/patient/patient-import/schemas.ts
+++ b/packages/shared/src/domain/patient/patient-import/schemas.ts
@@ -35,6 +35,7 @@ export const updateJobSchema = z.object({
    */
   successful: z.number().optional(),
   failed: z.number().optional(),
+  reason: z.string().optional(),
   forceStatusUpdate: z.boolean().optional(),
 });
 export type UpdateJobSchema = z.infer<typeof updateJobSchema>;

--- a/packages/shared/src/domain/patient/patient-import/status.ts
+++ b/packages/shared/src/domain/patient/patient-import/status.ts
@@ -1,6 +1,9 @@
 import { BadRequestError } from "../../../error/bad-request";
 
-export const patientImportJobStatus = ["waiting", "processing", "completed", "failed"] as const;
+export const patientImportJobUpdatableStatus = ["processing", "completed", "failed"] as const;
+export type PatientImportJobUpdatableStatus = (typeof patientImportJobUpdatableStatus)[number];
+
+export const patientImportJobStatus = ["waiting", ...patientImportJobUpdatableStatus] as const;
 export type PatientImportJobStatus = (typeof patientImportJobStatus)[number];
 
 export function isPatientImportDone(status: PatientImportJobStatus): boolean {

--- a/packages/utils/src/patient-import/generate-patient-csv.ts
+++ b/packages/utils/src/patient-import/generate-patient-csv.ts
@@ -18,8 +18,8 @@ import {
   makePersonalIdentifierSsn,
 } from "@metriport/core/domain/__tests__/patient";
 import { sleep } from "@metriport/shared";
+import { buildDayjs } from "@metriport/shared/common/date";
 import { filterTruthy } from "@metriport/shared/common/filter-map";
-import dayjs from "dayjs";
 import fs from "fs";
 import { elapsedTimeAsStr } from "../shared/duration";
 import { makeDir } from "../shared/fs";
@@ -70,7 +70,7 @@ async function main() {
   const startedAt = Date.now();
   console.log(`############## Started at ${new Date(startedAt).toISOString()} ##############`);
 
-  const timestamp = dayjs().toISOString();
+  const timestamp = buildDayjs().toISOString();
   const outputBaseFolder = `runs/bulk-import-mock`;
   const outputFolderName = `${outputBaseFolder}/${timestamp}`;
   makeDir(outputFolderName);

--- a/packages/utils/src/s3/get-contents-as-string.ts
+++ b/packages/utils/src/s3/get-contents-as-string.ts
@@ -1,0 +1,48 @@
+import { S3Utils } from "@metriport/core/external/aws/s3";
+import { getEnvVarOrFail, sleep } from "@metriport/shared";
+import { buildDayjs } from "@metriport/shared/common/date";
+import { elapsedTimeAsStr } from "../shared/duration";
+import { makeDir, makeDirIfNeeded, writeFileContents } from "../shared/fs";
+
+/**
+ * Read files from S3 as string and store them locally.
+ *
+ * Set:
+ * - s3KeysToDownload: the list of files to read;
+ * - env vars
+ */
+
+const s3KeysToDownload: string[] = [""];
+
+const bucketName = getEnvVarOrFail("MEDICAL_DOCS_S3_BUCKET_NAME");
+const region = getEnvVarOrFail("AWS_REGION");
+
+const timestamp = buildDayjs().toISOString();
+const outputBaseFolder = `runs/get-contents-as-string`;
+const outputFolderName = `${outputBaseFolder}/${timestamp}`;
+
+async function main() {
+  await sleep(50); // Give some time to avoid mixing logs w/ Node's
+  const startedAt = Date.now();
+  console.log(`############## Started at ${new Date(startedAt).toISOString()} ##############`);
+
+  makeDir(outputFolderName);
+
+  for (const s3Key of s3KeysToDownload) {
+    console.log(`Getting file ${s3Key}...`);
+    const outputFileNameFull = `./${outputFolderName}/${s3Key}`;
+
+    const obj = await new S3Utils(region).getFileContentsAsString(bucketName, s3Key, "latin1");
+
+    makeDirIfNeeded(outputFileNameFull);
+    writeFileContents(outputFileNameFull, obj);
+  }
+
+  console.log(`>>> Done in ${elapsedTimeAsStr(startedAt)}`);
+  process.exit(0);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Dependencies

none

### Description

- **refactor(core): skip empty lines on pt bulk import**
- **refactor(core): indicate reason for failed bulk import file**
- **fix(core): quote csv values w/ new line for result file**
- **refactor(core): expose encoding on getFileContentsAsString**

### Testing

- Local
  - [x] Bulk import with empty lines don't mark those as error
  - [x] Failed bulk import for empty or invalid file gets proper reason
  - [x] When input file has new line, output files get generated properly
  - [x] Calling `getFileContentsAsString` w/ custom encoding works
- Staging
  - [ ] bulk import w/ successful and invalid records get processed properly
  - [ ] bulk import w/ new line on input gets reported/result properly
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Patient import updates now accept an optional failure reason and surface it in API/UI flows.
  - Status updates now restrict which statuses can be set via the update endpoints (excluding "waiting").

- Bug Fixes
  - CSV parsing improved: better quoting, trimmed/normalized whitespace, and empty lines are ignored.
  - Import jobs record clearer failure reasons for empty/invalid files and parsing errors.
  - S3 reads now allow specifying file encoding when fetching content.

- Chores
  - Added a utility script to download S3 files as strings for diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->