### PR TITLE
ENG-1048 Temporarily resume xcpd req storage

### DIFF
--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests.ts
@@ -1,9 +1,10 @@
-import { OutboundPatientDiscoveryReq, XCPDGateway } from "@metriport/ihe-gateway-sdk";
+import { XCPDGateway, OutboundPatientDiscoveryReq } from "@metriport/ihe-gateway-sdk";
 import { errorToString } from "../../../../../../util/error/shared";
-import { out } from "../../../../../../util/log";
-import { SamlClientResponse, sendSignedXml } from "../../../saml/saml-client";
 import { SamlCertsAndKeys } from "../../../saml/security/types";
+import { SamlClientResponse, sendSignedXml } from "../../../saml/saml-client";
 import { SignedXcpdRequest } from "../create/iti55-envelope";
+import { out } from "../../../../../../util/log";
+import { storeXcpdResponses } from "../../../monitor/store";
 
 const { log } = out("Sending XCPD Requests");
 
@@ -37,12 +38,11 @@ export async function sendSignedXcpdRequest({
         request.gateway.oid
       }`
     );
-    // ENG-1048 Disable S3 storage for IHE raw requests/responses
-    // await storeXcpdResponses({
-    //   response,
-    //   outboundRequest: request.outboundRequest,
-    //   gateway: request.gateway,
-    // });
+    await storeXcpdResponses({
+      response,
+      outboundRequest: request.outboundRequest,
+      gateway: request.gateway,
+    });
     return {
       gateway: request.gateway,
       response,


### PR DESCRIPTION
This reverts commit 7816e276e9eeb9240557ee94d0db61bf45f40749.

### Description
- We want to store xcpd requests a little longer while we're testing cq changes 
### Testing
- N/A
### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

• New Features
  • Outbound Carequality patient discovery (XCPD) responses are now persisted after successful sends, improving auditability, troubleshooting, and visibility into exchange outcomes. No action required from integrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->