### PR TITLE
ENG-1070 feat(infra): use secret name instead of secret arn

### DIFF
--- a/packages/infra/lib/hl7-notification-stack/vpn.ts
+++ b/packages/infra/lib/hl7-notification-stack/vpn.ts
@@ -1,7 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import { Fn } from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
-import * as secret from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 import { MLLP_DEFAULT_PORT } from "./constants";
 import { HieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
@@ -87,16 +86,6 @@ export class VpnStack extends cdk.Stack {
       ]);
     });
 
-    const presharedKey1 = secret.Secret.fromSecretNameV2(
-      this,
-      `PresharedKey1-${hieName}`,
-      `PresharedKey1-${hieName}`
-    );
-    const presharedKey2 = secret.Secret.fromSecretNameV2(
-      this,
-      `PresharedKey2-${hieName}`,
-      `PresharedKey2-${hieName}`
-    );
     /**
      * We use 2 tunnels here because state HIEs often have a failover to a backup IP..
      */
@@ -113,13 +102,13 @@ export class VpnStack extends cdk.Stack {
       ],
       vpnTunnelOptionsSpecifications: [
         {
-          preSharedKey: Fn.sub("{{resolve:secretsmanager:${SecretArn}:SecretString}}", {
-            SecretArn: presharedKey1.secretArn,
+          preSharedKey: Fn.sub("{{resolve:secretsmanager:${SecretName}:SecretString}}", {
+            SecretName: `PresharedKey1-${hieName}`,
           }),
         },
         {
-          preSharedKey: Fn.sub("{{resolve:secretsmanager:${SecretArn}:SecretString}}", {
-            SecretArn: presharedKey2.secretArn,
+          preSharedKey: Fn.sub("{{resolve:secretsmanager:${SecretName}:SecretString}}", {
+            SecretName: `PresharedKey2-${hieName}`,
           }),
         },
       ],


### PR DESCRIPTION
### Dependencies

None

### Description

We've been having issues deploying the VPN tunnel. I did not properly root cause the issue, but was able to repro the tunnel creation cdk failures from my local device, and updating the CDK code to use the secret names instead of ARNs resolves the issue on local.

### Testing

- Local
  - [x] repro'd running cdk diff + deploy against staging stacks from local
  - [x] fix addresses issue against both staging + production stacks from local
- Production
  - [ ] Next integration, try booting up tunnels from github actions again.

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated VPN tunnel configuration to resolve pre-shared keys by secret name instead of ARN, improving clarity, maintainability, and compatibility with standardized secret naming. No behavioral changes or interface updates.
- Chores
  - Removed an unnecessary Secrets Manager dependency import to reduce overhead. No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->