### PR TITLE
RELEASE Temporary resume saving xcpd responses

### DIFF
--- a/packages/api/src/external/commonwell-v2/command/organization/organization.ts
+++ b/packages/api/src/external/commonwell-v2/command/organization/organization.ts
@@ -1,7 +1,7 @@
 import {
+  Organization as CwSdkOrganization,
   CwTreatmentType,
   isOrgInitiatorAndResponder,
-  Organization as CwSdkOrganization,
   OrganizationBase,
   OrganizationWithNetworkInfo,
 } from "@metriport/commonwell-sdk";
@@ -10,7 +10,6 @@ import { OrganizationData } from "@metriport/core/domain/organization";
 import { out } from "@metriport/core/util/log";
 import { capture } from "@metriport/core/util/notifications";
 import {
-  defaultOptionsRequestNotAccepted,
   errorToString,
   executeWithNetworkRetries,
   getEnvVarOrFail,
@@ -19,7 +18,6 @@ import {
   TreatmentType,
   USState,
 } from "@metriport/shared";
-import { AxiosError } from "axios";
 import { Config } from "../../../../shared/config";
 import { getCertificate, makeCommonWellMemberAPI } from "../../api";
 
@@ -155,10 +153,7 @@ export async function get(orgOid: string): Promise<CwSdkOrganization | undefined
   const commonWell = makeCommonWellMemberAPI();
   try {
     const resp = await executeWithNetworkRetries(() => commonWell.getOneOrg(orgOid), {
-      httpCodesToRetry: [
-        ...defaultOptionsRequestNotAccepted.httpCodesToRetry,
-        AxiosError.ECONNABORTED,
-      ],
+      retryOnTimeout: true,
     });
     debug(`resp getOneOrg: `, JSON.stringify(resp));
     return resp;

--- a/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests.ts
+++ b/packages/core/src/external/carequality/ihe-gateway-v2/outbound/xcpd/send/xcpd-requests.ts
@@ -1,9 +1,10 @@
-import { OutboundPatientDiscoveryReq, XCPDGateway } from "@metriport/ihe-gateway-sdk";
+import { XCPDGateway, OutboundPatientDiscoveryReq } from "@metriport/ihe-gateway-sdk";
 import { errorToString } from "../../../../../../util/error/shared";
-import { out } from "../../../../../../util/log";
-import { SamlClientResponse, sendSignedXml } from "../../../saml/saml-client";
 import { SamlCertsAndKeys } from "../../../saml/security/types";
+import { SamlClientResponse, sendSignedXml } from "../../../saml/saml-client";
 import { SignedXcpdRequest } from "../create/iti55-envelope";
+import { out } from "../../../../../../util/log";
+import { storeXcpdResponses } from "../../../monitor/store";
 
 const { log } = out("Sending XCPD Requests");
 
@@ -37,12 +38,11 @@ export async function sendSignedXcpdRequest({
         request.gateway.oid
       }`
     );
-    // ENG-1048 Disable S3 storage for IHE raw requests/responses
-    // await storeXcpdResponses({
-    //   response,
-    //   outboundRequest: request.outboundRequest,
-    //   gateway: request.gateway,
-    // });
+    await storeXcpdResponses({
+      response,
+      outboundRequest: request.outboundRequest,
+      gateway: request.gateway,
+    });
     return {
       gateway: request.gateway,
       response,


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-1048

### Description
- https://github.com/metriport/metriport/pull/4649

### Testing

Check each PR.

### Release Plan
- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enables storage of Carequality IHE Gateway XCPD request/response payloads to cloud storage after successful sends.
  - Adds persistence for raw transaction data to support downstream retrieval.
- Chores
  - Minor import reordering with no functional impact.
- Notes
  - No changes to public APIs or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->