### PR TITLE
ENG-1058: setup client vpn endpoint for hl7 notification routing infra

### DIFF
--- a/packages/infra/bin/infrastructure.ts
+++ b/packages/infra/bin/infrastructure.ts
@@ -90,7 +90,7 @@ async function deploy(config: EnvConfig) {
     //---------------------------------------------------------------------------------
     // 5.1. Deploy VPC Peering between API VPC and HL7 VPC
     //---------------------------------------------------------------------------------
-    // ⚠️ NOTE: VPC Peering depends on both API and HL7 stacks being deployed
+    // ⚠️ NOTE: VPC Peering depends on both API and HL7 stacks being correct / deployed.
     // But to prevent CI from spending time re-diffing and deploying these stacks,
     // we assume that these dependencies are being managed and deployed in proper sequence
     // by the CI pipeline.

--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -1,11 +1,11 @@
 import {
   Aspects,
-  aws_wafv2 as wafv2,
   CfnOutput,
   Duration,
   RemovalPolicy,
   Stack,
   StackProps,
+  aws_wafv2 as wafv2,
 } from "aws-cdk-lib";
 import * as apig from "aws-cdk-lib/aws-apigateway";
 import { BackupResource } from "aws-cdk-lib/aws-backup";
@@ -43,6 +43,7 @@ import { createDocQueryChecker } from "./api-stack/doc-query-checker";
 import * as documentUploader from "./api-stack/document-upload";
 import { createFHIRConverterService } from "./api-stack/fhir-converter-service";
 import { TerminologyServerNestedStack } from "./api-stack/terminology-server-service";
+import { API_STACK_VPC_NAME } from "./constants";
 import { EhrNestedStack } from "./ehr-nested-stack";
 import { EnvType } from "./env-type";
 import { FeatureFlagsNestedStack } from "./feature-flags-nested-stack";
@@ -54,6 +55,11 @@ import { LambdasLayersNestedStack } from "./lambda-layers-nested-stack";
 import { CDA_TO_VIS_TIMEOUT, LambdasNestedStack } from "./lambdas-nested-stack";
 import { PatientImportNestedStack } from "./patient-import-nested-stack";
 import { PatientMonitoringNestedStack } from "./patient-monitoring-nested-stack";
+import { QuestNestedStack } from "./quest/quest-stack";
+import {
+  createDownloadResponseScheduledLambda,
+  createUploadRosterScheduledLambda,
+} from "./quest/scheduled-lambda";
 import { RateLimitingNestedStack } from "./rate-limiting-nested-stack";
 import { DailyBackup } from "./shared/backup";
 import { addErrorAlarmToLambdaFunc, createLambda, MAXIMUM_LAMBDA_TIMEOUT } from "./shared/lambda";
@@ -64,11 +70,6 @@ import { provideAccessToQueue } from "./shared/sqs";
 import { isProd, isSandbox } from "./shared/util";
 import { wafRules } from "./shared/waf-rules";
 import { SurescriptsNestedStack } from "./surescripts/surescripts-stack";
-import { QuestNestedStack } from "./quest/quest-stack";
-import {
-  createUploadRosterScheduledLambda,
-  createDownloadResponseScheduledLambda,
-} from "./quest/scheduled-lambda";
 
 const FITBIT_LAMBDA_TIMEOUT = Duration.seconds(60);
 
@@ -100,8 +101,7 @@ export class APIStack extends Stack {
     //-------------------------------------------
     // VPC + NAT Gateway.
     //-------------------------------------------
-    const vpcConstructId = "APIVpc";
-    this.vpc = new ec2.Vpc(this, vpcConstructId, {
+    this.vpc = new ec2.Vpc(this, API_STACK_VPC_NAME, {
       flowLogs: {
         apiVPCFlowLogs: { trafficType: ec2.FlowLogTrafficType.REJECT },
       },

--- a/packages/infra/lib/constants.ts
+++ b/packages/infra/lib/constants.ts
@@ -1,0 +1,3 @@
+export const API_STACK_VPC_NAME = "APIVpc";
+export const HL7_NOTIFICATION_STACK_NAME = "Hl7NotificationStack";
+export const HL7_NOTIFICATION_VPC_NAME = "Vpc";

--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -1,4 +1,5 @@
 export const MLLP_DEFAULT_PORT = 2575;
+export const HL7_NLB_CIDR = "10.1.1.20/30";
 export const HL7_NOTIFICATION_VPC_CIDR = "10.1.0.0/16";
 export const PROBLEMATIC_IPSEC_CHARACTERS = "!@#$%^&*()_+-=[]{}|;:,.<>?~`'\"\\/";
 export const MLLP_SERVER_CONTAINER_NAME = "MllpServer";

--- a/packages/infra/lib/hl7-notification-stack/index.ts
+++ b/packages/infra/lib/hl7-notification-stack/index.ts
@@ -75,5 +75,11 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
       description: "MLLP ECR repository URI",
       value: ecrRepo.repositoryUri,
     });
+
+    new cdk.CfnOutput(this, "Hl7VpcId", {
+      description: "HL7 Notification VPC ID",
+      value: vpc.vpcId,
+      exportName: "Hl7NotificationStack-VpcId",
+    });
   }
 }

--- a/packages/infra/lib/hl7-notification-stack/index.ts
+++ b/packages/infra/lib/hl7-notification-stack/index.ts
@@ -75,11 +75,5 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
       description: "MLLP ECR repository URI",
       value: ecrRepo.repositoryUri,
     });
-
-    new cdk.CfnOutput(this, "Hl7VpcId", {
-      description: "HL7 Notification VPC ID",
-      value: vpc.vpcId,
-      exportName: "Hl7NotificationStack-VpcId",
-    });
   }
 }

--- a/packages/infra/lib/vpc-peering-stack.ts
+++ b/packages/infra/lib/vpc-peering-stack.ts
@@ -22,11 +22,11 @@ export class VpcPeeringStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: VpcPeeringStackProps) {
     super(scope, id, props);
 
+    // Skip if HL7 notifications are not configured
     if (!props.config.hl7Notification) {
-      return; // Skip if HL7 notifications are not configured
+      return;
     }
 
-    // Import existing VPCs by their known construct IDs
     const apiVpc = ec2.Vpc.fromLookup(this, "ImportedApiVpc", {
       vpcName: `${props.config.stackName}/${API_STACK_SUBNAME}`,
     });
@@ -50,22 +50,6 @@ export class VpcPeeringStack extends cdk.Stack {
     this.addRoutesToApiVpc(apiVpc, vpcPeeringConnection);
     this.addRoutesToHl7Vpc(hl7Vpc, apiVpc.vpcCidrBlock, vpcPeeringConnection);
     this.updateHl7NetworkAclForPeering(apiVpc.vpcCidrBlock);
-
-    // Outputs
-    new cdk.CfnOutput(this, "VpcPeeringConnectionId", {
-      description: "VPC Peering Connection ID between API and HL7 VPCs",
-      value: vpcPeeringConnection.ref,
-    });
-
-    new cdk.CfnOutput(this, "ApiVpcId", {
-      description: "API VPC ID",
-      value: apiVpc.vpcId,
-    });
-
-    new cdk.CfnOutput(this, "Hl7VpcId", {
-      description: "HL7 VPC ID",
-      value: hl7Vpc.vpcId,
-    });
   }
 
   private addRoutesToApiVpc(apiVpc: ec2.IVpc, vpcPeeringConnection: ec2.CfnVPCPeeringConnection) {

--- a/packages/infra/lib/vpc-peering-stack.ts
+++ b/packages/infra/lib/vpc-peering-stack.ts
@@ -12,6 +12,11 @@ interface VpcPeeringStackProps extends cdk.StackProps {
  * This allows Client VPN users connected to the API VPC to access HL7 servers
  * in the HL7 Notification VPC on port 2575.
  */
+
+const API_STACK_SUBNAME = "APIVpc";
+
+const HL7_NOTIFICATION_STACK_NAME = "Hl7NotificationStack";
+const HL7_NOTIFICATION_VPC_SUBNAME = "Vpc";
 export class VpcPeeringStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: VpcPeeringStackProps) {
     super(scope, id, props);
@@ -22,13 +27,11 @@ export class VpcPeeringStack extends cdk.Stack {
 
     // Import existing VPCs by their known construct IDs
     const apiVpc = ec2.Vpc.fromLookup(this, "ImportedApiVpc", {
-      tags: {
-        "aws:cloudformation:logical-id": "APIVpc",
-      },
+      vpcName: `${props.config.stackName}/${API_STACK_SUBNAME}`,
     });
 
     const hl7Vpc = ec2.Vpc.fromLookup(this, "ImportedHl7Vpc", {
-      vpcId: cdk.Fn.importValue("Hl7NotificationStack-VpcId"),
+      vpcName: `${HL7_NOTIFICATION_STACK_NAME}/${HL7_NOTIFICATION_VPC_SUBNAME}`,
     });
 
     // Create VPC Peering Connection
@@ -63,11 +66,6 @@ export class VpcPeeringStack extends cdk.Stack {
     new cdk.CfnOutput(this, "Hl7VpcId", {
       description: "HL7 VPC ID",
       value: hl7Vpc.vpcId,
-    });
-
-    new cdk.CfnOutput(this, "PeeringStatus", {
-      description: "Instructions for testing connectivity",
-      value: `Minimal VPC Peering established. VPN clients can access HL7 servers at 10.1.1.20-23:2575`,
     });
   }
 

--- a/packages/infra/lib/vpc-peering-stack.ts
+++ b/packages/infra/lib/vpc-peering-stack.ts
@@ -1,0 +1,128 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { Construct } from "constructs";
+import { EnvConfig } from "../config/env-config";
+
+interface VpcPeeringStackProps extends cdk.StackProps {
+  config: EnvConfig;
+}
+
+/**
+ * Stack to establish VPC peering between API VPC and HL7 Notification VPC.
+ * This allows Client VPN users connected to the API VPC to access HL7 servers
+ * in the HL7 Notification VPC on port 2575.
+ */
+export class VpcPeeringStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: VpcPeeringStackProps) {
+    super(scope, id, props);
+
+    if (!props.config.hl7Notification) {
+      return; // Skip if HL7 notifications are not configured
+    }
+
+    // Import existing VPCs by their known construct IDs
+    const apiVpc = ec2.Vpc.fromLookup(this, "ImportedApiVpc", {
+      tags: {
+        "aws:cloudformation:logical-id": "APIVpc",
+      },
+    });
+
+    const hl7Vpc = ec2.Vpc.fromLookup(this, "ImportedHl7Vpc", {
+      vpcId: cdk.Fn.importValue("Hl7NotificationStack-VpcId"),
+    });
+
+    // Create VPC Peering Connection
+    const vpcPeeringConnection = new ec2.CfnVPCPeeringConnection(this, "ApiToHl7VpcPeering", {
+      vpcId: apiVpc.vpcId,
+      peerVpcId: hl7Vpc.vpcId,
+      tags: [
+        {
+          key: "Name",
+          value: "API-to-HL7-VPC-Peering",
+        },
+      ],
+    });
+
+    this.addMinimalRoutesToApiVpc(apiVpc, vpcPeeringConnection);
+    this.addReturnRoutesToHl7Vpc(hl7Vpc, apiVpc.vpcCidrBlock, vpcPeeringConnection);
+
+    // Update HL7 VPC's Network ACL to allow egress traffic back to API VPC
+    this.updateHl7NetworkAclForPeering(apiVpc.vpcCidrBlock);
+
+    // Outputs
+    new cdk.CfnOutput(this, "VpcPeeringConnectionId", {
+      description: "VPC Peering Connection ID between API and HL7 VPCs",
+      value: vpcPeeringConnection.ref,
+    });
+
+    new cdk.CfnOutput(this, "ApiVpcId", {
+      description: "API VPC ID",
+      value: apiVpc.vpcId,
+    });
+
+    new cdk.CfnOutput(this, "Hl7VpcId", {
+      description: "HL7 VPC ID",
+      value: hl7Vpc.vpcId,
+    });
+
+    new cdk.CfnOutput(this, "PeeringStatus", {
+      description: "Instructions for testing connectivity",
+      value: `Minimal VPC Peering established. VPN clients can access HL7 servers at 10.1.1.20-23:2575`,
+    });
+  }
+
+  private addMinimalRoutesToApiVpc(
+    apiVpc: ec2.IVpc,
+    vpcPeeringConnection: ec2.CfnVPCPeeringConnection
+  ) {
+    // Only add routes for the specific HL7 server IPs (10.1.1.20-23)
+    const hl7NlbCidr = "10.1.1.20/30";
+
+    // Get route tables from API VPC (where VPN clients connect)
+    const apiVpcRouteTables = apiVpc.privateSubnets
+      .concat(apiVpc.publicSubnets)
+      .map(subnet => subnet.routeTable.routeTableId);
+
+    apiVpcRouteTables.forEach((routeTableId, routeIndex) => {
+      new ec2.CfnRoute(this, `ApiToHl7Route${routeIndex}`, {
+        routeTableId,
+        destinationCidrBlock: hl7NlbCidr,
+        vpcPeeringConnectionId: vpcPeeringConnection.ref,
+      });
+    });
+  }
+
+  private addReturnRoutesToHl7Vpc(
+    hl7Vpc: ec2.IVpc,
+    apiVpcCidrBlock: string,
+    vpcPeeringConnection: ec2.CfnVPCPeeringConnection
+  ) {
+    // Get all route tables in the HL7 VPC
+    const hl7VpcRouteTables = hl7Vpc.privateSubnets
+      .concat(hl7Vpc.publicSubnets)
+      .map(subnet => subnet.routeTable.routeTableId);
+
+    hl7VpcRouteTables.forEach((routeTableId, index) => {
+      new ec2.CfnRoute(this, `Hl7ToApiReturnRoute${index}`, {
+        routeTableId,
+        destinationCidrBlock: apiVpcCidrBlock, // API VPC CIDR
+        vpcPeeringConnectionId: vpcPeeringConnection.ref,
+      });
+    });
+  }
+
+  private updateHl7NetworkAclForPeering(apiVpcCidrBlock: string) {
+    // Import the existing Network ACL from HL7 stack
+    const networkAclId = cdk.Fn.importValue("NestedNetworkStack-NetworkAclId");
+    const networkAcl = ec2.NetworkAcl.fromNetworkAclId(this, "ImportedHl7NetworkAcl", networkAclId);
+
+    // Allow egress traffic back to API VPC (for VPC peering response traffic)
+    networkAcl.addEntry("AllowApiVpcEgress", {
+      ruleNumber: 4500,
+      direction: ec2.TrafficDirection.EGRESS,
+      traffic: ec2.AclTraffic.tcpPortRange(1024, 65535), // Ephemeral ports for responses
+      ruleAction: ec2.Action.ALLOW,
+      cidr: ec2.AclCidr.ipv4(apiVpcCidrBlock),
+    });
+  }
+}

--- a/packages/infra/lib/vpc-peering-stack.ts
+++ b/packages/infra/lib/vpc-peering-stack.ts
@@ -3,6 +3,9 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
 import { EnvConfig } from "../config/env-config";
 import { HL7_NLB_CIDR, MLLP_DEFAULT_PORT } from "./hl7-notification-stack/constants";
+import { API_STACK_VPC_NAME } from "./constants";
+import { HL7_NOTIFICATION_STACK_NAME } from "./constants";
+import { HL7_NOTIFICATION_VPC_NAME } from "./constants";
 
 interface VpcPeeringStackProps extends cdk.StackProps {
   config: EnvConfig;
@@ -13,11 +16,6 @@ interface VpcPeeringStackProps extends cdk.StackProps {
  * This allows Client VPN users connected to the API VPC to access HL7 servers
  * in the HL7 Notification VPC on port 2575.
  */
-
-const API_STACK_SUBNAME = "APIVpc";
-const HL7_NOTIFICATION_STACK_NAME = "Hl7NotificationStack";
-const HL7_NOTIFICATION_VPC_SUBNAME = "Vpc";
-
 export class VpcPeeringStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: VpcPeeringStackProps) {
     super(scope, id, props);
@@ -28,11 +26,11 @@ export class VpcPeeringStack extends cdk.Stack {
     }
 
     const apiVpc = ec2.Vpc.fromLookup(this, "ImportedApiVpc", {
-      vpcName: `${props.config.stackName}/${API_STACK_SUBNAME}`,
+      vpcName: `${props.config.stackName}/${API_STACK_VPC_NAME}`,
     });
 
     const hl7Vpc = ec2.Vpc.fromLookup(this, "ImportedHl7Vpc", {
-      vpcName: `${HL7_NOTIFICATION_STACK_NAME}/${HL7_NOTIFICATION_VPC_SUBNAME}`,
+      vpcName: `${HL7_NOTIFICATION_STACK_NAME}/${HL7_NOTIFICATION_VPC_NAME}`,
     });
 
     // Create VPC Peering Connection


### PR DESCRIPTION
### Dependencies

### Description

This pr sets up VPC peering between the API Vpc + Hl7 Notification Vpc, as well as tight routing rules and nacls to permit only very specific traffic between the two vpcs. 

We were previously doing adhoc tests of the MLLP server via an EC2 box in staging over a vpn tunnel same as our integrated state hies. This is super janky, error prone, and also a security risk. We need to setup access to the mllp server via the vpn everyone uses.

### Testing

- Local
  - [x] cdk diff + cdk deploy passes against staging + im able to telnet into the staging mllp server over vpn
- Staging
  - [ ] try to telnet into the mllp server
- Production
  - [ ] try to telnet into the mllp server

### Release Plan

- [x] No dependencies between API and Infra that will cause errors during deployment
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added VPC peering to provide private connectivity between API and HL7 Notification environments for secure, low-latency routing.
  * Wired new scheduled background tasks related to quest functionality (download/roster upload).

* Chores
  * Ensured secrets are provisioned before VPN setup by adjusting infrastructure ordering.
  * Centralized network naming/constants and tightened network rules to allow VPN client access and proper bidirectional routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->