### PR TITLE
ENG-1076 Add debug FF

### DIFF
--- a/packages/api/src/__tests__/e2e/mapi/webhook/webhook-server.ts
+++ b/packages/api/src/__tests__/e2e/mapi/webhook/webhook-server.ts
@@ -15,9 +15,12 @@ const app = express();
 app.post(
   "/",
   raw({ type: "*/*" }),
-  asyncHandler(async (req: Request, res: Response) => {
-    await whHandler.handleRequest(req, res);
-  }, true)
+  asyncHandler(
+    async (req: Request, res: Response) => {
+      await whHandler.handleRequest(req, res);
+    },
+    async () => true
+  )
 );
 app.use(express.json({ limit: "20mb" }));
 

--- a/packages/api/src/external/commonwell-v1/proxy/cw-fhir-proxy.ts
+++ b/packages/api/src/external/commonwell-v1/proxy/cw-fhir-proxy.ts
@@ -1,3 +1,4 @@
+import { isDebugFeatureFlagEnabled } from "@metriport/core/command/feature-flags/domain-ffs";
 import { NotFoundError } from "@metriport/shared";
 import Router from "express-promise-router";
 import { requestLogger } from "../../../routes/helpers/request-logger";
@@ -25,10 +26,13 @@ const fhirRouter = Router();
 fhirRouter.get(
   "/DocumentReference",
   requestLogger,
-  asyncHandler(async (req, res) => {
-    const bundle = await processRequest(req);
-    return res.status(200).json(bundle);
-  })
+  asyncHandler(
+    async (req, res) => {
+      const bundle = await processRequest(req);
+      return res.status(200).json(bundle);
+    },
+    async () => isDebugFeatureFlagEnabled()
+  )
 );
 fhirRouter.all(
   "/*",

--- a/packages/api/src/routes/util.ts
+++ b/packages/api/src/routes/util.ts
@@ -20,9 +20,14 @@ export function asyncHandler(
     try {
       await f(req, res, next);
     } catch (err) {
-      const isLogErrorDetails = shouldLogErrorDetails
-        ? await shouldLogErrorDetails()
-        : !Config.isCloudEnv();
+      let isLogErrorDetails = !Config.isCloudEnv();
+      if (shouldLogErrorDetails) {
+        try {
+          isLogErrorDetails = await shouldLogErrorDetails();
+        } catch (e) {
+          log(`shouldLogErrorDetails() failed: ${removeNewLines(errorToString(e))}`);
+        }
+      }
       if (isLogErrorDetails) log("", err);
       else log(removeNewLines(errorToString(err)));
       next(err);

--- a/packages/api/src/routes/util.ts
+++ b/packages/api/src/routes/util.ts
@@ -14,13 +14,16 @@ export function asyncHandler(
     next: NextFunction
     //eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) => Promise<Response<any, Record<string, any>> | void>,
-  logErrorDetails = !Config.isCloudEnv()
+  shouldLogErrorDetails?: () => Promise<boolean>
 ) {
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       await f(req, res, next);
     } catch (err) {
-      if (logErrorDetails) log("", err);
+      const isLogErrorDetails = shouldLogErrorDetails
+        ? await shouldLogErrorDetails()
+        : !Config.isCloudEnv();
+      if (isLogErrorDetails) log("", err);
       else log(removeNewLines(errorToString(err)));
       next(err);
     }

--- a/packages/core/src/command/feature-flags/domain-ffs.ts
+++ b/packages/core/src/command/feature-flags/domain-ffs.ts
@@ -101,6 +101,10 @@ export async function getCxsWithFeatureFlagEnabled(
   return [];
 }
 
+export async function isDebugFeatureFlagEnabled(): Promise<boolean> {
+  return await isFeatureFlagEnabled("debugFeatureFlag");
+}
+
 export async function isCommonwellEnabled(): Promise<boolean> {
   return isFeatureFlagEnabled("commonwellFeatureFlag");
 }

--- a/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
+++ b/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
@@ -58,6 +58,7 @@ export const initialFeatureFlags: FeatureFlagDatastore = {
   e2eCxIds: { enabled: false, values: [] },
   commonwellFeatureFlag: { enabled: false },
   carequalityFeatureFlag: { enabled: false },
+  debugFeatureFlag: { enabled: false },
   cxsWithPcpVisitAiSummaryFeatureFlag: { enabled: false, values: [] },
   cxsWithHl7NotificationWebhookFeatureFlag: { enabled: false, values: [] },
   cxsWithDischargeRequeryFeatureFlag: { enabled: false, values: [] },

--- a/packages/core/src/command/feature-flags/types.ts
+++ b/packages/core/src/command/feature-flags/types.ts
@@ -15,6 +15,7 @@ export const booleanFFsSchema = z.object({
   commonwellFeatureFlag: ffBooleanSchema,
   carequalityFeatureFlag: ffBooleanSchema,
   cqDoaFeatureFlag: ffBooleanSchema,
+  debugFeatureFlag: ffBooleanSchema,
 });
 export type BooleanFeatureFlags = z.infer<typeof booleanFFsSchema>;
 


### PR DESCRIPTION
### Dependencies

none

### Description

Add Debug FF and attach it to CW's inbound endpoint.

### Testing

All based on inbound CW endpoint:

- Local
  - [x] successful requests work without debug FF
  - [x] failed requests don't get logged when not cloud without debug FF (defaults to false)
  - [x] failed requests don't get logged when cloud without debug FF
  - [x] successful requests work WITH debug FF true
  - [x] failed requests DO NOT get logged when WITH debug FF false
  - [x] failed requests get logged when not cloud WITH debug FF true
  - [x] failed requests DO get logged when cloud WITH debug FF true
- Staging
  - [ ] successful requests work without debug FF
  - [ ] failed requests don't get logged when not cloud without debug FF (defaults to false)
  - [ ] failed requests don't get logged when cloud without debug FF
  - [ ] successful requests work WITH debug FF true
  - [ ] failed requests DO NOT get logged when WITH debug FF false
  - [ ] failed requests get logged when not cloud WITH debug FF true
  - [ ] failed requests DO get logged when cloud WITH debug FF true
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Add the FF to all envs as disabled
   ```
        "debugFeatureFlag": {
            "enabled": false
        }
   ```
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a debug feature flag to enable enhanced debugging when toggled.
  * Specific API endpoints now respect this flag, allowing controlled activation of debug behavior without affecting normal usage.
  * Error logging adapts at runtime, optionally including detailed information when permitted by the flag.
  * Default behavior remains unchanged for all users when the flag is off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->