### PR TITLE
skip roster upload lambda on MyTestHIE

### DIFF
--- a/packages/lambdas/src/hl7v2-roster.ts
+++ b/packages/lambdas/src/hl7v2-roster.ts
@@ -25,6 +25,10 @@ export const handler = capture.wrapHandler(async (config: HieConfig): Promise<vo
   const secretArn = Config.getHl7Base64ScramblerSeedArn();
   const hl7Base64ScramblerSeed = await getSecretValueOrFail(secretArn, Config.getAWSRegion());
   process.env["HL7_BASE64_SCRAMBLER_SEED"] = hl7Base64ScramblerSeed;
+  if (config.name === "MyTestHIE") {
+    log("MyTestHIE is a test hie with no sftp connection. Skipping roster upload.");
+    return;
+  }
 
   log(`Starting roster generation for config: ${config.name}`);
   await new Hl7v2RosterGenerator(apiUrl, bucketName).execute(config);


### PR DESCRIPTION
Part of ENG-920

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-920

### Dependencies
None

### Description
Skip my test hie roster upload lambda. So that it doesn't show up in alerts.

### Testing
- [ ] Trigger the lambda, make sure it is skipped and no logs show up in staging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added a safeguard to skip HL7 v2 roster uploads in a designated test environment, preventing unnecessary processing and noisy logs without impacting other environments.

- Tests
  - Improved test stability by bypassing roster generation for the designated test configuration, ensuring cleaner, faster test runs with no change to production behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->