### PR TITLE
grant read the hl7 base64 scrambler seed secret

### DIFF
--- a/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
+++ b/packages/infra/lib/hl7-notification-webhook-sender-nested-stack.ts
@@ -162,6 +162,7 @@ export class Hl7NotificationWebhookSenderNestedStack extends NestedStack {
     outgoingHl7NotificationBucket.grantReadWrite(lambda);
     hl7ConversionBucket.grantReadWrite(lambda);
     incomingHl7NotificationBucket.grantReadWrite(lambda);
+    hl7Base64ScramblerSeed.grantRead(lambda);
 
     lambda.addEventSource(new SqsEventSource(queue, eventSourceSettings));
     analyticsSecret.grantRead(lambda);


### PR DESCRIPTION
Part of ENG-986

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-968

### Description
..... grant read ....


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved intermittent failures in HL7 notification processing due to missing access to secure configuration, improving reliability and consistency across environments.
- Chores
  - Updated service permissions to securely read required configuration at runtime, aligning deployed settings with operational needs.
  - Strengthened operational stability for HL7 payload handling with no changes required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->