### PR TITLE
ENG-1079: Surescripts util script for batch requesting by facility

### DIFF
--- a/packages/core/src/external/surescripts/data-mapper.ts
+++ b/packages/core/src/external/surescripts/data-mapper.ts
@@ -50,6 +50,21 @@ export class SurescriptsDataMapper {
     return { cxId, facility, org, patients };
   }
 
+  async getBatchRequestDataByFacility(
+    cxId: string
+  ): Promise<Record<string, SurescriptsBatchRequestData>> {
+    const customer = await this.getCustomerData(cxId);
+    const facilities = customer.facilities;
+    const batchRequests: Record<string, SurescriptsBatchRequestData> = {};
+    for (const facility of facilities) {
+      const facilityId = facility.id;
+      const patientIds = await this.getPatientIdsForFacility({ cxId, facilityId });
+      const patients = await this.getEachPatientById(cxId, patientIds);
+      batchRequests[facilityId] = { cxId, facility, org: customer.org, patients };
+    }
+    return batchRequests;
+  }
+
   convertBatchRequestToPatientRequests(
     batchRequestData: SurescriptsBatchRequestData
   ): SurescriptsPatientRequestData[] {

--- a/packages/shared/src/domain/patient.ts
+++ b/packages/shared/src/domain/patient.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const patientSchema = z.object({
   id: z.string(),
-  externalId: z.string().optional(),
+  externalId: z.string().optional().or(z.null()),
   facilityIds: z.array(z.string()),
   firstName: z.string(),
   lastName: z.string(),

--- a/packages/utils/src/surescripts/index.ts
+++ b/packages/utils/src/surescripts/index.ts
@@ -23,6 +23,7 @@ import findLargest from "./find-largest";
 import bundleVerification from "./bundle-verification";
 import generateCsv from "./generate-csv";
 import sendBatchPatientRequest from "./send-batch-patient-request";
+import sendCustomerRequest from "./send-customer-request";
 
 /**
  * This is the main command registry for the Surescripts CLI. You should add any new
@@ -49,4 +50,5 @@ program.addCommand(findLargest);
 program.addCommand(bundleVerification);
 program.addCommand(generateCsv);
 program.addCommand(sendBatchPatientRequest);
+program.addCommand(sendCustomerRequest);
 program.parse();

--- a/packages/utils/src/surescripts/send-customer-request.ts
+++ b/packages/utils/src/surescripts/send-customer-request.ts
@@ -1,0 +1,54 @@
+import { Command } from "commander";
+import { out } from "@metriport/core/util/log";
+// import { SurescriptsSftpClient } from "@metriport/core/external/surescripts/client";
+import { SurescriptsDataMapper } from "@metriport/core/external/surescripts/data-mapper";
+// import { writeSurescriptsIdentifiersFile, getPatientIdsFromCsv } from "./shared";
+
+/**
+ * Sends a request for all patients of the given customer, batching requests by facility. This is the preferred method
+ * to accurately send a backfill request to Surescripts for all patients with the minimum number of SFTP transactions.
+ */
+const program = new Command();
+
+program
+  .name("customer-request")
+  .requiredOption("--cx-id <cx>", "The CX ID of the requester")
+  .requiredOption("--csv-output <csvOutput>", "The file to write CSV IDs to")
+  .option("--batch-size <batchSize>", "The maximum number of patients per batch request", "100")
+  .description(
+    "Send a request to Surescripts for all patients of the given customer, batched by facility"
+  )
+  .showHelpAfterError()
+  .version("1.0.0")
+  .action(
+    async ({
+      cxId,
+      batchSizeString,
+    }: {
+      cxId: string;
+      batchSizeString?: string;
+      csvOutput: string;
+    }) => {
+      const batchSize = parseInt(batchSizeString ?? "100");
+      if (isNaN(batchSize)) {
+        throw new Error("Batch size must be a number");
+      }
+
+      const dataMapper = new SurescriptsDataMapper();
+      const { log } = out(`Surescripts sendCustomerRequest - cxId ${cxId}`);
+
+      const batchRequests = await dataMapper.getBatchRequestDataByFacility(cxId, batchSize);
+      const facilityIds = Object.keys(batchRequests);
+      log(`Customer has ${facilityIds.length} facilities`);
+      console.log(batchRequests);
+
+      // for (const facilityId in facilityIds) {
+      //   const batches = batchRequests[facilityId];
+
+      //   // log(`There are ${ batches.length } batches for facility ${facilityId}`);
+      //   // console.log(batches[0])
+      // }
+    }
+  );
+
+export default program;

--- a/packages/utils/src/surescripts/shared.ts
+++ b/packages/utils/src/surescripts/shared.ts
@@ -29,7 +29,7 @@ export function getSurescriptsDirOrFail(): string {
   return dir;
 }
 
-export function writeSurescriptsRunsFile(filePath: string, content: string): void {
+export function writeSurescriptsRunsFile(filePath: string, content: string): string {
   const dir = getSurescriptsDirOrFail();
   const fullFilePath = path.join(dir, filePath);
   const fileDir = path.dirname(fullFilePath);
@@ -37,6 +37,12 @@ export function writeSurescriptsRunsFile(filePath: string, content: string): voi
     fs.mkdirSync(fileDir, { recursive: true });
   }
   fs.writeFileSync(fullFilePath, content, "utf-8");
+  return fullFilePath;
+}
+
+export function appendToSurescriptsRunsFile(fullFilePath: string, content: string): string {
+  fs.appendFileSync(fullFilePath, content, "utf-8");
+  return fullFilePath;
 }
 
 export function writeSurescriptsIdentifiersFile(


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-1079

### Dependencies

- Upstream: None
- Downstream: None

### Description

For customers with multiple facilities, this ensures that an accurate NPI number is sent for the patient request when requesting all patients for the customer across all facilities. This also implements the existing batch requesting mechanism to reduce the number of SFTP transactions with Surescripts, as per a recent incoming request by their technical support team.

### Testing

- Staging
  - [x] Sent batch requests for Surescripts staging facility against 9 test patients
- Production
  - [ ] Validate that this works for an immediate customer use case

### Release Plan

- [ ] Merge this
