### PR TITLE
PATCH RELEASE ENG-743 bulk ingestion's merge step runs in parallel

### DIFF
--- a/packages/utils/src/analytics-platform/2-merge-csvs.ts
+++ b/packages/utils/src/analytics-platform/2-merge-csvs.ts
@@ -9,7 +9,7 @@ import { S3Utils } from "@metriport/core/external/aws/s3";
 import { SQSClient } from "@metriport/core/external/aws/sqs";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
 import { out } from "@metriport/core/util/log";
-import { errorToString, getEnvVarOrFail, sleep } from "@metriport/shared";
+import { errorToString, getEnvVarOrFail, sleep, uuidv4 } from "@metriport/shared";
 import { buildDayjs } from "@metriport/shared/common/date";
 import { createUuidFromText } from "@metriport/shared/common/uuid";
 import { Command } from "commander";
@@ -51,7 +51,6 @@ const maxUncompressedSizePerFileInMB = 800;
 
 const mergeCsvJobId = "MRG_" + buildDayjs().toISOString().slice(0, 19).replace(/[:.]/g, "-");
 
-const messageGroupId = "merge-csvs";
 const numberOfParallelPutSqsOperations = 20;
 
 const cxId = getEnvVarOrFail("CX_ID");
@@ -123,7 +122,7 @@ async function main({ fhirToCsvJobId }: { fhirToCsvJobId: string }) {
         await sqsClient.sendMessageToQueue(queueUrl, payloadString, {
           fifo: true,
           messageDeduplicationId: createUuidFromText(ptIdsOfThisRun.join(",")),
-          messageGroupId,
+          messageGroupId: uuidv4(),
         });
 
         amountOfPatientsProcessed += ptIdsOfThisRun.length;


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-743

### Dependencies

none

### Description

Bulk ingestion's merge step runs in parallel - [context](https://metriport.slack.com/archives/C04DBBJSKGB/p1758171270217989?thread_ts=1758165959.164249&cid=C04DBBJSKGB)

### Testing

none

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and throughput of CSV merge processing by assigning unique queue groups per message, reducing bottlenecks in FIFO handling.
  * Decreases chances of processing delays and improves parallelism without altering existing behavior or interfaces.
  * No changes required from users; existing workflows continue to function with more consistent performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->