### PR TITLE
ENG-000 Single Bulk import queue for all cxs

### DIFF
--- a/packages/core/src/command/patient-import/steps/create/patient-import-create-cloud.ts
+++ b/packages/core/src/command/patient-import/steps/create/patient-import-create-cloud.ts
@@ -4,6 +4,10 @@ import { Config } from "../../../../util/config";
 import { out } from "../../../../util/log";
 import { PatientImportCreate, ProcessPatientCreateRequest } from "./patient-import-create";
 
+// All customers use the same virtual queue; i.e., their bulk imports DO NOT run in parallel
+// AKA, one bulk import at a time, across all customers
+const globalVirtualQueueId = "global-virtual-queue";
+
 export class PatientImportCreateCloud implements PatientImportCreate {
   constructor(
     private readonly patientCreateQueueUrl = Config.getPatientImportCreateQueueUrl(),
@@ -22,7 +26,7 @@ export class PatientImportCreateCloud implements PatientImportCreate {
     await this.sqsClient.sendMessageToQueue(this.patientCreateQueueUrl, payload, {
       fifo: true,
       messageDeduplicationId: createUuidFromText(payload),
-      messageGroupId: cxId,
+      messageGroupId: globalVirtualQueueId,
     });
   }
 }

--- a/packages/infra/lib/patient-import-nested-stack.ts
+++ b/packages/infra/lib/patient-import-nested-stack.ts
@@ -14,7 +14,7 @@ import { LambdaLayers } from "./shared/lambda-layers";
 import { QueueAndLambdaSettings } from "./shared/settings";
 import { createQueue } from "./shared/sqs";
 
-const waitTimePatientCreate = Duration.seconds(12); // 5 patients/min
+const waitTimePatientCreate = Duration.seconds(6); // 10 patients/min (assumes single virtual queue across all customers)
 const waitTimePatientQuery = Duration.seconds(0);
 
 function settings() {


### PR DESCRIPTION
### Dependencies

none

### Description

Single Bulk import queue for all cxs - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1758168971812049).

### Testing

- Local
  - none
- Staging
  - [ ] wait time on patient import create lambda is 6s
  - [ ] run bulk import successfully
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Consolidated bulk import processing into a single virtual FIFO queue group across all customers, ensuring serialized processing and consistent ordering.
  - Reduced the default wait time between patient-create operations from 12s to 6s, decreasing related timeouts and visibility windows for faster turnaround during imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->