### PR TITLE
ENG-1083: Support new state HIE connection / Support all PCC ADTs over one connection 

### DIFF
--- a/packages/core/src/domain/hl7-notification/utils.ts
+++ b/packages/core/src/domain/hl7-notification/utils.ts
@@ -14,7 +14,7 @@ export const MLLP_SERVER_LAST_VALID_PORT = SUPPORTED_MLLP_SERVER_PORTS[
  * @param hieName
  * @returns true if the data is from a PCC connection, false otherwise
  */
-export function isDataFromPccConnection(hieName: string): boolean {
+export function isPccConnection(hieName: string): boolean {
   return hieName === "HieTexasPcc";
 }
 export function getPccSourceHieNameByLocalPort(port: number): string {

--- a/packages/core/src/domain/hl7-notification/utils.ts
+++ b/packages/core/src/domain/hl7-notification/utils.ts
@@ -8,6 +8,20 @@ export const MLLP_SERVER_FIRST_VALID_PORT = SUPPORTED_MLLP_SERVER_PORTS[0] as nu
 export const MLLP_SERVER_LAST_VALID_PORT = SUPPORTED_MLLP_SERVER_PORTS[
   SUPPORTED_MLLP_SERVER_PORTS.length - 1
 ] as number;
-export function isPccConnection(hieName: string): boolean {
+
+/**
+ * All data from PCC connections is sent to the MLLP server over the HieTexasPcc tunnel.
+ * @param hieName
+ * @returns true if the data is from a PCC connection, false otherwise
+ */
+export function isDataFromPccConnection(hieName: string): boolean {
   return hieName === "HieTexasPcc";
+}
+export function getPccSourceHieNameByLocalPort(port: number): string {
+  if (port === 2575) {
+    return "HieTexasPcc";
+  } else if (port === 2576) {
+    return "Flhie";
+  }
+  throw new Error(`No mapping declared for specified port: ${port}`);
 }

--- a/packages/core/src/domain/hl7-notification/utils.ts
+++ b/packages/core/src/domain/hl7-notification/utils.ts
@@ -1,0 +1,13 @@
+import * as _ from "lodash";
+
+/**
+ * IF YOU CHANGE THIS, YOU MUST CHANGE THE EXPOSED PORTS IN THE MLLP_SERVER'S DOCKERFILE
+ */
+export const SUPPORTED_MLLP_SERVER_PORTS = _.range(2575, 2585);
+export const MLLP_SERVER_FIRST_VALID_PORT = SUPPORTED_MLLP_SERVER_PORTS[0] as number;
+export const MLLP_SERVER_LAST_VALID_PORT = SUPPORTED_MLLP_SERVER_PORTS[
+  SUPPORTED_MLLP_SERVER_PORTS.length - 1
+] as number;
+export function isPccConnection(hieName: string): boolean {
+  return hieName === "HieTexasPcc";
+}

--- a/packages/infra/lib/hl7-notification-stack/constants.ts
+++ b/packages/infra/lib/hl7-notification-stack/constants.ts
@@ -1,4 +1,3 @@
-export const MLLP_DEFAULT_PORT = 2575;
 export const HL7_NOTIFICATION_VPC_CIDR = "10.1.0.0/16";
 export const PROBLEMATIC_IPSEC_CHARACTERS = "!@#$%^&*()_+-=[]{}|;:,.<>?~`'\"\\/";
 export const MLLP_SERVER_CONTAINER_NAME = "MllpServer";

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -65,18 +65,17 @@ const setupNlb = (
   // END BACKWARDS COMPATIBILITY
 
   SUPPORTED_MLLP_SERVER_PORTS.forEach(port => {
-    console.log("skipping");
-    // const listener = nlb.addListener(`MllpListener${identifier}-${port}`, {
-    //   port,
-    // });
+    const listener = nlb.addListener(`MllpListener${identifier}-${port}`, {
+      port,
+    });
 
-    // listener
-    //   .addTargets(`MllpTargets${identifier}-${port}`, {
-    //     port,
-    //     protocol: elbv2.Protocol.TCP,
-    //     preserveClientIp: true,
-    //   })
-    //   .addTarget(fargateService);
+    listener
+      .addTargets(`MllpTargets${identifier}-${port}`, {
+        port,
+        protocol: elbv2.Protocol.TCP,
+        preserveClientIp: true,
+      })
+      .addTarget(fargateService);
   });
 };
 

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -49,6 +49,23 @@ const setupNlb = (
     },
   ];
 
+  // ❗️ BACKWARDS COMPATIBILITY
+  // Update the existing listener's post to 2574 so we can create our other listeners starting at port 2575
+  // with nice clean cdk identifiers.
+  // TODO: Remove this once we've migrated all our infra to the listeners with new cdk identifiers.
+  const listener = nlb.addListener(`MllpListener${identifier}`, {
+    port: 2574,
+  });
+
+  listener
+    .addTargets(`MllpTargets${identifier}`, {
+      port: 2574,
+      protocol: elbv2.Protocol.TCP,
+      preserveClientIp: true,
+    })
+    .addTarget(fargateService);
+  // END BACKWARDS COMPATIBILITY
+
   SUPPORTED_MLLP_SERVER_PORTS.forEach(port => {
     const listener = nlb.addListener(`MllpListener${identifier}-${port}`, {
       port,

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -49,8 +49,8 @@ const setupNlb = (
     },
   ];
 
-  // ❗️ BACKWARDS COMPATIBILITY
-  // Update the existing listener's post to 2574 so we can create our other listeners starting at port 2575
+  // ❗️ BACKWARDS COMPATIBILITY: TODO(ENG-1090)
+  // Update the existing listener's port to 2574 so we can create our other listeners starting at port 2575
   // with nice clean cdk identifiers.
   // TODO: Remove this once we've migrated all our infra to the listeners with new cdk identifiers.
   const listener = nlb.addListener(`MllpListener${identifier}`, {

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -57,27 +57,26 @@ const setupNlb = (
     port: 2574,
   });
 
-  listener
-    .addTargets(`MllpTargets${identifier}`, {
-      port: 2574,
-      protocol: elbv2.Protocol.TCP,
-      preserveClientIp: true,
-    })
-    .addTarget(fargateService);
+  listener.addTargets(`MllpTargets${identifier}`, {
+    port: 2574,
+    protocol: elbv2.Protocol.TCP,
+    preserveClientIp: true,
+  });
   // END BACKWARDS COMPATIBILITY
 
   SUPPORTED_MLLP_SERVER_PORTS.forEach(port => {
-    const listener = nlb.addListener(`MllpListener${identifier}-${port}`, {
-      port,
-    });
+    console.log("skipping");
+    // const listener = nlb.addListener(`MllpListener${identifier}-${port}`, {
+    //   port,
+    // });
 
-    listener
-      .addTargets(`MllpTargets${identifier}-${port}`, {
-        port,
-        protocol: elbv2.Protocol.TCP,
-        preserveClientIp: true,
-      })
-      .addTarget(fargateService);
+    // listener
+    //   .addTargets(`MllpTargets${identifier}-${port}`, {
+    //     port,
+    //     protocol: elbv2.Protocol.TCP,
+    //     preserveClientIp: true,
+    //   })
+    //   .addTarget(fargateService);
   });
 };
 

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -74,6 +74,14 @@ const setupNlb = (
         port,
         protocol: elbv2.Protocol.TCP,
         preserveClientIp: true,
+        healthCheck: {
+          port: port.toString(),
+          protocol: elbv2.Protocol.TCP,
+          healthyThresholdCount: 3,
+          unhealthyThresholdCount: 2,
+          timeout: Duration.seconds(10),
+          interval: Duration.seconds(30),
+        },
       })
       .addTarget(fargateService);
   });

--- a/packages/infra/lib/hl7-notification-stack/vpn.ts
+++ b/packages/infra/lib/hl7-notification-stack/vpn.ts
@@ -2,7 +2,7 @@ import { HieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
 import {
   MLLP_SERVER_FIRST_VALID_PORT,
   MLLP_SERVER_LAST_VALID_PORT,
-  isDataFromPccConnection,
+  isPccConnection,
 } from "@metriport/core/domain/hl7-notification/utils";
 import * as cdk from "aws-cdk-lib";
 import { Fn } from "aws-cdk-lib";
@@ -58,7 +58,7 @@ export class VpnStack extends cdk.Stack {
        **/
       const offset = props.index * 10 + internalCidrBlockIndex * 3;
 
-      const permittedIngressPorts = isDataFromPccConnection(hieName)
+      const permittedIngressPorts = isPccConnection(hieName)
         ? ec2.AclTraffic.tcpPortRange(MLLP_SERVER_FIRST_VALID_PORT, MLLP_SERVER_LAST_VALID_PORT)
         : ec2.AclTraffic.tcpPort(MLLP_SERVER_FIRST_VALID_PORT);
 

--- a/packages/infra/lib/hl7-notification-stack/vpn.ts
+++ b/packages/infra/lib/hl7-notification-stack/vpn.ts
@@ -2,7 +2,7 @@ import { HieConfig } from "@metriport/core/command/hl7v2-subscriptions/types";
 import {
   MLLP_SERVER_FIRST_VALID_PORT,
   MLLP_SERVER_LAST_VALID_PORT,
-  isPccConnection,
+  isDataFromPccConnection,
 } from "@metriport/core/domain/hl7-notification/utils";
 import * as cdk from "aws-cdk-lib";
 import { Fn } from "aws-cdk-lib";
@@ -58,7 +58,7 @@ export class VpnStack extends cdk.Stack {
        **/
       const offset = props.index * 10 + internalCidrBlockIndex * 3;
 
-      const permittedIngressPorts = isPccConnection(hieName)
+      const permittedIngressPorts = isDataFromPccConnection(hieName)
         ? ec2.AclTraffic.tcpPortRange(MLLP_SERVER_FIRST_VALID_PORT, MLLP_SERVER_LAST_VALID_PORT)
         : ec2.AclTraffic.tcpPort(MLLP_SERVER_FIRST_VALID_PORT);
 

--- a/packages/mllp-server/Dockerfile
+++ b/packages/mllp-server/Dockerfile
@@ -3,5 +3,11 @@ ENV NODE_ENV production
 WORKDIR /usr/src/app
 ADD ./metriport-mllp-server.tar.gz ./
 RUN npm ci --ignore-scripts --omit=dev --no-fund
-EXPOSE 2575
+
+###########################################################
+# IF YOU CHANGE THIS, YOU MUST CHANGE THE NLB LISTENERS AND 
+# TARGET GROUP PORTS IN INFRA/LIB/HL7-NOTIFICATION-STACK/MLLP.TS
+###########################################################
+EXPOSE 2575-2584
+
 ENTRYPOINT [ "node", "packages/mllp-server/dist/app.js" ]

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -19,7 +19,7 @@ import { asString, getCleanIpAddress, lookupHieTzEntryForIp, withErrorHandling }
 
 initSentry();
 
-const MLLP_DEFAULT_PORT = 2575;
+import { SUPPORTED_MLLP_SERVER_PORTS } from "@metriport/core/command/hl7-notification/constants";
 
 async function createHl7Server(logger: Logger): Promise<Hl7Server> {
   const { log } = logger;
@@ -84,7 +84,9 @@ async function main() {
   const logger = out("MLLP Server");
   try {
     const server = await createHl7Server(logger);
-    server.start(MLLP_DEFAULT_PORT);
+    SUPPORTED_MLLP_SERVER_PORTS.forEach(port => {
+      server.start(port);
+    });
   } catch (error) {
     logger.log("Error starting MLLP server", error);
     capture.error(error);

--- a/packages/mllp-server/src/app.ts
+++ b/packages/mllp-server/src/app.ts
@@ -9,18 +9,18 @@ import {
   getSendingApplication,
 } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/msh";
 import { getCxIdAndPatientIdOrFail } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
-import {
-  SUPPORTED_MLLP_SERVER_PORTS,
-  getPccSourceHieNameByLocalPort,
-  isDataFromPccConnection,
-} from "@metriport/core/domain/hl7-notification/utils";
-import { getHieConfigDictionary } from "@metriport/core/external/hl7-notification/hie-config-dictionary";
+import { SUPPORTED_MLLP_SERVER_PORTS } from "@metriport/core/domain/hl7-notification/utils";
 import { capture } from "@metriport/core/util";
 import type { Logger } from "@metriport/core/util/log";
 import { out } from "@metriport/core/util/log";
 import { buildDayjs } from "@metriport/shared/common/date";
 import { initSentry } from "./sentry";
-import { asString, getCleanIpAddress, lookupHieTzEntryForIp, withErrorHandling } from "./utils";
+import {
+  asString,
+  getCleanIpAddress,
+  getHieNameByConnectionInfo,
+  withErrorHandling,
+} from "./utils";
 
 initSentry();
 
@@ -31,14 +31,14 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
     connection.addEventListener(
       "message",
       withErrorHandling(connection, logger, async ({ message: rawMessage }) => {
-        const clientIp = getCleanIpAddress(connection.socket.remoteAddress);
-        const clientPort = connection.socket.remotePort;
+        const remoteIp = getCleanIpAddress(connection.socket.remoteAddress);
+        const remotePort = connection.socket.remotePort;
         const localPort = connection.socket.localPort;
         if (!localPort) {
           throw new Error("Local port is undefined");
         }
 
-        log(`New message over connection ${clientIp}:${clientPort}`);
+        log(`New message over connection ${remoteIp}:${remotePort}`);
 
         const { cxId, patientId } = getCxIdAndPatientIdOrFail(rawMessage);
 
@@ -49,11 +49,7 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
         log(
           `cx: ${cxId}, pt: ${patientId} Received ${triggerEvent} message from ${sendingApplication} at ${messageReceivedTimestamp} (messageId: ${messageId})`
         );
-        const hieConfigDictionary = getHieConfigDictionary();
-        const { hieName: rawHieName } = lookupHieTzEntryForIp(hieConfigDictionary, clientIp);
-        const hieName = isDataFromPccConnection(rawHieName)
-          ? getPccSourceHieNameByLocalPort(localPort)
-          : rawHieName;
+        const hieName = getHieNameByConnectionInfo(remoteIp, localPort);
 
         capture.setExtra({
           cxId,
@@ -81,7 +77,7 @@ async function createHl7Server(logger: Logger): Promise<Hl7Server> {
           logger.log("Connection error:", error);
           capture.error(error);
         } else {
-          logger.log("Connection terminated by client");
+          logger.log("Connection terminated by remote");
         }
       })
     );

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -12,7 +12,14 @@ import { MetriportError } from "@metriport/shared";
 import * as Sentry from "@sentry/node";
 import { Hl7Message } from "@medplum/core";
 import IPCIDR from "ip-cidr";
-import { HieConfigDictionary } from "@metriport/core/external/hl7-notification/hie-config-dictionary";
+import {
+  getHieConfigDictionary,
+  HieConfigDictionary,
+} from "@metriport/core/external/hl7-notification/hie-config-dictionary";
+import {
+  getPccSourceHieNameByLocalPort,
+  isDataFromPccConnection,
+} from "@metriport/core/domain/hl7-notification/utils";
 
 const crypto = new Base64Scrambler(Config.getHl7Base64ScramblerSeed());
 export const s3Utils = new S3Utils(Config.getAWSRegion());
@@ -80,6 +87,26 @@ export function getCleanIpAddress(address: string | undefined): string {
  */
 export function asString(message: Hl7Message) {
   return message.segments.map(s => s.toString()).join("\n");
+}
+
+/**
+ * 💡 Gets the HIE name given theconnection info.
+ *
+ * Most messages from simple HIE integrations can be identified by the sender's
+ * internalCidrBlocks. However, messages from PCC connections are sent to the MLLP
+ * server over a single tunnel. The PCC integration is set up to send each HIE's
+ * messages through the single tunnel to a unique port on the MLLP server.
+ * @param remoteIp The remote IP address - the IP address of the sender's internalCidrBlock.
+ * @param localPort The local port - the port the MLLP server is listening on..
+ * @returns The hie name for the message.
+ */
+export function getHieNameByConnectionInfo(remoteIp: string, localPort: number) {
+  const hieConfigDictionary = getHieConfigDictionary();
+  const { hieName: rawHieName } = lookupHieTzEntryForIp(hieConfigDictionary, remoteIp);
+  const hieName = isDataFromPccConnection(rawHieName)
+    ? getPccSourceHieNameByLocalPort(localPort)
+    : rawHieName;
+  return hieName;
 }
 
 /**

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -90,7 +90,7 @@ export function asString(message: Hl7Message) {
 }
 
 /**
- * 💡 Gets the HIE name given theconnection info.
+ * 💡 Gets the HIE name given the connection info.
  *
  * Most messages from simple HIE integrations can be identified by the sender's
  * internalCidrBlocks. However, messages from PCC connections are sent to the MLLP

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -18,7 +18,7 @@ import {
 } from "@metriport/core/external/hl7-notification/hie-config-dictionary";
 import {
   getPccSourceHieNameByLocalPort,
-  isDataFromPccConnection,
+  isPccConnection,
 } from "@metriport/core/domain/hl7-notification/utils";
 
 const crypto = new Base64Scrambler(Config.getHl7Base64ScramblerSeed());
@@ -103,7 +103,7 @@ export function asString(message: Hl7Message) {
 export function getHieNameByConnectionInfo(remoteIp: string, localPort: number) {
   const hieConfigDictionary = getHieConfigDictionary();
   const { hieName: rawHieName } = lookupHieTzEntryForIp(hieConfigDictionary, remoteIp);
-  const hieName = isDataFromPccConnection(rawHieName)
+  const hieName = isPccConnection(rawHieName)
     ? getPccSourceHieNameByLocalPort(localPort)
     : rawHieName;
   return hieName;


### PR DESCRIPTION
### Dependencies

None

### Description

Supports accepting ADTs for our newest state HIE over our existing PCC connection. Doing this requires dedicating a port to each state hie we want to support, and then mapping the traffic from each port to the corresponding hie in the mllp server.

### Testing

- Local
  - [x] cdk diff + deploy 
  - [x] Verified traffic is accepted over 2576 (non-2575 port)
- Staging
  - [ ] Check existing ADTs still processed fine.
- Production
  - [ ] Have them send us a test message, verify it is handled correctly.

### Release Plan

- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-port MLLP support: server now listens across a configurable MLLP port range.
  * Improved source detection: PCC-origin messages are remapped to the correct HIE source; webhook payloads include the refined HIE name.

* **Infrastructure**
  * Load balancer, VPN, NACLs and security groups updated for the MLLP port range with PCC-aware ingress.
  * Container exposes the MLLP port range; original listener preserved for backwards compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->