### PR TITLE
Fix lahie ingestion change date format to match the file formats.

### DIFF
--- a/packages/core/src/command/hl7-sftp-ingestion/sftp-ingestion-client.ts
+++ b/packages/core/src/command/hl7-sftp-ingestion/sftp-ingestion-client.ts
@@ -11,7 +11,7 @@ import {
 import { buildDayjs } from "@metriport/shared/common/date";
 
 export class LahieSftpIngestionClient extends SftpClient {
-  private readonly FILE_FORMAT = "YYYY-MM-DD";
+  private readonly FILE_FORMAT = "YYYY_MM_DD";
   protected override readonly log: typeof console.log;
 
   private constructor(sftpConfig: SftpConfig, log: typeof console.log) {

--- a/packages/utils/src/hl7v2-ingestion/hl7-sftp-ingestion.ts
+++ b/packages/utils/src/hl7v2-ingestion/hl7-sftp-ingestion.ts
@@ -55,16 +55,18 @@ const username = Config.getLahieIngestionUsername();
 const remotePath = Config.getLahieIngestionRemotePath();
 const bucketName = Config.getLahieIngestionBucket();
 const awsRegion = Config.getAWSRegion();
-const hl7IncomingMessageBucketName = Config.getHl7IncomingMessageBucketName(); //eslint-disable-line @typescript-eslint/no-unused-vars
+Config.getHl7IncomingMessageBucketName();
+Config.getLahieIngestionLambdaName();
+
 // Note these two should point to an actual arn in aws secret manager.
-const privateKeyArn = Config.getLahieIngestionPrivateKeyArn(); //eslint-disable-line @typescript-eslint/no-unused-vars
-const privateKeyPassphraseArn = Config.getLahieIngestionPrivateKeyPassphraseArn(); //eslint-disable-line @typescript-eslint/no-unused-vars
+Config.getLahieIngestionPrivateKeyArn();
+Config.getLahieIngestionPrivateKeyPassphraseArn();
 
 ////// CLOUD //////
-const lambdaName = Config.getLahieIngestionLambdaName(); //eslint-disable-line @typescript-eslint/no-unused-vars
+Config.getLahieIngestionLambdaName(); //eslint-disable-line @typescript-eslint/no-unused-vars
 
 /// GENERAL /////
-const envType = Config.getEnvType(); //eslint-disable-line @typescript-eslint/no-unused-vars
+Config.getEnvType(); //eslint-disable-line @typescript-eslint/no-unused-vars
 
 // !!(Runs a contains so this might do multiple files at a time)!!
 const filename = ""; // usually done by YYYY_MM_DD but can actually be any filename.

--- a/packages/utils/src/hl7v2-ingestion/hl7-sftp-ingestion.ts
+++ b/packages/utils/src/hl7v2-ingestion/hl7-sftp-ingestion.ts
@@ -63,10 +63,10 @@ Config.getLahieIngestionPrivateKeyArn();
 Config.getLahieIngestionPrivateKeyPassphraseArn();
 
 ////// CLOUD //////
-Config.getLahieIngestionLambdaName(); //eslint-disable-line @typescript-eslint/no-unused-vars
+Config.getLahieIngestionLambdaName();
 
 /// GENERAL /////
-Config.getEnvType(); //eslint-disable-line @typescript-eslint/no-unused-vars
+Config.getEnvType();
 
 // !!(Runs a contains so this might do multiple files at a time)!!
 const filename = ""; // usually done by YYYY_MM_DD but can actually be any filename.


### PR DESCRIPTION
…format from using - to using _

Part of ENG-1086

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1086

### Dependencies
None

### Description
Fix lahie ingestion change date format to match the file formats.
Fix comments in the lahie ingestion script to make it clearer

### Testing
- Local
  - [x] Run lahie ingestion with no parameter. So that it can create the datetimestamp itself and ingest the file.
<img width="2014" height="236" alt="image" src="https://github.com/user-attachments/assets/deb43c5c-4371-4581-bdd7-0098e3897cb9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Environment-specific configuration for LOCAL and CLOUD, including local password support and explicit environment selection.
  - Configurable option to automatically delete ingested files from cloud storage after processing.
  - Enhanced diagnostic logging and ensured script entrypoint execution.

- Changes
  - Default date format in generated HL7 SFTP filenames updated from YYYY-MM-DD to YYYY_MM_DD, which may affect filename matching and filtering workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->