### PR TITLE
fix(core): remove optional from patient class

### DIFF
--- a/packages/core/src/command/hl7-sftp-ingestion/psv-converter-schema.ts
+++ b/packages/core/src/command/hl7-sftp-ingestion/psv-converter-schema.ts
@@ -39,7 +39,6 @@ const PatClassEnum = z.preprocess(
     .refine(isAdtPatientClass, {
       message: "Invalid patient class code",
     })
-    .optional()
     .catch(ctx => {
       const input = ctx.input ?? "undefined";
       log(`WARNING: Patient Class: Invalid value "${input}" mapped to "U"`);


### PR DESCRIPTION
Part of ENG-1084

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1084

### Dependencies
None

### Description
Remove optional

### Testing

<img width="590" height="53" alt="Screenshot 2025-09-18 at 4 03 37 PM" src="https://github.com/user-attachments/assets/897afd41-eebd-4e9e-9e1d-f67bf4f27ffd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data validation for patient class during HL7 SFTP ingestion. Invalid or missing values are now treated as invalid and safely mapped to “Unknown,” reducing misclassification.
  * Enhanced logging with clearer warnings when patient class values are invalid, aiding troubleshooting.
  * No changes to public APIs or file formats; existing integrations continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->