### PR TITLE
Add Konza timezone integration

### DIFF
--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -41,7 +41,7 @@ import {
   persistHl7MessageError,
   SupportedTriggerEvent,
 } from "./utils";
-import { getBambooTimezone } from "./timezone";
+import { getBambooTimezone, getKonzaTimezone } from "./timezone";
 
 type HieConfig = { timezone: string };
 
@@ -53,6 +53,9 @@ function getTimezoneFromHieName(
   if (hieName === "Bamboo") {
     log("HIE is Bamboo, getting timezone based off state in the facility");
     return getBambooTimezone(hl7Message);
+  } else if (hieName === "Konza") {
+    log("HIE is Konza, getting timezone based off state in the facility");
+    return getKonzaTimezone(hl7Message);
   } else {
     const hieConfigDictionary = getHieConfigDictionary() as Record<string, HieConfig>;
     const hieConfig = hieConfigDictionary[hieName];


### PR DESCRIPTION
Part of ENG-1081

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1081

### Dependencies
None

### Description
Add Konza timezone integration.

### Testing
- Local
  - [ ] Send a msg to MLLP server with a PV1.39 field

<img width="1157" height="73" alt="Screenshot 2025-09-18 at 5 28 27 PM" src="https://github.com/user-attachments/assets/baa7773c-36df-4239-a603-bca9ce8807aa" />
