### PR TITLE
infrastructure for Alohr sftp ingestion

### DIFF
--- a/packages/infra/config/example.ts
+++ b/packages/infra/config/example.ts
@@ -168,6 +168,7 @@ export const config: EnvConfigNonSandbox = {
       LAHIE_INGESTION_PASSPHRASE: "your-lahie-ingestion-passphrase",
       LAHIE_INGESTION_PRIVATE_KEY: "your-lahie-ingestion-private-key",
       LAHIE_INGESTION_PASSWORD: "your-lahie-ingestion-password",
+      ALOHR_INGESTION_PASSWORD: "your-alohr-ingestion-password",
     },
     mllpServer: {
       sentryDSN: "your-sentry-dsn",
@@ -182,6 +183,15 @@ export const config: EnvConfigNonSandbox = {
       bucketName: "your-roster-bucket",
     },
     LahieSftpIngestionLambda: {
+      sftpConfig: {
+        host: "your-sftp-host",
+        port: 22,
+        username: "your-sftp-username",
+        remotePath: "your-directory-path",
+      },
+      bucketName: "your-bucket-name",
+    },
+    AlohrSftpIngestionLambda: {
       sftpConfig: {
         host: "your-sftp-host",
         port: 22,

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -7,6 +7,7 @@ export interface Hl7NotificationConfig {
     LAHIE_INGESTION_PASSPHRASE: string;
     LAHIE_INGESTION_PRIVATE_KEY: string;
     LAHIE_INGESTION_PASSWORD: string;
+    ALOHR_INGESTION_PASSWORD: string;
   };
   deprecatedIncomingMessageBucketName: string;
   incomingMessageBucketName: string;
@@ -29,6 +30,10 @@ export interface Hl7NotificationConfig {
     bucketName: string;
   };
   LahieSftpIngestionLambda: {
+    sftpConfig: HieSftpConfig;
+    bucketName: string;
+  };
+  AlohrSftpIngestionLambda: {
     sftpConfig: HieSftpConfig;
     bucketName: string;
   };

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -1,4 +1,4 @@
-import { Duration, NestedStack, NestedStackProps, Size } from "aws-cdk-lib";
+import { Duration, NestedStack, NestedStackProps, RemovalPolicy, Size } from "aws-cdk-lib";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
@@ -335,6 +335,7 @@ export class LambdasNestedStack extends NestedStack {
         publicReadAccess: false,
         encryption: s3.BucketEncryption.S3_MANAGED,
         versioned: true,
+        removalPolicy: RemovalPolicy.DESTROY,
         cors: [
           {
             allowedOrigins: ["*"],

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -121,6 +121,7 @@ export class LambdasNestedStack extends NestedStack {
   readonly acmCertificateMonitorLambda: Lambda;
   readonly hl7v2RosterUploadLambdas: Lambda[] | undefined;
   readonly hl7LahieSftpIngestionLambda: Lambda | undefined;
+  readonly hl7AlohrSftpIngestionLambda: Lambda | undefined;
   readonly conversionResultNotifierLambda: Lambda;
   readonly reconversionKickoffLambda: Lambda;
   readonly reconversionKickoffQueue: Queue;
@@ -329,6 +330,19 @@ export class LambdasNestedStack extends NestedStack {
         ],
       });
 
+      const alohrSftpIngestionBucket = new s3.Bucket(this, "alohrSftpIngestionBucket", {
+        bucketName: props.config.hl7Notification.AlohrSftpIngestionLambda.bucketName,
+        publicReadAccess: false,
+        encryption: s3.BucketEncryption.S3_MANAGED,
+        versioned: true,
+        cors: [
+          {
+            allowedOrigins: ["*"],
+            allowedMethods: [s3.HttpMethods.PUT, s3.HttpMethods.POST],
+          },
+        ],
+      });
+
       this.hl7v2RosterUploadLambdas = this.setupRosterUploadLambdas({
         lambdaLayers: props.lambdaLayers,
         vpc: props.vpc,
@@ -345,6 +359,15 @@ export class LambdasNestedStack extends NestedStack {
         config: props.config,
         alarmAction: props.alarmAction,
         lahieSftpIngestionBucket,
+      });
+
+      this.hl7AlohrSftpIngestionLambda = this.setupAlohrSftpIngestionLambda({
+        lambdaLayers: props.lambdaLayers,
+        vpc: props.vpc,
+        secrets: props.secrets,
+        config: props.config,
+        alarmAction: props.alarmAction,
+        alohrSftpIngestionBucket,
       });
     }
 
@@ -1028,6 +1051,74 @@ export class LambdasNestedStack extends NestedStack {
     );
 
     return acmCertificateMonitorLambda;
+  }
+
+  private setupAlohrSftpIngestionLambda(ownProps: {
+    lambdaLayers: LambdaLayers;
+    vpc: ec2.IVpc;
+    secrets: Secrets;
+    config: EnvConfig;
+    alohrSftpIngestionBucket: s3.IBucket;
+    alarmAction: SnsAction | undefined;
+  }): Lambda {
+    const envType = ownProps.config.environmentType;
+    const alohrProps = ownProps.config.hl7Notification?.AlohrSftpIngestionLambda;
+    if (!alohrProps) {
+      throw new Error("AlohrSftpIngestionLambda is undefined in config.");
+    }
+
+    const sftpPasswordSecret = ownProps.secrets["ALOHR_INGESTION_PASSWORD"];
+
+    if (!ownProps.config.hl7Notification) {
+      throw new Error("HL7Notification is undefined in config.");
+    }
+    const queue = ownProps.config.hl7Notification.notificationWebhookSenderQueue;
+
+    if (!queue) {
+      throw new Error("HL7NotificationWebhookSenderQueue is undefined in config.");
+    }
+
+    if (!sftpPasswordSecret) {
+      throw new Error("ALOHR_INGESTION_PASSWORD is not defined in config.");
+    }
+
+    const sftpConfig = alohrProps.sftpConfig;
+    const lambdaTimeout = Duration.minutes(5);
+    const lambdaMemorySize = 1024;
+    const hl7Base64ScramblerSeed = ownProps.secrets["HL7_BASE64_SCRAMBLER_SEED"];
+
+    if (!hl7Base64ScramblerSeed) {
+      throw new Error("HL7_BASE64_SCRAMBLER_SEED is not defined in config.");
+    }
+
+    const lambda = createScheduledLambda({
+      layers: [ownProps.lambdaLayers.shared],
+      vpc: ownProps.vpc,
+      timeout: lambdaTimeout,
+      memory: lambdaMemorySize,
+      scheduleExpression: "0/15 * * * ? *",
+      envType,
+      entry: "hl7-alohr-sftp-ingestion",
+      envVars: {
+        ALOHR_INGESTION_SFTP_CONFIG: JSON.stringify(sftpConfig),
+        ALOHR_INGESTION_REMOTE_PATH: sftpConfig.remotePath,
+        ALOHR_INGESTION_PASSWORD_ARN: sftpPasswordSecret.secretArn,
+        ALOHR_INGESTION_BUCKET_NAME: ownProps.alohrSftpIngestionBucket.bucketName,
+        HL7_BASE64_SCRAMBLER_SEED_ARN: hl7Base64ScramblerSeed.secretArn,
+        HL7_NOTIFICATION_QUEUE_URL: queue.url,
+      },
+      stack: this,
+      name: "Hl7SftpIngestionAlohr",
+      alarmSnsAction: ownProps.alarmAction,
+    });
+
+    sftpPasswordSecret.grantRead(lambda);
+
+    ownProps.alohrSftpIngestionBucket.grantReadWrite(lambda);
+    hl7Base64ScramblerSeed.grantRead(lambda);
+    const webhookSenderQueue = Queue.fromQueueArn(this, "Hl7WebhookSenderQueue", queue.arn);
+    webhookSenderQueue.grantSendMessages(lambda);
+    return lambda;
   }
 
   private setupLahieSftpIngestionLambda(ownProps: {

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -1113,7 +1113,7 @@ export class LambdasNestedStack extends NestedStack {
 
     ownProps.alohrSftpIngestionBucket.grantReadWrite(lambda);
     hl7Base64ScramblerSeed.grantRead(lambda);
-    const webhookSenderQueue = Queue.fromQueueArn(this, "Hl7WebhookSenderQueue", queue.arn);
+    const webhookSenderQueue = Queue.fromQueueArn(this, "Hl7WebhookSenderQueueAlohr", queue.arn);
     webhookSenderQueue.grantSendMessages(lambda);
     return lambda;
   }

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -1,4 +1,4 @@
-import { Duration, NestedStack, NestedStackProps, RemovalPolicy, Size } from "aws-cdk-lib";
+import { Duration, NestedStack, NestedStackProps, Size } from "aws-cdk-lib";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
@@ -335,7 +335,6 @@ export class LambdasNestedStack extends NestedStack {
         publicReadAccess: false,
         encryption: s3.BucketEncryption.S3_MANAGED,
         versioned: true,
-        removalPolicy: RemovalPolicy.DESTROY,
         cors: [
           {
             allowedOrigins: ["*"],

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -1063,21 +1063,18 @@ export class LambdasNestedStack extends NestedStack {
   }): Lambda {
     const envType = ownProps.config.environmentType;
     const alohrProps = ownProps.config.hl7Notification?.AlohrSftpIngestionLambda;
+    const sftpPasswordSecret = ownProps.secrets["ALOHR_INGESTION_PASSWORD"];
+    const queue = ownProps.config.hl7Notification?.notificationWebhookSenderQueue;
+
     if (!alohrProps) {
       throw new Error("AlohrSftpIngestionLambda is undefined in config.");
     }
-
-    const sftpPasswordSecret = ownProps.secrets["ALOHR_INGESTION_PASSWORD"];
-
     if (!ownProps.config.hl7Notification) {
       throw new Error("HL7Notification is undefined in config.");
     }
-    const queue = ownProps.config.hl7Notification.notificationWebhookSenderQueue;
-
     if (!queue) {
       throw new Error("HL7NotificationWebhookSenderQueue is undefined in config.");
     }
-
     if (!sftpPasswordSecret) {
       throw new Error("ALOHR_INGESTION_PASSWORD is not defined in config.");
     }


### PR DESCRIPTION
_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1101

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/3279
- Downstream: https://github.com/metriport/metriport/pull/4692

### Description
Add infrastructure code for Alohr sftp ingestion

### Testing
Trivial
- Staging
  - [x] Deploy to staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Alohr SFTP ingestion support and integrated it into the HL7 notification pipeline.
  * New configuration options for Alohr SFTP (host, port, username, remote path) and target bucket.
  * Added a secret for Alohr ingestion password to secure access.
  * Provisioned an encrypted, versioned storage bucket, configured lifecycle/removal behavior, and granted required access for the Alohr flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->