### PR TITLE
ENG-1123: Add requestId to webhook payload creation + update docs

### DIFF
--- a/docs/medical-api/getting-started/webhooks.mdx
+++ b/docs/medical-api/getting-started/webhooks.mdx
@@ -187,7 +187,7 @@ The format follows:
     <ResponseField name="messageId" type="string" required>
       The ID for this message from Metriport, useful for debugging purposes only;
     </ResponseField>
-    <ResponseField name="requestId" type="string" required>
+    <ResponseField name="requestId" type="string">
       The ID of the request that initiated the async flow for this webhook;
     </ResponseField>
     <ResponseField name="when" type="string" required>

--- a/docs/medical-api/getting-started/webhooks.mdx
+++ b/docs/medical-api/getting-started/webhooks.mdx
@@ -135,6 +135,7 @@ accept a `POST` request with this body...
   "ping": "<random-sequence>"
   "meta": {
     "messageId": "<message-id>",
+    "requestId": "<request-id>",
     "when": "<date-time-in-utc>",
     "type": "ping"
   }
@@ -170,6 +171,7 @@ Example payload:
 {
   "meta": {
     "messageId": "<message-id>",
+    "requestId": "<request-id>",
     "when": "<date-time-in-utc>",
     "type": "medical.medical.consolidated-data"
   },
@@ -185,7 +187,9 @@ The format follows:
     <ResponseField name="messageId" type="string" required>
       The ID for this message from Metriport, useful for debugging purposes only;
     </ResponseField>
-
+    <ResponseField name="requestId" type="string" required>
+      The ID of the request that initiated the async flow for this webhook;
+    </ResponseField>
     <ResponseField name="when" type="string" required>
       The timestamp when this message was originally sent, formatted as [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601)
       (example: `2022-12-24T00:46:05.413Z`)

--- a/docs/medical-api/handling-data/realtime-patient-notifications.mdx
+++ b/docs/medical-api/handling-data/realtime-patient-notifications.mdx
@@ -18,6 +18,7 @@ Each realtime notification we send via webhook has a payload that includes key i
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
+    "requestId": "a77c8bd6-f290-492d-85d5-a9e40d900432",
     "when": "2025-01-30T23:00:01.000Z",
     "type": "patient.admit"
   },
@@ -137,6 +138,9 @@ A Patient Admit event is emitted when a patient undergoes the admission process,
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
     </ResponseField>
+    <ResponseField name="requestId" type="string" required>
+      The ID of the request that initiated the async flow for this webhook;
+    </ResponseField>
     <ResponseField name="when" type="string" required>
       An ISO-8601 datetime of when this webhook was sent.
     </ResponseField>
@@ -203,6 +207,7 @@ A Patient Admit event is emitted when a patient undergoes the admission process,
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
+    "requestId": "a77c8bd6-f290-492d-85d5-a9e40d900432",
     "when": "2025-01-30T23:00:01.000Z",
     "type": "patient.admit"
   },
@@ -230,6 +235,9 @@ A Patient Transfer event indicates that a patient has been moved from one locati
   <Expandable title="meta properties">
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
+    </ResponseField>
+    <ResponseField name="requestId" type="string" required>
+      The ID of the request that initiated the async flow for this webhook;
     </ResponseField>
     <ResponseField name="when" type="string" required>
       An ISO-8601 datetime of when this webhook was sent.
@@ -333,6 +341,7 @@ A Patient Transfer event indicates that a patient has been moved from one locati
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
+    "requestId": "a77c8bd6-f290-492d-85d5-a9e40d900432",
     "when": "2025-01-30T20:30:01.000Z",
     "type": "patient.transfer"
   },
@@ -384,6 +393,9 @@ A Patient Discharge event indicates the end of a patient's stay in a healthcare 
   <Expandable title="meta properties">
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
+    </ResponseField>
+    <ResponseField name="requestId" type="string" required>
+      The ID of the request that initiated the async flow for this webhook;
     </ResponseField>
     <ResponseField name="when" type="string" required>
       An ISO-8601 datetime of when this webhook was sent.
@@ -455,6 +467,7 @@ A Patient Discharge event indicates the end of a patient's stay in a healthcare 
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
+    "requestId": "a77c8bd6-f290-492d-85d5-a9e40d900432",
     "when": "2025-01-30T23:00:01.000Z",
     "type": "patient.discharge"
   },

--- a/docs/medical-api/handling-data/realtime-patient-notifications.mdx
+++ b/docs/medical-api/handling-data/realtime-patient-notifications.mdx
@@ -138,7 +138,7 @@ A Patient Admit event is emitted when a patient undergoes the admission process,
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
     </ResponseField>
-    <ResponseField name="requestId" type="string" required>
+    <ResponseField name="requestId" type="string">
       The ID of the request that initiated the async flow for this webhook;
     </ResponseField>
     <ResponseField name="when" type="string" required>
@@ -236,7 +236,7 @@ A Patient Transfer event indicates that a patient has been moved from one locati
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
     </ResponseField>
-    <ResponseField name="requestId" type="string" required>
+    <ResponseField name="requestId" type="string">
       The ID of the request that initiated the async flow for this webhook;
     </ResponseField>
     <ResponseField name="when" type="string" required>
@@ -394,7 +394,7 @@ A Patient Discharge event indicates the end of a patient's stay in a healthcare 
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
     </ResponseField>
-    <ResponseField name="requestId" type="string" required>
+    <ResponseField name="requestId" type="string">
       The ID of the request that initiated the async flow for this webhook;
     </ResponseField>
     <ResponseField name="when" type="string" required>

--- a/docs/medical-api/handling-data/webhooks.mdx
+++ b/docs/medical-api/handling-data/webhooks.mdx
@@ -135,6 +135,7 @@ These are messages you can expect to receive in the following scenarios:
 {
   "meta": {
     "messageId": "<message-id>",
+    "requestId": "<request-id>",
     "when": "<date-time-in-utc>",
     "type": "medical.document-download"
     "data": {
@@ -276,6 +277,7 @@ Example payload:
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
+    "requestId": "00000000-0000-0000-0000-000000000000",
     "when": "2023-08-23T22:09:11.373Z",
     "type": "medical.consolidated-data"
   },
@@ -411,7 +413,8 @@ Example payload:
 ```json
 {
   "meta": {
-    "messageId": "00000000-00000000-00000000-00000000",
+    "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
+    "requestId": "00000000-0000-0000-0000-000000000000",
     "when": "2024-12-30T05:05:12.215Z",
     "type": "medical.bulk-patient-create"
   },
@@ -510,6 +513,7 @@ Here is an example payload:
 {
 "meta": {
     "messageId": "bd4184dd-3b35-4c60-8130-447d1d528fea",
+    "requestId": "00000000-0000-0000-0000-000000000000",
     "when": "2023-11-30T05:05:12.215Z",
     "type": "medical.document-bulk-download-urls"
   },

--- a/fern/definition/medical/webhooks.yml
+++ b/fern/definition/medical/webhooks.yml
@@ -61,6 +61,9 @@ types:
       messageId:
         type: string
         docs: The ID of the message.
+      requestId:
+        type: string
+        docs: The ID of the request that initiated the async flow for this webhook.
       when:
         type: string
         docs: The timestamp of when the webhook was triggered.

--- a/fern/definition/medical/webhooks.yml
+++ b/fern/definition/medical/webhooks.yml
@@ -62,7 +62,7 @@ types:
         type: string
         docs: The ID of the message.
       requestId:
-        type: string
+        type: optional<string>
         docs: The ID of the request that initiated the async flow for this webhook.
       when:
         type: string

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -93,7 +93,7 @@ export async function processRequest(
     const payload = webhookRequest.payload;
     const meta: WebhookMetadata = {
       messageId: webhookRequest.id,
-      requestId: webhookRequest.requestId,
+      ...(webhookRequest.requestId ? { requestId: webhookRequest.requestId } : {}),
       when: buildDayjs(webhookRequest.createdAt).toISOString(),
       type: webhookRequest.type,
       data: cxWHRequestMeta,

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -93,6 +93,7 @@ export async function processRequest(
     const payload = webhookRequest.payload;
     const meta: WebhookMetadata = {
       messageId: webhookRequest.id,
+      requestId: webhookRequest.requestId,
       when: buildDayjs(webhookRequest.createdAt).toISOString(),
       type: webhookRequest.type,
       data: cxWHRequestMeta,

--- a/packages/shared/src/medical/webhook/webhook-request.ts
+++ b/packages/shared/src/medical/webhook/webhook-request.ts
@@ -44,6 +44,7 @@ export type WebhookRequestStatus = (typeof webhookRequestStatus)[number];
 
 export const baseWebhookMetadataSchema = z.object({
   messageId: z.string(),
+  requestId: z.string(),
   when: dateSchema,
   /**
    * The metadata sent by the customer when they triggered the operation that resulted in this webhook.

--- a/packages/shared/src/medical/webhook/webhook-request.ts
+++ b/packages/shared/src/medical/webhook/webhook-request.ts
@@ -44,7 +44,7 @@ export type WebhookRequestStatus = (typeof webhookRequestStatus)[number];
 
 export const baseWebhookMetadataSchema = z.object({
   messageId: z.string(),
-  requestId: z.string(),
+  requestId: z.string().optional(),
   when: dateSchema,
   /**
    * The metadata sent by the customer when they triggered the operation that resulted in this webhook.

--- a/samples/typescript-express/.env.example
+++ b/samples/typescript-express/.env.example
@@ -1,3 +1,5 @@
 METRIPORT_API_KEY="..."
 METRIPORT_WH_KEY="..."
 FACILITY_ID="..."
+# Keep this set to false in order to hit the Metriport sandbox environment.
+IS_PROD="false"

--- a/samples/typescript-express/src/index.ts
+++ b/samples/typescript-express/src/index.ts
@@ -5,10 +5,11 @@ import { MetriportMedicalApi, USState } from "@metriport/api-sdk";
 import { getEnvVarOrFail } from "@metriport/shared";
 
 const apiKey = getEnvVarOrFail("METRIPORT_API_KEY");
-const isProd = getEnvVarOrFail("IS_PROD") === "true";
+// const isProd = getEnvVarOrFail("IS_PROD") === "true";
 
 const metriportClient = new MetriportMedicalApi(apiKey, {
-  baseAddress: isProd ? "https://api.metriport.com" : "https://api.sandbox.metriport.com",
+  // baseAddress: isProd ? "https://api.metriport.com" : "https://api.sandbox.metriport.com",
+  baseAddress: "http://localhost:8080",
 });
 
 async function main() {
@@ -51,9 +52,10 @@ async function main() {
 
   let page = 1;
   // const { meta, patients } = await metriportClient.listPatients({ facilityId });
-  const { meta, patients } = await metriportClient.listPatients();
+  const { meta, patients } = await metriportClient.listPatients({ pagination: { count: 10 } });
   console.log(`Page ${page++} has ${patients.length} patients`);
   // do something with the patients...
+  console.log(await metriportClient.listPatients());
   let nextPage = meta.nextPage;
   while (nextPage) {
     const { meta, patients } = await metriportClient.listPatientsPage(nextPage);


### PR DESCRIPTION
### Dependencies

None

### Description

Add requestId field to the meta payload for our webhook requests.

Issues:
1. requestId is optional in the DB and we have a small number of webhooks (2%) being written to `webhook_request` that _have no request id_, so I need to expose it to customers as an optional field, rather than one that is guaranteed to appear.
2. bulk patient create already has a request Id in the payload field. This is yucky as the request id is appearing in both the data object and the meta object.

Pics
<img width="4000" height="2156" alt="image" src="https://github.com/user-attachments/assets/00f37abe-7eef-49df-a0cc-9489d17fc194" />
<img width="3240" height="1692" alt="image" src="https://github.com/user-attachments/assets/83790645-1f80-4a90-be5b-a915166c2433" />
<img width="3128" height="1784" alt="image" src="https://github.com/user-attachments/assets/dafea3c6-8b6c-4f1c-89fb-0744789bee65" />
<img width="3232" height="1572" alt="image" src="https://github.com/user-attachments/assets/dbc69ff2-158c-4927-86ac-3133f286756a" />

### Testing

- Local
  - [x] Send webhook request, ensure that my webhook handler gets hit.
- Staging
  - [ ] Send webhook request, ensure that my webhook handler gets hit.
- Production
  - [ ] Send webhook request, ensure that my webhook handler gets hit.

### Release Plan

- [ ] Merge this
