### PR TITLE
ENG-1133: add status + code fields to assessment -> diagnostic report mapping

### DIFF
--- a/packages/fhir-converter/src/templates/cda/References/DiagnosticReport/assessment.hbs
+++ b/packages/fhir-converter/src/templates/cda/References/DiagnosticReport/assessment.hbs
@@ -30,11 +30,11 @@
         "resourceType": "DiagnosticReport",
         "id":"{{ID}}",
         "status":{{>ValueSet/DiagnosticReportStatus.hbs code="unknown"}},
-        "code": { "coding": [{{>DataType/Coding.hbs canBeUnknown=true}}] },
+        "code": {{>DataType/CodeableConcept.hbs code=code}},
         "presentedForm": [
                 {
                     "contentType": "text/plain",
-                    "data": "{{{base64Encode text}}}",
+                    "data": "{{{base64Encode rawText}}}",
                 }
             ],
     },

--- a/packages/fhir-converter/src/templates/cda/Sections/Assessments.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Assessments.hbs
@@ -30,7 +30,7 @@
         {{#each (toArray 2_16_840_1_113883_10_20_22_2_8) as |assessment|}}
             {{#if (and assessment.text (contains (toLower assessment.title._) "assessment"))}}
                 {{#with (extractAndMapTableData assessment.text) as |assessmentMap|}}
-                    {{>References/DiagnosticReport/assessment.hbs text=(convertMappedDataToPlainText assessmentMap) ID=(generateUUID (toJsonString assessment))}},
+                    {{>References/DiagnosticReport/assessment.hbs rawText=(convertMappedDataToPlainText assessmentMap) code=assessment.code ID=(generateUUID (toJsonString assessment))}},
                 {{/with}}
             {{/if}}
         {{/each}}


### PR DESCRIPTION
### Dependencies

None

### Description

This PR fixes an issue where the mapping from CDA Assessment sections to FHIR Diagnostic Reports did not include status or code fields, which was not to the R4 spec. 

Maps status from CDA -> FHIR, but no clear mapping to the status field in FHIR exists ([see spec](https://build.fhir.org/ig/HL7/CDA-ccda/StructureDefinition-AssessmentSection.html)) so it is set to unknown.

### Testing

- Local
  - [x] Run xml through fhir converter, diff outputs from before + after change
<img width="715" height="294" alt="image" src="https://github.com/user-attachments/assets/29b3c5d9-8bec-4f50-9965-8064cf7e52b5" />


- Staging
  - [x] Run xml through fhir converter, verify output
- Production
  - [ ] Run xml through fhir converter, verify output

### Release Plan
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DiagnosticReport now includes a status field (defaults to “unknown” when absent).
  * DiagnosticReport now includes a code entry to better represent assessment coding.
  * Report attachments now use raw text for base64-encoded presented form, improving fidelity of embedded content.

* **Impact**
  * Enhances completeness and interoperability of generated DiagnosticReport resources and improves accuracy of embedded report content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->