### PR TITLE
ENG-000 Log pt IDs w/o consolidated on snowflake script

### DIFF
--- a/packages/utils/src/analytics-platform/1-fhir-to-csv.ts
+++ b/packages/utils/src/analytics-platform/1-fhir-to-csv.ts
@@ -117,6 +117,8 @@ async function main({
         localStartedAt
       )}`
     );
+    const difference = uniquePatientIds.filter(id => !filtererdPatientIds.includes(id));
+    log(`>>> Patients without consolidated data (${difference.length}):\n${difference.join(", ")}`);
   } else {
     filtererdPatientIds = uniquePatientIds;
   }


### PR DESCRIPTION
### Dependencies

none

### Description

Log pt IDs w/o consolidated on snowflake script.

### Testing

- Local
  - [x] Run script w/ cx that has pts w/o consolidated and get those IDS on console
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added enhanced diagnostic logging during CSV generation from FHIR data. Each run now reports the count and list of patient IDs excluded due to missing consolidated data, improving observability and troubleshooting.
  * No changes to processing logic or output format; this update is log-only and does not affect results or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->