### PR TITLE
ENG-000 Docker compose sets host storage for Postgres

### DIFF
--- a/packages/api/docker-compose.dev.yml
+++ b/packages/api/docker-compose.dev.yml
@@ -85,6 +85,8 @@ services:
       - "5432:5432"
     networks:
       - metriportNetwork
+    volumes:
+      - ~/postgres_data/oss:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 2s

--- a/packages/utils/src/account-initialization/init-account.ts
+++ b/packages/utils/src/account-initialization/init-account.ts
@@ -14,7 +14,7 @@ import {
   OrganizationBizType,
   TreatmentType,
   USStateForAddress,
-  uuidv7,
+  uuidv4,
 } from "@metriport/shared";
 import { makeNPI } from "@metriport/shared/common/__tests__/npi";
 import { makeOid } from "@metriport/shared/common/__tests__/oid";
@@ -46,7 +46,7 @@ dayjs.extend(duration);
  * Options:
  * -o, --org-name <name>         Organization name (optional, auto-generated if not provided)
  * -t, --org-type <type>         Organization type: healthcare_provider or healthcare_it_vendor (required)
- * -f, --facility-type <type>    Type of facility: initiator-and-responder or initiator-only
+ * -f, --facility-type <type>    Type of facility: initiator_and_responder or initiator_only
  * --facility-count <number>     Number of facilities to create (1-50) (default: 3)
  * --cq-approved                 Set CareQuality approved status (default: false)
  * --cq-active                   Set CareQuality active status (default: false)
@@ -137,7 +137,7 @@ async function main() {
   }
 
   // Set configuration from command line arguments
-  cxId = options.cxId || uuidv7();
+  cxId = options.cxId || uuidv4();
   orgName = options.orgName || makeShortName();
   orgType = options.orgType as OrganizationBizType;
   orgTreatmentType = faker.helpers.enumValue(TreatmentType);


### PR DESCRIPTION
Ref eng-000

Signed-off-by: Rafael Leite <2132564+leite08@users.noreply.github.com>

### Dependencies

none

### Description

Docker compose set's host storage for Postgres. Currently, any issues w/ Postgres on Docker left you without access to the DB's underlying volume/storage - [example](https://metriport.slack.com/archives/C04DMKE9DME/p1758608592608199).

This changes it, so one can recreate containers w/o losing the underlying data.

### Testing

- Local
  - [x] create new container creates the data folder on host machine
  - [ ] running docker compose w/ existing container doesn't break it
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help: facility-type values now use underscores (initiator_and_responder / initiator_only). Adjust your commands accordingly.
* **Chores**
  * Dev environment: Postgres data in docker-compose now persists across container restarts via a local volume.
* **Refactor**
  * Default CX ID generation now uses a different UUID version, with no expected impact on typical usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->