### PR TITLE
PATCH Revert "Merge pull request #4715 from metriport/develop"

### DIFF
--- a/docs/medical-api/getting-started/webhooks.mdx
+++ b/docs/medical-api/getting-started/webhooks.mdx
@@ -135,7 +135,6 @@ accept a `POST` request with this body...
   "ping": "<random-sequence>"
   "meta": {
     "messageId": "<message-id>",
-    "requestId": "<request-id>",
     "when": "<date-time-in-utc>",
     "type": "ping"
   }
@@ -171,7 +170,6 @@ Example payload:
 {
   "meta": {
     "messageId": "<message-id>",
-    "requestId": "<request-id>",
     "when": "<date-time-in-utc>",
     "type": "medical.medical.consolidated-data"
   },
@@ -187,9 +185,7 @@ The format follows:
     <ResponseField name="messageId" type="string" required>
       The ID for this message from Metriport, useful for debugging purposes only;
     </ResponseField>
-    <ResponseField name="requestId" type="string">
-      The ID of the request that initiated the async flow for this webhook;
-    </ResponseField>
+
     <ResponseField name="when" type="string" required>
       The timestamp when this message was originally sent, formatted as [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601)
       (example: `2022-12-24T00:46:05.413Z`)

--- a/docs/medical-api/handling-data/realtime-patient-notifications.mdx
+++ b/docs/medical-api/handling-data/realtime-patient-notifications.mdx
@@ -18,7 +18,6 @@ Each realtime notification we send via webhook has a payload that includes key i
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
-    "requestId": "a77c8bd6-f290-492d-85d5-a9e40d900432",
     "when": "2025-01-30T23:00:01.000Z",
     "type": "patient.admit"
   },
@@ -138,9 +137,6 @@ A Patient Admit event is emitted when a patient undergoes the admission process,
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
     </ResponseField>
-    <ResponseField name="requestId" type="string">
-      The ID of the request that initiated the async flow for this webhook;
-    </ResponseField>
     <ResponseField name="when" type="string" required>
       An ISO-8601 datetime of when this webhook was sent.
     </ResponseField>
@@ -207,7 +203,6 @@ A Patient Admit event is emitted when a patient undergoes the admission process,
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
-    "requestId": "a77c8bd6-f290-492d-85d5-a9e40d900432",
     "when": "2025-01-30T23:00:01.000Z",
     "type": "patient.admit"
   },
@@ -235,9 +230,6 @@ A Patient Transfer event indicates that a patient has been moved from one locati
   <Expandable title="meta properties">
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
-    </ResponseField>
-    <ResponseField name="requestId" type="string">
-      The ID of the request that initiated the async flow for this webhook;
     </ResponseField>
     <ResponseField name="when" type="string" required>
       An ISO-8601 datetime of when this webhook was sent.
@@ -341,7 +333,6 @@ A Patient Transfer event indicates that a patient has been moved from one locati
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
-    "requestId": "a77c8bd6-f290-492d-85d5-a9e40d900432",
     "when": "2025-01-30T20:30:01.000Z",
     "type": "patient.transfer"
   },
@@ -393,9 +384,6 @@ A Patient Discharge event indicates the end of a patient's stay in a healthcare 
   <Expandable title="meta properties">
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
-    </ResponseField>
-    <ResponseField name="requestId" type="string">
-      The ID of the request that initiated the async flow for this webhook;
     </ResponseField>
     <ResponseField name="when" type="string" required>
       An ISO-8601 datetime of when this webhook was sent.
@@ -467,7 +455,6 @@ A Patient Discharge event indicates the end of a patient's stay in a healthcare 
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
-    "requestId": "a77c8bd6-f290-492d-85d5-a9e40d900432",
     "when": "2025-01-30T23:00:01.000Z",
     "type": "patient.discharge"
   },

--- a/docs/medical-api/handling-data/webhooks.mdx
+++ b/docs/medical-api/handling-data/webhooks.mdx
@@ -135,7 +135,6 @@ These are messages you can expect to receive in the following scenarios:
 {
   "meta": {
     "messageId": "<message-id>",
-    "requestId": "<request-id>",
     "when": "<date-time-in-utc>",
     "type": "medical.document-download"
     "data": {
@@ -277,7 +276,6 @@ Example payload:
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
-    "requestId": "00000000-0000-0000-0000-000000000000",
     "when": "2023-08-23T22:09:11.373Z",
     "type": "medical.consolidated-data"
   },
@@ -413,8 +411,7 @@ Example payload:
 ```json
 {
   "meta": {
-    "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
-    "requestId": "00000000-0000-0000-0000-000000000000",
+    "messageId": "00000000-00000000-00000000-00000000",
     "when": "2024-12-30T05:05:12.215Z",
     "type": "medical.bulk-patient-create"
   },
@@ -513,7 +510,6 @@ Here is an example payload:
 {
 "meta": {
     "messageId": "bd4184dd-3b35-4c60-8130-447d1d528fea",
-    "requestId": "00000000-0000-0000-0000-000000000000",
     "when": "2023-11-30T05:05:12.215Z",
     "type": "medical.document-bulk-download-urls"
   },

--- a/fern/definition/medical/webhooks.yml
+++ b/fern/definition/medical/webhooks.yml
@@ -61,9 +61,6 @@ types:
       messageId:
         type: string
         docs: The ID of the message.
-      requestId:
-        type: optional<string>
-        docs: The ID of the request that initiated the async flow for this webhook.
       when:
         type: string
         docs: The timestamp of when the webhook was triggered.

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -93,7 +93,6 @@ export async function processRequest(
     const payload = webhookRequest.payload;
     const meta: WebhookMetadata = {
       messageId: webhookRequest.id,
-      ...(webhookRequest.requestId ? { requestId: webhookRequest.requestId } : {}),
       when: buildDayjs(webhookRequest.createdAt).toISOString(),
       type: webhookRequest.type,
       data: cxWHRequestMeta,

--- a/packages/fhir-converter/src/templates/cda/References/DiagnosticReport/assessment.hbs
+++ b/packages/fhir-converter/src/templates/cda/References/DiagnosticReport/assessment.hbs
@@ -29,12 +29,10 @@
     "resource":{
         "resourceType": "DiagnosticReport",
         "id":"{{ID}}",
-        "status":{{>ValueSet/DiagnosticReportStatus.hbs code="unknown"}},
-        "code": {{>DataType/CodeableConcept.hbs code=code}},
         "presentedForm": [
                 {
                     "contentType": "text/plain",
-                    "data": "{{{base64Encode rawText}}}",
+                    "data": "{{{base64Encode text}}}",
                 }
             ],
     },

--- a/packages/fhir-converter/src/templates/cda/Sections/Assessments.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Assessments.hbs
@@ -30,7 +30,7 @@
         {{#each (toArray 2_16_840_1_113883_10_20_22_2_8) as |assessment|}}
             {{#if (and assessment.text (contains (toLower assessment.title._) "assessment"))}}
                 {{#with (extractAndMapTableData assessment.text) as |assessmentMap|}}
-                    {{>References/DiagnosticReport/assessment.hbs rawText=(convertMappedDataToPlainText assessmentMap) code=assessment.code ID=(generateUUID (toJsonString assessment))}},
+                    {{>References/DiagnosticReport/assessment.hbs text=(convertMappedDataToPlainText assessmentMap) ID=(generateUUID (toJsonString assessment))}},
                 {{/with}}
             {{/if}}
         {{/each}}

--- a/packages/shared/src/medical/webhook/webhook-request.ts
+++ b/packages/shared/src/medical/webhook/webhook-request.ts
@@ -44,7 +44,6 @@ export type WebhookRequestStatus = (typeof webhookRequestStatus)[number];
 
 export const baseWebhookMetadataSchema = z.object({
   messageId: z.string(),
-  requestId: z.string().optional(),
   when: dateSchema,
   /**
    * The metadata sent by the customer when they triggered the operation that resulted in this webhook.

--- a/packages/utils/src/analytics-platform/1-fhir-to-csv.ts
+++ b/packages/utils/src/analytics-platform/1-fhir-to-csv.ts
@@ -117,8 +117,6 @@ async function main({
         localStartedAt
       )}`
     );
-    const difference = uniquePatientIds.filter(id => !filtererdPatientIds.includes(id));
-    log(`>>> Patients without consolidated data (${difference.length}):\n${difference.join(", ")}`);
   } else {
     filtererdPatientIds = uniquePatientIds;
   }

--- a/samples/typescript-express/.env.example
+++ b/samples/typescript-express/.env.example
@@ -1,5 +1,3 @@
 METRIPORT_API_KEY="..."
 METRIPORT_WH_KEY="..."
 FACILITY_ID="..."
-# Keep this set to false in order to hit the Metriport sandbox environment.
-IS_PROD="false"

--- a/samples/typescript-express/src/index.ts
+++ b/samples/typescript-express/src/index.ts
@@ -51,7 +51,7 @@ async function main() {
 
   let page = 1;
   // const { meta, patients } = await metriportClient.listPatients({ facilityId });
-  const { meta, patients } = await metriportClient.listPatients({ pagination: { count: 10 } });
+  const { meta, patients } = await metriportClient.listPatients();
   console.log(`Page ${page++} has ${patients.length} patients`);
   // do something with the patients...
   let nextPage = meta.nextPage;


### PR DESCRIPTION
### Dependencies

None

### Description

Revert merge

### Testing

None - revert pr

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Webhook payloads: removed requestId from metadata; messageId, when, and type remain.
  - FHIR CDA output: removed DiagnosticReport status/code; presentedForm now encodes from text.
- Documentation
  - Updated webhook and real‑time patient notification examples and schemas to omit requestId; standardized example IDs.
- Samples
  - Simplified listPatients usage to default paging.
  - Pruned .env.example by removing IS_PROD guidance/variable.
- Chores
  - Removed analytics log about patients without consolidated data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->