### PR TITLE
ENG-1138: update staleloopbackhours to 2 weeks instead of 1 week

### DIFF
--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -25,7 +25,7 @@ import { getCqInitiator } from "../shared";
 import { createOutboundDocumentQueryRequests } from "./create-outbound-document-query-req";
 import { filterCqLinksByManagingOrg } from "./filter-oids-by-managing-org";
 
-const staleLookbackWeeks = 1;
+const staleLookbackWeeks = 2;
 
 export async function getDocumentsFromCQ({
   requestId,
@@ -125,7 +125,8 @@ export async function getDocumentsFromCQ({
     });
 
     const linksWithDqUrl: CQLink[] = [];
-    const addDqUrlToCqLink = async (patientLink: CQLink): Promise<void> => {
+    // eslint-disable-next-line no-inner-declarations
+    async function addDqUrlToCqLink(patientLink: CQLink): Promise<void> {
       const gateway = await getCQDirectoryEntry(patientLink.oid);
 
       if (!gateway) {
@@ -141,7 +142,7 @@ export async function getDocumentsFromCQ({
         ...patientLink,
         url: gateway.urlDQ,
       });
-    };
+    }
     await executeAsynchronously(cqPatientData.data.links, addDqUrlToCqLink, {
       numberOfParallelExecutions: 20,
     });

--- a/packages/api/src/external/commonwell-v1/document/document-query.ts
+++ b/packages/api/src/external/commonwell-v1/document/document-query.ts
@@ -67,7 +67,7 @@ import {
   getFileName,
 } from "./shared";
 
-const staleLookbackWeeks = 1;
+const staleLookbackWeeks = 2;
 
 const DOC_DOWNLOAD_CHUNK_SIZE = 10;
 

--- a/packages/api/src/external/commonwell-v2/document/document-query.ts
+++ b/packages/api/src/external/commonwell-v2/document/document-query.ts
@@ -65,7 +65,7 @@ import {
   getDocPrintableDetails,
 } from "./shared";
 
-const staleLookbackWeeks = 1;
+const staleLookbackWeeks = 2;
 
 const DOC_DOWNLOAD_CHUNK_SIZE = 10;
 


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/eng-1138

### Dependencies

- none

### Description

Change loopbackhours to 2 weeks


### Testing

- Local
  - [x]   Run (CQ) DQ on patient who has never had PD ran (should run PD and schedule DQ)
  - [x]  Run (CQ) DQ on patient who has had PD ran in the last week (exactly 2 days ago) (should NOT run PD but should run DQ)
  - [x]  Run (CQ) DQ on patient who has had PD ran but at least 2 week ago (should run PD and schedule DQ)
  - [x]  Run (CQ) DQ on patient who has had PD ran between 1-2 weeks ago (should NOT run PD but should run DQ)
  - [x]  Same tests but for CW with CQ disabled
- Staging
  - none 
- Sandbox
  - none 
- Production
  - none 


### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Increased the stale-patient lookback window to 2 weeks across Carequality and CommonWell document queries. This reduces redundant re-queries, smooths scheduling cadence, and improves overall system efficiency and stability for document retrieval.
* **Chores**
  * Applied internal code style consistency updates with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->