### PR TITLE
ENG-1133 + ENG-1123: Unrevert (requestId in wh + DiagnosticReport missing status / code) and fix breakage.

### DIFF
--- a/docs/_snippets/request-id.mdx
+++ b/docs/_snippets/request-id.mdx
@@ -1,3 +1,3 @@
-<ResponseField name="requestId" type="string">
+<ResponseField name="requestId" type="string" optional>
   The ID of your request. This can be referenced for support.
 </ResponseField>

--- a/docs/medical-api/getting-started/webhooks.mdx
+++ b/docs/medical-api/getting-started/webhooks.mdx
@@ -188,7 +188,7 @@ The format follows:
       The ID for this message from Metriport, useful for debugging purposes only;
     </ResponseField>
     <ResponseField name="requestId" type="string">
-      The ID of the request that initiated the async flow for this webhook;
+      The ID of the request that initiated the async flow for this webhook.
     </ResponseField>
     <ResponseField name="when" type="string" required>
       The timestamp when this message was originally sent, formatted as [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601)

--- a/docs/medical-api/getting-started/webhooks.mdx
+++ b/docs/medical-api/getting-started/webhooks.mdx
@@ -187,7 +187,7 @@ The format follows:
     <ResponseField name="messageId" type="string" required>
       The ID for this message from Metriport, useful for debugging purposes only;
     </ResponseField>
-    <ResponseField name="requestId" type="string">
+    <ResponseField name="requestId" type="string" optional>
       The ID of the request that initiated the async flow for this webhook.
     </ResponseField>
     <ResponseField name="when" type="string" required>

--- a/docs/medical-api/getting-started/webhooks.mdx
+++ b/docs/medical-api/getting-started/webhooks.mdx
@@ -135,6 +135,7 @@ accept a `POST` request with this body...
   "ping": "<random-sequence>"
   "meta": {
     "messageId": "<message-id>",
+    "requestId": "<request-id>",
     "when": "<date-time-in-utc>",
     "type": "ping"
   }
@@ -170,6 +171,7 @@ Example payload:
 {
   "meta": {
     "messageId": "<message-id>",
+    "requestId": "<request-id>",
     "when": "<date-time-in-utc>",
     "type": "medical.medical.consolidated-data"
   },
@@ -185,7 +187,9 @@ The format follows:
     <ResponseField name="messageId" type="string" required>
       The ID for this message from Metriport, useful for debugging purposes only;
     </ResponseField>
-
+    <ResponseField name="requestId" type="string">
+      The ID of the request that initiated the async flow for this webhook;
+    </ResponseField>
     <ResponseField name="when" type="string" required>
       The timestamp when this message was originally sent, formatted as [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601)
       (example: `2022-12-24T00:46:05.413Z`)

--- a/docs/medical-api/handling-data/realtime-patient-notifications.mdx
+++ b/docs/medical-api/handling-data/realtime-patient-notifications.mdx
@@ -18,6 +18,7 @@ Each realtime notification we send via webhook has a payload that includes key i
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
+    "requestId": "a77c8bd6-f290-492d-85d5-a9e40d900432",
     "when": "2025-01-30T23:00:01.000Z",
     "type": "patient.admit"
   },
@@ -137,6 +138,9 @@ A Patient Admit event is emitted when a patient undergoes the admission process,
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
     </ResponseField>
+    <ResponseField name="requestId" type="string">
+      The ID of the request that initiated the async flow for this webhook;
+    </ResponseField>
     <ResponseField name="when" type="string" required>
       An ISO-8601 datetime of when this webhook was sent.
     </ResponseField>
@@ -203,6 +207,7 @@ A Patient Admit event is emitted when a patient undergoes the admission process,
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
+    "requestId": "a77c8bd6-f290-492d-85d5-a9e40d900432",
     "when": "2025-01-30T23:00:01.000Z",
     "type": "patient.admit"
   },
@@ -230,6 +235,9 @@ A Patient Transfer event indicates that a patient has been moved from one locati
   <Expandable title="meta properties">
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
+    </ResponseField>
+    <ResponseField name="requestId" type="string">
+      The ID of the request that initiated the async flow for this webhook;
     </ResponseField>
     <ResponseField name="when" type="string" required>
       An ISO-8601 datetime of when this webhook was sent.
@@ -333,6 +341,7 @@ A Patient Transfer event indicates that a patient has been moved from one locati
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
+    "requestId": "a77c8bd6-f290-492d-85d5-a9e40d900432",
     "when": "2025-01-30T20:30:01.000Z",
     "type": "patient.transfer"
   },
@@ -384,6 +393,9 @@ A Patient Discharge event indicates the end of a patient's stay in a healthcare 
   <Expandable title="meta properties">
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
+    </ResponseField>
+    <ResponseField name="requestId" type="string">
+      The ID of the request that initiated the async flow for this webhook;
     </ResponseField>
     <ResponseField name="when" type="string" required>
       An ISO-8601 datetime of when this webhook was sent.
@@ -455,6 +467,7 @@ A Patient Discharge event indicates the end of a patient's stay in a healthcare 
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
+    "requestId": "a77c8bd6-f290-492d-85d5-a9e40d900432",
     "when": "2025-01-30T23:00:01.000Z",
     "type": "patient.discharge"
   },

--- a/docs/medical-api/handling-data/realtime-patient-notifications.mdx
+++ b/docs/medical-api/handling-data/realtime-patient-notifications.mdx
@@ -139,7 +139,7 @@ A Patient Admit event is emitted when a patient undergoes the admission process,
       A unique identifier for this webhook message. Use this only for debugging purposes.
     </ResponseField>
     <ResponseField name="requestId" type="string">
-      The ID of the request that initiated the async flow for this webhook;
+      The ID of the request that initiated the async flow for this webhook.
     </ResponseField>
     <ResponseField name="when" type="string" required>
       An ISO-8601 datetime of when this webhook was sent.
@@ -237,7 +237,7 @@ A Patient Transfer event indicates that a patient has been moved from one locati
       A unique identifier for this webhook message. Use this only for debugging purposes.
     </ResponseField>
     <ResponseField name="requestId" type="string">
-      The ID of the request that initiated the async flow for this webhook;
+      The ID of the request that initiated the async flow for this webhook.
     </ResponseField>
     <ResponseField name="when" type="string" required>
       An ISO-8601 datetime of when this webhook was sent.
@@ -395,7 +395,7 @@ A Patient Discharge event indicates the end of a patient's stay in a healthcare 
       A unique identifier for this webhook message. Use this only for debugging purposes.
     </ResponseField>
     <ResponseField name="requestId" type="string">
-      The ID of the request that initiated the async flow for this webhook;
+      The ID of the request that initiated the async flow for this webhook.
     </ResponseField>
     <ResponseField name="when" type="string" required>
       An ISO-8601 datetime of when this webhook was sent.

--- a/docs/medical-api/handling-data/realtime-patient-notifications.mdx
+++ b/docs/medical-api/handling-data/realtime-patient-notifications.mdx
@@ -138,7 +138,7 @@ A Patient Admit event is emitted when a patient undergoes the admission process,
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
     </ResponseField>
-    <ResponseField name="requestId" type="string">
+    <ResponseField name="requestId" type="string" optional>
       The ID of the request that initiated the async flow for this webhook.
     </ResponseField>
     <ResponseField name="when" type="string" required>
@@ -236,7 +236,7 @@ A Patient Transfer event indicates that a patient has been moved from one locati
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
     </ResponseField>
-    <ResponseField name="requestId" type="string">
+    <ResponseField name="requestId" type="string" optional>
       The ID of the request that initiated the async flow for this webhook.
     </ResponseField>
     <ResponseField name="when" type="string" required>
@@ -394,7 +394,7 @@ A Patient Discharge event indicates the end of a patient's stay in a healthcare 
     <ResponseField name="messageId" type="string" required>
       A unique identifier for this webhook message. Use this only for debugging purposes.
     </ResponseField>
-    <ResponseField name="requestId" type="string">
+    <ResponseField name="requestId" type="string" optional>
       The ID of the request that initiated the async flow for this webhook.
     </ResponseField>
     <ResponseField name="when" type="string" required>

--- a/docs/medical-api/handling-data/webhooks.mdx
+++ b/docs/medical-api/handling-data/webhooks.mdx
@@ -135,6 +135,7 @@ These are messages you can expect to receive in the following scenarios:
 {
   "meta": {
     "messageId": "<message-id>",
+    "requestId": "<request-id>",
     "when": "<date-time-in-utc>",
     "type": "medical.document-download"
     "data": {
@@ -276,6 +277,7 @@ Example payload:
 {
   "meta": {
     "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
+    "requestId": "00000000-0000-0000-0000-000000000000",
     "when": "2023-08-23T22:09:11.373Z",
     "type": "medical.consolidated-data"
   },
@@ -411,7 +413,8 @@ Example payload:
 ```json
 {
   "meta": {
-    "messageId": "00000000-00000000-00000000-00000000",
+    "messageId": "1e82424a-1220-473d-a0d1-6e5fde15159e",
+    "requestId": "00000000-0000-0000-0000-000000000000",
     "when": "2024-12-30T05:05:12.215Z",
     "type": "medical.bulk-patient-create"
   },
@@ -510,6 +513,7 @@ Here is an example payload:
 {
 "meta": {
     "messageId": "bd4184dd-3b35-4c60-8130-447d1d528fea",
+    "requestId": "00000000-0000-0000-0000-000000000000",
     "when": "2023-11-30T05:05:12.215Z",
     "type": "medical.document-bulk-download-urls"
   },

--- a/fern/definition/medical/webhooks.yml
+++ b/fern/definition/medical/webhooks.yml
@@ -61,6 +61,9 @@ types:
       messageId:
         type: string
         docs: The ID of the message.
+      requestId:
+        type: optional<string>
+        docs: The ID of the request that initiated the async flow for this webhook.
       when:
         type: string
         docs: The timestamp of when the webhook was triggered.

--- a/packages/api/src/command/webhook/webhook.ts
+++ b/packages/api/src/command/webhook/webhook.ts
@@ -93,6 +93,7 @@ export async function processRequest(
     const payload = webhookRequest.payload;
     const meta: WebhookMetadata = {
       messageId: webhookRequest.id,
+      ...(webhookRequest.requestId ? { requestId: webhookRequest.requestId } : {}),
       when: buildDayjs(webhookRequest.createdAt).toISOString(),
       type: webhookRequest.type,
       data: cxWHRequestMeta,

--- a/packages/fhir-converter/src/templates/cda/References/DiagnosticReport/assessment.hbs
+++ b/packages/fhir-converter/src/templates/cda/References/DiagnosticReport/assessment.hbs
@@ -29,12 +29,12 @@
     "resource":{
         "resourceType": "DiagnosticReport",
         "id":"{{ID}}",
-        "status":{{>ValueSet/DiagnosticReportStatus.hbs code="unknown"}},
-        "code": {{>DataType/CodeableConcept.hbs code=code}},
+        "code":{{>DataType/CodeableConcept.hbs code=diagReport.code text=diagReport.title._ canBeUnknown=true}},
+        "status":{{>ValueSet/DiagnosticReportStatus.hbs code=diagReport.statusCode.code}},
         "presentedForm": [
                 {
                     "contentType": "text/plain",
-                    "data": "{{{base64Encode rawText}}}",
+                    "data": "{{{base64Encode text}}}",
                 }
             ],
     },

--- a/packages/fhir-converter/src/templates/cda/References/DiagnosticReport/assessment.hbs
+++ b/packages/fhir-converter/src/templates/cda/References/DiagnosticReport/assessment.hbs
@@ -29,10 +29,12 @@
     "resource":{
         "resourceType": "DiagnosticReport",
         "id":"{{ID}}",
+        "status":{{>ValueSet/DiagnosticReportStatus.hbs code="unknown"}},
+        "code": {{>DataType/CodeableConcept.hbs code=code}},
         "presentedForm": [
                 {
                     "contentType": "text/plain",
-                    "data": "{{{base64Encode text}}}",
+                    "data": "{{{base64Encode rawText}}}",
                 }
             ],
     },

--- a/packages/fhir-converter/src/templates/cda/Sections/Assessments.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Assessments.hbs
@@ -30,7 +30,7 @@
         {{#each (toArray 2_16_840_1_113883_10_20_22_2_8) as |assessment|}}
             {{#if (and assessment.text (contains (toLower assessment.title._) "assessment"))}}
                 {{#with (extractAndMapTableData assessment.text) as |assessmentMap|}}
-                    {{>References/DiagnosticReport/assessment.hbs text=(convertMappedDataToPlainText assessmentMap) ID=(generateUUID (toJsonString assessment))}},
+                    {{>References/DiagnosticReport/assessment.hbs rawText=(convertMappedDataToPlainText assessmentMap) code=assessment.code ID=(generateUUID (toJsonString assessment))}},
                 {{/with}}
             {{/if}}
         {{/each}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Assessments.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Assessments.hbs
@@ -30,7 +30,7 @@
         {{#each (toArray 2_16_840_1_113883_10_20_22_2_8) as |assessment|}}
             {{#if (and assessment.text (contains (toLower assessment.title._) "assessment"))}}
                 {{#with (extractAndMapTableData assessment.text) as |assessmentMap|}}
-                    {{>References/DiagnosticReport/assessment.hbs rawText=(convertMappedDataToPlainText assessmentMap) code=assessment.code ID=(generateUUID (toJsonString assessment))}},
+                    {{>References/DiagnosticReport/assessment.hbs text=(convertMappedDataToPlainText assessmentMap) diagReport=assessment ID=(generateUUID (toJsonString assessment))}},
                 {{/with}}
             {{/if}}
         {{/each}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Notes.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Notes.hbs
@@ -33,7 +33,7 @@
                     {{#with (extractTextFromNestedProperties noteText) as |extractedText|}}
                         {{#with (buildDefaultDiagReportDetails notesSection) as |noteAct|}}
                             {{>Resources/DiagnosticReport.hbs diagReport=noteAct categoryCode=notesSection.code ID=(generateUUID (toJsonString noteText))}}
-                            {{>References/DiagnosticReport/assessment.hbs text=extractedText ID=(generateUUID (toJsonString noteText))}}
+                            {{>References/DiagnosticReport/assessment.hbs diagReport=noteAct text=extractedText ID=(generateUUID (toJsonString noteText))}}
                             {{#if @encompassingEncounterIds}} 
                                 {{>References/DiagnosticReport/encounter.hbs diagReport=noteAct ID=(generateUUID (toJsonString noteText)) REF=(concat 'Encounter/' @encompassingEncounterIds.newId)}}
                             {{/if}}
@@ -66,7 +66,7 @@
                     {{/if}}   
                     
                     {{#if noteEntry.act.text}} 
-                        {{>References/DiagnosticReport/assessment.hbs text=(extractTextFromNestedProperties noteEntry.act.text) ID=(generateUUID (toJsonString noteEntry.act))}}
+                        {{>References/DiagnosticReport/assessment.hbs diagReport=noteEntry.act text=(extractTextFromNestedProperties noteEntry.act.text) ID=(generateUUID (toJsonString noteEntry.act))}}
                     {{/if}}
 
                 {{/each}}

--- a/packages/shared/src/medical/webhook/webhook-request.ts
+++ b/packages/shared/src/medical/webhook/webhook-request.ts
@@ -44,6 +44,7 @@ export type WebhookRequestStatus = (typeof webhookRequestStatus)[number];
 
 export const baseWebhookMetadataSchema = z.object({
   messageId: z.string(),
+  requestId: z.string().optional(),
   when: dateSchema,
   /**
    * The metadata sent by the customer when they triggered the operation that resulted in this webhook.

--- a/packages/utils/src/analytics-platform/1-fhir-to-csv.ts
+++ b/packages/utils/src/analytics-platform/1-fhir-to-csv.ts
@@ -117,6 +117,8 @@ async function main({
         localStartedAt
       )}`
     );
+    const difference = uniquePatientIds.filter(id => !filtererdPatientIds.includes(id));
+    log(`>>> Patients without consolidated data (${difference.length}):\n${difference.join(", ")}`);
   } else {
     filtererdPatientIds = uniquePatientIds;
   }

--- a/packages/utils/src/fhir/fhir-converter/integration-test.ts
+++ b/packages/utils/src/fhir/fhir-converter/integration-test.ts
@@ -33,6 +33,8 @@ dayjs.extend(duration);
 /**
  * End-to-end test for the FHIR Converter. Requires a folder with C-CDA XML files. It can contain subfolders.
  *
+ * ! Read this Notion guide for info: https://www.notion.so/metriport/FHIR-Converter-Scaling-Updating-and-Testing-276b51bb9040803cb796d5872a779c33
+ *
  * IMPORTANT: This script will remove all partitions from the FHIR server if used with the `--use-fhir-server`
  * option! Create a backup before running it!
  * See: https://smilecdr.com/docs/fhir_repository/deleting_data.html#drop-all-data
@@ -143,6 +145,9 @@ export async function main() {
   }
 
   const relativeFileNames = clinicalDocuments.map(f => f.replace(cdaLocation, ""));
+
+  console.log(`Refreshing converter templates...`);
+  await converterApi.post(`/api/UpdateBaseTemplates`);
 
   // Convert them into JSON files
   const { nonXMLBodyCount } = await convertCDAsToFHIR(

--- a/samples/typescript-express/.env.example
+++ b/samples/typescript-express/.env.example
@@ -1,3 +1,5 @@
 METRIPORT_API_KEY="..."
 METRIPORT_WH_KEY="..."
 FACILITY_ID="..."
+# Keep this set to false in order to hit the Metriport sandbox environment.
+IS_PROD="false"

--- a/samples/typescript-express/src/index.ts
+++ b/samples/typescript-express/src/index.ts
@@ -51,7 +51,7 @@ async function main() {
 
   let page = 1;
   // const { meta, patients } = await metriportClient.listPatients({ facilityId });
-  const { meta, patients } = await metriportClient.listPatients();
+  const { meta, patients } = await metriportClient.listPatients({ pagination: { count: 10 } });
   console.log(`Page ${page++} has ${patients.length} patients`);
   // do something with the patients...
   let nextPage = meta.nextPage;


### PR DESCRIPTION
### Dependencies

None

### Description

This release needed to be rolled back due to conversion failures. See fix in the second sha - there were templates other than Assessments.hbs using the assessment.hbs partial, they needed to be updated as well. I realized that there was a pattern that other DiagnosticReport partials were using that the assessment.hbs partial had simply not been following, so also updated to match the pattern properly.

Here's the diff betw develop + my feature branch against the original problem file:
<img width="572" height="272" alt="image" src="https://github.com/user-attachments/assets/f8e4ca3f-0c43-4e5e-882d-44accc80d50f" />

Proof no resource counts were different:
<img width="943" height="101" alt="image" src="https://github.com/user-attachments/assets/97055be3-6713-4434-aefe-87b974fe4216" />

Proof of stdout differences between changes on develop + changes on my feature branch:
<img width="1728" height="469" alt="image" src="https://github.com/user-attachments/assets/e4c14490-858a-4a2a-a9bb-03b04ebc79d9" />

### Testing

- Local
  - [x] Run original offending file - verify that all DiagnosticReport resources have a status and a code.
  - [x] Reproduce base64 production failure using 2 different large XML files from different CXs 
  - [x] After making change verify that conversions do not fail.
  - [x] Run integration test over 10K xmls 
- Staging
  - [ ] Run original offending file - verify that all DiagnosticReport resources have a status and a code.
  - [ ] Reproduce base64 failure seen in production using 2 different large XML files from different CXs 
  - [ ] After making change verify that conversions do not fail.
- Production
  - [ ] Run original offending file - verify that all DiagnosticReport resources have a status and a code.

### Release Plan
- [ ] Merge this
- [ ] Reconvert xmls for problem CX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook payload metadata can include an optional requestId for async request tracing.
  * FHIR DiagnosticReport now surfaces code and status.
  * Analytics tool reports which patient IDs lack consolidated data during checks.

* **Documentation**
  * Webhook docs, realtime notifications, and request-id snippet updated to show optional requestId.

* **Chores**
  * Sample app paginates patient listing to 10; example env adds IS_PROD (false).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->