### PR TITLE
feat(ap): bump to two weeks

### DIFF
--- a/packages/api/src/external/carequality/document/query-documents.ts
+++ b/packages/api/src/external/carequality/document/query-documents.ts
@@ -25,7 +25,7 @@ import { getCqInitiator } from "../shared";
 import { createOutboundDocumentQueryRequests } from "./create-outbound-document-query-req";
 import { filterCqLinksByManagingOrg } from "./filter-oids-by-managing-org";
 
-const staleLookbackWeeks = 1;
+const staleLookbackWeeks = 2;
 
 export async function getDocumentsFromCQ({
   requestId,
@@ -125,26 +125,13 @@ export async function getDocumentsFromCQ({
     });
 
     const linksWithDqUrl: CQLink[] = [];
-    const addDqUrlToCqLink = async (patientLink: CQLink): Promise<void> => {
-      const gateway = await getCQDirectoryEntry(patientLink.oid);
-
-      if (!gateway) {
-        const msg = `Gateway not found - Doc Query`;
-        log(`${msg}: ${patientLink.oid} skipping...`);
-        return;
-      } else if (!gateway.urlDQ) {
-        log(`Gateway ${gateway.id} has no DQ URL, skipping...`);
-        return;
+    await executeAsynchronously(
+      cqPatientData.data.links,
+      patientLink => addDqUrlToCqLink(patientLink, linksWithDqUrl, log),
+      {
+        numberOfParallelExecutions: 20,
       }
-
-      linksWithDqUrl.push({
-        ...patientLink,
-        url: gateway.urlDQ,
-      });
-    };
-    await executeAsynchronously(cqPatientData.data.links, addDqUrlToCqLink, {
-      numberOfParallelExecutions: 20,
-    });
+    );
 
     const cqLinks = cqManagingOrgName
       ? await filterCqLinksByManagingOrg(cqManagingOrgName, linksWithDqUrl)
@@ -201,4 +188,26 @@ export async function getDocumentsFromCQ({
     });
     throw error;
   }
+}
+
+async function addDqUrlToCqLink(
+  patientLink: CQLink,
+  linksWithDqUrl: CQLink[],
+  log: typeof console.log
+): Promise<void> {
+  const gateway = await getCQDirectoryEntry(patientLink.oid);
+
+  if (!gateway) {
+    const msg = `Gateway not found - Doc Query`;
+    log(`${msg}: ${patientLink.oid} skipping...`);
+    return;
+  } else if (!gateway.urlDQ) {
+    log(`Gateway ${gateway.id} has no DQ URL, skipping...`);
+    return;
+  }
+
+  linksWithDqUrl.push({
+    ...patientLink,
+    url: gateway.urlDQ,
+  });
 }

--- a/packages/api/src/external/commonwell-v2/document/document-query.ts
+++ b/packages/api/src/external/commonwell-v2/document/document-query.ts
@@ -65,7 +65,7 @@ import {
   getDocPrintableDetails,
 } from "./shared";
 
-const staleLookbackWeeks = 1;
+const staleLookbackWeeks = 2;
 
 const DOC_DOWNLOAD_CHUNK_SIZE = 10;
 


### PR DESCRIPTION
Ref: ENG-000

### Description

- bumping PD rerun to 2 weeks for initial rollout

### Testing

- Local
  - [ ] N/A
- Staging
   - [ ] N/A
- Sandbox
   - [ ] N/A
- Production
   - [ ] N/A

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized document link enrichment with parallel processing for faster, more consistent results and clearer logging.

* **Chores**
  * Increased the stale data lookback from 1 to 2 weeks, reducing unnecessary background re-queries and improving overall efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->