### PR TITLE
add a bamboo specific scramble and unscramble method

### DIFF
--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -105,7 +105,7 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
     let parsedData: ParsedHl7Data;
     const timezone = getTimezoneFromHieName(params.hieName, hl7Message, log);
     try {
-      parsedData = await parseHl7Message(hl7Message, timezone);
+      parsedData = await parseHl7Message(hl7Message, timezone, params.hieName);
     } catch (parseError: unknown) {
       await persistHl7MessageError(hl7Message, parseError, log);
       throw parseError;

--- a/packages/core/src/command/hl7-notification/utils.ts
+++ b/packages/core/src/command/hl7-notification/utils.ts
@@ -3,6 +3,7 @@ import {
   createUnparseableHl7MessageErrorMessageFileKey,
   createUnparseableHl7MessageFileKey,
   getCxIdAndPatientIdOrFail,
+  getCxIdAndPatientIdOrFailNoSpecial,
   getOptionalValueFromMessage,
 } from "../hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
 import { utcifyHl7Message } from "../../external/hl7-notification/datetime";
@@ -28,11 +29,15 @@ export function isSupportedTriggerEvent(
 
 export async function parseHl7Message(
   rawMessage: Hl7Message,
-  hieConfig: string
+  hieConfig: string,
+  hieName: string
 ): Promise<ParsedHl7Data> {
   const message = utcifyHl7Message(rawMessage, hieConfig);
 
-  const { cxId, patientId } = getCxIdAndPatientIdOrFail(message);
+  const { cxId, patientId } =
+    hieName === "Bamboo"
+      ? getCxIdAndPatientIdOrFailNoSpecial(message)
+      : getCxIdAndPatientIdOrFail(message);
 
   return {
     message,

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -13,10 +13,10 @@ import { createUuidFromText } from "@metriport/shared/common/uuid";
 import axios, { AxiosResponse } from "axios";
 import { stringify } from "csv-stringify/sync";
 import _ from "lodash";
+import { stripInvalidCharactersFromPatientData } from "../../domain/character-sanitizer";
 import { getFirstNameAndMiddleInitial, Patient } from "../../domain/patient";
 import { S3Utils, storeInS3WithRetries } from "../../external/aws/s3";
 import { capture, out } from "../../util";
-import { stripInvalidCharactersFromPatientData } from "../../domain/character-sanitizer";
 import { Config } from "../../util/config";
 import { CSV_FILE_EXTENSION, CSV_MIME_TYPE } from "../../util/mime";
 import { METRIPORT_ASSIGNING_AUTHORITY_IDENTIFIER } from "./constants";
@@ -33,7 +33,7 @@ import {
   RosterRowData,
   VpnlessHieConfig,
 } from "./types";
-import { createScrambledId } from "./utils";
+import { createNoSpecialScrambledId, createScrambledId } from "./utils";
 const region = Config.getAWSRegion();
 
 type RosterRow = Record<string, string>;
@@ -249,6 +249,7 @@ export function createRosterRowInput(
   const phone = data.contact?.find(c => c.phone)?.phone;
   const email = data.contact?.find(c => c.email)?.email;
   const scrambledId = createScrambledId(p.cxId, p.id);
+  const noSpecialCharsScrambledId = createNoSpecialScrambledId(p.cxId, p.id);
   const rosterGenerationDate = buildDayjs(new Date()).format("YYYY-MM-DD");
   const dob = data.dob; // 2025-01-31
   const dobNoDelimiter = dob.replace(/[-]/g, ""); // 20250131
@@ -277,6 +278,7 @@ export function createRosterRowInput(
     cxId: p.cxId,
     rosterGenerationDate,
     scrambledId,
+    noSpecialCharsScrambledId,
     lastName: data.lastName,
     firstName,
     middleName: middleInitial,

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -18,6 +18,7 @@ export type RosterRowData = {
   genderOtherAsUnknown: string | undefined;
   genderOneTwoAndNine: string | undefined;
   scrambledId: string;
+  noSpecialCharsScrambledId: string;
   patientExternalId: string | undefined;
   ssn: string | undefined;
   driversLicense: string | undefined;

--- a/packages/core/src/command/hl7v2-subscriptions/utils.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/utils.ts
@@ -5,3 +5,19 @@ export function createScrambledId(cxId: string, patientId: string): string {
   const compressedPatientId = compressUuid(patientId);
   return `${compressedCxId}_${compressedPatientId}`;
 }
+
+export function createNoSpecialScrambledId(cxId: string, patientId: string): string {
+  const compressedCxId = compressUuid(cxId);
+  const compressedPatientId = compressUuid(patientId);
+
+  const normalizedCompressedCxId = compressedCxId
+    .replace(/_/g, "")
+    .replace(/=/g, ".")
+    .replace(/\+/g, "|");
+  const normalizedCompressedPatientId = compressedPatientId
+    .replace(/_/g, "")
+    .replace(/=/g, ".")
+    .replace(/\+/g, "|");
+
+  return `${normalizedCompressedCxId}_${normalizedCompressedPatientId}`;
+}


### PR DESCRIPTION
Part of ENG-1122

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1122

### Dependencies
None

### Description
Add bamboo specific scramble and unscramble for identifier. (Remove + and =, replace with either . or |)

### Testing
- Local
  - [ ] Send a Bamboo msg over to mllp server using new scramble method
  - [ ] Upload to local SFTP server as if Bamboo to make sure all identifiers dont have + or =
- Staging
  - [ ] Send a Bamboo msg over to mllp server using new scramble method
  - [ ] Upload to local SFTP server as if Bamboo to make sure all identifiers dont have + or =

