### PR TITLE
RELEASE - update removal policy for mllp server ecr repo

### DIFF
--- a/packages/infra/lib/hl7-notification-stack/index.ts
+++ b/packages/infra/lib/hl7-notification-stack/index.ts
@@ -26,6 +26,13 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
       props.config.hl7Notification.incomingMessageBucketName
     );
 
+    const ecrRepo = new Repository(this, "MllpServerRepo", {
+      repositoryName: "metriport/mllp-server",
+      lifecycleRules: [{ maxImageCount: 5000 }],
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      emptyOnDelete: true,
+    });
+
     const vpc = new ec2.Vpc(this, "Vpc", {
       maxAzs: NUM_AZS,
       ipAddresses: ec2.IpAddresses.cidr(HL7_NOTIFICATION_VPC_CIDR),
@@ -47,11 +54,6 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
       vpc,
       service: ec2.InterfaceVpcEndpointAwsService.SQS,
       privateDnsEnabled: true,
-    });
-
-    const ecrRepo = new Repository(this, "MllpServerRepo", {
-      repositoryName: "metriport/mllp-server",
-      lifecycleRules: [{ maxImageCount: 5000 }],
     });
 
     new MllpStack(this, "NestedMllpStack", {

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -2,8 +2,8 @@
 import * as cdk from "aws-cdk-lib";
 import { Duration } from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
-import { Repository } from "aws-cdk-lib/aws-ecr";
 import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as ecr from "aws-cdk-lib/aws-ecr";
 import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as logs from "aws-cdk-lib/aws-logs";
@@ -11,15 +11,15 @@ import { LogGroup } from "aws-cdk-lib/aws-logs";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import { EnvConfigNonSandbox } from "../../config/env-config";
+import { createHieConfigDictionary } from "../shared/hie-config-dictionary";
 import { buildSecrets, secretsToECS } from "../shared/secrets";
 import { MLLP_DEFAULT_PORT } from "./constants";
-import { createHieConfigDictionary } from "../shared/hie-config-dictionary";
 
 interface MllpStackProps extends cdk.StackProps {
   config: EnvConfigNonSandbox;
   version: string | undefined;
   vpc: ec2.Vpc;
-  ecrRepo: Repository;
+  ecrRepo: ecr.IRepository;
   incomingHl7NotificationBucket: s3.IBucket;
 }
 


### PR DESCRIPTION
### Dependencies

None

### Description

In order to help the Hl7 notification stack be able to boot up / down on its own without hacks, we need to change the removal policy on the ecr repo.

https://github.com/metriport/metriport/pull/4723

### Testing

Deployed fine to staging, and production diff looks safe - see feature pr.

Check each PR.

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Consolidated container image repository into a single, lifecycle-managed resource with automatic cleanup, improving consistency and reliability.
  - Streamlined infrastructure configuration and standardized dependencies; removed duplicate setup.
  - Preserves existing stack outputs and external behavior (no changes to integration points).

- Chores
  - Minor internal type/import adjustments to align with best practices.

No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->