### PR TITLE
feat(ehr): get raw body for parsing

### DIFF
--- a/packages/core/src/external/ehr/webhook.ts
+++ b/packages/core/src/external/ehr/webhook.ts
@@ -1,19 +1,18 @@
-import crypto from "crypto";
 import { MetriportError } from "@metriport/shared";
+import crypto from "crypto";
 
 const ed25519Prefix = "MCowBQYDK2VwAyEA";
 
 // Interpreted from Elation dosc https://docs.elationhealth.com/reference/webhooks
 export function verifyWebhookSignatureEd25519Elation(
   key: string,
-  body: object,
+  rawBody: string,
   signature: string
 ): boolean {
   const newKey = createPublicKey(key);
-  const newBody = createJsonDumpsBody(body);
   const verified = crypto.verify(
     null,
-    Buffer.from(newBody),
+    Buffer.from(rawBody),
     newKey,
     Buffer.from(signature, "base64")
   );
@@ -26,10 +25,6 @@ function createPublicKey(key: string) {
 ${ed25519Prefix}${key}
 -----END PUBLIC KEY-----
   `;
-}
-
-function createJsonDumpsBody(body: object) {
-  return JSON.stringify(body).replace(/":/g, '": ').replace(/,"/g, ', "');
 }
 
 // From Healthie docs https://docs.gethealthie.com/guides/webhooks/


### PR DESCRIPTION
Ref: ENG-460

### Description

- adding the rawBody as a query param on all requests so that we can validate WH signatures with it
- NOTE: we may decide it shouldn't be on ALL requests

### Testing

- Local
  - [ ] validate rawBody query param exists + an elation WH signature works
- Staging
  - [ ] elation WH validation works
- Sandbox
  - [ ] N/A
- Production
  - [ ] elation WH validation works

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook signature verification by validating against the exact raw JSON payload, reducing false negatives and improving compatibility.

* **New Features**
  * Captures the raw JSON request body for webhook requests to support accurate signature verification.

* **Refactor**
  * Streamlined webhook verification flow to operate on the raw payload.

* **Developer Notes**
  * If you use the verification helper directly, pass the raw JSON string (not a parsed object).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->