### PR TITLE
add timezone impersonation to the webhook sender

### DIFF
--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -106,7 +106,12 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
 
     const hl7Message = Hl7Message.parse(params.message);
     let parsedData: ParsedHl7Data;
-    const timezone = getTimezoneFromHieName(params.hieName, hl7Message, log);
+    if (params.impersonateTimezone) {
+      log(`Impersonation request! Impersonating timezone: ${params.impersonateTimezone}`);
+    }
+    const timezone = params.impersonateTimezone
+      ? params.impersonateTimezone
+      : getTimezoneFromHieName(params.hieName, hl7Message, log);
     try {
       parsedData = await parseHl7Message(hl7Message, timezone);
     } catch (parseError: unknown) {

--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender.ts
@@ -6,6 +6,7 @@ export const hl7NotificationSenderParamsSchema = z.object({
   message: z.string(),
   messageReceivedTimestamp: z.string(),
   hieName: z.string(),
+  impersonateTimezone: z.string().optional(),
 });
 
 export type Hl7NotificationSenderParams = z.infer<typeof hl7NotificationSenderParamsSchema>;


### PR DESCRIPTION
Part of ENG-1165

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1165

### Dependencies

- Downstream: https://github.com/metriport/metriport/pull/4741

### Description
Add ability to impersonate timezone for the webhook sender. Send in an optional impersonateTimezone param.

### Testing
Check Downstream PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional timezone override for HL7 notification webhooks. When provided, notifications use the specified timezone; otherwise, they continue to use automatic timezone detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->