### PR TITLE
feat(ehr): fixes

### DIFF
--- a/packages/core/src/external/ehr/athenahealth/index.ts
+++ b/packages/core/src/external/ehr/athenahealth/index.ts
@@ -1342,8 +1342,8 @@ class AthenaHealthApi {
   }: {
     cxId: string;
     patientId: string;
-    coding?: Coding;
-    text?: string;
+    coding?: Coding | undefined;
+    text?: string | undefined;
   }): Promise<MedicationReference | undefined> {
     const { log, debug } = out(
       `AthenaHealth searchForMedication - cxId ${cxId} practiceId ${this.practiceId} patientId ${patientId}`
@@ -1427,8 +1427,8 @@ class AthenaHealthApi {
   }: {
     cxId: string;
     patientId: string;
-    coding?: Coding;
-    text?: string;
+    coding?: Coding | undefined;
+    text?: string | undefined;
   }): Promise<AllergenReference | undefined> {
     const { log, debug } = out(
       `AthenaHealth searchForAllergen - cxId ${cxId} practiceId ${this.practiceId} patientId ${patientId}`

--- a/packages/core/src/external/ehr/job/bundle/create-resource-diff-bundles/steps/compute/ehr-compute-resource-diff-bundles-direct.ts
+++ b/packages/core/src/external/ehr/job/bundle/create-resource-diff-bundles/steps/compute/ehr-compute-resource-diff-bundles-direct.ts
@@ -1,20 +1,24 @@
 import { Resource } from "@medplum/fhirtypes";
 import { errorToString, sleep } from "@metriport/shared";
 import { createBundleFromResourceList } from "@metriport/shared/interface/external/ehr/fhir-resource";
-//import { EhrSource } from "@metriport/shared/interface/external/ehr/source";
+import { EhrSource, EhrSources } from "@metriport/shared/interface/external/ehr/source";
 import { getConsolidatedFile } from "../../../../../../../command/consolidated/consolidated-get";
 import { setJobEntryStatus } from "../../../../../../../command/job/patient/api/set-entry-status";
 import { computeResourcesXorAlongResourceType } from "../../../../../../../fhir-deduplication/compute-resources-xor";
 import { deduplicateResources } from "../../../../../../../fhir-deduplication/dedup-resources";
 import { out } from "../../../../../../../util/log";
-//import { getSecondaryMappings } from "../../../../../api/get-secondary-mappings";
+import { getSecondaryMappings } from "../../../../../api/get-secondary-mappings";
 import { startContributeBundlesJob } from "../../../../../api/job/start-contribute-bundles-job";
-//import { startWriteBackBundlesJob } from "../../../../../api/job/start-write-back-bundles-job";
+import { startWriteBackBundlesJob } from "../../../../../api/job/start-write-back-bundles-job";
 import { BundleType } from "../../../../../bundle/bundle-shared";
 import { createOrReplaceBundle } from "../../../../../bundle/command/create-or-replace-bundle";
 import { fetchBundle, FetchBundleParams } from "../../../../../bundle/command/fetch-bundle";
-//import { ehrCxMappingSecondaryMappingsSchemaMap } from "../../../../../mappings";
-//import { isSupportedWriteBackResourceType } from "../../../write-back-bundles/ehr-write-back-resource-diff-bundles-direct";
+import { isEhrSourceWithWriteBack } from "../../../../../command/write-back/shared";
+import {
+  ehrCxMappingSecondaryMappingsSchemaMap,
+  isEhrSourceWithSecondaryMappings,
+} from "../../../../../mappings";
+import { isSupportedWriteBackResourceType } from "../../../write-back-bundles/ehr-write-back-resource-diff-bundles-direct";
 import {
   ComputeResourceDiffBundlesRequest,
   EhrComputeResourceDiffBundlesHandler,
@@ -139,7 +143,6 @@ export class EhrComputeResourceDiffBundlesDirect implements EhrComputeResourceDi
           resourceType,
           createResourceDiffBundlesJobId: jobId,
         }),
-        /* TODO: Re-enable this when we're ready to have it on for all patients
         ...((await shouldWriteBack({ ehr, practiceId, resourceType }))
           ? [
               startWriteBackBundlesJob({
@@ -152,7 +155,6 @@ export class EhrComputeResourceDiffBundlesDirect implements EhrComputeResourceDi
               }),
             ]
           : []),
-        */
       ]);
     } catch (error) {
       if (reportError) {
@@ -210,7 +212,6 @@ async function getEhrResourcesFromS3({
   });
 }
 
-/* TODO: Re-enable this when we're ready to have it on for all patients
 async function shouldWriteBack({
   ehr,
   practiceId,
@@ -221,6 +222,10 @@ async function shouldWriteBack({
   resourceType: string;
 }): Promise<boolean> {
   if (!isSupportedWriteBackResourceType(resourceType)) return false;
+  if (!isEhrSourceWithWriteBack(ehr)) return false;
+  /* TODO Remove once Elation is validated */
+  if (ehr !== EhrSources.athena) return false;
+  if (!isEhrSourceWithSecondaryMappings(ehr)) return false;
   const mappingsSchema = ehrCxMappingSecondaryMappingsSchemaMap[ehr];
   if (!mappingsSchema) return false;
   const secondaryMappings = await getSecondaryMappings({
@@ -228,8 +233,6 @@ async function shouldWriteBack({
     practiceId,
     schema: mappingsSchema,
   });
-  if (!secondaryMappings) return false;
-  if (!secondaryMappings.writeBackEnabled) return false;
+  if (!secondaryMappings || !secondaryMappings.writeBackEnabled) return false;
   return true;
 }
-*/

--- a/packages/core/src/external/ehr/job/bundle/write-back-bundles/ehr-write-back-resource-diff-bundles-direct.ts
+++ b/packages/core/src/external/ehr/job/bundle/write-back-bundles/ehr-write-back-resource-diff-bundles-direct.ts
@@ -342,7 +342,11 @@ async function getWriteBackFilters({
   ehr: EhrSource;
   practiceId: string;
 }): Promise<WriteBackFiltersPerResourceType | undefined> {
-  if (!isEhrSourceWithSecondaryMappings(ehr)) return undefined;
+  if (!isEhrSourceWithSecondaryMappings(ehr)) {
+    throw new BadRequestError("EHR does not support secondary mappings", undefined, {
+      ehr,
+    });
+  }
   const mappingsSchema = ehrCxMappingSecondaryMappingsSchemaMap[ehr];
   if (!mappingsSchema) {
     throw new BadRequestError("No mappings schema found for EHR", undefined, {
@@ -354,14 +358,8 @@ async function getWriteBackFilters({
     practiceId,
     schema: mappingsSchema,
   });
-  if (!secondaryMappings) {
-    throw new BadRequestError("No secondary mappings found for EHR", undefined, {
-      ehr,
-      practiceId,
-    });
-  }
-  if (!secondaryMappings.writeBackEnabled) {
-    throw new BadRequestError("Write back is not enabled for EHR", undefined, {
+  if (!secondaryMappings || !secondaryMappings.writeBackEnabled) {
+    throw new BadRequestError("Write back is not enabled for practice", undefined, {
       ehr,
       practiceId,
     });


### PR DESCRIPTION
Ref: ENG-1140

### Description

- make allergy manifestation optional for athena writeback
- turn on automated writeback for athena

### Testing

- Local
  - [x] write back allergies with no manifestation
- Staging
  - [ ] write back allergies with no manifestation
  - [ ] write back starts automatically
- Sandbox
  - [ ] N/A
- Production
  - [ ] write back allergies with no manifestation
  - [ ] write back starts automatically

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-enabled automated write-back for supported EHRs with upfront validation and an explicit list of allowed sources.
  * Write-back job scheduling restored when eligibility and secondary mappings validate.

* **Bug Fixes**
  * Medication and allergy lookups accept text fallbacks when standard coding is missing; display prefers coding but falls back to text.
  * Allergy reactions are only added when matched, deduplicated, and omitted when none exist; error messages simplified for missing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->