### PR TITLE
PATCH-RELEASE Move incoming s3 upload earlier in the function

### DIFF
--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -126,7 +126,7 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
       patientId,
       timestamp,
       messageId: getMessageUniqueIdentifier(message),
-      messageCode: messageCode,
+      messageCode,
       triggerEvent,
     });
 

--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -118,22 +118,15 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
     const encounterId = createEncounterId(message, patientId);
 
     const { messageCode, triggerEvent } = getHl7MessageTypeOrFail(message);
-    if (!isSupportedTriggerEvent(triggerEvent)) {
-      log(`Trigger event ${triggerEvent} is not supported. Skipping...`);
-      return;
-    }
-    const timestamp = basicToExtendedIso8601(getOrCreateMessageDatetime(message));
 
-    const encounterPeriod = getEncounterPeriod(message);
-    const encounterClass = getEncounterClass(message);
-    const facilityName = getFacilityName(message);
+    const timestamp = basicToExtendedIso8601(getOrCreateMessageDatetime(message));
 
     const rawDataFileKey = createIncomingMessageFileKey({
       cxId,
       patientId,
       timestamp,
       messageId: getMessageUniqueIdentifier(message),
-      messageCode,
+      messageCode: messageCode,
       triggerEvent,
     });
 
@@ -144,6 +137,15 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
       file: Buffer.from(asString(message)),
       contentType: "text/plain",
     });
+
+    if (!isSupportedTriggerEvent(triggerEvent)) {
+      log(`Trigger event ${triggerEvent} is not supported. Skipping...`);
+      return;
+    }
+
+    const encounterPeriod = getEncounterPeriod(message);
+    const encounterClass = getEncounterClass(message);
+    const facilityName = getFacilityName(message);
 
     analytics({
       distinctId: cxId,


### PR DESCRIPTION
Part of ENG-1168

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1168

### Dependencies
None

### Description
Move incoming s3 upload in mllp server earlier in the function. To not lose data.

### Testing
- Local
  - [x] Send a mllp message with an unsupported trigger event and make sure it uploads to incoming.
  

<img width="948" height="111" alt="Screenshot 2025-09-26 at 1 51 40 PM" src="https://github.com/user-attachments/assets/9f0a2e6c-6d7f-40bd-a2b9-4cef069dcb43" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of HL7 notification processing, ensuring unsupported events are handled safely.
  * Standardized file naming for downstream systems.

* **Refactor**
  * Streamlined processing order to enhance stability and observability without changing user-facing behavior.

* **Chores**
  * Enhanced analytics and logging around HL7 notifications for better monitoring and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->