### PR TITLE
Alohr bug fixes/better error handling

### DIFF
--- a/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-client.ts
+++ b/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-client.ts
@@ -3,7 +3,7 @@ import { getSecretValueOrFail } from "../../../external/aws/secret-manager";
 import { SftpClient } from "../../../external/sftp/client";
 import { SftpConfig } from "../../../external/sftp/types";
 import { Config } from "../../../util/config";
-import { buildDayjs } from "@metriport/shared/common/date";
+import { buildDayjsTz } from "@metriport/shared/common/date";
 import { sftpConfigSchema } from "../sftp-config";
 
 export class AlohrSftpIngestionClient extends SftpClient {
@@ -90,8 +90,14 @@ export class AlohrSftpIngestionClient extends SftpClient {
   ): Promise<string[]> {
     this.log(`Syncing from remotePath: ${remotePath}`);
 
-    const start = startingDate ? startingDate : buildDayjs(Date.now()).format(this.FILE_FORMAT);
-    const end = endingDate ? endingDate : buildDayjs().add(1, "day").format(this.FILE_FORMAT);
+    const start = startingDate
+      ? startingDate
+      : buildDayjsTz(Date.now(), Config.getAlohrIngestionTimezone()).format(this.FILE_FORMAT);
+    const end = endingDate
+      ? endingDate
+      : buildDayjsTz(Date.now(), Config.getAlohrIngestionTimezone())
+          .add(1, "day")
+          .format(this.FILE_FORMAT);
     try {
       await this.connect();
 

--- a/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-client.ts
+++ b/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-client.ts
@@ -3,8 +3,10 @@ import { getSecretValueOrFail } from "../../../external/aws/secret-manager";
 import { SftpClient } from "../../../external/sftp/client";
 import { SftpConfig } from "../../../external/sftp/types";
 import { Config } from "../../../util/config";
-import { buildDayjsTz } from "@metriport/shared/common/date";
 import { sftpConfigSchema } from "../sftp-config";
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+dayjs.extend(timezone);
 
 export class AlohrSftpIngestionClient extends SftpClient {
   private readonly FILE_FORMAT = "YYYYMMDD";
@@ -89,13 +91,13 @@ export class AlohrSftpIngestionClient extends SftpClient {
     endingDate?: string
   ): Promise<string[]> {
     this.log(`Syncing from remotePath: ${remotePath}`);
-
     const start = startingDate
       ? startingDate
-      : buildDayjsTz(Date.now(), Config.getAlohrIngestionTimezone()).format(this.FILE_FORMAT);
+      : dayjs.tz(Date.now(), Config.getAlohrIngestionTimezone()).format(this.FILE_FORMAT);
     const end = endingDate
       ? endingDate
-      : buildDayjsTz(Date.now(), Config.getAlohrIngestionTimezone())
+      : dayjs
+          .tz(Date.now(), Config.getAlohrIngestionTimezone())
           .add(1, "day")
           .format(this.FILE_FORMAT);
     try {

--- a/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-client.ts
+++ b/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-client.ts
@@ -1,11 +1,12 @@
 import { BadRequestError, MetriportError } from "@metriport/shared";
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
 import { getSecretValueOrFail } from "../../../external/aws/secret-manager";
 import { SftpClient } from "../../../external/sftp/client";
 import { SftpConfig } from "../../../external/sftp/types";
 import { Config } from "../../../util/config";
 import { sftpConfigSchema } from "../sftp-config";
-import dayjs from "dayjs";
-import timezone from "dayjs/plugin/timezone";
+
 dayjs.extend(timezone);
 
 export class AlohrSftpIngestionClient extends SftpClient {

--- a/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-direct.ts
+++ b/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-direct.ts
@@ -51,7 +51,7 @@ export class Hl7AlohrSftpIngestionDirect implements Hl7AlohrSftpIngestion {
       }
 
       const message = await s3Utils.getFileContentsAsString(bucketName, filePath);
-      const recievedAt = buildDayjs(Date.now()).toISOString();
+      const receivedAt = buildDayjs().toISOString();
       const hl7Message = Hl7Message.parse(message);
 
       const remappedMessage = this.remapMessage(hl7Message);
@@ -60,7 +60,7 @@ export class Hl7AlohrSftpIngestionDirect implements Hl7AlohrSftpIngestion {
 
       timestampedMessages.push({
         message: remappedMessageString,
-        timestamp: recievedAt,
+        timestamp: receivedAt,
         cxId: cxId,
         patientId: patientId,
       });

--- a/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-direct.ts
+++ b/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-direct.ts
@@ -60,7 +60,7 @@ export class Hl7AlohrSftpIngestionDirect implements Hl7AlohrSftpIngestion {
     bucketName: string,
     remotePath: string,
     fileName: string
-  ): Promise<TimestampedMessage | null> {
+  ): Promise<TimestampedMessage | undefined> {
     try {
       const filePath = this.getFilePath(remotePath, fileName);
       const existsFile = await s3Utils.fileExists(bucketName, filePath);
@@ -95,7 +95,7 @@ export class Hl7AlohrSftpIngestionDirect implements Hl7AlohrSftpIngestion {
       const message = await s3Utils.getFileContentsAsString(bucketName, filePath);
 
       await this.persistError(message, fileName, String(error));
-      return null;
+      return undefined;
     }
   }
 

--- a/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-direct.ts
+++ b/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-direct.ts
@@ -84,17 +84,19 @@ export class Hl7AlohrSftpIngestionDirect implements Hl7AlohrSftpIngestion {
         fileName,
       };
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       capture.error("error processing file: ", {
         extra: {
           fileName,
-          error,
+          error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
         },
       });
-      log(`error processing file: ${error}`);
+      log(`error processing file ${fileName}: ${errorMessage}`);
       const filePath = this.getFilePath(remotePath, fileName);
       const message = await s3Utils.getFileContentsAsString(bucketName, filePath);
-
-      await this.persistError(message, fileName, String(error));
+      const errorDetails =
+        error instanceof Error ? `${error.message}\n\nStack: ${error.stack}` : String(error);
+      await this.persistError(message, fileName, errorDetails);
       return undefined;
     }
   }

--- a/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-direct.ts
+++ b/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion-direct.ts
@@ -90,11 +90,11 @@ export class Hl7AlohrSftpIngestionDirect implements Hl7AlohrSftpIngestion {
           error,
         },
       });
-      log("error processing file: ", error);
+      log(`error processing file: ${error}`);
       const filePath = this.getFilePath(remotePath, fileName);
       const message = await s3Utils.getFileContentsAsString(bucketName, filePath);
 
-      await this.persistError(message, fileName, error);
+      await this.persistError(message, fileName, String(error));
       return null;
     }
   }
@@ -113,7 +113,7 @@ export class Hl7AlohrSftpIngestionDirect implements Hl7AlohrSftpIngestion {
     }
   }
 
-  private async persistError(message: string, fileName: string, error: unknown): Promise<void> {
+  private async persistError(message: string, fileName: string, error: string): Promise<void> {
     const s3Utils = new S3Utils(Config.getAWSRegion());
     const bucketName = Config.getAlohrIngestionBucket();
     const filePath = this.getFilePath(this.ERROR_FILE_PATH, fileName);

--- a/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion.ts
+++ b/packages/core/src/command/hl7-sftp-ingestion/alohr/hl7-alohr-sftp-ingestion.ts
@@ -18,4 +18,5 @@ export interface TimestampedMessage {
   timestamp: string;
   cxId: string;
   patientId: string;
+  fileName: string;
 }

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -492,4 +492,8 @@ export class Config {
   static getAlohrIngestionLambdaName(): string {
     return getEnvVarOrFail("ALOHR_INGESTION_LAMBDA_NAME");
   }
+
+  static getAlohrIngestionTimezone(): string {
+    return getEnvVarOrFail("ALOHR_INGESTION_TIMEZONE");
+  }
 }

--- a/packages/infra/lib/lambdas-nested-stack.ts
+++ b/packages/infra/lib/lambdas-nested-stack.ts
@@ -1073,6 +1073,7 @@ export class LambdasNestedStack extends NestedStack {
     const alohrProps = ownProps.config.hl7Notification?.AlohrSftpIngestionLambda;
     const sftpPasswordSecret = ownProps.secrets["ALOHR_INGESTION_PASSWORD"];
     const queue = ownProps.config.hl7Notification?.notificationWebhookSenderQueue;
+    const alohr = ownProps.config.hl7Notification?.hieConfigs["Alohr"];
 
     if (!alohrProps) {
       throw new Error("AlohrSftpIngestionLambda is undefined in config.");
@@ -1085,6 +1086,9 @@ export class LambdasNestedStack extends NestedStack {
     }
     if (!sftpPasswordSecret) {
       throw new Error("ALOHR_INGESTION_PASSWORD is not defined in config.");
+    }
+    if (!alohr) {
+      throw new Error("Alohr is undefined in config.");
     }
 
     const sftpConfig = alohrProps.sftpConfig;
@@ -1111,6 +1115,7 @@ export class LambdasNestedStack extends NestedStack {
         ALOHR_INGESTION_BUCKET_NAME: ownProps.alohrSftpIngestionBucket.bucketName,
         HL7_BASE64_SCRAMBLER_SEED_ARN: hl7Base64ScramblerSeed.secretArn,
         HL7_NOTIFICATION_QUEUE_URL: queue.url,
+        ALOHR_INGESTION_TIMEZONE: alohr.timezone,
       },
       stack: this,
       name: "Hl7SftpIngestionAlohr",

--- a/packages/lambdas/src/hl7-alohr-sftp-ingestion.ts
+++ b/packages/lambdas/src/hl7-alohr-sftp-ingestion.ts
@@ -17,7 +17,7 @@ const lambdaName = getEnvVarOrFail("AWS_LAMBDA_FUNCTION_NAME");
 export const handler = capture.wrapHandler(
   async (params: Hl7AlohrSftpIngestionParams): Promise<void> => {
     if (Config.isStaging()) {
-      log("Staging environment is not supported (We don't want to ingest PHI in staging)");
+      log("Skipping Alohr SFTP ingestion in staging. (We don't want to ingest PHI in staging)");
       return;
     }
     const secretArn = Config.getHl7Base64ScramblerSeedArn();

--- a/packages/lambdas/src/hl7-alohr-sftp-ingestion.ts
+++ b/packages/lambdas/src/hl7-alohr-sftp-ingestion.ts
@@ -16,6 +16,10 @@ const lambdaName = getEnvVarOrFail("AWS_LAMBDA_FUNCTION_NAME");
 
 export const handler = capture.wrapHandler(
   async (params: Hl7AlohrSftpIngestionParams): Promise<void> => {
+    if (Config.isStaging()) {
+      log("Staging environment is not supported (We don't want to ingest PHI in staging)");
+      return;
+    }
     const secretArn = Config.getHl7Base64ScramblerSeedArn();
     const hl7Base64ScramblerSeed = await getSecretValueOrFail(secretArn, Config.getAWSRegion());
     process.env["HL7_BASE64_SCRAMBLER_SEED"] = hl7Base64ScramblerSeed;

--- a/packages/lambdas/src/hl7-lahie-sftp-ingestion.ts
+++ b/packages/lambdas/src/hl7-lahie-sftp-ingestion.ts
@@ -17,7 +17,7 @@ const lambdaName = getEnvVarOrFail("AWS_LAMBDA_FUNCTION_NAME");
 export const handler = capture.wrapHandler(
   async (params: Hl7LahieSftpIngestionParams): Promise<void> => {
     if (Config.isStaging()) {
-      log("Staging environment is not supported (We don't want to ingest PHI in staging)");
+      log("Skipping Lahie SFTP ingestion in staging. (We don't want to ingest PHI in staging)");
       return;
     }
     const secretArn = Config.getHl7Base64ScramblerSeedArn();

--- a/packages/lambdas/src/hl7-lahie-sftp-ingestion.ts
+++ b/packages/lambdas/src/hl7-lahie-sftp-ingestion.ts
@@ -16,6 +16,10 @@ const lambdaName = getEnvVarOrFail("AWS_LAMBDA_FUNCTION_NAME");
 
 export const handler = capture.wrapHandler(
   async (params: Hl7LahieSftpIngestionParams): Promise<void> => {
+    if (Config.isStaging()) {
+      log("Staging environment is not supported (We don't want to ingest PHI in staging)");
+      return;
+    }
     const secretArn = Config.getHl7Base64ScramblerSeedArn();
     const hl7Base64ScramblerSeed = await getSecretValueOrFail(secretArn, Config.getAWSRegion());
     process.env["HL7_BASE64_SCRAMBLER_SEED"] = hl7Base64ScramblerSeed;


### PR DESCRIPTION
Part of ENG-1103

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1103

### Dependencies
None

### Description
We don't want to run the ingestion lambda in staging to not ingest potential PHI.
Save files that error'd and keep going with the rest of the files ingested.
Use Alohr's timezone instead of UTC.

### Testing
Local
- [x] Send 2 files one of which has an error in it and make sure one of them goes to webhook sender and the other into errors/filename
- [x] console log the time to make sure we are using Alohr's timezone

Staging
- [ ] Deploy to staging


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Short-circuits HL7 ingestion in staging for Alohr and Lahie, logging the skip to avoid processing PHI.
  * Validates Alohr configuration and propagates its timezone into runtime environments.

* **New Features**
  * Adds file name to ingest message metadata for improved traceability.
  * Exposes a configurable ingestion timezone.

* **Bug Fixes**
  * Produces timezone-aware ingestion timestamps.
  * Captures and persists per-file errors and failing message contents for easier debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->