### PR TITLE
ENG-954 Remove DB cluster init sql 

### DIFF
--- a/packages/infra/lib/analytics-platform/analytics-platform-stack.ts
+++ b/packages/infra/lib/analytics-platform/analytics-platform-stack.ts
@@ -350,10 +350,41 @@ export class AnalyticsPlatformsNestedStack extends NestedStack {
       },
     });
 
-    // Create a custom resource to execute the schema creation SQL
+    // Create a custom resource to wait for cluster availability and execute schema creation SQL
     const sqlCommandsToRunOnClusterCreation = [`CREATE EXTENSION aws_s3 CASCADE`];
+
+    // First, create a custom resource to wait for the cluster to be available
+    const waitForClusterResource = new AwsCustomResource(this, "WaitForClusterAvailable", {
+      onCreate: {
+        service: "RDS",
+        action: "describeDBClusters",
+        parameters: {
+          DBClusterIdentifier: dbCluster.clusterIdentifier,
+        },
+        physicalResourceId: PhysicalResourceId.of("WaitForClusterAvailable"),
+        // This will retry until the cluster is available
+        ignoreErrorCodesMatching: ".*DBClusterNotFound.*",
+      },
+      policy: AwsCustomResourcePolicy.fromSdkCalls({
+        resources: [dbCluster.clusterArn],
+      }),
+      timeout: Duration.minutes(10),
+    });
+
+    // Then create the schema resource that depends on the cluster being available
     const createSchemaResource = new AwsCustomResource(this, "CreateSchemaCustomResource", {
       onCreate: {
+        service: "RDSDataService",
+        action: "executeStatement",
+        parameters: {
+          resourceArn: dbCluster.clusterArn,
+          secretArn: dbCredsSecret.secretArn,
+          database: dbConfig.name,
+          sql: sqlCommandsToRunOnClusterCreation.join("; "),
+        },
+        physicalResourceId: PhysicalResourceId.of("CreateSchemaCustomResource"),
+      },
+      onUpdate: {
         service: "RDSDataService",
         action: "executeStatement",
         parameters: {
@@ -367,10 +398,12 @@ export class AnalyticsPlatformsNestedStack extends NestedStack {
       policy: AwsCustomResourcePolicy.fromSdkCalls({
         resources: AwsCustomResourcePolicy.ANY_RESOURCE,
       }),
+      timeout: Duration.minutes(2),
     });
 
-    // Ensure the custom resource depends on the RDS instance
-    createSchemaResource.node.addDependency(dbCluster);
+    // Ensure proper dependency chain: DB Cluster -> Wait for Availability -> Create Schema
+    waitForClusterResource.node.addDependency(dbCluster);
+    createSchemaResource.node.addDependency(waitForClusterResource);
 
     addDBClusterPerformanceAlarms(this, dbCluster, dbClusterName, dbConfig, ownProps.alarmAction);
     return { dbCluster };
@@ -560,6 +593,7 @@ export class AnalyticsPlatformsNestedStack extends NestedStack {
       dbname: config.analyticsPlatform.rds.name,
       username: config.analyticsPlatform.rds.fhirToCsvDbUsername,
       passwordSecretArn: dbUserSecret.secretArn,
+      schemaName: "public",
     };
 
     // TODO ENG-1029 for reference only for now


### PR DESCRIPTION
Ref eng-954

Signed-off-by: Rafael Leite <2132564+leite08@users.noreply.github.com>

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4481
- Downstream: none

### Description

Remove DB cluster init sql  - [context1](https://github.com/metriport/metriport/actions/runs/18063971652/job/51404197538), [context2](https://metriport.slack.com/archives/C094AJ8L0E8/p1759003150212929?thread_ts=1758906123.315339&cid=C094AJ8L0E8)

### Testing

none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Removed automatic setup of the analytics database schema and S3 integration during deploys/updates.
* Bug Fixes
  * Removed automated wait-and-apply behavior that handled schema creation to prevent deployment race conditions.
  * Reverted explicit target-schema enforcement for the incremental FHIR-to-CSV pipeline.
* Chores
  * Tuned deployment timeouts to enhance stability during database initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->