### PR TITLE
ENG-954 re-add analytics stack

### DIFF
--- a/packages/infra/lib/api-stack.ts
+++ b/packages/infra/lib/api-stack.ts
@@ -423,18 +423,16 @@ export class APIStack extends Stack {
     //-------------------------------------------
     // Analytics Platform
     //-------------------------------------------
-    const analyticsPlatformStack: AnalyticsPlatformsNestedStack | undefined = undefined as
-      | AnalyticsPlatformsNestedStack
-      | undefined;
-    // if (!isSandbox(props.config)) {
-    // analyticsPlatformStack = new AnalyticsPlatformsNestedStack(this, "AnalyticsPlatforms", {
-    //   config: props.config,
-    //   vpc: this.vpc,
-    //   lambdaLayers,
-    //   medicalDocumentsBucket,
-    //   featureFlagsTable,
-    // });
-    // }
+    let analyticsPlatformStack: AnalyticsPlatformsNestedStack | undefined = undefined;
+    if (!isSandbox(props.config)) {
+      analyticsPlatformStack = new AnalyticsPlatformsNestedStack(this, "AnalyticsPlatforms", {
+        config: props.config,
+        vpc: this.vpc,
+        lambdaLayers,
+        medicalDocumentsBucket,
+        featureFlagsTable,
+      });
+    }
 
     //-------------------------------------------
     // General lambdas


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4762
- Downstream: none

### Description

Re-add analytics stack

This reverts commit d9e26dacb2074c3767dc70e95338934e5f0f0545, reversing changes made to d9ee98bd96df47af79fa0eee67439183f1bc9d29.

### Testing

- staging
   - [ ] analytics stack gets recreated

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the Analytics Platform in non-sandbox environments, making analytics capabilities available where applicable.

* **Chores**
  * Updated infrastructure logic to conditionally deploy the Analytics Platform only outside sandbox environments, preventing unnecessary stack creation during sandbox usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->