### PR TITLE
ENG-1187 - Util script for reconverting all FHIR bundles for a Surescripts customer

### DIFF
--- a/packages/utils/src/surescripts/fhir-convert-all.ts
+++ b/packages/utils/src/surescripts/fhir-convert-all.ts
@@ -1,0 +1,107 @@
+import { Command } from "commander";
+import fs from "fs";
+import { buildDayjs } from "@metriport/shared/common/date";
+import { SurescriptsReplica } from "@metriport/core/external/surescripts/replica";
+import { SurescriptsDataMapper } from "@metriport/core/external/surescripts/data-mapper";
+import { getSurescriptsRunsFilePath } from "./shared";
+
+/**
+ * Converts all patient responses to FHIR bundles for the given customer.
+ *
+ * Usage:
+ * npm run surescripts -- fhir-convert-all --cx-id <cx-id>
+ *
+ * Recommended:
+ * npm run surescripts -- fhir-convert-all --cx-id <cx-id> --use-cache
+ *
+ * Using the cache will download all S3 file keys and patient IDs for the customer into local cache files
+ * within the Surescripts runs directory, which provides a significant speedup in the conversion process
+ * when running this across multiple customers or multiple iterations.
+ */
+const program = new Command();
+program.name("fhir-convert-all");
+program.requiredOption("--cx-id <cx-id>", "The customer ID");
+program.option("--use-cache", "Use the cache");
+program.description("Converts all patient responses to FHIR bundles");
+program.action(fhirConvertAllResponses);
+program.showHelpAfterError();
+
+// Produces all response files
+type ListResponseFilesResponse = Awaited<ReturnType<SurescriptsReplica["listResponseFiles"]>>;
+type FacilityAndPatientIds = Array<{
+  facilityId: string;
+  patientIds: string[];
+}>;
+
+/**
+ * Gets all response files for the given customer.
+ *
+ * @param cxId - The customer ID
+ * @param useCache - Whether to use the cache
+ */
+async function fhirConvertAllResponses({ cxId, useCache }: { cxId: string; useCache?: boolean }) {
+  const responseFiles = await getAllResponseFiles(useCache);
+  const facilityAndPatientIds = await getFacilityAndPatientIdsForCustomer(cxId);
+  for (const { facilityId, patientIds } of facilityAndPatientIds) {
+    const patientIdSet = new Set(patientIds);
+    const responseFilesForFacility = responseFiles.filter(responseFile =>
+      patientIdSet.has(responseFile.patientId)
+    );
+    console.log(
+      `Found ${responseFilesForFacility.length} response files for facility ${facilityId}`
+    );
+
+    for (const responseFile of responseFilesForFacility) {
+      console.log(`Reconverting response file ${responseFile.key}`);
+    }
+  }
+}
+
+async function getFacilityAndPatientIdsForCustomer(cxId: string): Promise<FacilityAndPatientIds> {
+  const dataMapper = new SurescriptsDataMapper();
+  const customer = await dataMapper.getCustomerData(cxId);
+  const response: FacilityAndPatientIds = [];
+
+  for (const facility of customer.facilities) {
+    const facilityId = facility.id;
+    const patientIds = await dataMapper.getPatientIdsForFacility({ cxId, facilityId });
+    response.push({
+      facilityId,
+      patientIds,
+    });
+  }
+  return response;
+}
+
+async function getAllResponseFiles(useCache?: boolean): Promise<ListResponseFilesResponse> {
+  if (useCache) {
+    const cachedResponse = await getResponseFilesFromCache();
+    if (cachedResponse) return cachedResponse;
+  }
+  const replica = new SurescriptsReplica();
+  const responseFiles = await replica.listResponseFiles();
+  if (useCache) {
+    writeResponseFilesToCache(responseFiles);
+  }
+  return responseFiles;
+}
+
+async function getResponseFilesFromCache(): Promise<ListResponseFilesResponse | undefined> {
+  const cacheFile = buildResponseFileCacheName();
+  if (!fs.existsSync(cacheFile)) {
+    return undefined;
+  }
+  const cache = fs.readFileSync(cacheFile, "utf-8");
+  return JSON.parse(cache) as ListResponseFilesResponse;
+}
+
+function writeResponseFilesToCache(responseFiles: ListResponseFilesResponse): void {
+  const cacheFile = buildResponseFileCacheName();
+  fs.writeFileSync(cacheFile, JSON.stringify(responseFiles, null, 2));
+}
+
+function buildResponseFileCacheName(): string {
+  return getSurescriptsRunsFilePath(`response-keys/${buildDayjs().format("YYYY-MM-DD")}.json`);
+}
+
+export default program;

--- a/packages/utils/src/surescripts/index.ts
+++ b/packages/utils/src/surescripts/index.ts
@@ -24,6 +24,7 @@ import bundleVerification from "./bundle-verification";
 import generateCsv from "./generate-csv";
 import sendBatchPatientRequest from "./send-batch-patient-request";
 import sendCustomerRequest from "./send-customer-request";
+import fhirConvertAll from "./fhir-convert-all";
 
 /**
  * This is the main command registry for the Surescripts CLI. You should add any new
@@ -51,4 +52,5 @@ program.addCommand(bundleVerification);
 program.addCommand(generateCsv);
 program.addCommand(sendBatchPatientRequest);
 program.addCommand(sendCustomerRequest);
+program.addCommand(fhirConvertAll);
 program.parse();


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-1187

### Dependencies

- Upstream: None
- Downstream: None

### Description

WIP - reconvert all Surescripts customer response bundles

### Testing

TODO

- Local
  - [ ] `npm run surescripts -- fhir-convert-all`
- Staging
  - [ ] Run on staging facility/patients
- Production
  - [ ] Run on production customer

### Release Plan

- [ ] Merge this
