### PR TITLE
add raw incoming bucket to mllp server

### DIFF
--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -107,6 +107,9 @@ export class Config {
   static getHl7IncomingMessageBucketName(): string {
     return getEnvVarOrFail("HL7_INCOMING_MESSAGE_BUCKET_NAME");
   }
+  static getHl7RawMessageBucketName(): string {
+    return getEnvVarOrFail("HL7_RAW_MESSAGE_BUCKET_NAME");
+  }
   static getHl7OutgoingMessageBucketName(): string {
     return getEnvVarOrFail("HL7_OUTGOING_MESSAGE_BUCKET_NAME");
   }

--- a/packages/infra/config/hl7-notification-config.ts
+++ b/packages/infra/config/hl7-notification-config.ts
@@ -11,6 +11,7 @@ export interface Hl7NotificationConfig {
   };
   deprecatedIncomingMessageBucketName: string;
   incomingMessageBucketName: string;
+  rawIncomingMessageBucketName: string;
   outgoingMessageBucketName: string;
   hl7ConversionBucketName: string;
   notificationWebhookSenderQueue: {

--- a/packages/infra/lib/hl7-notification-stack/index.ts
+++ b/packages/infra/lib/hl7-notification-stack/index.ts
@@ -20,10 +20,10 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
   constructor(scope: Construct, id: string, props: Hl7NotificationStackProps) {
     super(scope, id, props);
 
-    const incomingHl7NotificationBucket = s3.Bucket.fromBucketName(
+    const rawIncomingHl7NotificationBucket = s3.Bucket.fromBucketName(
       this,
-      "IncomingHl7NotificationBucket",
-      props.config.hl7Notification.incomingMessageBucketName
+      "RawIncomingHl7NotificationBucket",
+      props.config.hl7Notification.rawIncomingMessageBucketName
     );
 
     const ecrRepo = new Repository(this, "MllpServerRepo", {
@@ -62,7 +62,7 @@ export class Hl7NotificationStack extends MetriportCompositeStack {
       version: props.version,
       vpc,
       ecrRepo,
-      incomingHl7NotificationBucket,
+      rawIncomingHl7NotificationBucket,
       description: "HL7 Notification MLLP Server",
     });
 

--- a/packages/infra/lib/hl7-notification-stack/mllp.ts
+++ b/packages/infra/lib/hl7-notification-stack/mllp.ts
@@ -20,7 +20,7 @@ interface MllpStackProps extends cdk.StackProps {
   version: string | undefined;
   vpc: ec2.Vpc;
   ecrRepo: ecr.IRepository;
-  incomingHl7NotificationBucket: s3.IBucket;
+  rawIncomingHl7NotificationBucket: s3.IBucket;
 }
 
 const setupNlb = (identifier: string, vpc: ec2.Vpc, nlb: elbv2.NetworkLoadBalancer, ip: string) => {
@@ -64,7 +64,7 @@ export class MllpStack extends cdk.NestedStack {
   constructor(scope: Construct, id: string, props: MllpStackProps) {
     super(scope, id, props);
 
-    const { vpc, ecrRepo, incomingHl7NotificationBucket, config } = props;
+    const { vpc, ecrRepo, rawIncomingHl7NotificationBucket, config } = props;
     const { notificationWebhookSenderQueue, hieConfigs } = config.hl7Notification;
     const {
       sentryDSN,
@@ -150,7 +150,7 @@ export class MllpStack extends cdk.NestedStack {
         NODE_ENV: "production",
         ENV_TYPE: props.config.environmentType,
         MLLP_PORT: MLLP_DEFAULT_PORT.toString(),
-        HL7_INCOMING_MESSAGE_BUCKET_NAME: incomingHl7NotificationBucket.bucketName,
+        HL7_RAW_MESSAGE_BUCKET_NAME: rawIncomingHl7NotificationBucket.bucketName,
         HL7_NOTIFICATION_QUEUE_URL: notificationWebhookSenderQueue.url,
         HIE_CONFIG_DICTIONARY: JSON.stringify(createHieConfigDictionary(hieConfigs)),
         ...(sentryDSN ? { SENTRY_DSN: sentryDSN } : {}),
@@ -170,7 +170,7 @@ export class MllpStack extends cdk.NestedStack {
     setupNlb("", vpc, nlbA, nlbInternalIpAddressA).addTarget(fargateService);
     setupNlb("B", vpc, nlbB, nlbInternalIpAddressB).addTarget(fargateService);
 
-    incomingHl7NotificationBucket.grantWrite(fargateService.taskDefinition.taskRole);
+    rawIncomingHl7NotificationBucket.grantWrite(fargateService.taskDefinition.taskRole);
 
     const scaling = fargateService.autoScaleTaskCount({
       minCapacity: fargateTaskCountMin,

--- a/packages/mllp-server/src/utils.ts
+++ b/packages/mllp-server/src/utils.ts
@@ -8,15 +8,17 @@ import { Config } from "@metriport/core/util/config";
 import { Logger } from "@metriport/core/util/log";
 import { unpackUuid } from "@metriport/core/util/pack-uuid";
 
-import { MetriportError } from "@metriport/shared";
-import * as Sentry from "@sentry/node";
 import { Hl7Message } from "@medplum/core";
-import IPCIDR from "ip-cidr";
-import { HieConfigDictionary } from "@metriport/core/external/hl7-notification/hie-config-dictionary";
 import {
   fromBambooId,
   remapMessageReplacingPid3,
 } from "@metriport/core/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/shared";
+import { HieConfigDictionary } from "@metriport/core/external/hl7-notification/hie-config-dictionary";
+import { MetriportError } from "@metriport/shared";
+import * as Sentry from "@sentry/node";
+import IPCIDR from "ip-cidr";
+import { buildDayjs } from "@metriport/shared/common/date";
+import { HL7_FILE_EXTENSION } from "@metriport/core/util/mime";
 
 const crypto = new Base64Scrambler(Config.getHl7Base64ScramblerSeed());
 export const s3Utils = new S3Utils(Config.getAWSRegion());
@@ -138,4 +140,9 @@ export function translateMessage(rawMessage: Hl7Message, hieName: string): Hl7Me
     return newMessage;
   }
   return rawMessage;
+}
+
+export function createRawHl7MessageFileKey(clientIp: string) {
+  const now = buildDayjs().toISOString();
+  return `${clientIp}/${now}.${HL7_FILE_EXTENSION}`;
 }


### PR DESCRIPTION
Part of ENG-1162

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1162

### Dependencies

- Upstream: _[this PR points to another PR or depends on its release]_

### Description
Adds a raw incoming bucket to mllp server so we never lose any adts.

### Testing
- Local
  - [ ] Test on local
- Staging
  - [ ] Test on staging
