### PR TITLE
ENG-000 Improve script to ingest into OpenSearch

### DIFF
--- a/packages/core/src/command/consolidated/search/fhir-resource/ingest-lexical.ts
+++ b/packages/core/src/command/consolidated/search/fhir-resource/ingest-lexical.ts
@@ -87,12 +87,10 @@ function processErrors({
 }) {
   const errorMapToObj = Object.fromEntries(errors.entries());
   log(`Errors: `, () => JSON.stringify(errorMapToObj));
-  throw new MetriportError("Errors ingesting resources into OpenSearch", {
-    extra: {
-      cxId,
-      patientId,
-      countPerErrorType: JSON.stringify(errorMapToObj),
-    },
+  throw new MetriportError("Errors ingesting resources into OpenSearch", undefined, {
+    cxId,
+    patientId,
+    countPerErrorType: JSON.stringify(errorMapToObj),
   });
 }
 


### PR DESCRIPTION
### Dependencies

none

### Description

Ingest pt into OS w/ warning + and better error handling.

Done while running [this](https://metriport.slack.com/archives/C04GEQ1GH9D/p1759002190602159?thread_ts=1758991920.342729&cid=C04GEQ1GH9D).

### Testing

- Local
  - [x] Ingest patients into OS successfully
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a confirmation prompt before patient ingestion to prevent accidental runs.
  - Displayed per-account patient counts prior to ingestion for better visibility.

- Chores
  - Reduced ingestion batch size for safer, more controlled processing.
  - Improved logging, including clearer totals and timing output.
  - Added early exit if confirmation is not “yes”.
  - Standardized error reporting for more consistent diagnostics during ingestion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->