### PR TITLE
ENG-954 Don't require job ID on bulk ingestion

### DIFF
--- a/packages/lambdas/src/analytics-platform/fhir-to-csv-bulk.ts
+++ b/packages/lambdas/src/analytics-platform/fhir-to-csv-bulk.ts
@@ -22,16 +22,16 @@ export const handler = capture.wrapHandler(async (event: SQSEvent, context: Cont
   if (!message) return;
 
   const parsedBody = parseBody(fhirToCsvSchema, message.body);
-  const { jobId, cxId, patientId } = parsedBody;
+  const { cxId, patientId } = parsedBody;
 
-  const log = prefixedLog(`jobId ${jobId}, cxId ${cxId}, patientId ${patientId}`);
+  const log = prefixedLog(`cxId ${cxId}, patientId ${patientId}`);
   log(`Parsed: ${JSON.stringify(parsedBody)}`);
 
   const doesPatientHaveConsolidatedBundle = await doesConsolidatedDataExist(cxId, patientId);
   if (!doesPatientHaveConsolidatedBundle) {
     const msg = `Patient does not have a consolidated bundle`;
     log(msg);
-    throw new MetriportError(msg, undefined, { cxId, patientId, jobId });
+    throw new MetriportError(msg, undefined, { cxId, patientId });
   }
 
   const timeoutForCsvTransform = Math.max(0, context.getRemainingTimeInMillis() - 200);
@@ -48,7 +48,6 @@ export const handler = capture.wrapHandler(async (event: SQSEvent, context: Cont
 
 const fhirToCsvSchema = z.object({
   cxId: z.string(),
-  jobId: z.string(),
   patientId: z.string(),
   outputPrefix: z.string(),
 });


### PR DESCRIPTION
### Dependencies

- none

### Description

Don't require job ID on bulk ingestion  - [contex](https://metriport.slack.com/archives/C04T5Q9JHFX/p1759192735164669)

### Testing

- Local
  - none
- Staging
  - [ ] bulk ingestion on Snowflake works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed jobId from request handling, logs, and error messages; only cxId and patientId are used. Results in leaner payloads and consistent identifiers across processing.

- Chores
  - Updated input validation to drop the jobId field from the schema, aligning checks with the revised payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->