### PR TITLE
ENG-954 bulk ingestion using original s3 prefix

### DIFF
--- a/packages/data-transformation/fhir-to-csv/main.py
+++ b/packages/data-transformation/fhir-to-csv/main.py
@@ -6,7 +6,7 @@ import ndjson
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from src.parseNdjsonBundle import parseNdjsonBundle
 from src.utils.environment import Environment
-from src.utils.file import create_consolidated_key
+from src.utils.file import create_consolidated_key, create_patient_output_prefix
 
 transform_name = 'fhir-to-csv'
 
@@ -59,12 +59,13 @@ def transform_and_upload_data(
     local_output_files = parseNdjsonBundle.parse(local_ndjson_bundle_key, local_patient_path)
 
     output_bucket_and_file_keys_and_table_names = []
+    pt_output_file_prefix = create_patient_output_prefix(output_file_prefix, patient_id)
     
     with ThreadPoolExecutor(max_workers=3) as executor:
         future_to_file = {}
         for file in local_output_files:
-            file_name = file.split("/")[-1].replace("/", "_")
-            output_file_key = f"{output_file_prefix}/{file_name}"
+            file_name = file.replace("/", "_")
+            output_file_key = f"{pt_output_file_prefix}/{file_name}"
             future = executor.submit(upload_file_to_s3, file, output_bucket, output_file_key)
             future_to_file[future] = file
         

--- a/packages/data-transformation/fhir-to-csv/src/utils/file.py
+++ b/packages/data-transformation/fhir-to-csv/src/utils/file.py
@@ -2,3 +2,6 @@ consolidated_data_file_suffix = 'CONSOLIDATED_DATA.json'
 
 def create_consolidated_key(cx_id: str, patient_id: str) -> str:
     return f'{cx_id}/{patient_id}/{cx_id}_{patient_id}_{consolidated_data_file_suffix}'
+
+def create_patient_output_prefix(base_prefix: str, patient_id: str) -> str:
+    return f"{base_prefix}/pt={patient_id}"

--- a/packages/utils/src/analytics-platform/2-merge-csvs.ts
+++ b/packages/utils/src/analytics-platform/2-merge-csvs.ts
@@ -5,6 +5,7 @@ import {
   buildFhirToCsvBulkJobPrefix,
   parsePatientIdFromFhirToCsvBulkPatientPrefix,
 } from "@metriport/core/command/analytics-platform/fhir-to-csv/file-name";
+import { groupAndMergeCSVs } from "@metriport/core/command/analytics-platform/merge-csvs/index";
 import { S3Utils } from "@metriport/core/external/aws/s3";
 import { SQSClient } from "@metriport/core/external/aws/sqs";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
@@ -64,12 +65,19 @@ program
   .name("2-merge-csvs")
   .description("CLI to trigger the merging of patients' CSV files into single files")
   .requiredOption("-f2c, --fhir-to-csv-job-id <id>", "The FhirToCsv job ID to merge the CSVs for")
+  .option("-l, --run-on-local", "Run the merge on local")
   .showHelpAfterError()
   .action(main);
 
 const sqsClient = new SQSClient({ region });
 
-async function main({ fhirToCsvJobId }: { fhirToCsvJobId: string }) {
+async function main({
+  fhirToCsvJobId,
+  runOnLocal = false,
+}: {
+  fhirToCsvJobId: string;
+  runOnLocal: boolean;
+}) {
   await sleep(100);
   const { log } = out("");
 
@@ -96,7 +104,7 @@ async function main({ fhirToCsvJobId }: { fhirToCsvJobId: string }) {
   const uniquePatientIds = [...new Set(patientsToMerge)];
   const patientIdChunks = chunk(uniquePatientIds, maxPatientCountPerLambda);
 
-  await displayWarningAndConfirmation(uniquePatientIds, isAllPatients, orgName, log);
+  await displayWarningAndConfirmation(uniquePatientIds, isAllPatients, orgName, runOnLocal, log);
   log(
     `>>> Running it for ${uniquePatientIds.length} patients (${patientIdChunks.length} chunks of ` +
       `${maxPatientCountPerLambda} patients each)...\n- mergeCsvJobId: ${mergeCsvJobId}\n- fhirToCsvJobId: ${fhirToCsvJobId}` +
@@ -118,12 +126,21 @@ async function main({ fhirToCsvJobId }: { fhirToCsvJobId: string }) {
           ...defaultPayload,
           patientIds: ptIdsOfThisRun,
         };
-        const payloadString = JSON.stringify(payload);
-        await sqsClient.sendMessageToQueue(queueUrl, payloadString, {
-          fifo: true,
-          messageDeduplicationId: createUuidFromText(ptIdsOfThisRun.join(",")),
-          messageGroupId: uuidv4(),
-        });
+        if (runOnLocal) {
+          await groupAndMergeCSVs({
+            ...payload,
+            sourceBucket: bucketName,
+            destinationBucket: bucketName,
+            region,
+          });
+        } else {
+          const payloadString = JSON.stringify(payload);
+          await sqsClient.sendMessageToQueue(queueUrl, payloadString, {
+            fifo: true,
+            messageDeduplicationId: createUuidFromText(ptIdsOfThisRun.join(",")),
+            messageGroupId: uuidv4(),
+          });
+        }
 
         amountOfPatientsProcessed += ptIdsOfThisRun.length;
         log(
@@ -181,12 +198,14 @@ async function displayWarningAndConfirmation(
   patientsToInsert: string[],
   isAllPatients: boolean,
   orgName: string,
+  runOnLocal: boolean,
   log: typeof console.log
 ) {
   const allPatientsMsg = isAllPatients ? ` That's all patients of customer ${cxId}!` : "";
+  const runOnLocalMsg = runOnLocal ? `\n\nRUNNING ON LOCAL!\n` : "";
   const msg =
     `You are about to merge CSV files for ${patientsToInsert.length} patients of ` +
-    `customer ${orgName} (${cxId}). Are you sure?${allPatientsMsg}`;
+    `customer ${orgName} (${cxId}). ${allPatientsMsg}${runOnLocalMsg}`;
   log(msg);
   log("Are you sure you want to proceed?");
   const rl = readline.createInterface({


### PR DESCRIPTION
### Dependencies

none

### Description

bulk ingestion using original s3 prefix

### Testing

- Local
  - [x] run bulk import and fhir-to-csv and merge generate s3 prefixes as expected (same as prod)
- Staging
  - none
- Sandbox
  - none
- Production
  - [ ] run bulk import for a cx

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag (-l/--run-on-local) to run CSV merging locally without queueing.
  * Displays a clear “RUNNING ON LOCAL” warning when local mode is enabled.

* **Improvements**
  * Output files are now organized under patient-specific prefixes for easier navigation and management.
  * More consistent and predictable output file names and upload paths across datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->