### PR TITLE
ENG-1171: fix Epic EHR docs duplicated text

### DIFF
--- a/docs/ehr-apps/epic.mdx
+++ b/docs/ehr-apps/epic.mdx
@@ -13,9 +13,9 @@ To enable the Metriport Epic app, contact our team at [support@metriport.com](ma
 Patients can be created in Metriport via the following workflow:
 
 1. When an Epic user opens the embedded Metriport app on a patient's chart for the first time, Metriport creates the patient if they don't already exist.
-2. Once a patient is created, you can access their comprehensive medical history by navigating to the Metriport app.
+2. After creation, Metriport automatically triggers a Document Query to begin gathering available health data.
 
-Once a patient is created, you can access their comprehensive medical history by navigating to Metriport app.
+Once a patient is created, you can access their comprehensive medical history by navigating to the Metriport app.
 
 <Note>
   Version information: Epic SMART on FHIR R4, Scope SMART


### PR DESCRIPTION

Issues:

- https://linear.app/metriport/issue/ENG-1171

### Dependencies

- none

### Description


### Testing

- Local
- [x] documentation check
- Staging
-none
- Sandbox
-none
- Production
-none


### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated Epic workflow docs to reflect an automatic Document Query triggered after patient creation.
  - Removed outdated step to manually access medical history; guidance now mirrors the new automated behavior.
  - Improved phrasing and consistency when referencing the app (capitalization and article usage).
  - Clarifies user expectations, reduces manual steps, and enhances readability for clinicians using the Epic workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->