### PR TITLE
feat(utils): add backfill script for cohorts

### DIFF
--- a/packages/utils/src/cohorts/backfill-default-cohorts.ts
+++ b/packages/utils/src/cohorts/backfill-default-cohorts.ts
@@ -1,0 +1,47 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import { createDefaultCohorts } from "../../../api/src/command/medical/cohort/create-default-cohorts";
+import initDB from "../../../api/src/models/db";
+import { sleep } from "@metriport/shared/common/sleep";
+import dayjs, { duration } from "dayjs";
+dayjs.extend(duration);
+
+/**
+ * This script creates the default cohorts for a list of cxIds.
+ *
+ * Update the `listOfCxIds` array with the list of cxIds you want to create the default cohorts for.
+ *
+ * Execute this with:
+ * $ ts-node src/cohorts/backfill-default-cohorts.ts
+ */
+
+const listOfCxIds: string[] = [];
+const waitBetweenCxs = dayjs.duration(50, "milliseconds");
+
+async function main() {
+  await sleep(50); // Avoid mixing logs with Node's
+  const failedCxIds: string[] = [];
+
+  console.log(`Creating default cohorts for ${listOfCxIds.length} cxs...`);
+  await sleep(3000); // Give time for user to cancel if needed
+  await initDB();
+  for (const cxId of listOfCxIds) {
+    try {
+      await createDefaultCohorts({ cxId });
+      console.log(`Completed creating default cohorts for ${cxId}`);
+    } catch (error) {
+      console.error(`Error creating default cohorts for ${cxId}: ${error}`);
+      failedCxIds.push(cxId);
+    } finally {
+      await sleep(waitBetweenCxs.asMilliseconds());
+    }
+  }
+  const message =
+    failedCxIds.length > 0
+      ? `Failed to create default cohorts for ${failedCxIds.join(", ")}`
+      : "All default cohorts created successfully";
+  console.log(message);
+}
+
+main();


### PR DESCRIPTION
Part of ENG-1194

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1194

### Dependencies
None

### Description
Add a backfill for creating cohorts 

### Testing
- Local
  - [ ] Create cohorts for cxs
- Staging
  - [ ] Create cohorts for cxs
- Production
  - [ ] Create cohorts for a select few cxs before running the whole thing

### Release Plan
- [ ] Execute this on production after merging.
  - [ ] Go to backfill-default-cohorts.ts and follow instructions
 