### PR TITLE
ENG-1198 Retry on missing CCD

### DIFF
--- a/packages/commonwell-sdk/src/client/commonwell.ts
+++ b/packages/commonwell-sdk/src/client/commonwell.ts
@@ -565,7 +565,14 @@ export class CommonWell extends CommonWellBase implements CommonWellAPI {
         });
       }
       const data = binary.data;
-      if (!data) throw new CommonwellError(errorMessage, undefined, { reason: "Missing data" });
+      if (!data)
+        throw new CommonwellError(errorMessage, undefined, {
+          reason: "Missing data",
+          contentType,
+          resourceType,
+          properties: typeof binary === "object" ? Object.keys(binary).join(", ") : "not-a-object",
+          inputUrl,
+        });
       const dataBuffer = base64ToBuffer(data);
       outputStream.write(dataBuffer);
       outputStream.end();

--- a/packages/core/src/shareback/metadata/get-metadata-xml.ts
+++ b/packages/core/src/shareback/metadata/get-metadata-xml.ts
@@ -4,6 +4,7 @@ import duration from "dayjs/plugin/duration";
 import { executeWithRetriesS3, S3Utils } from "../../external/aws/s3";
 import { XDSRegistryError } from "../../external/carequality/error";
 import { Config } from "../../util/config";
+import { out } from "../../util/log";
 import { capture } from "../../util/notifications";
 import { createSharebackFolderName, METADATA_SUFFIX } from "../file";
 
@@ -21,6 +22,7 @@ export async function getMetadataDocumentContents(
   cxId: string,
   patientId: string
 ): Promise<string[]> {
+  const { log } = out(`getMetadataDocumentContents - cxId ${cxId}, patientId ${patientId}`);
   const alreadyLoadedFiles: { key: string; contents: string }[] = [];
 
   await executeWithRetries(
@@ -44,6 +46,7 @@ export async function getMetadataDocumentContents(
       initialDelay: initialTimeToWaitBetweenAttempts.asMilliseconds(),
       maxDelay: maxTimeToWaitBetweenAttempts.asMilliseconds(),
       maxAttempts,
+      log,
     }
   );
 

--- a/packages/core/src/shareback/metadata/get-metadata-xml.ts
+++ b/packages/core/src/shareback/metadata/get-metadata-xml.ts
@@ -66,10 +66,10 @@ async function retrieveXmlContentsFromMetadataFilesOnS3(
 ): Promise<{ key: string; contents: string }[]> {
   const prefix = createSharebackFolderName({ cxId, patientId });
 
-  const data = await executeWithRetriesS3(() => s3Utils.listObjects(bucketName, prefix));
+  const files = await executeWithRetriesS3(() => s3Utils.listObjects(bucketName, prefix));
   const keysAndMetaContents = (
     await Promise.all(
-      data
+      files
         .filter(item => item.Key && item.Key.endsWith(METADATA_SUFFIX))
         .map(async item => {
           const key = item.Key;


### PR DESCRIPTION
Ref eng-1198

Signed-off-by: Rafael Leite <2132564+leite08@users.noreply.github.com>

### Dependencies

none

### Description

Retry on missing CCD during the inbound flow.

### Testing

- Local
  - [x] inbound works
  - [x] inbound with missing CCD retries 8 times
- Staging
  - [ ] inbound works
  - [ ] inbound with missing CCD works
- Sandbox
  - none
- Production
  - none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retrying with configurable timing to improve availability when metadata files aren’t immediately present.

* **Bug Fixes / Improvements**
  * Reduced intermittent “metadata not found” failures by accumulating partial results across attempts.
  * Enhanced error messages for document retrieval with richer context to aid troubleshooting.

* **Refactor**
  * Metadata retrieval now returns structured file entries (key + contents) for more reliable downstream processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->