### PR TITLE
build: custom ai summary and pdf tweak

### DIFF
--- a/packages/core/src/command/ai-brief/create.ts
+++ b/packages/core/src/command/ai-brief/create.ts
@@ -11,12 +11,20 @@ import { analytics, EventTypes } from "../../external/analytics/posthog";
 import { getAnthropicModelId } from "../../external/bedrock/model/anthropic/version";
 import { BedrockChat } from "../../external/langchain/bedrock";
 import { out } from "../../util";
-import { isPcpVisitAiSummaryFeatureFlagEnabledForCx } from "../feature-flags/domain-ffs";
+import {
+  isPcpVisitAiSummaryFeatureFlagEnabledForCx,
+  isRecentVisitAiSummaryFeatureFlagEnabledForCx,
+} from "../feature-flags/domain-ffs";
 import {
   documentVariableName as pcpVisitDocumentVariableName,
   mainSummaryPrompt as pcpVisitMainSummaryPrompt,
   refinedSummaryPrompt as pcpVisitRefinedSummaryPrompt,
 } from "./pcp-visit-prompt";
+import {
+  documentVariableName as recentVisitDocumentVariableName,
+  mainSummaryPrompt as recentVisitMainSummaryPrompt,
+  refinedSummaryPrompt as recentVisitRefinedSummaryPrompt,
+} from "./recent-visit-prompt";
 import { documentVariableName, mainSummaryPrompt, refinedSummaryPrompt } from "./prompts";
 import { AiBriefControls } from "./shared";
 
@@ -147,7 +155,16 @@ async function getInputsForAiBriefGeneration(cxId: string): Promise<{
   refinedPrompt: string;
   documentVariable: string;
 }> {
+  const isRecentVisit = await isRecentVisitAiSummaryFeatureFlagEnabledForCx(cxId);
   const isPcpVisit = await isPcpVisitAiSummaryFeatureFlagEnabledForCx(cxId);
+
+  if (isRecentVisit) {
+    return {
+      mainPrompt: recentVisitMainSummaryPrompt,
+      refinedPrompt: recentVisitRefinedSummaryPrompt,
+      documentVariable: recentVisitDocumentVariableName,
+    };
+  }
 
   if (isPcpVisit) {
     return {

--- a/packages/core/src/command/ai-brief/create.ts
+++ b/packages/core/src/command/ai-brief/create.ts
@@ -13,7 +13,7 @@ import { BedrockChat } from "../../external/langchain/bedrock";
 import { out } from "../../util";
 import {
   isPcpVisitAiSummaryFeatureFlagEnabledForCx,
-  isRecentVisitAiSummaryFeatureFlagEnabledForCx,
+  isRecentVisitAiSummaryEnabledForCx,
 } from "../feature-flags/domain-ffs";
 import {
   documentVariableName as pcpVisitDocumentVariableName,
@@ -155,7 +155,7 @@ async function getInputsForAiBriefGeneration(cxId: string): Promise<{
   refinedPrompt: string;
   documentVariable: string;
 }> {
-  const isRecentVisit = await isRecentVisitAiSummaryFeatureFlagEnabledForCx(cxId);
+  const isRecentVisit = await isRecentVisitAiSummaryEnabledForCx(cxId);
   const isPcpVisit = await isPcpVisitAiSummaryFeatureFlagEnabledForCx(cxId);
 
   if (isRecentVisit) {

--- a/packages/core/src/command/ai-brief/filter.ts
+++ b/packages/core/src/command/ai-brief/filter.ts
@@ -8,6 +8,7 @@ import {
 } from "@medplum/fhirtypes";
 import { toArray } from "@metriport/shared";
 import { buildDayjs, ISO_DATE } from "@metriport/shared/common/date";
+import { Dayjs } from "dayjs";
 import { cloneDeep } from "lodash";
 import { condenseBundle } from "../../domain/ai-brief/condense-bundle";
 import {
@@ -85,13 +86,13 @@ export function prepareBundleForAiSummarization(bundle: Bundle, log: typeof cons
 
 function determineOptimalTimeframe(
   bundle: Bundle,
-  initialDate: ReturnType<typeof buildDayjs>
+  initialDate: Dayjs
 ): {
   finalSlimPayloadBundle: SlimResource[] | undefined;
   timeframeUsed: number;
 } {
-  const dateFromOneYear = initialDate.subtract(NUM_HISTORICAL_YEARS, "year").format(ISO_DATE);
-  const filteredBundleOneYear = filterBundleByDate(bundle, dateFromOneYear);
+  const initialStartDate = initialDate.subtract(NUM_HISTORICAL_YEARS, "year").format(ISO_DATE);
+  const filteredBundleOneYear = filterBundleByDate(bundle, initialStartDate);
   const slimPayloadBundleOneYear = buildSlimmerPayload(filteredBundleOneYear);
   const resourceCount = slimPayloadBundleOneYear?.length ?? 0;
 
@@ -104,8 +105,8 @@ function determineOptimalTimeframe(
     };
   }
 
-  const dateFromTwoYears = initialDate.subtract(MAX_HISTORICAL_YEARS, "year").format(ISO_DATE);
-  const finalFilteredBundle = filterBundleByDate(bundle, dateFromTwoYears);
+  const maxStartDate = initialDate.subtract(MAX_HISTORICAL_YEARS, "year").format(ISO_DATE);
+  const finalFilteredBundle = filterBundleByDate(bundle, maxStartDate);
   const finalSlimPayloadBundle = buildSlimmerPayload(finalFilteredBundle);
 
   return {

--- a/packages/core/src/command/ai-brief/filter.ts
+++ b/packages/core/src/command/ai-brief/filter.ts
@@ -74,7 +74,7 @@ export function prepareBundleForAiSummarization(bundle: Bundle, log: typeof cons
   const metrics = {
     initialBundleSize: bundle.entry?.length,
     initialBundleBytes: sizeInBytes(JSON.stringify(bundle)),
-    finalBundleSize: finalSlimPayloadBundle?.length,
+    finalBundleSize: finalSlimPayloadBundle.length,
     finalBundleBytes: sizeInBytes(bundleText),
     timeframeUsed,
     durationMs: duration,
@@ -88,13 +88,13 @@ function determineOptimalTimeframe(
   bundle: Bundle,
   initialDate: Dayjs
 ): {
-  finalSlimPayloadBundle: SlimResource[] | undefined;
+  finalSlimPayloadBundle: SlimResource[];
   timeframeUsed: number;
 } {
   const initialStartDate = initialDate.subtract(NUM_HISTORICAL_YEARS, "year").format(ISO_DATE);
   const filteredBundleOneYear = filterBundleByDate(bundle, initialStartDate);
-  const slimPayloadBundleOneYear = buildSlimmerPayload(filteredBundleOneYear);
-  const resourceCount = slimPayloadBundleOneYear?.length ?? 0;
+  const slimPayloadBundleOneYear = buildSlimmerPayload(filteredBundleOneYear) ?? [];
+  const resourceCount = slimPayloadBundleOneYear.length;
 
   const hasSufficientData = resourceCount >= MIN_RESOURCES_FOR_SUFFICIENT_DATA;
 
@@ -107,7 +107,7 @@ function determineOptimalTimeframe(
 
   const maxStartDate = initialDate.subtract(MAX_HISTORICAL_YEARS, "year").format(ISO_DATE);
   const finalFilteredBundle = filterBundleByDate(bundle, maxStartDate);
-  const finalSlimPayloadBundle = buildSlimmerPayload(finalFilteredBundle);
+  const finalSlimPayloadBundle = buildSlimmerPayload(finalFilteredBundle) ?? [];
 
   return {
     finalSlimPayloadBundle,

--- a/packages/core/src/command/ai-brief/filter.ts
+++ b/packages/core/src/command/ai-brief/filter.ts
@@ -25,7 +25,9 @@ import { filterBundleByDate } from "../consolidated/consolidated-filter-by-date"
 import { getDatesFromEffectiveDateTimeOrPeriod } from "../consolidated/consolidated-filter-shared";
 
 const NUM_HISTORICAL_YEARS = 1;
+const MAX_HISTORICAL_YEARS = 2; // Maximum 24 months for recent visit prompt
 const MAX_REPORTS_PER_GROUP = 3;
+const MIN_RESOURCES_FOR_SUFFICIENT_DATA = 50;
 
 /**
  * List of resource types that are referenced by other resources but not directly relevant
@@ -60,10 +62,10 @@ export function prepareBundleForAiSummarization(bundle: Bundle, log: typeof cons
     .filter((date): date is string => date !== undefined)
     .sort((a, b) => b.localeCompare(a))[0];
   const initialDate = latestReportDate ? buildDayjs(latestReportDate) : buildDayjs(new Date());
-  const dateFrom = initialDate.subtract(NUM_HISTORICAL_YEARS, "year").format(ISO_DATE);
-  const filteredBundle = filterBundleByDate(bundle, dateFrom);
-  const slimPayloadBundle = buildSlimmerPayload(filteredBundle);
-  const bundleText = JSON.stringify(slimPayloadBundle);
+
+  const { finalSlimPayloadBundle, timeframeUsed } = determineOptimalTimeframe(bundle, initialDate);
+
+  const bundleText = JSON.stringify(finalSlimPayloadBundle);
 
   const duration = Date.now() - startedAt;
   // TODO At some point we should remove this, at least the metrics on initial bundle since we're
@@ -71,13 +73,45 @@ export function prepareBundleForAiSummarization(bundle: Bundle, log: typeof cons
   const metrics = {
     initialBundleSize: bundle.entry?.length,
     initialBundleBytes: sizeInBytes(JSON.stringify(bundle)),
-    finalBundleSize: slimPayloadBundle?.length,
+    finalBundleSize: finalSlimPayloadBundle?.length,
     finalBundleBytes: sizeInBytes(bundleText),
+    timeframeUsed,
     durationMs: duration,
   };
   log(`Bundle filtering metrics: ${JSON.stringify(metrics)}`);
 
   return bundleText;
+}
+
+function determineOptimalTimeframe(
+  bundle: Bundle,
+  initialDate: ReturnType<typeof buildDayjs>
+): {
+  finalSlimPayloadBundle: SlimResource[] | undefined;
+  timeframeUsed: number;
+} {
+  const dateFromOneYear = initialDate.subtract(NUM_HISTORICAL_YEARS, "year").format(ISO_DATE);
+  const filteredBundleOneYear = filterBundleByDate(bundle, dateFromOneYear);
+  const slimPayloadBundleOneYear = buildSlimmerPayload(filteredBundleOneYear);
+  const resourceCount = slimPayloadBundleOneYear?.length ?? 0;
+
+  const hasSufficientData = resourceCount >= MIN_RESOURCES_FOR_SUFFICIENT_DATA;
+
+  if (hasSufficientData) {
+    return {
+      finalSlimPayloadBundle: slimPayloadBundleOneYear,
+      timeframeUsed: NUM_HISTORICAL_YEARS,
+    };
+  }
+
+  const dateFromTwoYears = initialDate.subtract(MAX_HISTORICAL_YEARS, "year").format(ISO_DATE);
+  const finalFilteredBundle = filterBundleByDate(bundle, dateFromTwoYears);
+  const finalSlimPayloadBundle = buildSlimmerPayload(finalFilteredBundle);
+
+  return {
+    finalSlimPayloadBundle,
+    timeframeUsed: MAX_HISTORICAL_YEARS,
+  };
 }
 
 export function buildSlimmerPayload(bundle: Bundle): SlimResource[] | undefined {
@@ -156,7 +190,7 @@ function removeUselessAttributes(res: Resource) {
 
   // Remove unknown coding displays, empty arrays, and "unknown" string values recursively
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const cleanupObject = (obj: any): void => {
+  function cleanupObject(obj: any): void {
     if (!obj || typeof obj !== "object") return;
 
     if (Array.isArray(obj)) {
@@ -201,7 +235,7 @@ function removeUselessAttributes(res: Resource) {
         }
       }
     }
-  };
+  }
 
   cleanupObject(res);
   return res;

--- a/packages/core/src/command/ai-brief/pcp-visit-prompt.ts
+++ b/packages/core/src/command/ai-brief/pcp-visit-prompt.ts
@@ -1,4 +1,6 @@
-const todaysDate = new Date().toISOString().split("T")[0];
+import { buildDayjs } from "@metriport/shared/common/date";
+
+const todaysDate = buildDayjs().format("YYYY-MM-DD");
 const systemPrompt =
   "You are a medical record reviewer and your task is to extract key information from a patient's medical chart. Do not include any demographic information such as name, date of birth, address, or other personal identifiers in your summary.";
 

--- a/packages/core/src/command/ai-brief/prompts.ts
+++ b/packages/core/src/command/ai-brief/prompts.ts
@@ -1,4 +1,6 @@
-const todaysDate = new Date().toISOString().split("T")[0];
+import { buildDayjs } from "@metriport/shared/common/date";
+
+const todaysDate = buildDayjs().format("YYYY-MM-DD");
 const systemPrompt = "You are an expert primary care doctor.";
 
 export const documentVariableName = "text";

--- a/packages/core/src/command/ai-brief/recent-visit-prompt.ts
+++ b/packages/core/src/command/ai-brief/recent-visit-prompt.ts
@@ -1,0 +1,68 @@
+const todaysDate = new Date().toISOString().split("T")[0];
+const systemPrompt =
+  "You are a medical record reviewer and your task is to extract key information from a patient's medical chart. Do not include any demographic information such as name, date of birth, address, or other personal identifiers in your summary.";
+
+export const documentVariableName = "text";
+
+const instructions = `
+Instructions:
+
+Review the patient medical records and format the output EXACTLY as follows, including the bullet points and indentation:
+    PCP Visits (up to last 24 months)
+    - [PCP Name], [PCP Specialty]
+      - [Visit Date MM/DD/YYYY]
+    - [PCP Name], [PCP Specialty]
+      - [Visit Date MM/DD/YYYY]
+
+Problem List (up to last 24 months):
+For any condition found, provide the most recent diagnosis date from the patient's record.
+  - [Condition] ([MM/DD/YYYY])
+  - [Condition] ([MM/DD/YYYY])
+Make sure any HCCs or Conditions are flagged.
+
+Medications Prescribed (up to last 24 months):
+Only include medications that have a MedicationRequest (prescription). For each prescription found, provide the prescription date from the MedicationRequest.
+  - [Medication Name] ([Prescription Date MM/DD/YYYY])
+   - [Medication Name] ([Prescription Date MM/DD/YYYY])
+
+For the PCP visit:
+- Find any visit with a provider who is an MD, DO, NP, or PA AND in the specialty of Family Medicine, Internal Medicine, or OB/GYN
+- Group all visits by provider (up to last 24 months).
+- Do not include telephone encounters
+- Provider specialty must be Family Medicine, Internal Medicine, or OB/GYN
+- ONLY include providers where you can clearly see their specialty information in the medical records
+- If a provider's specialty is not clearly documented or is missing, DO NOT include them in the PCP visits list
+
+For PCP name, only include the physician if they are a MD, DO, NP, PA and are associated with the specialty of Family Medicine, Internal Medicine or OB/GYN. If you cannot determine their specialty from the available data, exclude them from the list.
+
+CRITICAL DATE FILTERING: All dates must be within the last 24 months from the latest report date. The data has already been filtered to include the most relevant timeframe of medical records (up to 24 months maximum).
+
+CRITICAL: If there is no data within the available timeframe (up to 24 months), DO NOT include that section at all. Do not show sections with old data. Do not modify dates to make them appear recent.
+
+If any of the above information is not present, do not include that section in the summary at all. Do not write "No data available" or similar messages for empty sections - simply omit those sections entirely.
+Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided. Consolidate information and link directly to original sources. Avoid any relative terms, e.g. "recently" or "currently." Use specific dates only.
+`;
+
+export const mainSummaryPrompt = `
+${systemPrompt}
+
+Today's date is ${todaysDate}.
+Review the patient medical records:
+--------
+{${documentVariableName}}
+--------
+${instructions}
+`;
+
+export const refinedSummaryPrompt = `
+${systemPrompt}
+
+Today's date is ${todaysDate}.
+Here are the previous summaries written by you of sections of the patient's medical history:
+--------
+{${documentVariableName}}
+--------
+
+Combine these summaries into a single, comprehensive summary.
+Use these ${instructions}.
+`;

--- a/packages/core/src/command/ai-brief/recent-visit-prompt.ts
+++ b/packages/core/src/command/ai-brief/recent-visit-prompt.ts
@@ -1,6 +1,8 @@
-const todaysDate = new Date().toISOString().split("T")[0];
-const systemPrompt =
-  "You are a medical record reviewer and your task is to extract key information from a patient's medical chart. Do not include any demographic information such as name, date of birth, address, or other personal identifiers in your summary.";
+import { buildDayjs } from "@metriport/shared/common/date";
+
+const todaysDate = buildDayjs().format("YYYY-MM-DD");
+const systemPrompt = `You are a medical record reviewer and your task is to extract key information from a patient's medical chart.
+  Do not include any demographic information such as name, date of birth, address, or other personal identifiers in your summary.`;
 
 export const documentVariableName = "text";
 
@@ -21,7 +23,8 @@ For any condition found, provide the most recent diagnosis date from the patient
 Make sure any HCCs or Conditions are flagged.
 
 Medications Prescribed (up to last 24 months):
-Only include medications that have a MedicationRequest (prescription). For each prescription found, provide the prescription date from the MedicationRequest.
+Only include medications that have a MedicationRequest (prescription).
+For each prescription found, provide the prescription date from the MedicationRequest.
   - [Medication Name] ([Prescription Date MM/DD/YYYY])
    - [Medication Name] ([Prescription Date MM/DD/YYYY])
 
@@ -33,14 +36,19 @@ For the PCP visit:
 - ONLY include providers where you can clearly see their specialty information in the medical records
 - If a provider's specialty is not clearly documented or is missing, DO NOT include them in the PCP visits list
 
-For PCP name, only include the physician if they are a MD, DO, NP, PA and are associated with the specialty of Family Medicine, Internal Medicine or OB/GYN. If you cannot determine their specialty from the available data, exclude them from the list.
+For PCP name, only include the physician if they are a MD, DO, NP, PA and are associated with the specialty of Family Medicine,
+Internal Medicine or OB/GYN. If you cannot determine their specialty from the available data, exclude them from the list.
 
-CRITICAL DATE FILTERING: All dates must be within the last 24 months from the latest report date. The data has already been filtered to include the most relevant timeframe of medical records (up to 24 months maximum).
+CRITICAL DATE FILTERING: All dates must be within the last 24 months from the latest report date.
+The data has already been filtered to include the most relevant timeframe of medical records (up to 24 months maximum).
 
-CRITICAL: If there is no data within the available timeframe (up to 24 months), DO NOT include that section at all. Do not show sections with old data. Do not modify dates to make them appear recent.
+CRITICAL: If there is no data within the available timeframe (up to 24 months), DO NOT include that section at all.
+Do not show sections with old data. Do not modify dates to make them appear recent.
 
-If any of the above information is not present, do not include that section in the summary at all. Do not write "No data available" or similar messages for empty sections - simply omit those sections entirely.
-Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided. Consolidate information and link directly to original sources. Avoid any relative terms, e.g. "recently" or "currently." Use specific dates only.
+If any of the above information is not present, do not include that section in the summary at all.
+Do not write "No data available" or similar messages for empty sections - simply omit those sections entirely.
+Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided.
+Consolidate information and link directly to original sources. Avoid any relative terms, e.g. "recently" or "currently." Use specific dates only.
 `;
 
 export const mainSummaryPrompt = `

--- a/packages/core/src/command/feature-flags/domain-ffs.ts
+++ b/packages/core/src/command/feature-flags/domain-ffs.ts
@@ -253,6 +253,16 @@ export async function isPcpVisitAiSummaryFeatureFlagEnabledForCx(cxId: string): 
   return cxIdsWithPcpVisitAiSummaryEnabled.some(i => i === cxId);
 }
 
+export async function getCxsWithRecentVisitAiSummaryFeatureFlag(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithRecentVisitAiSummaryFeatureFlag");
+}
+export async function isRecentVisitAiSummaryFeatureFlagEnabledForCx(
+  cxId: string
+): Promise<boolean> {
+  const cxIdsWithRecentVisitAiSummaryEnabled = await getCxsWithRecentVisitAiSummaryFeatureFlag();
+  return cxIdsWithRecentVisitAiSummaryEnabled.some(i => i === cxId);
+}
+
 export async function getCxsWithHl7NotificationWebhookFeatureFlag(): Promise<string[]> {
   return getCxsWithFeatureFlagEnabled("cxsWithHl7NotificationWebhookFeatureFlag");
 }

--- a/packages/core/src/command/feature-flags/domain-ffs.ts
+++ b/packages/core/src/command/feature-flags/domain-ffs.ts
@@ -253,13 +253,11 @@ export async function isPcpVisitAiSummaryFeatureFlagEnabledForCx(cxId: string): 
   return cxIdsWithPcpVisitAiSummaryEnabled.some(i => i === cxId);
 }
 
-export async function getCxsWithRecentVisitAiSummaryFeatureFlag(): Promise<string[]> {
-  return getCxsWithFeatureFlagEnabled("cxsWithRecentVisitAiSummaryFeatureFlag");
+export async function getCxsWithRecentVisitAiSummary(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithRecentVisitAiSummary");
 }
-export async function isRecentVisitAiSummaryFeatureFlagEnabledForCx(
-  cxId: string
-): Promise<boolean> {
-  const cxIdsWithRecentVisitAiSummaryEnabled = await getCxsWithRecentVisitAiSummaryFeatureFlag();
+export async function isRecentVisitAiSummaryEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithRecentVisitAiSummaryEnabled = await getCxsWithRecentVisitAiSummary();
   return cxIdsWithRecentVisitAiSummaryEnabled.some(i => i === cxId);
 }
 

--- a/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
+++ b/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
@@ -60,7 +60,7 @@ export const initialFeatureFlags: FeatureFlagDatastore = {
   carequalityFeatureFlag: { enabled: false },
   debugFeatureFlag: { enabled: false },
   cxsWithPcpVisitAiSummaryFeatureFlag: { enabled: false, values: [] },
-  cxsWithRecentVisitAiSummaryFeatureFlag: { enabled: false, values: [] },
+  cxsWithRecentVisitAiSummary: { enabled: false, values: [] },
   cxsWithHl7NotificationWebhookFeatureFlag: { enabled: false, values: [] },
   cxsWithDischargeRequeryFeatureFlag: { enabled: false, values: [] },
   cxsWithDischargeSlackNotificationFeatureFlag: { enabled: false, values: [] },

--- a/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
+++ b/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
@@ -60,6 +60,7 @@ export const initialFeatureFlags: FeatureFlagDatastore = {
   carequalityFeatureFlag: { enabled: false },
   debugFeatureFlag: { enabled: false },
   cxsWithPcpVisitAiSummaryFeatureFlag: { enabled: false, values: [] },
+  cxsWithRecentVisitAiSummaryFeatureFlag: { enabled: false, values: [] },
   cxsWithHl7NotificationWebhookFeatureFlag: { enabled: false, values: [] },
   cxsWithDischargeRequeryFeatureFlag: { enabled: false, values: [] },
   cxsWithDischargeSlackNotificationFeatureFlag: { enabled: false, values: [] },

--- a/packages/core/src/command/feature-flags/types.ts
+++ b/packages/core/src/command/feature-flags/types.ts
@@ -41,6 +41,7 @@ export const cxBasedFFsSchema = z.object({
   cxsWithStrictMatchingAlgorithm: ffStringValuesSchema,
   cxsWithAthenaCustomFieldsEnabled: ffStringValuesSchema,
   cxsWithPcpVisitAiSummaryFeatureFlag: ffStringValuesSchema,
+  cxsWithRecentVisitAiSummaryFeatureFlag: ffStringValuesSchema,
   cxsWithHl7NotificationWebhookFeatureFlag: ffStringValuesSchema,
   cxsWithDischargeSlackNotificationFeatureFlag: ffStringValuesSchema,
   cxsWithDischargeRequeryFeatureFlag: ffStringValuesSchema,

--- a/packages/core/src/command/feature-flags/types.ts
+++ b/packages/core/src/command/feature-flags/types.ts
@@ -41,7 +41,7 @@ export const cxBasedFFsSchema = z.object({
   cxsWithStrictMatchingAlgorithm: ffStringValuesSchema,
   cxsWithAthenaCustomFieldsEnabled: ffStringValuesSchema,
   cxsWithPcpVisitAiSummaryFeatureFlag: ffStringValuesSchema,
-  cxsWithRecentVisitAiSummaryFeatureFlag: ffStringValuesSchema,
+  cxsWithRecentVisitAiSummary: ffStringValuesSchema,
   cxsWithHl7NotificationWebhookFeatureFlag: ffStringValuesSchema,
   cxsWithDischargeSlackNotificationFeatureFlag: ffStringValuesSchema,
   cxsWithDischargeRequeryFeatureFlag: ffStringValuesSchema,

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -24,6 +24,8 @@ import { sortObservationsForDisplay } from "@metriport/shared/medical";
 import dayjs from "dayjs";
 import { intersection, uniqWith } from "lodash";
 import { Brief } from "../../../command/ai-brief/brief";
+import { isChronicCondition } from "../../ehr/shared";
+import { HCC_EXTENSION_URL } from "../../fhir/shared/extensions/hcc-extension";
 import {
   buildEncounterSections,
   createBrief,
@@ -923,7 +925,8 @@ function createMedicationSection(
   });
 
   const otherMedications = removeDuplicate.filter(
-    medicationStatement => medicationStatement.status !== ("active" || "unknown")
+    medicationStatement =>
+      medicationStatement.status !== "active" && medicationStatement.status !== "unknown"
   );
 
   const activeMedications = removeDuplicate.filter(
@@ -1040,6 +1043,7 @@ type RenderCondition = {
   firstSeen: string | undefined;
   lastSeen: string | undefined;
   clinicalStatus: string;
+  isChronic: boolean;
 };
 
 function createConditionSection(conditions: Condition[], encounter: Encounter[]) {
@@ -1093,13 +1097,26 @@ function createConditionSection(conditions: Condition[], encounter: Encounter[])
         onsetEndTime = conditionDateDict[condition.id]?.end;
       }
 
+      const isChronic = isChronicCondition(condition);
+
+      const hccExtensions = condition.extension?.filter(ext => ext.url === HCC_EXTENSION_URL) ?? [];
+      const hccCodes = hccExtensions
+        .map(ext => {
+          const code = ext.valueCodeableConcept?.coding?.[0]?.code;
+          const version = ext.valueCodeableConcept?.coding?.[0]?.version;
+          return version && code ? `HCC ${version}: ${code}` : "";
+        })
+        .filter(Boolean)
+        .join("; ");
+
       const newCondition: RenderCondition = {
         id: condition.id,
-        code: codeName,
+        code: codeName + (hccCodes ? ` (${hccCodes})` : ""),
         name,
         firstSeen: onsetStartTime && onsetStartTime.length ? onsetStartTime : onsetDateTime,
         lastSeen: onsetEndTime && onsetEndTime.length ? onsetEndTime : onsetDateTime,
         clinicalStatus,
+        isChronic,
       };
 
       const existingCondition = acc.find(
@@ -1170,11 +1187,12 @@ function createConditionSection(conditions: Condition[], encounter: Encounter[])
 
     <thead>
       <tr>
-        <th style="width: 40%">Condition</th>
-        <th style="width: 15%">Code</th>
-        <th style="width: 15%">First seen</th>
-        <th style="width: 15%">Last seen</th>
-        <th style="width: 15%">Status</th>
+        <th style="width: 30%">Condition</th>
+        <th style="width: 25%">Code</th>
+        <th style="width: 10%">Chronic</th>
+        <th style="width: 12%">First seen</th>
+        <th style="width: 12%">Last seen</th>
+        <th style="width: 11%">Status</th>
       </tr>
     </thead>
     <tbody>
@@ -1184,6 +1202,7 @@ function createConditionSection(conditions: Condition[], encounter: Encounter[])
             <tr>
               <td>${condition.name}</td>
               <td>${condition.code ?? ""}</td>
+              <td>${condition.isChronic ? "Yes" : "No"}</td>
               <td>${formatDateForDisplay(condition.firstSeen)}</td>
               <td>${formatDateForDisplay(condition.lastSeen)}</td>
               <td>${condition.clinicalStatus}</td>

--- a/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
+++ b/packages/core/src/external/aws/lambda-logic/bundle-to-html.ts
@@ -1111,7 +1111,7 @@ function createConditionSection(conditions: Condition[], encounter: Encounter[])
 
       const newCondition: RenderCondition = {
         id: condition.id,
-        code: codeName + (hccCodes ? ` (${hccCodes})` : ""),
+        code: (codeName ?? "") + (hccCodes ? ` (${hccCodes})` : ""),
         name,
         firstSeen: onsetStartTime && onsetStartTime.length ? onsetStartTime : onsetDateTime,
         lastSeen: onsetEndTime && onsetEndTime.length ? onsetEndTime : onsetDateTime,


### PR DESCRIPTION
Part of cs-2472

Issues:

- https://linear.app/metriport/issue/CS-2472
- https://linear.app/metriport/issue/CS-2473

### Dependencies

- Upstream: none
- Downstream: none

### Description

- Add a new AI Summary prompt for recent visits 
- Update the MR Summary to include isChronic and HCC codes in the Conditions table

### Testing

- Local
  - [x] The AI summary generates the expected output
  - [x] The Conditions table contains the isChronic and HCC codes
- Staging
  - [ ] The AI summary generates the expected output
  - [ ] The Conditions table contains the isChronic and HCC codes
- Sandbox
  - [ ] The AI summary generates the expected output
  - [ ] The Conditions table contains the isChronic and HCC codes
- Production
  - [ ] The AI summary generates the expected output
  - [ ] The Conditions table contains the isChronic and HCC codes


### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced “Recent Visit” AI summary with per-customer feature-flag support; recent-visit summaries are prioritized when enabled.
  - New structured prompts for recent-visit and unified date handling for PCP/recent summaries.
  - AI summarization dynamically selects a 1–2 year timeframe based on available data for fuller results.
  - Conditions table now includes a Chronic column and displays HCC codes.

- **Bug Fixes**
  - Fixed medication filtering to exclude inactive/unknown statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->