### PR TITLE
ENG-000 Safer deploy to prod CICD

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -20,13 +20,38 @@ on:
       - "packages/lambdas/**"
       - "packages/terminology/**"
       - "packages/mllp-server/**"
+      - "packages/data-transformation/**"
   workflow_dispatch: # manually executed by a user
+    inputs:
+      ref:
+        description: "Branch to run the workflow on"
+        required: false
+        default: "master"
+        type: string
 
 jobs:
+  branch-validation:
+    name: validate branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Validate branch
+        run: |
+          if [ "${{ github.ref_name }}" != "master" ]; then
+            echo "❌ This workflow can only run on the 'master' branch. Current branch: ${{ github.ref_name }}"
+            echo "Please ensure you are running this workflow from the master branch."
+            exit 1
+          else
+            echo "✅ Running on master branch - proceeding with deployment"
+          fi
+
   files-changed:
     name: detect changes
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    needs: branch-validation
     # Map a step output to a job output
     outputs:
       api: ${{ steps.changes.outputs.api }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -22,12 +22,37 @@ on:
       - "packages/mllp-server/**"
       - "packages/data-transformation/**"
   workflow_dispatch: # manually executed by a user
+    inputs:
+      ref:
+        description: "Branch to run the workflow on"
+        required: false
+        default: "develop"
+        type: string
 
 jobs:
+  branch-validation:
+    name: validate branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Validate branch
+        run: |
+          if [ "${{ github.ref_name }}" != "develop" ]; then
+            echo "❌ This workflow can only run on the 'develop' branch. Current branch: ${{ github.ref_name }}"
+            echo "Please ensure you are running this workflow from the develop branch."
+            echo "If you want to deploy a different branch, you can use the 'branch to staging' workflow."
+            exit 1
+          else
+            echo "✅ Running on develop branch - proceeding with deployment"
+          fi
+
   files-changed:
     name: detect changes
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    needs: branch-validation
     # Map a step output to a job output
     outputs:
       api: ${{ steps.changes.outputs.api }}
@@ -53,12 +78,13 @@ jobs:
         with:
           filters: |
             api:
-              - "packages/shared/**"
               - "packages/api/**"
               - "packages/api-sdk/**"
               - "packages/commonwell-sdk/**"
               - "packages/ihe-gateway-sdk/**"
+              - "packages/infra/**"
               - "packages/core/**"
+              - "packages/shared/**"
               - "package*.json"
             mllp-server:
               - "packages/shared/**"
@@ -76,6 +102,7 @@ jobs:
               - "packages/fhir-converter/src/**"
               - "packages/fhir-converter/test/**"
               - "packages/fhir-converter/deploy/**"
+              - "packages/infra/**"
             terminology:
               - "packages/terminology/Dockerfile"
               - "packages/terminology/package*.json"


### PR DESCRIPTION
### Dependencies

none

### Description

Safer deploy to prod CICD - [context](https://metriport.slack.com/archives/C04DMKE9DME/p1759343934848729)

### Testing

- Local
  - none
- Staging
  - [ ] Deploy to staging fails if selects a branch other than `develop`
  - [ ] Deploy to staging works if selects the `develop` branch
- Sandbox
  - none
- Production
  - [ ] Deploy to production fails if selects a branch other than `master`
     - ⚠️ if the test fails, cancel the job IMMEDIATELY
  - [ ] Deploy to staging works if selects the `master` branch

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual deploy trigger now accepts a branch ref for staging and production.
  * Branch validation gates deployments (develop for staging, master for production) with clear feedback.
  * Expanded conditional deployments to additional services and infra based on change detection.

* **Chores**
  * Enforced workflow dependencies so change detection and deploy steps run only after branch validation.
  * Added clearer success logs during production deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->