### PR TITLE
Fix Konza adts not having the correct facility name

### DIFF
--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -119,7 +119,7 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
     }
 
     const { message, cxId, patientId } = parsedData;
-    const encounterId = createEncounterId(message, patientId);
+    const encounterId = createEncounterId(message, patientId, params.hieName);
 
     const { messageCode, triggerEvent } = getHl7MessageTypeOrFail(message);
 
@@ -147,9 +147,10 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
       return;
     }
 
+    //TODO: use strategy pattern based on hieName for the following functions
     const encounterPeriod = getEncounterPeriod(message);
     const encounterClass = getEncounterClass(message);
-    const facilityName = getFacilityName(message);
+    const facilityName = getFacilityName(message, params.hieName);
 
     capture.setExtra({
       cxId,

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/encounter.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/encounter.ts
@@ -11,9 +11,13 @@ import { DEFAULT_ENCOUNTER_CLASS, adtToFhirEncounterClassMap, isAdtPatientClass 
 import { getParticipantsFromAdt } from "./practitioner";
 import { createEncounterId, getEncounterPeriod, getPatientClassCode } from "./utils";
 
-export function convertAdtToFhirResources(adt: Hl7Message, patientId: string): Resource[] {
+export function convertAdtToFhirResources(
+  adt: Hl7Message,
+  patientId: string,
+  hieName: string
+): Resource[] {
   const msgType = getHl7MessageTypeOrFail(adt);
-  const encounterId = createEncounterId(adt, patientId);
+  const encounterId = createEncounterId(adt, patientId, hieName);
   const encounterReason = getEncounterReason({ adt, patientId, encounterId });
   const status = getPatientStatus(msgType);
   const encounterClass = getEncounterClass(adt);
@@ -23,7 +27,7 @@ export function convertAdtToFhirResources(adt: Hl7Message, patientId: string): R
   const conditionReferences = conditions.map(condition =>
     buildConditionReference({ resource: condition })
   );
-  const location = getLocationFromAdt(adt);
+  const location = getLocationFromAdt(adt, hieName);
 
   const encounter: Encounter = {
     id: encounterId,

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/location.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/adt/location.ts
@@ -9,9 +9,10 @@ type LocationWithId = Location & {
 };
 
 export function getLocationFromAdt(
-  adt: Hl7Message
+  adt: Hl7Message,
+  hieName: string
 ): { location: Location; locationReference: EncounterLocation } | undefined {
-  const name = getFacilityName(adt);
+  const name = getFacilityName(adt, hieName);
   // TODO 2883: Parse the address, if possible
 
   if (!name) return undefined;

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-to-fhir-conversion/index.ts
@@ -41,7 +41,7 @@ export function convertHl7v2MessageToFhir({
   const { messageCode } = getHl7MessageTypeOrFail(message);
 
   if (messageCode === "ADT") {
-    const resources = convertAdtToFhirResources(message, patientId);
+    const resources = convertAdtToFhirResources(message, patientId, hieName);
     const bundle = buildBundleFromResources({ type: "collection", resources });
     const duration = elapsedTimeFromNow(startedAt);
 

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts
@@ -1,0 +1,171 @@
+/* eslint-disable no-useless-escape */
+import * as dotenv from "dotenv";
+dotenv.config();
+// keep that ^ on top
+
+import { Hl7Message } from "@medplum/core";
+import { Hl7NotificationSenderParams } from "@metriport/core/command/hl7-notification/hl7-notification-webhook-sender";
+import { buildHl7NotificationWebhookSender } from "@metriport/core/command/hl7-notification/hl7-notification-webhook-sender-factory";
+import { S3Utils } from "@metriport/core/external/aws/s3";
+import { Config } from "@metriport/core/util/config";
+import { makeDir, writeFileContents } from "@metriport/core/util/fs";
+import { sleep } from "@metriport/shared";
+import { buildDayjs } from "@metriport/shared/common/date";
+
+/**
+ * Reprocesses ADTs for a list of CXs
+ * This will find all adts for a cx and send them to the webhook for reprocessing
+ *  ⚠️⚠️⚠️ THIS ONLY WORKS WITH KONZA FOR NOW ⚠️⚠️⚠️
+ *
+ * Steps:
+ * 1. Ensure your .env file has the required AWS and bucket configuration (AWS_REGION)
+ * 2. Update the listOfCxIds array on line 20 with the CX IDs to process
+ * 2.5. Set dryRun to false to actually send the adts to the webhook
+ * 3. Run the script:
+ *    npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts
+ *
+ * Usage:
+ * Run with: ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts
+ */
+const bucketName = Config.getHl7IncomingMessageBucketName();
+const region = Config.getAWSRegion();
+Config.getHl7NotificationQueueUrl(); // If running for realsies, comment out otherwise.
+
+// ⚠️ THIS ONLY WORKS WITH KONZA ⚠️
+const listOfCxIds: string[] = [
+  "68dfa720-d927-450c-932b-cfc9bbfd0a4f",
+  "2d55c892-d07a-4b0f-a319-2c5845e0a02b",
+];
+const dryRun = true;
+
+type IdentifiedMessage = {
+  cxId: string;
+  ptId: string;
+  hl7Message: string;
+  messageReceivedTimestamp: string;
+  hieName: string;
+};
+
+const s3Utils = new S3Utils(region);
+async function reprocessAdtsForCxs() {
+  await sleep(50); // Avoid mixing logs with Node
+  console.log(`Getting all ADTs for cxs`);
+  const allAdts = await getAllAdtsForCxs();
+  console.log(`Found ${allAdts.length} ADTs`);
+
+  for (const adt of allAdts) {
+    const params: Hl7NotificationSenderParams = {
+      cxId: adt.cxId,
+      patientId: adt.ptId,
+      message: adt.hl7Message,
+      messageReceivedTimestamp: adt.messageReceivedTimestamp,
+      hieName: adt.hieName,
+    };
+    if (!dryRun) {
+      const handler = buildHl7NotificationWebhookSender();
+      handler.execute(params);
+    }
+    console.log(`Processed ${adt.cxId} - ${adt.ptId}`);
+    await sleep(50); // Even though theres a sqs queue, we still don't want to overwhelm it
+  }
+
+  const fileName = `./runs/send-hl7-message-to-webhook/processed_adts_${buildDayjs().format(
+    "YYYY-MM-DD_HH-mm-ss-SSS"
+  )}.json`;
+
+  makeDir("./runs/send-hl7-message-to-webhook");
+
+  writeFileContents(fileName, JSON.stringify(allAdts, null, 2));
+  console.log(`Wrote ${allAdts.length} ADTs to ${fileName}`);
+}
+
+async function getAllAdtsForCxs(): Promise<IdentifiedMessage[]> {
+  const allAdts: IdentifiedMessage[] = [];
+  for (const cxId of listOfCxIds) {
+    const cxAdts = await getAllAdtsFromCx(cxId);
+    allAdts.push(...cxAdts);
+  }
+
+  return allAdts;
+}
+
+async function getAllAdtsFromCx(cxId: string): Promise<IdentifiedMessage[]> {
+  const allAdts: IdentifiedMessage[] = [];
+  const listOfPatients = await getAllPatientFolderNames(cxId);
+  for (const ptId of listOfPatients) {
+    const ptAdts = await getAllAdtsFromPt(cxId, ptId);
+    allAdts.push(...ptAdts);
+  }
+  return allAdts;
+}
+
+async function getAllPatientFolderNames(cxId: string): Promise<string[]> {
+  try {
+    const objects = await s3Utils.listObjects(bucketName, `${cxId}/`);
+
+    const folderSet = new Set<string>();
+    for (const object of objects) {
+      if (object.Key) {
+        const pathParts = object.Key.split("/");
+        if (pathParts.length >= 2) {
+          folderSet.add(pathParts[1]);
+        }
+      }
+    }
+
+    return Array.from(folderSet);
+  } catch (error) {
+    console.error(`Error getting patient folders for cxId ${cxId}:`, error);
+    return [];
+  }
+}
+
+async function getAllAdtsFromPt(cxId: string, ptId: string): Promise<IdentifiedMessage[]> {
+  const allAdts: IdentifiedMessage[] = [];
+  const objects = await s3Utils.listObjects(bucketName, `${cxId}/${ptId}/`);
+
+  for (const object of objects) {
+    if (!object.Key) continue;
+
+    const adt = await s3Utils.getFileContentsAsString(bucketName, object.Key);
+    const hl7Message = Hl7Message.parse(adt);
+    const hieName = getHieNameFromMessage(hl7Message);
+    if (!hieName) {
+      continue;
+    }
+    if (hieName !== "KONZA") {
+      console.log(`Skipping ${object.Key} because it's not from Konza`);
+      continue;
+    }
+    console.log(`Found konza adt ${object.Key}`);
+    const lastModified = object.LastModified;
+    if (!lastModified) {
+      continue;
+    }
+    const fileTimestamp = lastModified.toISOString();
+
+    allAdts.push({
+      cxId,
+      ptId,
+      hl7Message: adt,
+      messageReceivedTimestamp: fileTimestamp,
+      hieName: "Konza",
+    });
+  }
+  return allAdts;
+}
+
+function getHieNameFromMessage(hl7Message: Hl7Message): string | undefined {
+  const mshSegment = hl7Message.getSegment("MSH");
+  if (!mshSegment) {
+    return undefined;
+  }
+  const hieField = mshSegment.getField(3);
+  if (!hieField) {
+    return undefined;
+  }
+  const hieName = hieField.toString();
+  return hieName;
+}
+
+reprocessAdtsForCxs();

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts
@@ -29,7 +29,7 @@ import { buildDayjs } from "@metriport/shared/common/date";
  */
 const bucketName = Config.getHl7IncomingMessageBucketName();
 const region = Config.getAWSRegion();
-Config.getHl7NotificationQueueUrl(); // If running for realsies, comment out otherwise.
+Config.getHl7NotificationQueueUrl(); // Needed if running for realsies. Comment out otherwise.
 
 // ⚠️ THIS ONLY WORKS WITH KONZA ⚠️
 const listOfCxIds: string[] = [];

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts
@@ -19,7 +19,7 @@ import { buildDayjs } from "@metriport/shared/common/date";
  *
  * Steps:
  * 1. Ensure your .env file has the required AWS and bucket configuration (AWS_REGION)
- * 2. Update the listOfCxIds array on line 20 with the CX IDs to process
+ * 2. Update the listOfCxIds array on line 35 with the CX IDs to process
  * 2.5. Set dryRun to false to actually send the adts to the webhook
  * 3. Run the script:
  *    npx ts-node src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts
@@ -32,10 +32,7 @@ const region = Config.getAWSRegion();
 Config.getHl7NotificationQueueUrl(); // If running for realsies, comment out otherwise.
 
 // ⚠️ THIS ONLY WORKS WITH KONZA ⚠️
-const listOfCxIds: string[] = [
-  "68dfa720-d927-450c-932b-cfc9bbfd0a4f",
-  "2d55c892-d07a-4b0f-a319-2c5845e0a02b",
-];
+const listOfCxIds: string[] = [];
 const dryRun = true;
 
 type IdentifiedMessage = {

--- a/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts
+++ b/packages/utils/src/hl7v2-notifications/reprocess-adt-conversion-bundles/reprocess-adts-for-cx.ts
@@ -60,7 +60,7 @@ async function reprocessAdtsForCxs() {
     };
     if (!dryRun) {
       const handler = buildHl7NotificationWebhookSender();
-      handler.execute(params);
+      await handler.execute(params);
     }
     console.log(`Processed ${adt.cxId} - ${adt.ptId}`);
     await sleep(50); // Even though theres a sqs queue, we still don't want to overwhelm it


### PR DESCRIPTION
_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1205

### Dependencies
None

### Description
Get the name from the proper place for Konza adts
Create a re-convert script for konza adts

### Testing
- Local
  - [x] Rerun conversion on a patient
  - [x] Send an adt to mllp server
- Staging
- [ ] repeat local tests
- Production
  - [ ] Only reconvert a small portion before running the entire reconvert


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ADT-to-FHIR conversion is HIE-aware: conversion now uses the HIE name to derive encounter IDs and facility/location details (including Konza special-casing).
  * Added a reprocessing tool to scan stored ADTs, filter by HIE, aggregate results, and optionally resend via webhook with dry-run support and JSON export.

* **Reliability**
  * Improved handling of missing or non-eligible ADTs during reprocessing with clearer progress logging and safer retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->