### PR TITLE
feat(core): fix dob validation old school style

### DIFF
--- a/packages/shared/src/common/__tests__/date.test.ts
+++ b/packages/shared/src/common/__tests__/date.test.ts
@@ -204,10 +204,6 @@ describe("shared date functions", () => {
     });
 
     it("returns true when date is valid ISO datetime", () => {
-      expect(validateDob("2004-02-26T12:30:00Z")).toBe(true);
-    });
-
-    it("returns true when date is valid ISO datetime", () => {
       expect(validateDob("2004-02-26")).toBe(true);
     });
 
@@ -296,6 +292,12 @@ describe("isValidateDayAndMonthStringBased", () => {
       expect(isValidateDayAndMonthStringBased("2000-06-15")).toBe(true);
     });
 
+    it("should return true for valid US date strings", () => {
+      expect(isValidateDayAndMonthStringBased("01/01/2023")).toBe(true);
+      expect(isValidateDayAndMonthStringBased("12/31/2023")).toBe(true);
+      expect(isValidateDayAndMonthStringBased("02/29/2024")).toBe(true);
+    });
+
     it("should return true for leap year dates", () => {
       expect(isValidateDayAndMonthStringBased("2020-02-29")).toBe(true);
       expect(isValidateDayAndMonthStringBased("2000-02-29")).toBe(true);
@@ -322,7 +324,6 @@ describe("isValidateDayAndMonthStringBased", () => {
 
   describe("invalid date formats", () => {
     it("should return false for non-ISO date format strings", () => {
-      expect(isValidateDayAndMonthStringBased("01/01/2023")).toBe(false);
       expect(isValidateDayAndMonthStringBased("2023/01/01")).toBe(false);
       expect(isValidateDayAndMonthStringBased("01-01-2023")).toBe(false);
       expect(isValidateDayAndMonthStringBased("2023-1-1")).toBe(false);

--- a/packages/shared/src/common/date.ts
+++ b/packages/shared/src/common/date.ts
@@ -9,6 +9,7 @@ dayjs.extend(timezone);
 
 export const ISO_DATE = "YYYY-MM-DD";
 export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+export const US_DATE_REGEX = /^\d{2}\/\d{2}\/\d{4}$/;
 export const ISO_DATE_TIME = "YYYY-MM-DDTHH:mm:ss.SSSZ";
 
 /** @see https://day.js.org/docs/en/parse/is-valid  */
@@ -21,15 +22,11 @@ export function isValidISODateTime(date: string): boolean {
 }
 
 function isLeapYear(year: number): boolean {
-  return year % 4 === 0 && year % 100 !== 0 && year % 400 === 0;
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
 }
 
-export function isValidateDayAndMonthStringBased(date: string): boolean {
-  if (!ISO_DATE_REGEX.test(date)) return false;
-  const year = parseInt(date.substring(0, 4));
-  const month = parseInt(date.substring(5, 7));
-  const day = parseInt(date.substring(8, 10));
-  if (month > 12 || day > 31) return false;
+export function validateDateAndMonth(day: number, month: number, year: number): boolean {
+  if (month < 1 || month > 12 || day < 1 || day > 31) return false;
   if (month === 2 && day > 29 && isLeapYear(year)) return false; // leap year
   if (month === 2 && day > 28 && !isLeapYear(year)) return false; // not a leap year
   if (month === 4 && day > 30) return false;
@@ -37,6 +34,22 @@ export function isValidateDayAndMonthStringBased(date: string): boolean {
   if (month === 9 && day > 30) return false;
   if (month === 11 && day > 30) return false;
   return true;
+}
+
+export function isValidateDayAndMonthStringBased(date: string): boolean {
+  if (ISO_DATE_REGEX.test(date)) {
+    const year = parseInt(date.substring(0, 4));
+    const month = parseInt(date.substring(5, 7));
+    const day = parseInt(date.substring(8, 10));
+    return validateDateAndMonth(day, month, year);
+  }
+  if (US_DATE_REGEX.test(date)) {
+    const year = parseInt(date.substring(6, 10));
+    const month = parseInt(date.substring(0, 2));
+    const day = parseInt(date.substring(3, 5));
+    return validateDateAndMonth(day, month, year);
+  }
+  return false;
 }
 
 function isValidISODateOptional(date: string | undefined | null): boolean {
@@ -61,7 +74,7 @@ export function validateDateOfBirth(
 ): boolean {
   if (!date || typeof date !== "string") return false;
   if (date.length < 10) return false;
-  if (!isValidateDayAndMonthStringBased(date)) return true;
+  if (!isValidateDayAndMonthStringBased(date)) return false;
   const parsedDate = buildDayjs(date);
   if (!parsedDate.isValid()) return false;
   const {


### PR DESCRIPTION
Ref: ENG-1207

### Description

- updating dob validation on the server to prevent bad dates like `2011-21-01`

### Testing

- Local
  - [ ] unit tests
  - [ ] patient create with bad date fails
- Staging
  - [ ] patient create with bad date fails
- Sandbox
  - [ ] N/A
- Production
  - [ ]  patient create with bad date fails

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Stricter date-of-birth validation: rejects impossible dates (e.g., April 31), enforces correct month/day ranges, handles leap-year Feb 29, and now pre-validates common ISO and US-style date strings before parsing to reduce invalid submissions.

- **Tests**
  - Added comprehensive tests for ISO/US formats, leap years, month-length edge cases; removed a test that previously allowed ISO datetimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->