### PR TITLE
feat(core): adding refresh on consolidated after every ADT

### DIFF
--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -3,7 +3,7 @@ import { errorToString } from "@metriport/shared";
 import { parseFhirBundle } from "@metriport/shared/medical";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
-import { generateAiBriefBundleEntry, getAiBriefFromS3 } from "../../domain/ai-brief/generate";
+import { generateAiBriefBundleEntry, getCachedAiBriefFromS3 } from "../../domain/ai-brief/generate";
 import { createConsolidatedDataFilePath } from "../../domain/consolidated/filename";
 import { createFolderName } from "../../domain/filename";
 import { Patient } from "../../domain/patient";
@@ -149,12 +149,14 @@ export async function createConsolidatedFromConversions({
     }
   }
 
-  const shouldGetAiBriefFromS3 =
+  const shouldUseCachedAiBrief =
     isAiBriefFeatureFlagEnabled && useCachedAiBrief && bundle.entry && bundle.entry.length > 0;
 
-  if (shouldGetAiBriefFromS3) {
+  //Generates AI brief if it doesn't exist in S3
+  if (shouldUseCachedAiBrief) {
     const aiBriefEntry = await generateAiBriefWithTimeout(
-      controls => getAiBriefFromS3({ cxId, patientId, bundle, log, aiBriefControls: controls }),
+      controls =>
+        getCachedAiBriefFromS3({ cxId, patientId, bundle, log, aiBriefControls: controls }),
       cxId,
       patientId,
       log

--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -3,7 +3,10 @@ import { errorToString } from "@metriport/shared";
 import { parseFhirBundle } from "@metriport/shared/medical";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
-import { generateAiBriefBundleEntry, getCachedAiBriefFromS3 } from "../../domain/ai-brief/generate";
+import {
+  generateAiBriefBundleEntry,
+  getCachedAiBriefOrGenerateNewOne,
+} from "../../domain/ai-brief/generate";
 import { createConsolidatedDataFilePath } from "../../domain/consolidated/filename";
 import { createFolderName } from "../../domain/filename";
 import { Patient } from "../../domain/patient";
@@ -156,7 +159,13 @@ export async function createConsolidatedFromConversions({
   if (shouldUseCachedAiBrief) {
     const aiBriefEntry = await generateAiBriefWithTimeout(
       controls =>
-        getCachedAiBriefFromS3({ cxId, patientId, bundle, log, aiBriefControls: controls }),
+        getCachedAiBriefOrGenerateNewOne({
+          cxId,
+          patientId,
+          bundle,
+          log,
+          aiBriefControls: controls,
+        }),
       cxId,
       patientId,
       log

--- a/packages/core/src/command/consolidated/consolidated-get.ts
+++ b/packages/core/src/command/consolidated/consolidated-get.ts
@@ -121,6 +121,7 @@ export async function getConsolidatedPatientDataAsync({
   requestId,
   conversionType,
   fromDashboard,
+  useCachedAiBrief,
 }: GetConsolidatedPatientData & {
   requestId: string;
   conversionType: ConsolidationConversionType;
@@ -134,6 +135,7 @@ export async function getConsolidatedPatientDataAsync({
     dateTo,
     isAsync: true,
     fromDashboard,
+    useCachedAiBrief,
   };
   const connector = buildConsolidatedSnapshotConnector();
   connector

--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -377,7 +377,7 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
     try {
       const posthogApiKeyArn = Config.getPostHogApiKey();
       if (!posthogApiKeyArn) {
-        throw new Error("No posthog API key provided in webhook sender");
+        throw new MetriportError("No posthog API key provided in webhook sender");
       }
 
       const posthogApiKey = await getSecretValueOrFail(posthogApiKeyArn, Config.getAWSRegion());

--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -358,7 +358,8 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
   }
 
   private getConsolidatedRefreshEndpoint(patientId: string, cxId: string): string {
-    return `${this.apiUrl}/internal/patient/${patientId}/consolidated/refresh?cxId=${cxId}&useCachedAiBrief=${USE_CACHED_AI_BRIEF}`;
+    const baseUrl = `${this.apiUrl}/internal/patient/${patientId}/consolidated/refresh`;
+    return `${baseUrl}?cxId=${cxId}&useCachedAiBrief=${USE_CACHED_AI_BRIEF}`;
   }
 
   private async notifyAnalytics({

--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -75,7 +75,7 @@ export const dischargeEventCode = "A03";
 const INTERNAL_HL7_ENDPOINT = `notification`;
 const INTERNAL_PATIENT_ENDPOINT = "internal/patient";
 const DISCHARGE_REQUERY_ENDPOINT = "monitoring/discharge-requery";
-const SKIP_AI_BRIEF_GENERATION = true;
+const USE_CACHED_AI_BRIEF = true;
 const SIGNED_URL_DURATION_SECONDS = dayjs.duration({ minutes: 10 }).asSeconds();
 
 type ClinicalInformation = {
@@ -358,7 +358,7 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
   }
 
   private getConsolidatedRefreshEndpoint(patientId: string, cxId: string): string {
-    return `${this.apiUrl}/internal/patient/${patientId}/consolidated/refresh?cxId=${cxId}&skipAiBriefGeneration=${SKIP_AI_BRIEF_GENERATION}`;
+    return `${this.apiUrl}/internal/patient/${patientId}/consolidated/refresh?cxId=${cxId}&useCachedAiBrief=${USE_CACHED_AI_BRIEF}`;
   }
 
   private async notifyAnalytics({

--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -75,6 +75,7 @@ export const dischargeEventCode = "A03";
 const INTERNAL_HL7_ENDPOINT = `notification`;
 const INTERNAL_PATIENT_ENDPOINT = "internal/patient";
 const DISCHARGE_REQUERY_ENDPOINT = "monitoring/discharge-requery";
+const SKIP_AI_BRIEF_GENERATION = true;
 const SIGNED_URL_DURATION_SECONDS = dayjs.duration({ minutes: 10 }).asSeconds();
 
 type ClinicalInformation = {
@@ -343,14 +344,15 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
     if (!isConsolidatedRefreshTriggerEvent(triggerEvent)) {
       return;
     }
-    log(`POST /internal/patient/${patientId}/consolidated/refresh ${triggerEvent}`);
+    log(`POST ${this.getConsolidatedRefreshEndpoint(patientId, cxId)}`);
     await executeWithNetworkRetries(
-      async () =>
-        axios.post(
-          `${this.apiUrl}/internal/patient/${patientId}/consolidated/refresh?cxId=${cxId}`
-        ),
+      async () => axios.post(this.getConsolidatedRefreshEndpoint(patientId, cxId)),
       { log }
     );
+  }
+
+  private getConsolidatedRefreshEndpoint(patientId: string, cxId: string): string {
+    return `${this.apiUrl}/internal/patient/${patientId}/consolidated/refresh?cxId=${cxId}&skipAiBriefGeneration=${SKIP_AI_BRIEF_GENERATION}`;
   }
 
   private async notifyAnalytics({

--- a/packages/core/src/command/hl7-notification/utils.ts
+++ b/packages/core/src/command/hl7-notification/utils.ts
@@ -18,12 +18,17 @@ export interface ParsedHl7Data {
 }
 
 const supportedTypes = ["A01", "A03"] as const;
+const CONSOLIDATED_REFRESH_TRIGGER_EVENTS = ["A01", "A03"] as const;
 
 export type SupportedTriggerEvent = (typeof supportedTypes)[number];
 export function isSupportedTriggerEvent(
   triggerEvent: string
 ): triggerEvent is SupportedTriggerEvent {
   return supportedTypes.includes(triggerEvent as SupportedTriggerEvent);
+}
+
+export function isConsolidatedRefreshTriggerEvent(triggerEvent: string): boolean {
+  return CONSOLIDATED_REFRESH_TRIGGER_EVENTS.includes(triggerEvent as SupportedTriggerEvent);
 }
 
 export async function parseHl7Message(
@@ -81,9 +86,4 @@ export async function persistHl7MessageError(
  */
 export function asString(message: Hl7Message) {
   return message.segments.map(s => s.toString()).join("\n");
-}
-
-const CONSOLIDATED_REFRESH_TRIGGER_EVENTS = ["A01", "A03"] as const;
-export function isConsolidatedRefreshTriggerEvent(triggerEvent: string): boolean {
-  return CONSOLIDATED_REFRESH_TRIGGER_EVENTS.includes(triggerEvent as SupportedTriggerEvent);
 }

--- a/packages/core/src/command/hl7-notification/utils.ts
+++ b/packages/core/src/command/hl7-notification/utils.ts
@@ -82,3 +82,8 @@ export async function persistHl7MessageError(
 export function asString(message: Hl7Message) {
   return message.segments.map(s => s.toString()).join("\n");
 }
+
+const CONSOLIDATED_REFRESH_TRIGGER_EVENTS = ["A01", "A03"] as const;
+export function isConsolidatedRefreshTriggerEvent(triggerEvent: string): boolean {
+  return CONSOLIDATED_REFRESH_TRIGGER_EVENTS.includes(triggerEvent as SupportedTriggerEvent);
+}

--- a/packages/core/src/domain/ai-brief/generate.ts
+++ b/packages/core/src/domain/ai-brief/generate.ts
@@ -149,21 +149,18 @@ export async function getCachedAiBriefOrGenerateNewOne({
     const aiBrief = await s3Utils.getFileContentsAsString(Config.getAiBriefBucketName(), filePath);
 
     if (!aiBrief) {
-      log(`No AI Brief found in S3, generating new one`);
-      return await generateAiBriefBundleEntry(params);
+      throw new Error("No AI Brief found in S3");
     }
 
     log(`Got AI Brief from S3`);
     const aiBriefBundle = parseFhirBundle(aiBrief) as Bundle<Binary>;
     if (!aiBriefBundle) {
-      log(`Failed to parse AI Brief bundle, generating new one`);
-      return await generateAiBriefBundleEntry(params);
+      throw new Error("Failed to parse AI Brief bundle");
     }
 
     const aiBriefResource = getAiBriefResourceFromBundle(aiBriefBundle);
     if (!aiBriefResource) {
-      log(`No AI Brief resource found in bundle, generating new one`);
-      return await generateAiBriefBundleEntry(params);
+      throw new Error("No AI Brief resource found in bundle");
     }
 
     return buildBundleEntry(aiBriefResource);

--- a/packages/core/src/domain/ai-brief/generate.ts
+++ b/packages/core/src/domain/ai-brief/generate.ts
@@ -1,5 +1,5 @@
 import { Binary, Bundle, BundleEntry, Resource } from "@medplum/fhirtypes";
-import { errorToString, executeWithNetworkRetries } from "@metriport/shared";
+import { errorToString, executeWithNetworkRetries, MetriportError } from "@metriport/shared";
 import { parseFhirBundle } from "@metriport/shared/medical/fhir/bundle";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
@@ -149,18 +149,18 @@ export async function getCachedAiBriefOrGenerateNewOne({
     const aiBrief = await s3Utils.getFileContentsAsString(Config.getAiBriefBucketName(), filePath);
 
     if (!aiBrief) {
-      throw new Error("No AI Brief found in S3");
+      throw new MetriportError("No AI Brief found in S3");
     }
 
     log(`Got AI Brief from S3`);
     const aiBriefBundle = parseFhirBundle(aiBrief) as Bundle<Binary>;
     if (!aiBriefBundle) {
-      throw new Error("Failed to parse AI Brief bundle");
+      throw new MetriportError("Failed to parse AI Brief bundle");
     }
 
     const aiBriefResource = getAiBriefResourceFromBundle(aiBriefBundle);
     if (!aiBriefResource) {
-      throw new Error("No AI Brief resource found in bundle");
+      throw new MetriportError("No AI Brief resource found in bundle");
     }
 
     return buildBundleEntry(aiBriefResource);

--- a/packages/core/src/domain/ai-brief/generate.ts
+++ b/packages/core/src/domain/ai-brief/generate.ts
@@ -121,7 +121,7 @@ async function uploadAiBriefToS3({
  * @param log - The log function.
  * @returns The AI Brief bundle entry.
  */
-export async function getCachedAiBriefFromS3({
+export async function getCachedAiBriefOrGenerateNewOne({
   cxId,
   patientId,
   bundle,

--- a/packages/core/src/domain/ai-brief/generate.ts
+++ b/packages/core/src/domain/ai-brief/generate.ts
@@ -56,7 +56,7 @@ export async function generateAiBriefBundleEntry({
 
     if (aiBriefContent) {
       const aiBriefFhirResource = generateAiBriefFhirResource(aiBriefContent);
-      await uploadAiBriefToS3(aiBriefFhirResource, cxId, patientId, log);
+      await uploadAiBriefToS3({ aiBriefFhirResource, cxId, patientId, log });
       return buildBundleEntry(aiBriefFhirResource);
     }
     return undefined;
@@ -77,12 +77,17 @@ export async function generateAiBriefBundleEntry({
   return undefined;
 }
 
-async function uploadAiBriefToS3(
-  aiBriefFhirResource: Binary,
-  cxId: string,
-  patientId: string,
-  log: typeof console.log
-) {
+async function uploadAiBriefToS3({
+  aiBriefFhirResource,
+  cxId,
+  patientId,
+  log,
+}: {
+  aiBriefFhirResource: Binary;
+  cxId: string;
+  patientId: string;
+  log: typeof console.log;
+}): Promise<void> {
   try {
     const aiBriefWrappedInBundle = buildBundleFromResources({
       resources: [aiBriefFhirResource],
@@ -116,7 +121,7 @@ async function uploadAiBriefToS3(
  * @param log - The log function.
  * @returns The AI Brief bundle entry.
  */
-export async function getAiBriefFromS3({
+export async function getCachedAiBriefFromS3({
   cxId,
   patientId,
   bundle,


### PR DESCRIPTION
Part of ENG-1208

_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1208

### Dependencies
Upstream: https://github.com/metriport/metriport/pull/4821

### Description
Refresh consolidated after every adt
Bring posthog analytics back to before 

### Testing
- Local
  - [x] Make sure consolidated gets new adt resources
- Staging
  - [ ] Make sure consolidated gets new adt resources
  - [ ] Make sure posthog still works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trigger conditional consolidated refreshes for specific HL7 events (A01, A03) and include a cached-AI-brief flag when applicable.
  * Move analytics reporting earlier in the notification flow with non-blocking error handling.

* **Reliability**
  * Prefer cached AI-brief retrieval when available to reduce latency.
  * Add retry-aware consolidated-refresh calls and extra logging for observability.

* **API Changes**
  * Renamed cached-AI-brief retrieval helper and updated an async call to accept a useCachedAiBrief flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->