### PR TITLE
ENG-1212: Quest multi-roster support for historical data and notifications

### DIFF
--- a/packages/api/src/routes/internal/medical/patient-settings.ts
+++ b/packages/api/src/routes/internal/medical/patient-settings.ts
@@ -1,7 +1,7 @@
 import {
   parseAdtSubscriptionRequest,
   parsePatientSettingsRequest,
-  parseQuestMonitoringRequest,
+  parseQuestPatientRequest,
 } from "@metriport/core/domain/patient-settings";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
@@ -123,11 +123,12 @@ router.post(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
-    const { patientIds } = parseQuestMonitoringRequest(req.body);
+    const { notifications, patientIds } = parseQuestPatientRequest(req.body);
 
     const result = await addQuestSubscriptionToPatients({
       cxId,
       patientIds,
+      notifications,
     });
 
     return res.status(status.OK).json(result);
@@ -149,11 +150,12 @@ router.delete(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getUUIDFrom("query", req, "cxId").orFail();
-    const { patientIds } = parseQuestMonitoringRequest(req.body);
+    const { notifications, patientIds } = parseQuestPatientRequest(req.body);
 
     const result = await removeQuestSubscriptionFromPatients({
       cxId,
       patientIds,
+      notifications,
     });
 
     return res.status(status.OK).json(result);

--- a/packages/core/src/domain/patient-settings.ts
+++ b/packages/core/src/domain/patient-settings.ts
@@ -4,8 +4,8 @@ import {
   createQueryMetaSchema,
   PatientSettingsRequest,
   patientSettingsRequestSchema,
-  QuestMonitoringRequest,
-  questMonitoringRequestSchema,
+  QuestPatientRequest,
+  questPatientRequestSchema,
 } from "@metriport/shared";
 import { z } from "zod";
 import {
@@ -20,6 +20,7 @@ const { log } = out("PatientSettings");
 export type Subscriptions = {
   adt?: string[];
   quest?: boolean;
+  questMonitoring?: boolean;
 };
 
 export type PatientSettingsData = {
@@ -74,6 +75,6 @@ export function parseAdtSubscriptionRequest(data: unknown): AdtSubscriptionReque
   return result;
 }
 
-export function parseQuestMonitoringRequest(data: unknown): QuestMonitoringRequest {
-  return questMonitoringRequestSchema.parse(data);
+export function parseQuestPatientRequest(data: unknown): QuestPatientRequest {
+  return questPatientRequestSchema.parse(data);
 }

--- a/packages/core/src/external/fhir/resources/diagnostic-report.ts
+++ b/packages/core/src/external/fhir/resources/diagnostic-report.ts
@@ -1,7 +1,7 @@
 import { Attachment, CodeableConcept, DiagnosticReport } from "@medplum/fhirtypes";
 import { DIAGNOSTIC_SERVICE_SECTIONS_URL } from "@metriport/shared/medical";
 import { cleanUpNote } from "../../../domain/ai-brief/modify-resources";
-import { base64ToString } from "../../../util/base64";
+import { stringToBase64 } from "@metriport/shared/util/base64";
 import { removeHtmlTags } from "../../html/remove-tags";
 
 export function presentedFormsToText(report: DiagnosticReport): string[] {
@@ -22,7 +22,7 @@ export function presentedFormsToText(report: DiagnosticReport): string[] {
 export function attachmentToText(attachment: Attachment): string | undefined {
   if (!attachment.data) return undefined;
   if (attachment.language && !attachment.language.startsWith("en")) return undefined;
-  const formTextRaw = base64ToString(attachment.data);
+  const formTextRaw = stringToBase64(attachment.data);
   const text = cleanUpNote(formTextRaw);
   const extraCleanText = additionalNoteCleanup(text);
   return extraCleanText;

--- a/packages/core/src/external/fhir/resources/diagnostic-report.ts
+++ b/packages/core/src/external/fhir/resources/diagnostic-report.ts
@@ -1,7 +1,7 @@
 import { Attachment, CodeableConcept, DiagnosticReport } from "@medplum/fhirtypes";
 import { DIAGNOSTIC_SERVICE_SECTIONS_URL } from "@metriport/shared/medical";
 import { cleanUpNote } from "../../../domain/ai-brief/modify-resources";
-import { stringToBase64 } from "@metriport/shared/util/base64";
+import { base64ToString } from "@metriport/shared/util/base64";
 import { removeHtmlTags } from "../../html/remove-tags";
 
 export function presentedFormsToText(report: DiagnosticReport): string[] {
@@ -22,7 +22,7 @@ export function presentedFormsToText(report: DiagnosticReport): string[] {
 export function attachmentToText(attachment: Attachment): string | undefined {
   if (!attachment.data) return undefined;
   if (attachment.language && !attachment.language.startsWith("en")) return undefined;
-  const formTextRaw = stringToBase64(attachment.data);
+  const formTextRaw = base64ToString(attachment.data);
   const text = cleanUpNote(formTextRaw);
   const extraCleanText = additionalNoteCleanup(text);
   return extraCleanText;

--- a/packages/core/src/external/quest/fhir/diagnostic-report.ts
+++ b/packages/core/src/external/quest/fhir/diagnostic-report.ts
@@ -16,7 +16,7 @@ import { getDiagnosticReportCategory } from "../../fhir/resources/diagnostic-rep
 import { getServiceRequestReference } from "./service-request";
 import { getQuestDataSourceExtension } from "./shared";
 import { getObservationReference } from "./observation";
-import { base64ToString } from "@metriport/shared/util/base64";
+import { stringToBase64 } from "@metriport/shared/util/base64";
 
 export function getDiagnosticReport(
   detail: ResponseDetail,
@@ -64,7 +64,7 @@ export function getDiagnosticReport(
 
 function getPresentedForm(detail: ResponseDetail): DiagnosticReport["presentedForm"] | undefined {
   if (!detail.resultComments || detail.resultComments.trim().length === 0) return undefined;
-  return [{ contentType: "text/plain", data: base64ToString(detail.resultComments) }];
+  return [{ contentType: "text/plain", data: stringToBase64(detail.resultComments) }];
 }
 
 function getDiagnosticReportCoding(detail: ResponseDetail): CodeableConcept | undefined {

--- a/packages/shared/src/domain/patient/patient-settings.ts
+++ b/packages/shared/src/domain/patient/patient-settings.ts
@@ -28,7 +28,8 @@ export const adtSubscriptionRequestSchema = z.object({
 });
 export type AdtSubscriptionRequest = z.infer<typeof adtSubscriptionRequestSchema>;
 
-export const questMonitoringRequestSchema = z.object({
+export const questPatientRequestSchema = z.object({
+  notifications: z.boolean().optional(),
   patientIds: z.array(z.string()).nonempty(),
 });
-export type QuestMonitoringRequest = z.infer<typeof questMonitoringRequestSchema>;
+export type QuestPatientRequest = z.infer<typeof questPatientRequestSchema>;


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-1212

### Dependencies

- Upstream: None
- Downstream: None

### Description

Adds an additional `questMonitoring` setting for uploading patients to a separate roster for real-time updates, separate from the `quest` setting which is only for historical data pulls.

### Testing

- Local
  - [ ] `npm run quest -- fhir-convert-all`
- Staging
  - [ ] TODO
- Production
  - [ ] TODO

### Release Plan

- [ ] Merge this
