### PR TITLE
ENG-1214 Remove CW DoA FF

### DIFF
--- a/packages/api/src/external/commonwell/shared.ts
+++ b/packages/api/src/external/commonwell/shared.ts
@@ -1,6 +1,5 @@
 import {
   isCommonwellEnabled,
-  isCwDoaEnabled,
   isCWEnabledForCx,
 } from "@metriport/core/command/feature-flags/domain-ffs";
 import { Patient } from "@metriport/core/domain/patient";
@@ -16,8 +15,7 @@ export async function getCwInitiator(
   patient: Pick<Patient, "id" | "cxId">,
   facilityId?: string
 ): Promise<HieInitiator> {
-  const isCwDoaFeatureFlagEnabled = await isCwDoaEnabled();
-  return getHieInitiator(patient, facilityId, isCwDoaFeatureFlagEnabled);
+  return getHieInitiator(patient, facilityId, true);
 }
 
 export async function isFacilityEnabledToQueryCW(

--- a/packages/core/src/command/feature-flags/domain-ffs.ts
+++ b/packages/core/src/command/feature-flags/domain-ffs.ts
@@ -322,10 +322,6 @@ export async function isCqDoaEnabled(): Promise<boolean> {
   return isFeatureFlagEnabled("cqDoaFeatureFlag");
 }
 
-export async function isCwDoaEnabled(): Promise<boolean> {
-  return isFeatureFlagEnabled("cwDoaFeatureFlag");
-}
-
 export async function getCxsWithNewSoapEnvelopeFeatureFlag(): Promise<string[]> {
   return getCxsWithFeatureFlagEnabled("cxsWithNewSoapEnvelopeFeatureFlag");
 }

--- a/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
+++ b/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
@@ -68,7 +68,6 @@ export const initialFeatureFlags: FeatureFlagDatastore = {
   cxsWithQuestFeatureFlag: { enabled: false, values: [] },
   analyticsIncrementalIngestion: { enabled: false, values: [] },
   cqDoaFeatureFlag: { enabled: false },
-  cwDoaFeatureFlag: { enabled: false },
   cxsWithNewSoapEnvelopeFeatureFlag: { enabled: false, values: [] },
 };
 

--- a/packages/core/src/command/feature-flags/types.ts
+++ b/packages/core/src/command/feature-flags/types.ts
@@ -15,7 +15,6 @@ export const booleanFFsSchema = z.object({
   commonwellFeatureFlag: ffBooleanSchema,
   carequalityFeatureFlag: ffBooleanSchema,
   cqDoaFeatureFlag: ffBooleanSchema,
-  cwDoaFeatureFlag: ffBooleanSchema,
   debugFeatureFlag: ffBooleanSchema,
 });
 export type BooleanFeatureFlags = z.infer<typeof booleanFFsSchema>;


### PR DESCRIPTION
Part of ENG-1214

### Description

- CW DoA flow works, so we don't need the FF anymore 

### Testing
- N/A

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CommonWell (HIE) initialization is now always enabled for all users, providing consistent access without reliance on a feature flag. This should improve reliability and reduce intermittent availability issues.

- Chores
  - Removed the legacy feature flag and related configuration for CommonWell DOA, simplifying rollout and maintenance.
  - Cleaned up schema and datastore entries associated with the removed flag to prevent stale configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->