### PR TITLE
ENG-1218 Package release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31577,7 +31577,7 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "8.1.0-alpha.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "@metriport/shared": "^0.26.8-alpha.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31152,7 +31152,7 @@
       }
     },
     "packages/api": {
-      "version": "1.29.8-alpha.0",
+      "version": "1.29.8",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.800.0",
@@ -31239,11 +31239,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "18.0.8-alpha.0",
+      "version": "18.0.8",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/shared": "^0.26.8-alpha.0",
+        "@metriport/shared": "^0.26.8",
         "axios": "^1.8.2",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -31333,11 +31333,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.20.8-alpha.0",
+      "version": "1.20.8",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.21.8-alpha.0",
-        "@metriport/shared": "^0.26.8-alpha.0"
+        "@metriport/ihe-gateway-sdk": "^0.21.8",
+        "@metriport/shared": "^0.26.8"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -31345,7 +31345,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.9.8-alpha.0",
+      "version": "1.9.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -31369,7 +31369,7 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "2.1.8-alpha.0",
+      "version": "2.1.8",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "file:packages/commonwell-sdk",
@@ -31466,7 +31466,7 @@
     "packages/commonwell-cert-runner/packages/shared": {},
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.27.8-alpha.0",
+      "version": "1.27.8",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^5.9.20",
@@ -31577,10 +31577,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.26.8-alpha.0",
+        "@metriport/shared": "^0.26.8",
         "axios": "^1.8.2",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -31628,7 +31628,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.26.8-alpha.0",
+      "version": "1.26.8",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -32096,7 +32096,7 @@
     "packages/core/packages/shared": {},
     "packages/eslint-rules": {
       "name": "@metriport/eslint-plugin-eslint-rules",
-      "version": "1.2.8-alpha.0",
+      "version": "1.2.8",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/rule-tester": "^6.0.0",
@@ -32112,7 +32112,7 @@
     },
     "packages/fhir-sdk": {
       "name": "@metriport/fhir-sdk",
-      "version": "1.3.3-alpha.0",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.2.10"
@@ -32233,17 +32233,17 @@
     },
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.21.8-alpha.0",
+      "version": "0.21.8",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.26.8-alpha.0",
+        "@metriport/shared": "^0.26.8",
         "axios": "^1.8.2",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.24.8-alpha.0",
+      "version": "1.24.8",
       "dependencies": {
         "@metriport/core": "file:packages/core",
         "@metriport/shared": "file:packages/shared",
@@ -32306,7 +32306,7 @@
     "packages/infra/packages/core": {},
     "packages/infra/packages/shared": {},
     "packages/mllp-server": {
-      "version": "0.5.8-alpha.0",
+      "version": "0.5.8",
       "license": "ISC",
       "dependencies": {
         "@medplum/core": "^3.2.33",
@@ -32507,7 +32507,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.26.8-alpha.0",
+      "version": "0.26.8",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -32561,7 +32561,7 @@
       "dev": true
     },
     "packages/utils": {
-      "version": "1.27.8-alpha.0",
+      "version": "1.27.8",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.800.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31152,7 +31152,7 @@
       }
     },
     "packages/api": {
-      "version": "1.29.7",
+      "version": "1.29.8-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.800.0",
@@ -31239,11 +31239,11 @@
     },
     "packages/api-sdk": {
       "name": "@metriport/api-sdk",
-      "version": "18.0.7",
+      "version": "18.0.8-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/fhirtypes": "^2.0.32",
-        "@metriport/shared": "^0.26.7",
+        "@metriport/shared": "^0.26.8-alpha.0",
         "axios": "^1.8.2",
         "dayjs": "^1.11.7",
         "dotenv": "^16.3.1",
@@ -31333,11 +31333,11 @@
     "packages/api/packages/shared": {},
     "packages/carequality-cert-runner": {
       "name": "@metriport/carequality-cert-runner",
-      "version": "1.20.7",
+      "version": "1.20.8-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/ihe-gateway-sdk": "^0.21.7",
-        "@metriport/shared": "^0.26.7"
+        "@metriport/ihe-gateway-sdk": "^0.21.8-alpha.0",
+        "@metriport/shared": "^0.26.8-alpha.0"
       },
       "bin": {
         "carequality-cert-runner": "dist/index.js"
@@ -31345,7 +31345,7 @@
     },
     "packages/carequality-sdk": {
       "name": "@metriport/carequality-sdk",
-      "version": "1.9.7",
+      "version": "1.9.8-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -31369,7 +31369,7 @@
     },
     "packages/commonwell-cert-runner": {
       "name": "@metriport/commonwell-cert-runner",
-      "version": "2.1.7",
+      "version": "2.1.8-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "file:packages/commonwell-sdk",
@@ -31466,7 +31466,7 @@
     "packages/commonwell-cert-runner/packages/shared": {},
     "packages/commonwell-jwt-maker": {
       "name": "@metriport/commonwell-jwt-maker",
-      "version": "1.27.7",
+      "version": "1.27.8-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@metriport/commonwell-sdk": "^5.9.20",
@@ -31577,10 +31577,10 @@
     },
     "packages/commonwell-sdk": {
       "name": "@metriport/commonwell-sdk",
-      "version": "8.0.0",
+      "version": "8.1.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.26.7",
+        "@metriport/shared": "^0.26.8-alpha.0",
         "axios": "^1.8.2",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -31628,7 +31628,7 @@
     },
     "packages/core": {
       "name": "@metriport/core",
-      "version": "1.26.7",
+      "version": "1.26.8-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.0.0",
@@ -32096,7 +32096,7 @@
     "packages/core/packages/shared": {},
     "packages/eslint-rules": {
       "name": "@metriport/eslint-plugin-eslint-rules",
-      "version": "1.2.7",
+      "version": "1.2.8-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/rule-tester": "^6.0.0",
@@ -32112,11 +32112,10 @@
     },
     "packages/fhir-sdk": {
       "name": "@metriport/fhir-sdk",
-      "version": "1.2.7",
+      "version": "1.3.3-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@medplum/fhirtypes": "^2.2.10",
-        "@metriport/shared": "file:packages/shared"
+        "@medplum/fhirtypes": "^2.2.10"
       },
       "devDependencies": {
         "@metriport/eslint-rules": "file:packages/eslint-rules",
@@ -32135,10 +32134,6 @@
     },
     "packages/fhir-sdk/node_modules/@metriport/eslint-rules": {
       "resolved": "packages/fhir-sdk/packages/eslint-rules",
-      "link": true
-    },
-    "packages/fhir-sdk/node_modules/@metriport/shared": {
-      "resolved": "packages/fhir-sdk/packages/shared",
       "link": true
     },
     "packages/fhir-sdk/node_modules/brace-expansion": {
@@ -32233,20 +32228,22 @@
     "packages/fhir-sdk/packages/eslint-rules": {
       "dev": true
     },
-    "packages/fhir-sdk/packages/shared": {},
+    "packages/fhir-sdk/packages/shared": {
+      "extraneous": true
+    },
     "packages/ihe-gateway-sdk": {
       "name": "@metriport/ihe-gateway-sdk",
-      "version": "0.21.7",
+      "version": "0.21.8-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@metriport/shared": "^0.26.7",
+        "@metriport/shared": "^0.26.8-alpha.0",
         "axios": "^1.8.2",
         "zod": "^3.22.1"
       }
     },
     "packages/infra": {
       "name": "infrastructure",
-      "version": "1.24.7",
+      "version": "1.24.8-alpha.0",
       "dependencies": {
         "@metriport/core": "file:packages/core",
         "@metriport/shared": "file:packages/shared",
@@ -32309,7 +32306,7 @@
     "packages/infra/packages/core": {},
     "packages/infra/packages/shared": {},
     "packages/mllp-server": {
-      "version": "0.5.7",
+      "version": "0.5.8-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@medplum/core": "^3.2.33",
@@ -32510,7 +32507,7 @@
     },
     "packages/shared": {
       "name": "@metriport/shared",
-      "version": "0.26.7",
+      "version": "0.26.8-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@medplum/core": "^2.2.10",
@@ -32564,7 +32561,7 @@
       "dev": true
     },
     "packages/utils": {
-      "version": "1.27.7",
+      "version": "1.27.8-alpha.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.800.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "18.0.8-alpha.0",
+  "version": "18.0.8",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/shared": "^0.26.8-alpha.0",
+    "@metriport/shared": "^0.26.8",
     "axios": "^1.8.2",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/api-sdk",
-  "version": "18.0.7",
+  "version": "18.0.8-alpha.0",
   "description": "Metriport helps you access and manage health and medical data, through a single open source API.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@medplum/fhirtypes": "^2.0.32",
-    "@metriport/shared": "^0.26.7",
+    "@metriport/shared": "^0.26.8-alpha.0",
     "axios": "^1.8.2",
     "dayjs": "^1.11.7",
     "dotenv": "^16.3.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.29.7",
+  "version": "1.29.8-alpha.0",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.29.8-alpha.0",
+  "version": "1.29.8",
   "description": "",
   "main": "app.js",
   "private": true,

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.20.7",
+  "version": "1.20.8-alpha.0",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.21.7",
-    "@metriport/shared": "^0.26.7"
+    "@metriport/ihe-gateway-sdk": "^0.21.8-alpha.0",
+    "@metriport/shared": "^0.26.8-alpha.0"
   }
 }

--- a/packages/carequality-cert-runner/package.json
+++ b/packages/carequality-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-cert-runner",
-  "version": "1.20.8-alpha.0",
+  "version": "1.20.8",
   "description": "Tool to run through Carequality certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -41,7 +41,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/ihe-gateway-sdk": "^0.21.8-alpha.0",
-    "@metriport/shared": "^0.26.8-alpha.0"
+    "@metriport/ihe-gateway-sdk": "^0.21.8",
+    "@metriport/shared": "^0.26.8"
   }
 }

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.9.8-alpha.0",
+  "version": "1.9.8",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/carequality-sdk/package.json
+++ b/packages/carequality-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/carequality-sdk",
-  "version": "1.9.7",
+  "version": "1.9.8-alpha.0",
   "description": "SDK to interact with the Carequality directory - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "2.1.7",
+  "version": "2.1.8-alpha.0",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-cert-runner/package.json
+++ b/packages/commonwell-cert-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-cert-runner",
-  "version": "2.1.8-alpha.0",
+  "version": "2.1.8",
   "description": "Tool to run through Edge System CommonWell certification test cases - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.27.8-alpha.0",
+  "version": "1.27.8",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-jwt-maker/package.json
+++ b/packages/commonwell-jwt-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-jwt-maker",
-  "version": "1.27.7",
+  "version": "1.27.8-alpha.0",
   "description": "CLI to create a JWT for use in CommonWell queries - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "8.1.0-alpha.0",
+  "version": "8.1.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.26.8-alpha.0",
+    "@metriport/shared": "^0.26.8",
     "axios": "^1.8.2",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/commonwell-sdk/package.json
+++ b/packages/commonwell-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/commonwell-sdk",
-  "version": "8.0.0",
+  "version": "8.1.0-alpha.0",
   "description": "SDK to simplify CommonWell API integration - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -60,7 +60,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.26.7",
+    "@metriport/shared": "^0.26.8-alpha.0",
     "axios": "^1.8.2",
     "http-status": "~1.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.26.8-alpha.0",
+  "version": "1.26.8",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/core",
-  "version": "1.26.7",
+  "version": "1.26.8-alpha.0",
   "private": true,
   "description": "Metriport helps you access and manage health and medical data, through a single open source API. Common code shared across packages.",
   "author": "Metriport Inc. <contact@metriport.com>",

--- a/packages/eslint-rules/package.json
+++ b/packages/eslint-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/eslint-plugin-eslint-rules",
-  "version": "1.2.8-alpha.0",
+  "version": "1.2.8",
   "description": "Custom ESLint rules for Metriport's monorepo",
   "main": "index.js",
   "keywords": [

--- a/packages/eslint-rules/package.json
+++ b/packages/eslint-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/eslint-plugin-eslint-rules",
-  "version": "1.2.7",
+  "version": "1.2.8-alpha.0",
   "description": "Custom ESLint rules for Metriport's monorepo",
   "main": "index.js",
   "keywords": [

--- a/packages/fhir-sdk/package.json
+++ b/packages/fhir-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/fhir-sdk",
-  "version": "1.3.2",
+  "version": "1.3.3-alpha.0",
   "description": "FHIR Bundle SDK for parsing, querying, and manipulating FHIR bundles with reference resolution",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/fhir-sdk/package.json
+++ b/packages/fhir-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/fhir-sdk",
-  "version": "1.3.3-alpha.0",
+  "version": "1.3.3",
   "description": "FHIR Bundle SDK for parsing, querying, and manipulating FHIR bundles with reference resolution",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.21.7",
+  "version": "0.21.8-alpha.0",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.26.7",
+    "@metriport/shared": "^0.26.8-alpha.0",
     "axios": "^1.8.2",
     "zod": "^3.22.1"
   }

--- a/packages/ihe-gateway-sdk/package.json
+++ b/packages/ihe-gateway-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/ihe-gateway-sdk",
-  "version": "0.21.8-alpha.0",
+  "version": "0.21.8",
   "description": "SDK to interact with other IHE Gateways - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",
@@ -53,7 +53,7 @@
     "url": "https://github.com/metriport/metriport/issues"
   },
   "dependencies": {
-    "@metriport/shared": "^0.26.8-alpha.0",
+    "@metriport/shared": "^0.26.8",
     "axios": "^1.8.2",
     "zod": "^3.22.1"
   }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.24.7",
+  "version": "1.24.8-alpha.0",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infrastructure",
-  "version": "1.24.8-alpha.0",
+  "version": "1.24.8",
   "private": true,
   "bin": {
     "infrastructure": "bin/infrastructure.js"

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mllp-server",
-  "version": "0.5.8-alpha.0",
+  "version": "0.5.8",
   "description": "MLLP server that reads HL7 messages off of a raw tcp connection",
   "main": "app.js",
   "private": true,

--- a/packages/mllp-server/package.json
+++ b/packages/mllp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mllp-server",
-  "version": "0.5.7",
+  "version": "0.5.8-alpha.0",
   "description": "MLLP server that reads HL7 messages off of a raw tcp connection",
   "main": "app.js",
   "private": true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.26.7",
+  "version": "0.26.8-alpha.0",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/shared",
-  "version": "0.26.8-alpha.0",
+  "version": "0.26.8",
   "description": "Common code shared across packages - by Metriport Inc.",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.27.7",
+  "version": "1.27.8-alpha.0",
   "description": "",
   "private": true,
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "1.27.8-alpha.0",
+  "version": "1.27.8",
   "description": "",
   "private": true,
   "scripts": {


### PR DESCRIPTION
- **chore(release): publish**
- **chore(release): publish**

### Description
- Released alpha packages (forgot to on the [original PR](https://github.com/metriport/metriport/pull/4827))
- Released prod packages 

### Testing
- N/A

### Release Plan

- [x] Release NPM packages
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Bumped package versions across SDKs, services, and utilities for consistency.
  - Updated shared/internal dependencies to aligned patch releases.
  - No functional or API changes; behavior remains unchanged.
  - Applies to API/SDKs, Carequality/CommonWell tooling, core libraries, FHIR/IHE SDKs, infra, MLLP server, shared utilities, and linting rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->