### PR TITLE
ENG-1225: Improve regex for finding unescaped ampersands

### DIFF
--- a/packages/core/src/domain/conversion/cleanup.ts
+++ b/packages/core/src/domain/conversion/cleanup.ts
@@ -3,6 +3,7 @@ export const xmlTranslationCodeRegex = /(<translation[^>]*\scode=")([^"]*?)(")/g
 export const LESS_THAN = "&lt;";
 export const GREATER_THAN = "&gt;";
 const AMPERSAND = "&amp;";
+const UNESCAPED_AMPERSAND_REGEX = /&(?!((?:lt|gt|amp|quot|apos);|#[0-9]+;|#x[0-9A-Fa-f]+;))/g;
 
 export function cleanUpPayload(payloadRaw: string): string {
   const payloadNoCdUnk = replaceCdUnkString(payloadRaw);
@@ -25,10 +26,8 @@ function replaceNullFlavor(payloadRaw: string): string {
   return payloadRaw.replace(stringToReplace, replacement);
 }
 
-function replaceAmpersand(payloadRaw: string): string {
-  const stringToReplace = /\s&\s/g;
-  const replacement = ` ${AMPERSAND} `;
-  return payloadRaw.replace(stringToReplace, replacement);
+export function replaceAmpersand(payloadRaw: string): string {
+  return payloadRaw.replace(UNESCAPED_AMPERSAND_REGEX, AMPERSAND);
 }
 
 export function replaceXmlTagChars(doc: string): string {


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-1225

### Dependencies

- Upstream: None
- Downstream: None

### Description

The current normalization is insufficient for finding all cases where there is an unescaped ampersand, since an incorrectly escaped ampersand may be next to non-space characters. This PR is in response to a large number of on-call errors related to this issue - see the ticket for more details.

### Testing

- Local
  - [x] ran `cda-to-html.ts` in `utils` with the failing XML, works correctly with better normalization
- Staging
  - [ ] check normal CDA to visualization is working
- Production
  - [ ] ensure normal CDA to visualization works

### Release Plan

- [ ] Merge this
