### PR TITLE
RELEASE refresh consolidated on every adt (but skip ai regeneration :) )

### DIFF
--- a/packages/core/src/command/consolidated/consolidated-create.ts
+++ b/packages/core/src/command/consolidated/consolidated-create.ts
@@ -3,7 +3,10 @@ import { errorToString } from "@metriport/shared";
 import { parseFhirBundle } from "@metriport/shared/medical";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
-import { generateAiBriefBundleEntry, getAiBriefFromS3 } from "../../domain/ai-brief/generate";
+import {
+  generateAiBriefBundleEntry,
+  getCachedAiBriefOrGenerateNewOne,
+} from "../../domain/ai-brief/generate";
 import { createConsolidatedDataFilePath } from "../../domain/consolidated/filename";
 import { createFolderName } from "../../domain/filename";
 import { Patient } from "../../domain/patient";
@@ -149,12 +152,20 @@ export async function createConsolidatedFromConversions({
     }
   }
 
-  const shouldGetAiBriefFromS3 =
+  const shouldUseCachedAiBrief =
     isAiBriefFeatureFlagEnabled && useCachedAiBrief && bundle.entry && bundle.entry.length > 0;
 
-  if (shouldGetAiBriefFromS3) {
+  //Generates AI brief if it doesn't exist in S3
+  if (shouldUseCachedAiBrief) {
     const aiBriefEntry = await generateAiBriefWithTimeout(
-      controls => getAiBriefFromS3({ cxId, patientId, bundle, log, aiBriefControls: controls }),
+      controls =>
+        getCachedAiBriefOrGenerateNewOne({
+          cxId,
+          patientId,
+          bundle,
+          log,
+          aiBriefControls: controls,
+        }),
       cxId,
       patientId,
       log

--- a/packages/core/src/command/consolidated/consolidated-get.ts
+++ b/packages/core/src/command/consolidated/consolidated-get.ts
@@ -121,6 +121,7 @@ export async function getConsolidatedPatientDataAsync({
   requestId,
   conversionType,
   fromDashboard,
+  useCachedAiBrief,
 }: GetConsolidatedPatientData & {
   requestId: string;
   conversionType: ConsolidationConversionType;
@@ -134,6 +135,7 @@ export async function getConsolidatedPatientDataAsync({
     dateTo,
     isAsync: true,
     fromDashboard,
+    useCachedAiBrief,
   };
   const connector = buildConsolidatedSnapshotConnector();
   connector

--- a/packages/core/src/command/hl7-notification/utils.ts
+++ b/packages/core/src/command/hl7-notification/utils.ts
@@ -18,12 +18,17 @@ export interface ParsedHl7Data {
 }
 
 const supportedTypes = ["A01", "A03"] as const;
+const CONSOLIDATED_REFRESH_TRIGGER_EVENTS = ["A01", "A03"] as const;
 
 export type SupportedTriggerEvent = (typeof supportedTypes)[number];
 export function isSupportedTriggerEvent(
   triggerEvent: string
 ): triggerEvent is SupportedTriggerEvent {
   return supportedTypes.includes(triggerEvent as SupportedTriggerEvent);
+}
+
+export function isConsolidatedRefreshTriggerEvent(triggerEvent: string): boolean {
+  return CONSOLIDATED_REFRESH_TRIGGER_EVENTS.includes(triggerEvent as SupportedTriggerEvent);
 }
 
 export async function parseHl7Message(


### PR DESCRIPTION
_[Release PRs:]_

Issues:

- https://linear.app/metriport/issue/ENG-1208

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4836

### Description
- https://github.com/metriport/metriport/pull/4810

### Testing

Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added option to use a cached AI Brief for faster responses, with automatic generation when missing.
  - Automatic consolidated data refresh triggered for specific HL7 events (A01, A03).

- Improvements
  - Reduced latency and improved reliability for AI Brief retrieval through cache-first logic with graceful fallback.
  - Enhanced HL7 notification handling with smarter routing and non-blocking analytics, improving observability without impacting delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->