### PR TITLE
ENG-1226 Lambda updates

### DIFF
--- a/packages/lambdas/package-lock.json
+++ b/packages/lambdas/package-lock.json
@@ -19,7 +19,7 @@
         "@aws-sdk/s3-request-presigner": "^3.800.0",
         "@medplum/core": "^2.2.10",
         "@metriport/api-sdk": "^18.0.2",
-        "@metriport/commonwell-sdk": "8.0.0",
+        "@metriport/commonwell-sdk": "8.2.0",
         "@metriport/commonwell-sdk-v1": "npm:@metriport/commonwell-sdk@^5.9.11",
         "@opensearch-project/opensearch": "^2.3.1",
         "@sentry/serverless": "^7.120.3",
@@ -10807,11 +10807,11 @@
       }
     },
     "node_modules/@metriport/commonwell-sdk": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-8.0.0.tgz",
-      "integrity": "sha512-5p9Pv3bvplKyAZScUfNH+wn04YaDDs4CT2HTuVNiePlWr/SChqXzULE61cqEH2dSpemrfm3weDecTfFy23XGcA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@metriport/commonwell-sdk/-/commonwell-sdk-8.2.0.tgz",
+      "integrity": "sha512-5YVqFjF5D0SkQj4Xgx4MtXK9XKHhy2fFG9CT/o8/Yct3VdVCeVg1XBvf+gkyjG8v2Si2MhmaUvp1rv46y+9b8Q==",
       "dependencies": {
-        "@metriport/shared": "^0.26.7",
+        "@metriport/shared": "^0.26.9",
         "axios": "^1.8.2",
         "http-status": "~1.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -10847,9 +10847,9 @@
       }
     },
     "node_modules/@metriport/commonwell-sdk/node_modules/@metriport/shared": {
-      "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/@metriport/shared/-/shared-0.26.7.tgz",
-      "integrity": "sha512-uk1SHeOlyEojlQTJaVjyQ2KClT+M+8kvidTGVxhdY6mdJRVkYlSa+CjMBNidtZSOQu2FwjXBoCW3qnFHkAk2Rw==",
+      "version": "0.26.9",
+      "resolved": "https://registry.npmjs.org/@metriport/shared/-/shared-0.26.9.tgz",
+      "integrity": "sha512-d+og5E/qCmgHJABjBXFRXAOP1+WHyQE6kcA61Q+OGbPyEQETXd0VhvqYlI1j/dxFadWeR9WpoJi1rzvffp+gZA==",
       "dependencies": {
         "@medplum/core": "^2.2.10",
         "axios": "^1.8.2",

--- a/packages/lambdas/package.json
+++ b/packages/lambdas/package.json
@@ -34,7 +34,7 @@
     "@aws-sdk/s3-request-presigner": "^3.800.0",
     "@medplum/core": "^2.2.10",
     "@metriport/api-sdk": "^18.0.2",
-    "@metriport/commonwell-sdk": "8.0.0",
+    "@metriport/commonwell-sdk": "8.2.0",
     "@metriport/commonwell-sdk-v1": "npm:@metriport/commonwell-sdk@^5.9.11",
     "@opensearch-project/opensearch": "^2.3.1",
     "@sentry/serverless": "^7.120.3",

--- a/packages/lambdas/src/document-downloader.ts
+++ b/packages/lambdas/src/document-downloader.ts
@@ -24,6 +24,9 @@ dayjs.extend(duration);
 
 const timeout = dayjs.duration({ minutes: 4 });
 
+const MAX_ATTEMPTS = 3;
+const INITIAL_DELAY = 1_000;
+
 // Automatically set by AWS
 const lambdaName = getEnv("AWS_LAMBDA_FUNCTION_NAME");
 const region = getEnvOrFail("AWS_REGION");
@@ -91,7 +94,14 @@ export const handler = capture.wrapHandler(
       npi,
       apiMode,
       authGrantorReferenceOid,
-      options: { timeout: timeout.asMilliseconds() },
+      options: {
+        timeout: timeout.asMilliseconds(),
+        onError500: {
+          retry: true,
+          maxAttempts: MAX_ATTEMPTS,
+          initialDelay: INITIAL_DELAY,
+        },
+      },
     });
 
     const docDownloader = new DocumentDownloaderLocalV2({


### PR DESCRIPTION
Part of ENG-1226

### Description

- CW Document Downloader lambda to also use retries on doc downloads

### Testing

- Staging
  - [x] Rerun a DQ on a patient

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Added automatic retries with backoff for server errors during document downloads, reducing intermittent failures, timeouts, and improving overall stability and success rates.
- Chores
  - Upgraded external healthcare SDK to version 8.2.0, aligning with improved error handling and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->