### PR TITLE
ENG-1224: support row data field in payload on backend

### DIFF
--- a/packages/api/src/routes/medical/inference.ts
+++ b/packages/api/src/routes/medical/inference.ts
@@ -89,9 +89,8 @@ router.post(
   requestLogger,
   asyncHandler(async (req: Request, res: Response) => {
     const cxId = getCxIdOrFail(req);
-    const { resourceType, resourceDisplays, context } = resourceSummaryInferenceSchema.parse(
-      req.body
-    );
+    const { resourceType, resourceDisplays, resourceRowData, context } =
+      resourceSummaryInferenceSchema.parse(req.body);
     console.log(`resourceType: ${resourceType}, resourceDisplays: ${resourceDisplays.join(", ")}`);
 
     const agent = new AnthropicAgent({
@@ -112,7 +111,11 @@ router.post(
       This is about a patient.
       The resource type is: ${resourceType}
       The resource displays are: ${resourceDisplays.join(", ")}
-      The core relevant data for this resource is: ${JSON.stringify(resourceRowData, null, 2)}
+      The core data for the resource we are asking about is: ${JSON.stringify(
+        resourceRowData,
+        null,
+        2
+      )}
 
       ---
       

--- a/packages/api/src/routes/medical/inference.ts
+++ b/packages/api/src/routes/medical/inference.ts
@@ -15,7 +15,7 @@ const router = Router();
 const resourceSummaryInferenceSchema = z.object({
   resourceType: z.string(),
   resourceDisplays: z.array(z.string()),
-  resourceRowData: z.record(z.unknown()),
+  resourceRowData: z.record(z.unknown()).optional(),
   context: z.string(),
 });
 
@@ -106,16 +106,20 @@ router.post(
       questionsByResourceType[resourceType as keyof typeof questionsByResourceType] ??
       defaultQuestions;
 
+    const resourceRowDataString = resourceRowData
+      ? `The core data for the resource we are asking about is: ${JSON.stringify(
+          resourceRowData,
+          null,
+          2
+        )}`
+      : "";
+
     agent.addUserMessageText(
       `
       This is about a patient.
       The resource type is: ${resourceType}
       The resource displays are: ${resourceDisplays.join(", ")}
-      The core data for the resource we are asking about is: ${JSON.stringify(
-        resourceRowData,
-        null,
-        2
-      )}
+      ${resourceRowDataString}
 
       ---
       

--- a/packages/api/src/routes/medical/inference.ts
+++ b/packages/api/src/routes/medical/inference.ts
@@ -15,6 +15,7 @@ const router = Router();
 const resourceSummaryInferenceSchema = z.object({
   resourceType: z.string(),
   resourceDisplays: z.array(z.string()),
+  resourceRowData: z.record(z.unknown()),
   context: z.string(),
 });
 
@@ -108,7 +109,12 @@ router.post(
 
     agent.addUserMessageText(
       `
-      This is about a patient - ${resourceType}: ${resourceDisplays.join(", ")}
+      This is about a patient.
+      The resource type is: ${resourceType}
+      The resource displays are: ${resourceDisplays.join(", ")}
+      The core relevant data for this resource is: ${JSON.stringify(resourceRowData, null, 2)}
+
+      ---
       
       ### Citing claims
       In your response, create a source list at the bottom. These sources MUST use markdown link syntax, but have the link point to the UUID of the resource that contains proof of the claim.


### PR DESCRIPTION
### Dependencies

- Downstream: https://github.com/metriport/metriport-internal/pull/3361

### Description

This allows us to cleanly pass the data from a given row to the backend for inference. It's backwards compatible.

### Testing

Tested against api on my machine

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Medical inference responses now include a structured preface summarizing resource type, displays, and core data.
  * Requests can supply optional additional resource data, which is incorporated and shown in the generated response.
  * Assistant outputs provide expanded, multi-line context ahead of the main message for clearer interpretation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->