### PR TITLE
ENG-1237: feat(core): add cloudwatch reporting metrics to webhook sender

### DIFF
--- a/packages/api/src/routes/medical/inference.ts
+++ b/packages/api/src/routes/medical/inference.ts
@@ -1,4 +1,4 @@
-import { reportAdvancedMetric } from "@metriport/core/external/aws/cloudwatch";
+import { reportAdvancedMetrics } from "@metriport/core/external/aws/cloudwatch";
 import { AnthropicAgent } from "@metriport/core/external/bedrock/agent/anthropic";
 import { AnthropicMessageText } from "@metriport/core/external/bedrock/model/anthropic/messages";
 import { initTimer } from "@metriport/shared/common/timer";
@@ -180,47 +180,35 @@ ${context}
     const response = await agent.continueConversation();
     const duration = timer.getElapsedTime();
 
-    await Promise.all([
-      reportAdvancedMetric({
-        service: "OSS API",
-        metrics: [
-          {
-            name: "LLM.ResourceSummary.Duration",
-            unit: "Milliseconds",
-            value: duration,
-            dimensions: {
-              Customer: cxId,
-            },
+    await reportAdvancedMetrics({
+      service: "OSS API",
+      metrics: [
+        {
+          name: "LLM.ResourceSummary.Duration",
+          unit: "Milliseconds",
+          value: duration,
+          dimensions: {
+            Customer: cxId,
           },
-        ],
-      }),
-      reportAdvancedMetric({
-        service: "OSS API",
-        metrics: [
-          {
-            name: "LLM.ResourceSummary.InputTokens",
-            unit: "Count",
-            value: response.usage.input_tokens,
-            dimensions: {
-              Customer: cxId,
-            },
+        },
+        {
+          name: "LLM.ResourceSummary.InputTokens",
+          unit: "Count",
+          value: response.usage.input_tokens,
+          dimensions: {
+            Customer: cxId,
           },
-        ],
-      }),
-      reportAdvancedMetric({
-        service: "OSS API",
-        metrics: [
-          {
-            name: "LLM.ResourceSummary.OutputTokens",
-            unit: "Count",
-            value: response.usage.output_tokens,
-            dimensions: {
-              Customer: cxId,
-            },
+        },
+        {
+          name: "LLM.ResourceSummary.OutputTokens",
+          unit: "Count",
+          value: response.usage.output_tokens,
+          dimensions: {
+            Customer: cxId,
           },
-        ],
-      }),
-    ]);
+        },
+      ],
+    });
 
     const responseText = (response.content[response.content.length - 1] as AnthropicMessageText)
       .text;

--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -7,7 +7,7 @@ import { TcmEncounterUpsertInput } from "@metriport/shared/domain/tcm-encounter"
 import axios from "axios";
 import dayjs from "dayjs";
 import { analytics, EventTypes } from "../../external/analytics/posthog";
-import { reportAdvancedMetric } from "../../external/aws/cloudwatch";
+import { reportAdvancedMetrics } from "../../external/aws/cloudwatch";
 import { S3Utils } from "../../external/aws/s3";
 import { getSecretValueOrFail } from "../../external/aws/secret-manager";
 import {
@@ -383,7 +383,7 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
       }
 
       await Promise.all([
-        reportAdvancedMetric({
+        reportAdvancedMetrics({
           service: "Hl7NotificationWebhookSender",
           metrics: [
             {

--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-analytics.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-analytics.ts
@@ -2,7 +2,7 @@ import { InternalOrganizationDTO } from "@metriport/shared/domain/organization";
 import _ from "lodash";
 import { Patient } from "../../domain/patient";
 import { analyticsAsync, EventTypes } from "../../external/analytics/posthog";
-import { reportAdvancedMetric } from "../../external/aws/cloudwatch";
+import { reportAdvancedMetrics } from "../../external/aws/cloudwatch";
 import { getSecretValueOrFail } from "../../external/aws/secret-manager";
 import { Config } from "../../util/config";
 
@@ -58,7 +58,7 @@ export async function trackRosterSizePerCustomer({
           },
           posthogSecret
         ),
-        reportAdvancedMetric({
+        reportAdvancedMetrics({
           service: "Hl7v2RosterGenerator",
           metrics: [
             {

--- a/packages/core/src/external/aws/cloudwatch.ts
+++ b/packages/core/src/external/aws/cloudwatch.ts
@@ -75,7 +75,7 @@ export type AdvancedMetric = {
  * @param metrics - The metrics to report.
  * @param dimensionLimitOverride - Set to true to override the 3-metric safety limit.
  */
-export async function reportAdvancedMetric({
+export async function reportAdvancedMetrics({
   service,
   metrics,
   dimensionLimitOverride = false,
@@ -120,6 +120,6 @@ export async function reportAdvancedMetric({
       .promise();
   } catch (err) {
     console.error(`Error reporting metrics ${JSON.stringify(metrics)}: ${err}`);
-    capture.error(err, { extra: { metrics, context: "reportAdvancedMetric" } });
+    capture.error(err, { extra: { metrics, context: "reportAdvancedMetrics" } });
   }
 }


### PR DESCRIPTION
### Dependencies

None

### Description

Add metrics for cloudwatch reporting (so we can set up an alarm) 

Cost analysis (monthly) for current metrics: 
- LLM inference metrics:
  - 3 metrics, $0.30 / cx => $0.90 / cx 
- Roster upload metrics 
  - By customer: $0.30 / cx / hie (only happens + is billed if the pairing actually exists)
- Incoming ADT notifications
  - By customer: $0.30 / cx / hie (only happens + is billed if the pairing actually exists)
    - Priced the same as the above roster upload metric.
  - By ADT event type: ~ $5 / integrated hie. 

### Testing

- Local
  - [x] Branch to staging, ensure metric is logged and ADTs continue to run without error.
- Staging
  - [x]  Branch to staging was successful
- Production
  - [ ] ensure metric is logged and ADTs continue to run without error.

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advanced metric reporting for richer CloudWatch telemetry (multi-metric payloads and validation).

* **Refactor**
  * Parallelized analytics and metric reporting to reduce end-to-end latency for notifications, roster uploads, and inference flows.

* **Chores**
  * Consolidated emitted metrics and standardized dimensions for clearer per-customer, event-type, and service-level observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->