### PR TITLE
PATCH RELEASE Revert change for XML preprocessing

### DIFF
--- a/packages/core/src/external/cda/remove-b64.ts
+++ b/packages/core/src/external/cda/remove-b64.ts
@@ -98,7 +98,6 @@ export function removeBase64PdfEntries(payloadRaw: string): {
     attributeNamePrefix: "_",
     suppressEmptyNode: true,
     suppressBooleanAttributes: false,
-    preserveOrder: true, // Preserve order of elements and text
   });
   const xml = builder.build(json);
 
@@ -138,8 +137,6 @@ function getJsonFromXml(payloadRaw: string): any {
     ignoreAttributes: false,
     attributeNamePrefix: "_",
     removeNSPrefix: true,
-    trimValues: false, // Don't trim whitespace from text values
-    preserveOrder: true, // Preserve order of elements and text
   });
 
   try {


### PR DESCRIPTION
Part of ENG-000

### Description

- Reverting changes re XML preprocessing introduced in this PR:
- https://github.com/metriport/metriport/pull/4813/files

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized XML parsing and building behavior, which may change element order and whitespace in generated outputs.
  * Ensures more consistent XML-to-JSON and JSON-to-XML conversions across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->