### PR TITLE
feat(fhir-sdk): if dates are out of order, flip them when trying to index in fhir-sdk

### DIFF
--- a/packages/fhir-sdk/package.json
+++ b/packages/fhir-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metriport/fhir-sdk",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "FHIR Bundle SDK for parsing, querying, and manipulating FHIR bundles with reference resolution",
   "author": "Metriport Inc. <contact@metriport.com>",
   "homepage": "https://metriport.com/",

--- a/packages/fhir-sdk/src/internal/indexing.ts
+++ b/packages/fhir-sdk/src/internal/indexing.ts
@@ -151,7 +151,19 @@ export function buildDateRangeIndex(
     const dateIntervals = extractDateIntervalsFromResource(resource);
 
     for (const interval of dateIntervals) {
-      dateRangeIndex.insert(interval);
+      try {
+        dateRangeIndex.insert(interval);
+      } catch (error) {
+        // Handle bad data case where low > high
+        console.warn(
+          `Error inserting date interval (${interval.low}, ${interval.high}) into index. Swapping values.`
+        );
+        dateRangeIndex.insert({
+          ...interval,
+          low: interval.high,
+          high: interval.low,
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
metriport/metriport-internal#1040

Ref: ENG-1242
Signed-off-by: Lucas Della Bella <dellabella.lucas@gmail.com>

### Dependencies

None

### Description

If dates are out of order during fhir sdk interval tree indexing, just swap them instead of failing.

### Testing

Already released + working in prod

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves stability when processing malformed date ranges (e.g., reversed bounds), handling them gracefully instead of failing. This reduces unexpected errors during indexing operations and increases resilience when working with imperfect data.

* **Chores**
  * Bumped fhir-sdk package version to 1.3.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->