### PR TITLE
ENG-1230 Recreate HIE Directory entry view

### DIFF
--- a/packages/api/src/external/commonwell/command/cw-directory/parse-cw-organization.ts
+++ b/packages/api/src/external/commonwell/command/cw-directory/parse-cw-organization.ts
@@ -15,13 +15,6 @@ export function parseCWOrganization(org: Organization): CwDirectoryEntryData {
     });
   }
 
-  const active = org.isActive;
-  if (active == undefined) {
-    throw new MetriportError("Missing isActive on CW Org", undefined, {
-      org: stringify(org),
-    });
-  }
-
   // Get the first location (primary address)
   const location = org.locations?.[0];
   if (!location) {
@@ -44,24 +37,19 @@ export function parseCWOrganization(org: Organization): CwDirectoryEntryData {
     });
   }
 
-  // Determine organization type based on NPI types or use the type field
-  const orgType = org.npiType1 || org.npiType2 || org.type || "Unknown";
-
-  // Determine status based on active state
+  const orgType = org.type || "Unknown";
   const delegateOids = getDelegateOids(org.networks ?? []);
 
   return {
     id: organizationId,
-    organizationName: org.name,
-    organizationId,
+    name: org.name,
+    oid: organizationId,
     orgType,
-    memberName: org.memberName,
-    addressLine1,
-    addressLine2: addressLine2 ?? undefined,
+    rootOrganization: org.memberName,
+    addressLine: `${addressLine1} ${addressLine2 ?? ""}`,
     city,
     state: normalizeUSStateForAddressSafe(state) ?? undefined,
-    zipCode: normalizeZipCodeNewSafe(zipCode) ?? undefined,
-    country,
+    zip: normalizeZipCodeNewSafe(zipCode) ?? undefined,
     data: org,
     active: org.isActive,
     npi,

--- a/packages/api/src/external/commonwell/command/cw-directory/rebuild-cw-directory-raw-sql.ts
+++ b/packages/api/src/external/commonwell/command/cw-directory/rebuild-cw-directory-raw-sql.ts
@@ -1,7 +1,7 @@
 import { QueryTypes, Sequelize } from "sequelize";
 import { executeOnDBTx } from "../../../../models/transaction-wrapper";
-import { CwDirectoryEntryData } from "../../cw-directory";
 import { CwDirectoryEntryViewModel } from "../../../commonwell/models/cw-directory-view";
+import { CwDirectoryEntryData } from "../../cw-directory";
 
 export const cwDirectoryEntry = `cw_directory_entry_new`;
 export const cwDirectoryEntryView = `cw_directory_entry_view`;
@@ -26,16 +26,14 @@ export async function insertCwDirectoryEntries(
     .join(", ");
 
   const flattenedData = orgDataArray.flatMap(entry => [
-    entry.organizationName,
-    entry.organizationId,
+    entry.name,
+    entry.oid,
     entry.orgType,
-    entry.memberName,
-    entry.addressLine1,
-    entry.addressLine2 ?? null,
+    entry.rootOrganization,
+    entry.addressLine,
     entry.city,
     entry.state,
-    entry.zipCode,
-    entry.country,
+    entry.zip,
     entry.data ? JSON.stringify(entry.data) : null,
     entry.active,
     entry.npi ?? null,
@@ -55,16 +53,14 @@ function createKeys(): string {
     keyof Omit<CwDirectoryEntryData, "id" | "createdAt" | "updatedAt" | "delegateOids">,
     string
   > = {
-    organizationName: "organization_name",
-    organizationId: "organization_id",
+    name: "name",
+    oid: "oid",
     orgType: "org_type",
-    memberName: "member_name",
-    addressLine1: "address_line1",
-    addressLine2: "address_line2",
+    rootOrganization: "root_organization",
+    addressLine: "address_line",
     city: "city",
     state: "state",
-    zipCode: "zip_code",
-    country: "country",
+    zip: "zip",
     data: "data",
     active: "active",
     npi: "npi",
@@ -74,9 +70,9 @@ function createKeys(): string {
 }
 
 export async function getCwDirectoryIds(sequelize: Sequelize): Promise<string[]> {
-  const query = `SELECT id FROM ${cwDirectoryEntryTemp};`;
-  const result = await sequelize.query<{ id: string }>(query, { type: QueryTypes.SELECT });
-  return result.map(row => row.id);
+  const query = `SELECT oid FROM ${cwDirectoryEntryTemp};`;
+  const result = await sequelize.query<{ oid: string }>(query, { type: QueryTypes.SELECT });
+  return result.map(row => row.oid);
 }
 
 export async function createTempCwDirectoryTable(sequelize: Sequelize): Promise<void> {

--- a/packages/api/src/external/commonwell/command/cw-directory/rebuild-cw-directory.ts
+++ b/packages/api/src/external/commonwell/command/cw-directory/rebuild-cw-directory.ts
@@ -1,5 +1,5 @@
 import { safelyUploadPrincipalAndDelegatesToS3 } from "@metriport/core/external/hie-shared/principal-and-delegates";
-import { capture, executeAsynchronously } from "@metriport/core/util";
+import { capture } from "@metriport/core/util";
 import { out } from "@metriport/core/util/log";
 import { initDbPool } from "@metriport/core/util/sequelize";
 import { errorToString, sleep } from "@metriport/shared";
@@ -22,7 +22,6 @@ dayjs.extend(duration);
 // CW Directory API is limited to 100 organizations per request
 const BATCH_SIZE = 100;
 
-const parallelQueriesToGetManagingOrg = 20;
 const SLEEP_TIME = dayjs.duration({ milliseconds: 750 });
 
 const dbCreds = Config.getDBCreds();
@@ -53,33 +52,25 @@ export async function rebuildCwDirectory(failGracefully = false): Promise<void> 
         log(`Loading active CW directory entries, from ${currentPosition} up to ${maxPosition}`);
         const loadStartedAt = Date.now();
 
-        const orgs = await cw.listOrganizations({
+        const response = await cw.listOrganizations({
           offset: currentPosition,
           limit: BATCH_SIZE,
         });
 
-        log(`Loaded ${orgs.organizations.length} entries in ${Date.now() - loadStartedAt}ms`);
-        if (orgs.organizations.length < BATCH_SIZE) isDone = true;
+        log(`Loaded ${response.organizations.length} entries in ${Date.now() - loadStartedAt}ms`);
+        if (response.organizations.length < BATCH_SIZE) isDone = true;
 
         const parsedOrgs: CwDirectoryEntryData[] = [];
-        const [alreadyInsertedIds] = await Promise.all([
-          getCwDirectoryIds(sequelize),
-          executeAsynchronously(
-            orgs.organizations,
-            async org => {
-              try {
-                const parsed = parseCWOrganization(org);
-                if (parsed.active) parsedOrgs.push(parsed);
-                if (parsed.delegateOids && parsed.delegateOids.length > 0) {
-                  principalAndDelegatesMap.set(parsed.id, parsed.delegateOids);
-                }
-              } catch (error) {
-                parsingErrors.push(error as Error);
-              }
-            },
-            { numberOfParallelExecutions: parallelQueriesToGetManagingOrg }
-          ),
-        ]);
+        const alreadyInsertedIds = await getCwDirectoryIds(sequelize);
+
+        for (const org of response.organizations) {
+          try {
+            const parsed = parseCWOrganization(org);
+            if (parsed.active) parsedOrgs.push(parsed); // we don't want to store inactive organizations
+          } catch (error) {
+            parsingErrors.push(error as Error);
+          }
+        }
 
         parsedOrgsCount += parsedOrgs.length;
         log(`Successfully parsed ${parsedOrgs.length} entries`);
@@ -87,6 +78,11 @@ export async function rebuildCwDirectory(failGracefully = false): Promise<void> 
         const orgsToInsert = parsedOrgs.filter(
           org => !alreadyInsertedIds.some(id => id === org.id)
         );
+        orgsToInsert.forEach(org => {
+          if (org.delegateOids && org.delegateOids.length > 0) {
+            principalAndDelegatesMap.set(org.id, org.delegateOids);
+          }
+        });
 
         log(`Adding ${orgsToInsert.length} entries in the DB...`);
         const insertStartedAt = Date.now();

--- a/packages/api/src/external/commonwell/cw-directory.ts
+++ b/packages/api/src/external/commonwell/cw-directory.ts
@@ -1,15 +1,13 @@
 export type CwDirectoryEntryData = {
-  id: string; // Organization's ID
-  organizationName: string;
-  organizationId: string;
+  id: string;
+  name: string;
+  oid: string;
   orgType: string;
-  memberName: string;
-  addressLine1: string;
-  addressLine2?: string;
+  rootOrganization: string;
+  addressLine: string;
   city: string | undefined;
   state: string | undefined;
-  zipCode: string | undefined;
-  country: string | undefined;
+  zip: string | undefined;
   data: unknown;
   active: boolean;
   npi?: string;

--- a/packages/api/src/external/commonwell/models/cw-directory-view.ts
+++ b/packages/api/src/external/commonwell/models/cw-directory-view.ts
@@ -9,15 +9,15 @@ export class CwDirectoryEntryViewModel
   static NAME = "cw_directory_entry_view";
 
   declare id: string; // Organization's OID
-  declare organizationName: string;
-  declare organizationId: string;
+  declare name: string;
+  declare oid: string;
   declare orgType: string;
-  declare memberName: string;
-  declare addressLine1: string;
+  declare rootOrganization: string;
+  declare addressLine: string;
   declare addressLine2?: string;
   declare city: string;
   declare state: string;
-  declare zipCode: string;
+  declare zip: string;
   declare country: string;
   declare data: unknown;
   declare active: boolean;
@@ -30,11 +30,11 @@ export class CwDirectoryEntryViewModel
           type: DataTypes.STRING,
           primaryKey: true,
         },
-        organizationName: {
+        name: {
           type: DataTypes.STRING,
           field: "organization_name",
         },
-        organizationId: {
+        oid: {
           type: DataTypes.STRING,
           field: "organization_id",
         },
@@ -42,11 +42,11 @@ export class CwDirectoryEntryViewModel
           type: DataTypes.STRING,
           field: "org_type",
         },
-        memberName: {
+        rootOrganization: {
           type: DataTypes.STRING,
           field: "member_name",
         },
-        addressLine1: {
+        addressLine: {
           type: DataTypes.STRING,
           field: "address_line1",
         },
@@ -60,7 +60,7 @@ export class CwDirectoryEntryViewModel
         state: {
           type: DataTypes.STRING,
         },
-        zipCode: {
+        zip: {
           type: DataTypes.STRING,
           field: "zip_code",
         },

--- a/packages/api/src/sequelize/migrations/2025-10-14_00_create-cw_directory_entry_new.ts
+++ b/packages/api/src/sequelize/migrations/2025-10-14_00_create-cw_directory_entry_new.ts
@@ -13,13 +13,13 @@ const cwTableColumns = {
     primaryKey: true,
     allowNull: false,
   },
-  organizationName: {
-    field: "organization_name",
+  name: {
+    field: "name",
     type: DataTypes.STRING,
     allowNull: false,
   },
-  organizationId: {
-    field: "organization_id",
+  oid: {
+    field: "oid",
     type: DataTypes.STRING,
     allowNull: false,
   },
@@ -37,37 +37,25 @@ const cwTableColumns = {
     type: DataTypes.STRING,
     allowNull: false,
   },
-  memberName: {
-    field: "member_name",
+  rootOrganization: {
+    field: "root_organization",
     type: DataTypes.STRING,
     allowNull: false,
   },
-  addressLine1: {
-    field: "address_line1",
+  addressLine: {
+    field: "address_line",
     type: DataTypes.STRING,
     allowNull: false,
-  },
-  addressLine2: {
-    field: "address_line2",
-    type: DataTypes.STRING,
-    allowNull: true,
   },
   city: {
     type: DataTypes.STRING,
-    allowNull: false,
   },
   state: {
     type: DataTypes.STRING,
-    allowNull: false,
   },
-  zipCode: {
-    field: "zip_code",
+  zip: {
+    field: "zip",
     type: DataTypes.STRING,
-    allowNull: false,
-  },
-  country: {
-    type: DataTypes.STRING,
-    allowNull: false,
   },
   data: {
     type: DataTypes.JSONB,
@@ -79,13 +67,13 @@ const alterSearchCriteriaColumnSql = `
 ALTER TABLE ${tableName}
 ADD COLUMN ${columnName} tsvector
 GENERATED ALWAYS AS (
-  to_tsvector('english', coalesce(organization_id, '')) || ' ' ||
-  to_tsvector('english', coalesce(organization_name, '')) || ' ' ||
-  to_tsvector('english', coalesce(member_name, '')) || ' ' ||
-  to_tsvector('english', coalesce(address_line1, '')) || ' ' ||
+  to_tsvector('english', coalesce(oid, '')) || ' ' ||
+  to_tsvector('english', coalesce(name, '')) || ' ' ||
+  to_tsvector('english', coalesce(root_organization, '')) || ' ' ||
+  to_tsvector('english', coalesce(address_line, '')) || ' ' ||
   to_tsvector('english', coalesce(city, '')) || ' ' ||
   to_tsvector('english', coalesce(state, '')) || ' ' ||
-  to_tsvector('english', coalesce(zip_code, ''))
+  to_tsvector('english', coalesce(zip, ''))
 ) STORED;
 `;
 

--- a/packages/api/src/sequelize/migrations/2025-10-14_01_recreate-hie-directory-view.ts
+++ b/packages/api/src/sequelize/migrations/2025-10-14_01_recreate-hie-directory-view.ts
@@ -24,10 +24,10 @@ FROM ${cqViewName} cq
 UNION ALL
 
 SELECT
-  organization_name as name,
-  organization_id as id,
-  organization_id as oid,
-  zip_code,
+  name,
+  oid as id,
+  oid,
+  zip as zip_code,
   state,
   'CommonWell' as root_organization,
   '2.16.840.1.113883.3.3330' as managing_organization_id,
@@ -38,7 +38,7 @@ FROM ${cwViewName} cw
 WHERE NOT EXISTS (
   SELECT 1
   FROM ${cqViewName} cq
-  WHERE cq.id = cw.organization_id
+  WHERE cq.id = cw.oid
 )
 ;`;
 

--- a/packages/core/src/external/hie-shared/principal-and-delegates.ts
+++ b/packages/core/src/external/hie-shared/principal-and-delegates.ts
@@ -1,13 +1,13 @@
 import { errorToString } from "@metriport/shared";
 import { Config } from "../../util/config";
 import { out } from "../../util/log";
-import { JSON_APP_MIME_TYPE } from "../../util/mime";
+import { JSON_APP_MIME_TYPE, JSON_FILE_EXTENSION } from "../../util/mime";
 import { capture } from "../../util/notifications";
 import { S3Utils } from "../aws/s3";
 
 const region = Config.getAWSRegion();
 const s3Utils = new S3Utils(region);
-const PRINCIPAL_AND_DELEGATES_FILE_NAME = "principal-and-delegates.json";
+const PRINCIPAL_AND_DELEGATES_FILE_NAME = "principal-and-delegates";
 
 /**
  * TODO: Move to a shared location, accept source to be part of the name
@@ -55,5 +55,5 @@ export async function getPrincipalAndDelegatesMap(
 }
 
 function buildPrincipalAndDelegatesMapKey(source: "cq" | "cw"): string {
-  return `${source}-${PRINCIPAL_AND_DELEGATES_FILE_NAME}`;
+  return `${PRINCIPAL_AND_DELEGATES_FILE_NAME}-${source}.${JSON_FILE_EXTENSION}`;
 }


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4858

### Description

- Migration to create the combined HIE directory view
- Sending as a separate PR to avoid errors during deployment. Though, i'm now thinking it would've been safe to do on the same PR anyway

### Testing

- Local
  - [x]  apply the migration
  - [x] confirm the hie directory view contains orgs from both directories
- Staging
  - [ ] confirm the hie directory view contains orgs from both directories
- Production
  - [ ] confirm the hie directory view contains orgs from both directories

### Release Plan

- :warning: This contains a DB migration
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added endpoint to fetch CommonWell directory entries with optional filters and counts.
  - Added internal endpoints to rebuild CommonWell and Carequality directories.
  - Introduced a unified HIE directory view that merges and de-duplicates entries across networks.

- Improvements
  - More resilient, batched directory rebuilds with throttling and enhanced error reporting.
  - Separate delegate caches per network for safer, clearer authorization behavior.

- Chores
  - New configuration option for scheduling the CommonWell directory rebuilder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->