### PR TITLE
Remove early return if roster is empty

### DIFF
--- a/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/hl7v2-roster-generator.ts
@@ -163,6 +163,9 @@ export class Hl7v2RosterGenerator {
   }
 
   private async getOrganizations(cxIds: string[]): Promise<InternalOrganizationDTO[]> {
+    if (cxIds.length === 0) {
+      return [];
+    }
     const currentUrl = `${this.apiUrl}/${GET_ORGANIZATION_ENDPOINT}`;
     const baseParams = { cxIds: cxIds.join(",") };
 


### PR DESCRIPTION
Part of ENG-000

### Dependencies
None

### Description
Remove early return if roster is empty

### Testing
- Local
  - [x] run roster generation and make sure its not broken :)
- Staging
  - [ ] Run roster generation on an hie with no subscribers and see if error pops up.
  - [ ] Run roster generation on an hie with subscribers (no error should pop up).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Roster generation now continues through downstream steps for zero-patient cases instead of exiting early.
  * Prevented unnecessary organization lookups when there are no identifiers, avoiding redundant external calls.

* **Changes**
  * Scrambled IDs are now converted to the Bamboo-specific format for Bamboo HIEs.
  * Logging narrowed to reduce noisy/preliminary warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->