### PR TITLE
ENG-1285: set up new per-cx ai summaries

### DIFF
--- a/packages/core/src/command/ai-brief/cardiac-care-prompt.ts
+++ b/packages/core/src/command/ai-brief/cardiac-care-prompt.ts
@@ -1,0 +1,73 @@
+import { buildDayjs } from "@metriport/shared/common/date";
+
+const todaysDate = buildDayjs().format("YYYY-MM-DD");
+const systemPrompt =
+  "You are a medical record reviewer and your task is to extract key information from a patient's medical chart. Do not include any demographic information such as name, date of birth, address, or other personal identifiers in your summary.";
+
+export const documentVariableName = "text";
+
+const instructions = `
+Instructions:
+
+You need to create a succinct Patient Summary with the following five sections:
+**1. Cardiac Conditions**
+Review the clinical data for evidence (with dates) of these specific cardiac conditions: Hypertension (HTN), Coronary Artery Disease (CAD), Congestive Heart Failure (CHF), Atrial Fibrillation (AFib), Peripheral Vascular Disease (PVD), and Hyperlipidemia. For each condition found, note whether it's currently active, resolved, or under investigation.
+**2. Cardiovascular Medications**
+Identify all medications used to treat the cardiac conditions mentioned above. Organize these medications into three categories:
+- Active medications (currently prescribed/being taken)
+- Stopped medications (discontinued with reason if available)
+- Previously tried medications (attempted but changed)
+For each medication, include the last fill date and days supply when this information is available.
+**3. Non-Cardiac Chronic Risk Factors**
+Identify chronic conditions that may interact with or impact cardiac health management. Prioritize conditions such as:
+- Kidney disease/chronic kidney disease
+- Diabetes and other endocrine disorders
+- Obesity
+- Substance abuse
+- Other conditions that may complicate cardiovascular care
+**4. Acute Events**
+Look for recent acute healthcare encounters including:
+- Emergency Department visits
+- Hospitalizations
+- Significant symptom escalations or acute exacerbations
+Include dates, reasons for the encounters, and outcomes when available.
+**5. Care Insights**
+If there are any health conditions (excluding those discussed in sections 1 and 3: Heart, Kidney, Endocrine, Obesity, Substance abuse, cardiac complications) that are critical parts of this patient's health status, provide:
+- The date of the last encounter where the condition was evaluated or treated
+- Assessment of whether the condition appears well-managed or poorly controlled
+- Details of prescription drugs actively being used to treat these conditions
+- Any notable care gaps or management concerns
+`;
+
+export const mainSummaryPrompt = `
+${systemPrompt}
+
+Today's date is ${todaysDate}.
+Review the patient medical records:
+--------
+{${documentVariableName}}
+--------
+${instructions}
+
+If any of the above information is not present, do not include it in the summary.
+Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided.
+
+SUMMARY:
+`;
+
+export const refinedSummaryPrompt = `
+${systemPrompt}
+
+Today's date is ${todaysDate}.
+Here are the previous summaries written by you of sections of the patient's medical history:
+--------
+{${documentVariableName}}
+--------
+
+Combine these summaries into a single, comprehensive summary.
+Use these ${instructions}.
+
+Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided.
+
+SUMMARY:
+`;

--- a/packages/core/src/command/ai-brief/nitrates-and-conditions-prompt.ts
+++ b/packages/core/src/command/ai-brief/nitrates-and-conditions-prompt.ts
@@ -1,0 +1,78 @@
+import { buildDayjs } from "@metriport/shared/common/date";
+
+const todaysDate = buildDayjs().format("YYYY-MM-DD");
+const systemPrompt =
+  "You are a medical record reviewer and your task is to extract key information from a patient's medical chart. Do not include any demographic information such as name, date of birth, address, or other personal identifiers in your summary.";
+
+export const documentVariableName = "text";
+
+const instructions = `
+Instructions:
+1. Review the patient medical records and format the output EXACTLY as follows, including the bullet points and indentation:
+    Problem List: [Has Conditions: Yes/No]
+    Height (MM/DD/YYYY): [value] inches
+    Weight (MM/DD/YYYY): [value] lbs
+    BMI (MM/DD/YYYY): [value]
+     Conditions
+    - [Condition] ([MM/DD/YYYY])
+    Disqualifying Medications
+    - [Medications] ([MM/DD/YYYY])
+For any condition found, provide the most recent diagnosis date from the patient’s record. Only report exactly the conditions below, according to the additional constraints if applicable.
+List of conditions:
+- High blood pressure
+- Hypertension
+- High cholesterol
+- Hyperlipidemia
+- Dyslipidemia
+- Type 2 Diabetes
+- Sleep Apnea
+- OSA
+- Polycystic ovarian syndrome (PCOS)
+- Fatty Liver, Hepatic Steatosis, or Non-alcoholic fatty liver disease (NAFLD)*
+- Prediabetes Insulin Resistance*
+- Current pregnancy or currently breastfeeding
+- Active cancer or cancer treatment in the last 6 months
+- Active drug or alcohol abuse (not including marijuana use)
+- CKD Stage 4 or higher (eGFR <29) or kidney transplant (do not include CKD Stage 1, 2, or 3)
+- Active hepatitis or liver disease (do not include fatty liver)
+- Heart attack / stroke / any heart condition that limits daily activity in last 3 months
+- Serious uncontrolled mental health conditions: mental health conditions if there is evidence of uncontrolled symptoms or inpatient hospitalization
+
+List of Medications:
+- nitrates including isosorbide mononitrate, nitroglycerine, etc.
+
+Note: Do not suggest or infer conditions based on lab values or other observations. Only include explicitly documented conditions.
+`;
+
+export const mainSummaryPrompt = `
+${systemPrompt}
+
+Today's date is ${todaysDate}.
+Review the patient medical records:
+--------
+{${documentVariableName}}
+--------
+${instructions}
+
+If any of the above information is not present, do not include it in the summary.
+Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided.
+
+SUMMARY:
+`;
+
+export const refinedSummaryPrompt = `
+${systemPrompt}
+
+Today's date is ${todaysDate}.
+Here are the previous summaries written by you of sections of the patient's medical history:
+--------
+{${documentVariableName}}
+--------
+
+Combine these summaries into a single, comprehensive summary.
+Use these ${instructions}.
+
+Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided.
+
+SUMMARY:
+`;

--- a/packages/core/src/command/ai-brief/recent-visit-prompt.ts
+++ b/packages/core/src/command/ai-brief/recent-visit-prompt.ts
@@ -9,6 +9,20 @@ export const documentVariableName = "text";
 const instructions = `
 Instructions:
 
+Create a two section summary:
+
+** Core Summary **
+Write a summary of the patient's most recent medical history, considering the following goals:
+1. Specify whether a DNR or POLST form has been completed.
+2. Include a summary of the patient's most recent hospitalization, including the location of the hospitalization, the date of the hospitalization, the reason for the hospitalization, and the results of the hospitalization.
+3. Include a summary of the patient's current chronic conditions, allergies, and any previous surgeries.
+4. Include a summary of the patient's current medications, including dosages and frequency - do not include instructions on how to take the medications. Include any history of medication allergies or adverse reactions.
+5. Include any other relevant information about the patient's health.
+
+If any of the above information is not present, do not include it in the summary.
+Don't tell me that you are writing a summary, just write the summary. Also, don't tell me about any limitations of the information provided.
+
+** PCP Visits **
 Review the patient medical records and format the output EXACTLY as follows, including the bullet points and indentation:
     PCP Visits (up to last 24 months)
     - [PCP Name], [PCP Specialty]
@@ -71,6 +85,6 @@ Here are the previous summaries written by you of sections of the patient's medi
 {${documentVariableName}}
 --------
 
-Combine these summaries into a single, comprehensive summary.
+Combine these summaries into a comprehensive summary, but retain the structure of the underlying summary.
 Use these ${instructions}.
 `;

--- a/packages/core/src/command/feature-flags/domain-ffs.ts
+++ b/packages/core/src/command/feature-flags/domain-ffs.ts
@@ -253,6 +253,23 @@ export async function isRecentVisitAiSummaryEnabledForCx(cxId: string): Promise<
   return cxIdsWithRecentVisitAiSummaryEnabled.some(i => i === cxId);
 }
 
+export async function getCxsWithCardiacCareAiSummary(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithCardiacCareAiSummary");
+}
+export async function isCardiacCareAiSummaryEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithCardiacCareAiSummaryEnabled = await getCxsWithCardiacCareAiSummary();
+  return cxIdsWithCardiacCareAiSummaryEnabled.some(i => i === cxId);
+}
+
+export async function getCxsWithNitratesAndConditionsAiSummary(): Promise<string[]> {
+  return getCxsWithFeatureFlagEnabled("cxsWithNitratesAndConditionsAiSummary");
+}
+export async function isNitratesAndConditionsAiSummaryEnabledForCx(cxId: string): Promise<boolean> {
+  const cxIdsWithNitratesAndConditionsAiSummaryEnabled =
+    await getCxsWithNitratesAndConditionsAiSummary();
+  return cxIdsWithNitratesAndConditionsAiSummaryEnabled.some(i => i === cxId);
+}
+
 // ENG-536 remove this once we automatically find the discharge summary
 export async function getCxsWithDischargeSlackNotificationFeatureFlag(): Promise<string[]> {
   return getCxsWithFeatureFlagEnabled("cxsWithDischargeSlackNotificationFeatureFlag");

--- a/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
+++ b/packages/core/src/command/feature-flags/ffs-on-dynamodb.ts
@@ -60,6 +60,8 @@ export const initialFeatureFlags: FeatureFlagDatastore = {
   debugFeatureFlag: { enabled: false },
   cxsWithPcpVisitAiSummaryFeatureFlag: { enabled: false, values: [] },
   cxsWithRecentVisitAiSummary: { enabled: false, values: [] },
+  cxsWithCardiacCareAiSummary: { enabled: false, values: [] },
+  cxsWithNitratesAndConditionsAiSummary: { enabled: false, values: [] },
   cxsWithDischargeRequeryFeatureFlag: { enabled: false, values: [] },
   cxsWithDischargeSlackNotificationFeatureFlag: { enabled: false, values: [] },
   cxsWithXmlRedownloadFeatureFlag: { enabled: false, values: [] },

--- a/packages/core/src/command/feature-flags/types.ts
+++ b/packages/core/src/command/feature-flags/types.ts
@@ -41,6 +41,8 @@ export const cxBasedFFsSchema = z.object({
   cxsWithAthenaCustomFieldsEnabled: ffStringValuesSchema,
   cxsWithPcpVisitAiSummaryFeatureFlag: ffStringValuesSchema,
   cxsWithRecentVisitAiSummary: ffStringValuesSchema,
+  cxsWithCardiacCareAiSummary: ffStringValuesSchema,
+  cxsWithNitratesAndConditionsAiSummary: ffStringValuesSchema,
   cxsWithDischargeSlackNotificationFeatureFlag: ffStringValuesSchema,
   cxsWithDischargeRequeryFeatureFlag: ffStringValuesSchema,
   cxsWithXmlRedownloadFeatureFlag: ffStringValuesSchema,

--- a/packages/utils/src/customer-requests/medical-records-local-with-brief.ts
+++ b/packages/utils/src/customer-requests/medical-records-local-with-brief.ts
@@ -3,8 +3,10 @@ dotenv.config();
 // keep that ^ on top
 import { convertStringToBrief } from "@metriport/core/command/ai-brief/brief";
 import { getAiBriefContentFromBundle } from "@metriport/core/command/ai-brief/shared";
+import { FeatureFlags } from "@metriport/core/command/feature-flags/ffs-on-dynamodb";
 import { generateAiBriefBundleEntry } from "@metriport/core/domain/ai-brief/generate";
 import { bundleToHtml } from "@metriport/core/external/aws/lambda-logic/bundle-to-html";
+import { Config } from "@metriport/core/util/config";
 import { out } from "@metriport/core/util/log";
 import fs from "fs";
 
@@ -18,18 +20,27 @@ import fs from "fs";
  * To run this script:
  * - Set the `patientId`, `cxId` consts.
  * - Specify the path to the FHIR Bundle payload - the output of `GET /consolidated`).
+ * - Delete the ai summary from the underlying bundle.
  * - Make sure to set the env vars in addition the ones below this comment block:
+ *   - ENV_TYPE="dev"
+ *   - DYNAMODB_ENDPOINT=http://localhost:8000
  *   - BEDROCK_REGION
  *   - BEDROCK_VERSION
  *   - MR_BRIEF_MODEL_ID
+ *
+ * - NOTE: If an ai summary already exists in your bundle at `sourceFilePath`, this script
+ *   will use the pre-existing ai summary, so make sure to delete it from the underlying bundle.
  */
 
 const sourceFilePath = "";
 
 const cxId = "";
 const patientId = "";
+
 // Update this to staging or local URL if you want to test the brief link
-const dashUrl = "http://dash.metriport.com";
+const dashUrl = "";
+
+FeatureFlags.init(Config.getAWSRegion(), Config.getFeatureFlagsTableName());
 
 async function main() {
   if (!cxId || !patientId) throw new Error("cxId or patientId is missing");


### PR DESCRIPTION
### Dependencies

None

### Description

New AI summaries for custom CXs as described in these tickets:
- https://linear.app/metriport/issue/ENG-1285/enable-custom-ai-summary
- https://linear.app/metriport/issue/CS-2598/implement-ai-summary
- ?? There's a third one, having trouble finding it.

### Testing

- Local
  - [x] Run AI summary gen for each of 3 new cases.

### Release Notes

- [ ] Set cx FFs for different custom summaries
- [ ] Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI brief modes for Cardiac Care and Nitrates & Conditions, providing structured patient summaries when enabled.
  * Enhanced Recent Visit summaries with clearer sections; refined summaries now merge prior outputs while retaining structure.

* **Chores**
  * Introduced rollout controls to enable new AI brief modes per customer.
  * Initialized feature flags in the local medical-records script for consistent behavior.

* **Documentation**
  * Updated local script guidance to reflect feature-flag initialization and AI summary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->