### PR TITLE
RELEASE [step_2] tcm Viewer changes - api sort & multi select

### DIFF
--- a/packages/api/src/command/medical/tcm-encounter/__tests__/get-tcm-encounter.test.ts
+++ b/packages/api/src/command/medical/tcm-encounter/__tests__/get-tcm-encounter.test.ts
@@ -270,5 +270,245 @@ describe("TCM Encounter Commands", () => {
       const result = await getTcmEncounters(cmd);
       expect(result[0].outreachLogs).toEqual(outreachLogs);
     });
+
+    it("filters by multiple encounter classes", async () => {
+      const encounter = makeEncounter({
+        class: "emergency",
+        patient: makePatient({
+          patientData: {
+            firstName: "Jane",
+            lastName: "Smith",
+            dob: "1985-05-15",
+          },
+        }),
+      });
+
+      const mockQueryResult = [
+        {
+          ...encounter,
+          dataValues: {
+            ...encounter.dataValues,
+            patient_data: encounter.PatientModel.data,
+          },
+        },
+      ];
+
+      mockSequelize.query.mockResolvedValue(mockQueryResult);
+
+      const cmd = {
+        cxId: "cx-123",
+        encounterClass: ["emergency", "inpatient encounter"],
+        pagination: makePaginationWithCursor(),
+      };
+
+      const result = await getTcmEncounters(cmd);
+
+      expect(mockSequelize.query).toHaveBeenCalled();
+      const [queryString, queryOptions] = mockSequelize.query.mock.calls[0];
+      expect(queryString).toContain("tcm_encounter.class IN (:encounterClass)");
+      expect(queryOptions.replacements.encounterClass).toEqual([
+        "emergency",
+        "inpatient encounter",
+      ]);
+      expect(result).toEqual([
+        expect.objectContaining({
+          class: "emergency",
+          patientData: expect.objectContaining({
+            firstName: "Jane",
+            lastName: "Smith",
+          }),
+        }),
+      ]);
+    });
+
+    it("sorts by patient firstName ascending", async () => {
+      const encounter1 = makeEncounter({
+        id: "enc-1",
+        patient: makePatient({
+          patientData: {
+            firstName: "Alice",
+            lastName: "Johnson",
+            dob: "1990-01-01",
+          },
+        }),
+      });
+
+      const encounter2 = makeEncounter({
+        id: "enc-2",
+        patient: makePatient({
+          patientData: {
+            firstName: "Bob",
+            lastName: "Smith",
+            dob: "1985-05-15",
+          },
+        }),
+      });
+
+      const mockQueryResult = [
+        {
+          ...encounter1,
+          dataValues: {
+            ...encounter1.dataValues,
+            patient_data: encounter1.PatientModel.data,
+            patient_facility_ids: [],
+            patient_mappings: [],
+          },
+        },
+        {
+          ...encounter2,
+          dataValues: {
+            ...encounter2.dataValues,
+            patient_data: encounter2.PatientModel.data,
+            patient_facility_ids: [],
+            patient_mappings: [],
+          },
+        },
+      ];
+
+      mockSequelize.query.mockResolvedValue(mockQueryResult);
+
+      const cmd = {
+        cxId: "cx-123",
+        pagination: {
+          ...makePaginationWithCursor({
+            count: 10,
+          }),
+          orderByClause: "ORDER BY patient.data->>'firstName' ASC",
+        },
+      };
+
+      const result = await getTcmEncounters(cmd);
+
+      expect(mockSequelize.query).toHaveBeenCalled();
+      const [queryString] = mockSequelize.query.mock.calls[0];
+      expect(queryString).toContain("ORDER BY patient.data->>'firstName' ASC");
+      expect(result).toHaveLength(2);
+      expect(result[0].patientData.firstName).toBe("Alice");
+      expect(result[1].patientData.firstName).toBe("Bob");
+    });
+
+    it("sorts by patient lastName descending", async () => {
+      const encounter1 = makeEncounter({
+        id: "enc-1",
+        patient: makePatient({
+          patientData: {
+            firstName: "John",
+            lastName: "Zimmerman",
+            dob: "1990-01-01",
+          },
+        }),
+      });
+
+      const encounter2 = makeEncounter({
+        id: "enc-2",
+        patient: makePatient({
+          patientData: {
+            firstName: "Jane",
+            lastName: "Anderson",
+            dob: "1985-05-15",
+          },
+        }),
+      });
+
+      const mockQueryResult = [
+        {
+          ...encounter1,
+          dataValues: {
+            ...encounter1.dataValues,
+            patient_data: encounter1.PatientModel.data,
+            patient_facility_ids: [],
+            patient_mappings: [],
+          },
+        },
+        {
+          ...encounter2,
+          dataValues: {
+            ...encounter2.dataValues,
+            patient_data: encounter2.PatientModel.data,
+            patient_facility_ids: [],
+            patient_mappings: [],
+          },
+        },
+      ];
+
+      mockSequelize.query.mockResolvedValue(mockQueryResult);
+
+      const cmd = {
+        cxId: "cx-123",
+        pagination: {
+          ...makePaginationWithCursor({
+            count: 10,
+          }),
+          orderByClause: "ORDER BY patient.data->>'lastName' DESC",
+        },
+      };
+
+      const result = await getTcmEncounters(cmd);
+
+      expect(mockSequelize.query).toHaveBeenCalled();
+      const [queryString] = mockSequelize.query.mock.calls[0];
+      expect(queryString).toContain("ORDER BY patient.data->>'lastName' DESC");
+      expect(result).toHaveLength(2);
+      expect(result[0].patientData.lastName).toBe("Zimmerman");
+      expect(result[1].patientData.lastName).toBe("Anderson");
+    });
+
+    it("handles pagination with patient name sort fields", async () => {
+      const encounter = makeEncounter({
+        patient: makePatient({
+          patientData: {
+            firstName: "Charlie",
+            lastName: "Brown",
+            dob: "1992-03-10",
+          },
+        }),
+      });
+
+      const mockQueryResult = [
+        {
+          ...encounter,
+          dataValues: {
+            ...encounter.dataValues,
+            patient_data: encounter.PatientModel.data,
+            patient_facility_ids: [],
+            patient_mappings: [],
+          },
+        },
+      ];
+
+      mockSequelize.query.mockResolvedValue(mockQueryResult);
+
+      const cmd = {
+        cxId: "cx-123",
+        pagination: {
+          ...makePaginationWithCursor({
+            count: 10,
+            fromItem: {
+              clause: "AND (patient.data->>'firstName' >= :cursor_firstName_0)",
+              params: { cursor_firstName_0: "Charlie" },
+            },
+          }),
+          orderByClause: "ORDER BY patient.data->>'firstName' ASC",
+        },
+      };
+
+      const result = await getTcmEncounters(cmd);
+
+      expect(mockSequelize.query).toHaveBeenCalled();
+      const [queryString, queryOptions] = mockSequelize.query.mock.calls[0];
+      expect(queryString).toContain("ORDER BY patient.data->>'firstName' ASC");
+      expect(queryString).toContain("patient.data->>'firstName' >= :cursor_firstName_0");
+      expect(queryOptions.replacements).toMatchObject({
+        cursor_firstName_0: "Charlie",
+      });
+      expect(result).toEqual([
+        expect.objectContaining({
+          patientData: expect.objectContaining({
+            firstName: "Charlie",
+            lastName: "Brown",
+          }),
+        }),
+      ]);
+    });
   });
 });

--- a/packages/api/src/command/medical/tcm-encounter/get-tcm-encounters.ts
+++ b/packages/api/src/command/medical/tcm-encounter/get-tcm-encounters.ts
@@ -54,7 +54,7 @@ export async function getTcmEncounters({
   coding?: string;
   status?: string;
   pagination: PaginationV2WithQueryClauses;
-  encounterClass?: string;
+  encounterClass?: string[];
   search?: string;
 }): Promise<TcmEncounterResult[]> {
   const tcmEncounterTable = TcmEncounterModel.tableName;
@@ -111,7 +111,11 @@ export async function getTcmEncounters({
           : ""
       }
       ${coding === "cardiac" ? ` AND tcm_encounter.has_cardiac_code = true` : ""}
-      ${encounterClass ? ` AND tcm_encounter.class = :encounterClass` : ""}
+      ${
+        encounterClass !== undefined && encounterClass.length > 0
+          ? ` AND tcm_encounter.class IN (:encounterClass)`
+          : ""
+      }
       ${
         search
           ? ` AND (tcm_encounter.facility_name ILIKE :search OR CONCAT(patient.data->>'firstName', ' ', patient.data->>'lastName') ILIKE :search)`
@@ -189,7 +193,7 @@ export async function getTcmEncountersCount({
   coding?: string;
   status?: string;
   search?: string;
-  encounterClass?: string;
+  encounterClass?: string[];
 }): Promise<number> {
   const tcmEncounterTable = TcmEncounterModel.tableName;
   const patientTable = PatientModel.tableName;
@@ -227,7 +231,11 @@ export async function getTcmEncountersCount({
         : ""
     }
     ${coding === "cardiac" ? ` AND tcm_encounter.has_cardiac_code = true` : ""}
-    ${encounterClass ? ` AND tcm_encounter.class = :encounterClass` : ""}
+    ${
+      encounterClass !== undefined && encounterClass.length > 0
+        ? ` AND tcm_encounter.class IN (:encounterClass)`
+        : ""
+    }
     ${
       search
         ? ` AND (tcm_encounter.facility_name ILIKE :search OR CONCAT(patient.data->>'firstName', ' ', patient.data->>'lastName') ILIKE :search)`

--- a/packages/api/src/routes/medical/dtos/tcm-encounter-dto.ts
+++ b/packages/api/src/routes/medical/dtos/tcm-encounter-dto.ts
@@ -2,6 +2,8 @@ import { TcmEncounterResult } from "../../../command/medical/tcm-encounter/get-t
 
 export type TcmEncounterDTO = Omit<TcmEncounterResult, "patientData"> & {
   patientName: string;
+  patientFirstName: string;
+  patientLastName: string;
   patientDateOfBirth: string;
   patientPhoneNumbers: string[];
   patientStates: string[];
@@ -14,6 +16,8 @@ export function dtoFromTcmEncounter(queryResult: TcmEncounterResult): TcmEncount
   return {
     ...encounterData,
     patientName: patientData.firstName + " " + patientData.lastName,
+    patientFirstName: patientData.firstName,
+    patientLastName: patientData.lastName,
     patientDateOfBirth: patientData.dob,
     patientPhoneNumbers:
       patientData.contact?.flatMap(contact => (contact.phone ? [contact.phone] : [])) ?? [],

--- a/packages/api/src/routes/medical/tcm-encounter.ts
+++ b/packages/api/src/routes/medical/tcm-encounter.ts
@@ -4,6 +4,7 @@ import httpStatus from "http-status";
 import {
   getTcmEncounters,
   getTcmEncountersCount,
+  TcmEncounterResult,
 } from "../../command/medical/tcm-encounter/get-tcm-encounters";
 import { updateTcmEncounter } from "../../command/medical/tcm-encounter/update-tcm-encounter";
 import { requestLogger } from "../helpers/request-logger";
@@ -73,7 +74,7 @@ router.get(
     console.log("receiving fromItem cursor: ", query.fromItem);
     console.log("receiving toItem cursor: ", query.toItem);
 
-    const result = await paginatedV2({
+    const result = await paginatedV2<TcmEncounterResult>({
       request: req,
       additionalQueryParams,
       getItems: async pagination => {
@@ -92,9 +93,11 @@ router.get(
         });
       },
       allowedSortColumns: {
-        id: "tcm_encounter",
-        admitTime: "tcm_encounter",
-        dischargeTime: "tcm_encounter",
+        id: { type: "regular", table: "tcm_encounter", column: "id" },
+        admitTime: { type: "regular", table: "tcm_encounter", column: "admitTime" },
+        dischargeTime: { type: "regular", table: "tcm_encounter", column: "dischargeTime" },
+        patientFirstName: { type: "jsonb", table: "patient", sqlPath: "data->>'firstName'" },
+        patientLastName: { type: "jsonb", table: "patient", sqlPath: "data->>'lastName'" },
       },
       maxItemsPerPage: tcmEncounterMaxPageSize,
     });


### PR DESCRIPTION
Issues:

- https://linear.app/metriport/issue/ENG-1249

### Dependencies

- none 

### Description

- https://github.com/metriport/metriport/pull/4864

### Testing


Check each PR.

### Release Plan

- :warning: Points to `master`
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter TCM Encounters by multiple encounter classes using comma-separated or array query parameters.
  * Sort encounters by patientFirstName (ASC/DESC) and patientLastName, in addition to existing fields.
  * Cursor-based pagination now works seamlessly with name-based sorting.
  * API responses include patientFirstName and patientLastName fields in encounter items.
  * Next-page links preserve multi-value query parameters for consistent pagination across filtered/sorted views.

* **Tests**
  * Expanded test coverage for multi-class filtering, name-based sorting, and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->