### PR TITLE
ENG-1230 HIE Directory Entry View migration fix

### DIFF
--- a/packages/api/src/sequelize/migrations/2025-10-14_01_recreate-hie-directory-view.ts
+++ b/packages/api/src/sequelize/migrations/2025-10-14_01_recreate-hie-directory-view.ts
@@ -5,6 +5,7 @@ const hieViewName = "hie_directory_view";
 const cqViewName = "cq_directory_entry_view";
 const cwViewName = "cw_directory_entry_view";
 
+const commonWellManagingOrganizationId = "2.16.840.1.113883.3.3330.11";
 const dropHieViewSql = `DROP VIEW IF EXISTS ${hieViewName};`;
 
 const createHieViewSql = `
@@ -17,7 +18,7 @@ SELECT
   zip as zip_code,
   state,
   root_organization,
-  '2.16.840.1.113883.3.3330' as managing_organization_id,
+  ${commonWellManagingOrganizationId} as managing_organization_id,
   search_criteria,
   'COMMONWELL' as network
 FROM ${cwViewName} cw


### PR DESCRIPTION
Part of ENG-1275

### Description

- Added a default OID for `managing_organization_id` field on the HIE directory view migration
### Testing

- Local
  - [x] Migrate up and down a couple times

### Release Plan

- :warning: This contains a DB migration
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory view updated so the first branch now uses a fixed organization identifier for consistent directory results; the second branch remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->