### PR TITLE
Add heartbeat monitors for adts

### DIFF
--- a/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
+++ b/packages/core/src/command/hl7-notification/hl7-notification-webhook-sender-direct.ts
@@ -45,6 +45,7 @@ import {
   persistHl7MessageError,
   SupportedTriggerEvent,
 } from "./utils";
+import { sendHeartbeatToMonitoringService } from "../../external/monitoring/heartbeat";
 
 type HieConfig = { timezone: string };
 
@@ -422,6 +423,18 @@ export class Hl7NotificationWebhookSenderDirect implements Hl7NotificationWebhoo
             },
             posthogApiKey
           );
+        })(),
+        (async () => {
+          const heartBeatMonitorMap = Config.getHeartBeatMonitorMap();
+          const heartBeatMonitorUrl = heartBeatMonitorMap[hieName];
+          if (!heartBeatMonitorUrl) {
+            throw new MetriportError(
+              `Heartbeat monitor URL not found for HIE: ${hieName}`,
+              undefined,
+              { hieName, heartBeatMonitorMap: JSON.stringify(heartBeatMonitorMap) }
+            );
+          }
+          await sendHeartbeatToMonitoringService(heartBeatMonitorUrl);
         })(),
       ]);
     } catch (error) {

--- a/packages/core/src/command/hl7v2-subscriptions/types.ts
+++ b/packages/core/src/command/hl7v2-subscriptions/types.ts
@@ -54,6 +54,7 @@ export type HieConfig = {
   timezone: HieIanaTimezone;
   states: USState[];
   subscriptions: Hl7v2Subscription[];
+  checklyPingUrl?: string;
   cron: string;
   sftpConfig: HieSftpConfig;
   mapping: HiePatientRosterMapping;

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -514,4 +514,8 @@ export class Config {
   static getAiBriefBucketName(): string {
     return getEnvVarOrFail("AI_BRIEF_BUCKET_NAME");
   }
+
+  static getHeartBeatMonitorMap(): Record<string, string> {
+    return getEnvVarAsRecordOrFail("HEARTBEAT_MONITOR_MAP");
+  }
 }


### PR DESCRIPTION
Part of ENG-000

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/3406

### Description
Add heartbeat monitors for:
- Konza
- Lahie
- Alohr
- Bamboo
- HealthConnectTexas
- HieTexacPCC

### Testing
- Staging
  - [x] Send a hl7 notification msg to the mllp server and see if the new Checkly monitor picks it up.
 <img width="1451" height="67" alt="Screenshot 2025-10-20 at 7 21 49 PM" src="https://github.com/user-attachments/assets/3f8d7a20-e193-43a4-907c-749d35a7620e" />

- Production
  - [ ] Look at new checkly monitors to make sure they are gettings pings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added heartbeat monitoring for HL7 notification webhooks to track service health and uptime.
  * System now supports optional monitoring endpoint configuration for Health Information Exchange connections.
  * Monitoring executes automatically alongside existing analytics and reporting processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->