### PR TITLE
ENG-1304: fix format date

### DIFF
--- a/packages/api/src/external/carequality/document/shared.ts
+++ b/packages/api/src/external/carequality/document/shared.ts
@@ -8,7 +8,7 @@ import {
   type Coding,
 } from "@metriport/ihe-gateway-sdk";
 import { DocumentReferenceWithId, createDocReferenceContent } from "../../fhir/document";
-import { formatDate } from "../shared";
+import { formatDate, formatDatetime } from "../shared";
 
 const regex = /^(.+?)\^+(.+)$/;
 
@@ -54,8 +54,8 @@ export function cqToFHIR(
     ...(docRef.serviceStartTime || docRef.serviceStopTime
       ? {
           period: {
-            ...(docRef.serviceStartTime ? { start: formatDate(docRef.serviceStartTime) } : {}),
-            ...(docRef.serviceStopTime ? { end: formatDate(docRef.serviceStopTime) } : {}),
+            ...(docRef.serviceStartTime ? { start: formatDatetime(docRef.serviceStartTime) } : {}),
+            ...(docRef.serviceStopTime ? { end: formatDatetime(docRef.serviceStopTime) } : {}),
           },
         }
       : {}),

--- a/packages/api/src/external/carequality/shared.ts
+++ b/packages/api/src/external/carequality/shared.ts
@@ -133,6 +133,28 @@ export function formatDate(dateString: string | undefined): string | undefined {
   return undefined;
 }
 
+export function formatDatetime(dateString: string | undefined): string | undefined {
+  if (!dateString) return undefined;
+  const preprocessedDate = dateString.replace(/[-:TZ]/g, "");
+  const year = preprocessedDate.slice(0, 4);
+  const month = preprocessedDate.slice(4, 6);
+  const day = preprocessedDate.slice(6, 8);
+  const hour = preprocessedDate.slice(8, 10) || "00";
+  const minute = preprocessedDate.slice(10, 12) || "00";
+  const second = preprocessedDate.slice(12, 14) || "00";
+  const formattedDate = `${year}-${month}-${day}T${hour}:${minute}:${second}.000Z`;
+
+  try {
+    const date = new Date(formattedDate);
+    return date.toISOString();
+  } catch (error) {
+    const msg = "Error creating date object for document reference";
+    console.log(`${msg}: ${error}`);
+  }
+
+  return undefined;
+}
+
 export async function getCqInitiator(
   patient: Pick<Patient, "id" | "cxId">,
   facilityId?: string


### PR DESCRIPTION
### Dependencies

None

### Description

serviceStartTime + serviceEndTime were having their hour/minute/second granularity set to all 0s by the formatDate utility. This PR creates a similar formatDatetime utility that does not drop the hms granularity as this is relevant + real information about when the medical service provided took place, with h/m/s granularity.

### Testing

- Local
  - [x] Check that more granular period is created in the resulting docref for a patient
- Staging
  - [ ] Check that more granular period is created in the resulting docref for a patient
- Production
  - [ ] Check that more granular period is created in the resulting docref for a patient

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service period information now includes time components, providing enhanced scheduling precision beyond date-only data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->