### PR TITLE
ENG-1279: feat(fhir-converter): process nested observations in social history

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Sections/Social_History.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Social_History.hbs
@@ -31,22 +31,7 @@
                 {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
 					{{>References/Observation/subject.hbs ID=(generateUUID (toJsonString obsEntry.observation)) REF=(concat 'Patient/' patientId.Id)}},
 				{{/with}}
-                {{#if (toArray obsEntry.observation.author)}}
-                    {{#each (toArray obsEntry.observation.author) as |author|}}
-                        {{#if author.assignedAuthor}}
-                            {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=author.assignedAuthor) as |practitionerId|}}
-                                {{>Resources/Practitioner.hbs practitioner=author.assignedAuthor ID=practitionerId.Id}},
-                                {{>References/Observation/performer.hbs ID=(generateUUID (toJsonString obsEntry.observation)) REF=(concat 'Practitioner/' practitionerId.Id)}},
-                            {{/with}}
-                        {{/if}}
-                        {{#if author.assignedAuthor.representedOrganization}}
-                            {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=author.assignedAuthor.representedOrganization) as |orgId|}}
-                                {{>Resources/Organization.hbs org=author.assignedAuthor.representedOrganization ID=orgId.Id}},
-                                {{>References/Observation/performer.hbs ID=(generateUUID (toJsonString obsEntry.observation)) REF=(concat 'Organization/' orgId.Id)}},
-                            {{/with}}
-                        {{/if}}
-                    {{/each}}
-                {{/if}}
+                {{>Utils/ProcessObservationAuthors.hbs observation=obsEntry.observation observationJson=(toJsonString obsEntry.observation)}}
 
                 {{!-- LEVEL 2: Process first level of nested observations --}}
                 {{#each (toArray obsEntry.observation.entryRelationship) as |nestedEntry|}}
@@ -55,6 +40,10 @@
                         {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
                             {{>References/Observation/subject.hbs ID=(generateUUID (toJsonString nestedEntry.observation)) REF=(concat 'Patient/' patientId.Id)}},
                         {{/with}}
+                        {{>Utils/ProcessObservationAuthors.hbs observation=nestedEntry.observation observationJson=(toJsonString nestedEntry.observation)}}
+                        {{!-- Create bidirectional references between parent and this observation --}}
+                        {{>References/Observation/hasMember.hbs ID=(generateUUID (toJsonString obsEntry.observation)) REF=(concat 'Observation/' (generateUUID (toJsonString nestedEntry.observation)))}},
+                        {{>References/Observation/derivedFrom.hbs ID=(generateUUID (toJsonString nestedEntry.observation)) REF=(concat 'Observation/' (generateUUID (toJsonString obsEntry.observation)))}},
 
                         {{!-- LEVEL 3: Process second level of nested observations --}}
                         {{#each (toArray nestedEntry.observation.entryRelationship) as |doubleNestedEntry|}}
@@ -63,6 +52,11 @@
                                 {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
                                     {{>References/Observation/subject.hbs ID=(generateUUID (toJsonString doubleNestedEntry.observation)) REF=(concat 'Patient/' patientId.Id)}},
                                 {{/with}}
+                                {{>Utils/ProcessObservationAuthors.hbs observation=doubleNestedEntry.observation observationJson=(toJsonString doubleNestedEntry.observation)}}
+
+                                {{!-- Create bidirectional references between parent and this observation --}}
+                                {{>References/Observation/hasMember.hbs ID=(generateUUID (toJsonString nestedEntry.observation)) REF=(concat 'Observation/' (generateUUID (toJsonString doubleNestedEntry.observation)))}},
+                                {{>References/Observation/derivedFrom.hbs ID=(generateUUID (toJsonString doubleNestedEntry.observation)) REF=(concat 'Observation/' (generateUUID (toJsonString nestedEntry.observation)))}},
                             {{/if}}
                         {{/each}}
                     {{/if}}

--- a/packages/fhir-converter/src/templates/cda/Utils/ProcessObservationAuthors.hbs
+++ b/packages/fhir-converter/src/templates/cda/Utils/ProcessObservationAuthors.hbs
@@ -1,0 +1,51 @@
+{{!-- 
+  // ------------------------------------------------------------------------------------------------- 
+  // Copyright (c) 2022-present Metriport Inc.   
+  //  
+  // Licensed under AGPLv3. See LICENSE in the repo root for license information.
+  //  
+  // This file incorporates work covered by the following copyright and  
+  // permission notice:  
+  //  
+  //     Copyright (c) Microsoft Corporation. All rights reserved. 
+  //  
+  //     Permission to use, copy, modify, and/or distribute this software  
+  //     for any purpose with or without fee is hereby granted, provided  
+  //     that the above copyright notice and this permission notice appear  
+  //     in all copies.  
+  //  
+  //     THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL  
+  //     WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED  
+  //     WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE  
+  //     AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR  
+  //     CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS  
+  //     OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,  
+  //     NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN  
+  //     CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.  
+  // -------------------------------------------------------------------------------------------------
+--}}
+{{!-- 
+  Processes author elements for an observation and creates Practitioner/Organization resources 
+  with performer references.
+  
+  Parameters:
+  - observation: The observation object containing author elements
+  - observationJson: The stringified JSON of the observation for UUID generation
+--}}
+{{#if (toArray observation.author)}}
+    {{#each (toArray observation.author) as |author|}}
+        {{#if author.assignedAuthor}}
+            {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=author.assignedAuthor) as |practitionerId|}}
+                {{>Resources/Practitioner.hbs practitioner=author.assignedAuthor ID=practitionerId.Id}},
+                {{>References/Observation/performer.hbs ID=(generateUUID ../observationJson) REF=(concat 'Practitioner/' practitionerId.Id)}},
+            {{/with}}
+        {{/if}}
+        {{#if author.assignedAuthor.representedOrganization}}
+            {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=author.assignedAuthor.representedOrganization) as |orgId|}}
+                {{>Resources/Organization.hbs org=author.assignedAuthor.representedOrganization ID=orgId.Id}},
+                {{>References/Observation/performer.hbs ID=(generateUUID ../observationJson) REF=(concat 'Organization/' orgId.Id)}},
+            {{/with}}
+        {{/if}}
+    {{/each}}
+{{/if}}
+


### PR DESCRIPTION
### Dependencies

None

### Description

This PR fixes observations missing from conversions due to CCDA's support for hierarchical / nesting of entries. This digs 2 levels of nesting deep for entries embedded within the base or child entries for social history.

We should probably do this for other .hbs files - Vital_Signs.hbs , Procedures.hbs , Results.hbs all are clearly missing this. I'm not sure what resource types CCDA supports entryRelationships / nested entries, but we should support parsing nested items out of all of them. 

### Testing

See slack thread with before + after diff here: [link](https://metriport.slack.com/archives/C07GU9H37EK/p1760821264767999?thread_ts=1760818797.310249&cid=C07GU9H37EK)

- Local
  - [x] Run sample CCDA through FHIR converter 
  - [x] Fhir converter processes and results in some PHQ-2 data
  - [x] Fhir converter process and outputs valid references between resources in the hierarchy
  - [x] Fhir converter does not fail for the following test cases
    - Empty observation with no entry relationship
    - One level of nesting
    - Two levels of nesting
    - Single entryRelationship within a given observation
    - Multiple entryRelationships within a given observation
- [ ] Run fhir integration test
- Staging
  - [ ] Run sample CCDA through FHIR converter
- Production
  - [ ] Run sample CCDA through FHIR converter

### Metrics

Would be nice to quantify the data lift of this change across all bundles.

### Release Plan

- [ ] FHIR Integration Test ran with validation
- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved social-history observation conversion to correctly handle nested observations up to two levels, preserving identifiers and bidirectional references so hierarchical data is fully captured.
* **New Features**
  * Ensures authors/performers (practitioner or organization) are consistently captured and linked for top-level and nested observations during conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->