### PR TITLE
PATCH RELEASE Minor fixes for FHIR Normalization

### DIFF
--- a/packages/core/src/external/fhir/normalization/resources/observation.ts
+++ b/packages/core/src/external/fhir/normalization/resources/observation.ts
@@ -7,7 +7,7 @@ import {
 import { isLoincCoding } from "@metriport/shared/medical";
 import convert, { Unit } from "convert-units";
 import { cloneDeep } from "lodash";
-import { capture } from "../../../../util";
+import { capture, out } from "../../../../util";
 import {
   a1cUnitNormalizationMap,
   bmiPercentileUnitNormalizationMap,
@@ -86,18 +86,22 @@ const loincCodeToTargetCallbackFnMap = new Map<string, (unit: string) => string>
 ]);
 
 function getStandardObservationUnit(unit: string, map: Map<string, string>): string {
-  const normalized = unit.trim().toLowerCase().replace(/ /g, "");
+  const normalized = unit?.trim()?.toLowerCase().replace(/ /g, "");
   const standardUnit = map.get(normalized);
   if (!standardUnit) {
+    const { log } = out("getStandardObservationUnit");
+    const msg = `Detected unmapped Observation unit`;
+    const details = {
+      unit,
+      normalized,
+      map: Array.from(map.entries()),
+    };
+    log(`${msg}. Cause: ${JSON.stringify(details)}`);
     capture.message(`Detected unmapped Observation unit`, {
-      extra: {
-        unit,
-        normalized,
-        map,
-      },
+      extra: details,
       level: "warning",
     });
-    return unit.trim();
+    return unit?.trim();
   }
   return standardUnit;
 }

--- a/packages/core/src/external/fhir/normalization/resources/unit-maps.ts
+++ b/packages/core/src/external/fhir/normalization/resources/unit-maps.ts
@@ -99,6 +99,7 @@ export const gfrUnitNormalizationMap = new Map<string, string>([
 ]);
 
 export const a1cUnitNormalizationMap = new Map<string, string>([
+  ["%", "%"],
   ["%(non-diabetic)", "%"],
   ["%_a1c", "%"],
   ["%_hgb", "%"],


### PR DESCRIPTION
Part of ENG-1315

Signed-off-by: RamilGaripov <ramil@metriport.com>

Issues:

- https://linear.app/metriport/issue/ENG-1315

### Description

- Added standard unit for A1c as a recognized unit.. Can't believe it was missing 🤦‍♂️ 
- Improved logging/error reporting for unknown units

### Testing
- [x] Tested locally on normalization script 

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and diagnostics for unmapped observation units with detailed logging information.
  * Enhanced stability when processing observations with non-standard units.
  * Added support for percentage unit normalization in A1C measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->