### PR TITLE
ENG-630 Small adj on util script

### DIFF
--- a/packages/utils/src/sqs/process-dlq-xmls.ts
+++ b/packages/utils/src/sqs/process-dlq-xmls.ts
@@ -33,18 +33,18 @@ const converterUrl = getEnvVarOrFail("FHIR_CONVERTER_SERVER_URL");
 
 const filesToExclude: string[] = [];
 
+const numberOfParallelConversions = 10;
+const minJitterMillis = 500;
+const maxJitterMillis = 2_000;
 const LARGE_CHUNK_SIZE_IN_BYTES = 50_000_000;
-const axiosTimeoutSeconds = 30_000; // 30 seconds
+const axiosTimeoutSeconds = 30;
+
 const fhirConverter = axios.create({
   timeout: axiosTimeoutSeconds * 1_000,
   transitional: {
     clarifyTimeoutError: true,
   },
 });
-
-const numberOfParallelConversions = 10;
-const minJitterMillis = 500;
-const maxJitterMillis = 2_000;
 
 type ConversionResult = {
   fileName: string;


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4898
- Downstream: none

### Description

- missed fixing the timeout on axios for process-dlq-xmls (just a script)

### Testing

- Local
  - none
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Metrics

none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP timeout handling so stalled requests time out as intended (now 30s), improving reliability of remote calls.
* **Chores**
  * Tuned DLQ processing: limited parallel conversions and added jitter between retries to reduce spikes and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->