### PR TITLE
feat(ehr): hcc condition fitlering + enabling elation

### DIFF
--- a/packages/core/src/external/ehr/job/bundle/create-resource-diff-bundles/steps/compute/ehr-compute-resource-diff-bundles-direct.ts
+++ b/packages/core/src/external/ehr/job/bundle/create-resource-diff-bundles/steps/compute/ehr-compute-resource-diff-bundles-direct.ts
@@ -1,7 +1,7 @@
 import { Resource } from "@medplum/fhirtypes";
 import { errorToString, sleep } from "@metriport/shared";
 import { createBundleFromResourceList } from "@metriport/shared/interface/external/ehr/fhir-resource";
-import { EhrSource, EhrSources } from "@metriport/shared/interface/external/ehr/source";
+import { EhrSource } from "@metriport/shared/interface/external/ehr/source";
 import { getConsolidatedFile } from "../../../../../../../command/consolidated/consolidated-get";
 import { setJobEntryStatus } from "../../../../../../../command/job/patient/api/set-entry-status";
 import { computeResourcesXorAlongResourceType } from "../../../../../../../fhir-deduplication/compute-resources-xor";
@@ -223,8 +223,6 @@ async function shouldWriteBack({
 }): Promise<boolean> {
   if (!isSupportedWriteBackResourceType(resourceType)) return false;
   if (!isEhrSourceWithWriteBack(ehr)) return false;
-  /* TODO Remove once Elation is validated */
-  if (ehr !== EhrSources.athena) return false;
   if (!isEhrSourceWithSecondaryMappings(ehr)) return false;
   const mappingsSchema = ehrCxMappingSecondaryMappingsSchemaMap[ehr];
   if (!mappingsSchema) return false;

--- a/packages/core/src/external/ehr/job/bundle/write-back-bundles/ehr-write-back-resource-diff-bundles-direct.ts
+++ b/packages/core/src/external/ehr/job/bundle/write-back-bundles/ehr-write-back-resource-diff-bundles-direct.ts
@@ -64,6 +64,7 @@ import {
   getObservationObservedDate,
   getProcedureCptCode,
   isChronicCondition,
+  isHccCondition,
   isLab,
   isLabPanel,
   isVital,
@@ -433,6 +434,7 @@ export function shouldWriteBackResource({
     if (!isCondition(resource)) return false;
     const condition = resource;
     if (skipConditionChronicity(condition, writeBackFilters)) return false;
+    if (skipConditionHcc(condition, writeBackFilters)) return false;
     if (skipConditionStringFilters(ehr, condition, writeBackFilters)) return false;
     return true;
   } else if (writeBackResourceType === "lab") {
@@ -497,6 +499,17 @@ export function skipConditionChronicity(
   if (!chronicityFilter || chronicityFilter === "all") return false;
   if (isChronicCondition(condition) && chronicityFilter === "chronic") return false;
   if (!isChronicCondition(condition) && chronicityFilter === "non-chronic") return false;
+  return true;
+}
+
+export function skipConditionHcc(
+  condition: Condition,
+  writeBackFilters: WriteBackFiltersPerResourceType
+): boolean {
+  const hccFilter = writeBackFilters.problem?.hccFilter;
+  if (!hccFilter || hccFilter === "all") return false;
+  if (isHccCondition(condition) && hccFilter === "hcc") return false;
+  if (!isHccCondition(condition) && hccFilter === "non-hcc") return false;
   return true;
 }
 

--- a/packages/core/src/external/ehr/shared.ts
+++ b/packages/core/src/external/ehr/shared.ts
@@ -69,6 +69,7 @@ import { capture } from "../../util/notifications";
 import { uuidv7 } from "../../util/uuid-v7";
 import { S3Utils } from "../aws/s3";
 import { CONDITION_RELATED_URL } from "../fhir/shared/extensions/chronicity-extension";
+import { findHccExtension } from "../fhir/shared/extensions/hcc-extension";
 import { BundleType } from "./bundle/bundle-shared";
 import { createOrReplaceBundle } from "./bundle/command/create-or-replace-bundle";
 import { FetchBundleParams, fetchBundle } from "./bundle/command/fetch-bundle";
@@ -558,6 +559,12 @@ export function isChronicCondition(condition?: Condition): boolean {
     (e: Extension) => e.url === CONDITION_RELATED_URL
   );
   return chronicityExtension?.valueCoding?.code === "C" ? true : false;
+}
+
+export function isHccCondition(condition?: Condition): boolean {
+  if (!condition) return false;
+  const hccExtension = findHccExtension(condition.extension ?? []);
+  return hccExtension !== undefined;
 }
 
 export function getMedicationRxnormCoding(medication: Medication): Coding | undefined {

--- a/packages/shared/src/interface/external/ehr/shared.ts
+++ b/packages/shared/src/interface/external/ehr/shared.ts
@@ -32,6 +32,7 @@ export const writeBackFiltersPerResourceTypeSchema = z.object({
       latestOnly: z.boolean().optional(),
       earliestOnly: z.boolean().optional(),
       chronicityFilter: z.enum(["all", "chronic", "non-chronic"]).optional(),
+      hccFilter: z.enum(["all", "hcc", "non-hcc"]).optional(),
       relativeDateRange: relativeDateRangeSchema.optional(),
       disabled: z.boolean().optional(),
     })


### PR DESCRIPTION
Ref: ENG-1303

### Description

- adding hcc filtering for conditions
- turning on elation

### Testing

- Local
  - [ ] skipped
- Staging
  - [x] test run elation patient
- Sandbox
  - [ ] N/A
- Production
  - [ ] turn on elation writeback for CX

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HCC-based filtering for conditions during write-back operations, allowing users to filter by all conditions, HCC-only, or non-HCC-only.
  * Enabled write-back support for additional EHR sources beyond the previously supported system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->