### PR TITLE
ENG-000 Peek DLQ script stores unique pt IDs

### DIFF
--- a/packages/utils/src/sqs/peek-dlq-print-details.ts
+++ b/packages/utils/src/sqs/peek-dlq-print-details.ts
@@ -3,60 +3,48 @@ dotenv.config();
 // keep that ^ on top
 import { S3Utils } from "@metriport/core/external/aws/s3";
 import { executeAsynchronously } from "@metriport/core/util/concurrency";
-import { BadRequestError, errorToString, getEnvVarOrFail } from "@metriport/shared";
+import { BadRequestError, errorToString, getEnvVarOrFail, sleep } from "@metriport/shared";
 import { buildDayjs } from "@metriport/shared/common/date";
 import { SQS } from "aws-sdk";
-import fs from "fs";
-import path from "path";
+import { Command } from "commander";
+import * as fs from "fs";
+import * as path from "path";
 import { elapsedTimeAsStr } from "../shared/duration";
 
 /**
  * This script saves the details of the messages in the DLQ to a file.
+ * It assumes the messages are from the FHIR Converter DLQ, so the body contains the s3FileName and s3BucketName.
  *
  * Usage:
  * - set the `DLQ_URL` environment variable to the URL of the DLQ
- * - ts-node src/sqs/peek-dlq-print-details.ts     # peek all messages
- * - ts-node src/sqs/peek-dlq-print-details.ts 100 # peek 100 messages
+ * - ts-node src/sqs/peek-dlq-print-details.ts -m 100 # peeks 100 messages
+ * - ts-node src/sqs/peek-dlq-print-details.ts -d     # downloads files from S3
+ * - ts-node src/sqs/peek-dlq-print-details.ts        # peeks all messages
  */
 
 const dlqUrl = getEnvVarOrFail("DLQ_URL");
 const awsRegion = getEnvVarOrFail("AWS_REGION");
 
-const dirName = `runs/sqs/fhir-converter-dlq_${buildDayjs()
-  .toISOString()
-  .replace("T", "_")
-  .replace(":", "-")}`;
-
-const maxNumberOfMessagesPerQuery = 1;
 const numberOfParallelPeeks = 10;
 const numberOfParallelDownloadsFromS3 = 10;
-const maxMessagesToPeek = process.argv[2] ? parseInt(process.argv[2]) : undefined;
+const messagesToRetrievePerReceiveMsg = 10;
 
 /**
  * @deprecated Use @metriport/core instead
  */
-const sqs = new SQS({
-  apiVersion: "2012-11-05",
-  region: awsRegion,
-});
+const sqs = new SQS({ apiVersion: "2012-11-05", region: awsRegion });
 
 const s3Utils = new S3Utils(awsRegion);
 
-type GetMessageSQSParameters = SharedInternalGetMessageSQSParameters & {
-  /**
-   * How many messages to return per query, from 1 to 10. Defaults to 1.
-   */
-  maxNumberOfMessagesPerQuery?: number;
-  /**
-   * Maximum number of messages to return. Defaults to 10.
-   */
-  maxNumberOfMessages?: number;
-  /**
-   * Determines whether it should keep pooling until the queue is empty or `maxNumberOfMessages`
-   * has been reached. Defaults to false, which means it will only pool once.
-   */
-  poolUntilEmpty?: boolean;
-};
+const program = new Command();
+program
+  .name("peek-dlq-print-details")
+  .description("CLI to peek into DLQ messages and optionally download files from S3")
+  .option("-m, --max-messages <number>", "Maximum number of messages to peek")
+  .option("-d, --download-files", "Download files from S3", false)
+  .showHelpAfterError()
+  .action(main)
+  .parse();
 
 type MessageDetails = {
   messageId: string | undefined;
@@ -87,12 +75,28 @@ type DlqMessageAttributes = {
   };
 };
 
-async function peekIntoQueue() {
+async function main({
+  maxMessages,
+  downloadFiles,
+}: {
+  maxMessages: string;
+  downloadFiles: boolean;
+}) {
+  await sleep(50);
   const startedAt = Date.now();
   console.log(
     `###### Starting to peek into queue at ${buildDayjs(startedAt).toISOString()} ######`
   );
-  console.log(`Running with maxMessagesToPeek: ${maxMessagesToPeek}`);
+
+  const maxMessagesToPeek = maxMessages ? parseInt(maxMessages) : undefined;
+  console.log(
+    `Running with: maxMessagesToPeek: ${maxMessagesToPeek}, downloadFiles: ${downloadFiles}`
+  );
+
+  const dirName = `runs/sqs/fhir-converter-dlq_${buildDayjs()
+    .toISOString()
+    .replace("T", "_")
+    .replace(":", "-")}`;
 
   if (!fs.existsSync(dirName)) {
     fs.mkdirSync(dirName, { recursive: true });
@@ -103,27 +107,24 @@ async function peekIntoQueue() {
   console.log(`>>> Message count: ${messageCount}`);
 
   const messageDetailsMap = new Map<string, MessageDetails>();
+  const uniqueCxIdPatientIds = new Set<string>();
 
-  const messagesToPeek = Math.min(messageCount, maxMessagesToPeek ?? messageCount);
+  const messagesToPeek = Math.min(messageCount, maxMessagesToPeek ?? Number.MAX_SAFE_INTEGER);
+  const peekRequestCount = Math.ceil(messagesToPeek / messagesToRetrievePerReceiveMsg);
 
   console.log(`>>> Getting messages from source queue...`);
-  const tmpArr = Array.from({ length: messagesToPeek }, (_, i) => i + 1);
+  const loopArray = Array.from({ length: peekRequestCount }, (_, i) => i + 1);
   await executeAsynchronously(
-    tmpArr,
+    loopArray,
     async idx => {
-      console.log(`>>> Peek ${idx} of ${messagesToPeek}`);
-      const messagesOfRequest = await peekMessagesFromQueue(dlqUrl, {
-        maxNumberOfMessagesPerQuery,
-        maxNumberOfMessages: maxNumberOfMessagesPerQuery,
-      });
-
+      console.log(`Peek ${idx} of ${peekRequestCount}`);
+      const messagesOfRequest = await peekMessagesFromQueue(dlqUrl);
       if (!messagesOfRequest || !messagesOfRequest.length) {
         console.log(`>>> No messages found`);
         return;
       }
-
       messagesOfRequest.forEach(m => {
-        const attr = m.MessageAttributes as DlqMessageAttributes | undefined;
+        const attr = m.MessageAttributes as unknown as DlqMessageAttributes | undefined;
         if (!attr) return;
         const startedAt = attr.jobStartedAt?.StringValue ?? attr.startedAt?.StringValue;
         const patientId = attr.patientId?.StringValue;
@@ -131,6 +132,9 @@ async function peekIntoQueue() {
         const s3FileName = body.s3FileName;
         const s3BucketName = body.s3BucketName;
         if (!patientId || !startedAt || !s3FileName || !s3BucketName || !m.MessageId) return;
+
+        // Add cxId, patientId to unique set
+        uniqueCxIdPatientIds.add(`${attr.cxId?.StringValue ?? ""},${patientId}`);
 
         const details: MessageDetails = {
           messageId: m.MessageId,
@@ -153,27 +157,36 @@ async function peekIntoQueue() {
 
   const uniqueMessageDetails = Array.from(messageDetailsMap.values());
 
-  console.log(`>>> Downloading files from S3 for ${uniqueMessageDetails.length} messages...`);
-  const errors: unknown[] = [];
-  await executeAsynchronously(
-    uniqueMessageDetails,
-    async messageDetails => {
-      try {
-        await downloadFileFromS3(messageDetails, dirName);
-      } catch (error) {
-        errors.push(error);
-      }
-    },
-    {
-      numberOfParallelExecutions: numberOfParallelDownloadsFromS3,
-    }
-  );
+  // Store unique patient IDs to file
+  const patientIdsArray = Array.from(uniqueCxIdPatientIds).sort();
+  fs.writeFileSync(`${dirName}/patient_ids.csv`, ["cxId,patientId", ...patientIdsArray].join("\n"));
+  console.log(`>>> Saved ${patientIdsArray.length} unique patient IDs to patient_ids.txt`);
 
-  if (errors.length > 0) {
-    console.error(`>>> Failed to download files for ${errors.length} messages:`);
-    errors.forEach(error => {
-      console.error(errorToString(error));
-    });
+  if (downloadFiles) {
+    console.log(`>>> Downloading files from S3 for ${uniqueMessageDetails.length} messages...`);
+    const errors: unknown[] = [];
+    await executeAsynchronously(
+      uniqueMessageDetails,
+      async messageDetails => {
+        try {
+          await downloadFileFromS3(messageDetails, dirName);
+        } catch (error) {
+          errors.push(error);
+        }
+      },
+      {
+        numberOfParallelExecutions: numberOfParallelDownloadsFromS3,
+      }
+    );
+
+    if (errors.length > 0) {
+      console.error(`>>> Failed to download files for ${errors.length} messages:`);
+      errors.forEach(error => {
+        console.error(errorToString(error));
+      });
+    }
+  } else {
+    console.log(`>>> Skipping S3 file downloads (--download-files not specified)`);
   }
 
   // Also store a general summary of the messages in a file with the name of the output file.
@@ -190,50 +203,19 @@ async function peekIntoQueue() {
  * Reads messages from the queue, returns them, but does not remove them.
  * Only queries the queue once.
  */
-async function peekMessagesFromQueue(
-  queueUrl: string,
-  sqsParams: GetMessageSQSParameters
-): Promise<SQS.Message[]> {
-  return _getMessagesFromQueue(queueUrl, {
-    ...sqsParams,
-    visibilityTimeout: 1, // we don't want to leave them "in flight" after we peek into them
-  });
-}
-
-type SharedInternalGetMessageSQSParameters = {
-  maxNumberOfMessagesPerQuery?: number;
-  visibilityTimeout?: number;
-  waitTimeSeconds?: number;
-};
-type InternalGetMessageSQSParameters = SharedInternalGetMessageSQSParameters & {
-  maxNumberOfMessages?: number;
-};
-
-async function _getMessagesFromQueue(
-  queueUrl: string,
-  sqsParams: InternalGetMessageSQSParameters,
-  rollingResult: SQS.Message[] = []
-): Promise<SQS.Message[]> {
-  const { maxNumberOfMessages = 10, maxNumberOfMessagesPerQuery = 1 } = sqsParams;
-
-  const remainingMessagesToQuery = maxNumberOfMessages - rollingResult.length;
-  const maxMessagesOnQuery = Math.min(maxNumberOfMessagesPerQuery, remainingMessagesToQuery);
-  if (maxMessagesOnQuery <= 0) return rollingResult;
-
+async function peekMessagesFromQueue(queueUrl: string): Promise<SQS.Message[]> {
   const messageParams: SQS.Types.ReceiveMessageRequest = {
     QueueUrl: queueUrl,
-    MaxNumberOfMessages: maxMessagesOnQuery,
-    VisibilityTimeout: sqsParams.visibilityTimeout,
-    WaitTimeSeconds: sqsParams.waitTimeSeconds ?? 1,
+    MaxNumberOfMessages: messagesToRetrievePerReceiveMsg,
+    VisibilityTimeout: 1, // we don't want to leave them "in flight" after we peek into them
+    WaitTimeSeconds: 2, // Give it some time to get the messages
     AttributeNames: ["All"],
     MessageAttributeNames: ["All"],
   };
 
   const resultReceive = await sqs.receiveMessage(messageParams).promise();
   const messages = resultReceive.Messages ?? [];
-  const result = [...rollingResult, ...messages];
-
-  return result;
+  return messages;
 }
 
 /**
@@ -318,4 +300,4 @@ async function downloadFileFromS3(
   }
 }
 
-peekIntoQueue();
+export default program;


### PR DESCRIPTION
### Dependencies

none

### Description

Peek DLQ script stores unique pt IDs.

### Testing

- Local
  - [x] Run script against DLQ to get pt IDs
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Metrics

none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI flags for controlling message peeking: `--max-messages` to limit results and `--download-files` to optionally download S3 files.
  * Generates deduplicated customer and patient identifier exports in CSV and JSON formats.

* **Updates**
  * Refactored message retrieval logic with improved batch processing and deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->