### PR TITLE
ENG-000 Make reconversion-kickoff-loader to accept csv

### DIFF
--- a/packages/utils/src/document/reconversion-kickoff-loader.ts
+++ b/packages/utils/src/document/reconversion-kickoff-loader.ts
@@ -181,12 +181,9 @@ async function main() {
  * Loads data from a CSV file
  */
 async function loadDataFromCsvFile(path: string): Promise<{ patient_id: string; cx_id: string }[]> {
-  const records = await readCsv<{ cx_id: string; patient_id: string }>(path);
-  const patients = records.map(record => ({
-    cx_id: record.cx_id,
-    patient_id: record.patient_id,
-  }));
-  return patients;
+  const records = await readCsv<{ cx_id?: string; patient_id?: string }>(path);
+  const patients = records.filter(record => record.cx_id && record.patient_id);
+  return patients as { patient_id: string; cx_id: string }[];
 }
 
 /**
@@ -209,7 +206,9 @@ async function loadDataFromLargeJsonFile(
 }
 
 async function displayWarningAndConfirmationPrompt(payloadsLength: number) {
-  const msg = `You are about to send ${payloadsLength} messages to the reconversion kickoff queue, are you sure?`;
+  const msg =
+    `You are about to send ${payloadsLength} messages to the reconversion kickoff ` +
+    `queue, are you sure?`;
   console.log(msg);
   console.log("Are you sure you want to proceed?");
   const rl = readline.createInterface({

--- a/packages/utils/src/sqs/peek-dlq-print-details.ts
+++ b/packages/utils/src/sqs/peek-dlq-print-details.ts
@@ -163,7 +163,7 @@ async function main({
     `${dirName}/patient_ids.csv`,
     ["cx_id,patient_id", ...patientIdsArray].join("\n")
   );
-  console.log(`>>> Saved ${patientIdsArray.length} unique patient IDs to patient_ids.txt`);
+  console.log(`>>> Saved ${patientIdsArray.length} unique patient IDs to patient_ids.csv`);
 
   if (downloadFiles) {
     console.log(`>>> Downloading files from S3 for ${uniqueMessageDetails.length} messages...`);


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4908
- Downstream: none

### Description

Make reconversion-kickoff-loader to accept csv.

### Testing

- Local
  - [x] Trigger reconvert w/ CSV
- Staging
  - none
- Sandbox
  - none
- Production
  - none

### Metrics

none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV file input is now supported alongside JSON.
  * A confirmation prompt requires explicit approval before batch processing begins.
  * Basic input validation ensures required fields (file and start date) are provided before running.

* **Chores**
  * Exported patient IDs now use snake_case CSV headers and the output log references a .csv file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->