### PR TITLE
ENG-000 Revert Safer deploy to prod CICD

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -20,38 +20,13 @@ on:
       - "packages/lambdas/**"
       - "packages/terminology/**"
       - "packages/mllp-server/**"
-      - "packages/data-transformation/**"
   workflow_dispatch: # manually executed by a user
-    inputs:
-      ref:
-        description: "Branch to run the workflow on"
-        required: false
-        default: "master"
-        type: string
 
 jobs:
-  branch-validation:
-    name: validate branch
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Validate branch
-        run: |
-          if [ "${{ github.ref_name }}" != "master" ]; then
-            echo "❌ This workflow can only run on the 'master' branch. Current branch: ${{ github.ref_name }}"
-            echo "Please ensure you are running this workflow from the master branch."
-            exit 1
-          else
-            echo "✅ Running on master branch - proceeding with deployment"
-          fi
-
   files-changed:
     name: detect changes
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    needs: branch-validation
     # Map a step output to a job output
     outputs:
       api: ${{ steps.changes.outputs.api }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -22,37 +22,12 @@ on:
       - "packages/mllp-server/**"
       - "packages/data-transformation/**"
   workflow_dispatch: # manually executed by a user
-    inputs:
-      ref:
-        description: "Branch to run the workflow on"
-        required: false
-        default: "develop"
-        type: string
 
 jobs:
-  branch-validation:
-    name: validate branch
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Validate branch
-        run: |
-          if [ "${{ github.ref_name }}" != "develop" ]; then
-            echo "❌ This workflow can only run on the 'develop' branch. Current branch: ${{ github.ref_name }}"
-            echo "Please ensure you are running this workflow from the develop branch."
-            echo "If you want to deploy a different branch, you can use the 'branch to staging' workflow."
-            exit 1
-          else
-            echo "✅ Running on develop branch - proceeding with deployment"
-          fi
-
   files-changed:
     name: detect changes
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    needs: branch-validation
     # Map a step output to a job output
     outputs:
       api: ${{ steps.changes.outputs.api }}
@@ -78,13 +53,12 @@ jobs:
         with:
           filters: |
             api:
+              - "packages/shared/**"
               - "packages/api/**"
               - "packages/api-sdk/**"
               - "packages/commonwell-sdk/**"
               - "packages/ihe-gateway-sdk/**"
-              - "packages/infra/**"
               - "packages/core/**"
-              - "packages/shared/**"
               - "package*.json"
             mllp-server:
               - "packages/shared/**"
@@ -102,7 +76,6 @@ jobs:
               - "packages/fhir-converter/src/**"
               - "packages/fhir-converter/test/**"
               - "packages/fhir-converter/deploy/**"
-              - "packages/infra/**"
             terminology:
               - "packages/terminology/Dockerfile"
               - "packages/terminology/package*.json"


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/4801
- Downstream: none

### Description

Reverts https://github.com/metriport/metriport/pull/4801

This reverts commit 2c93ea18b2787bd3160c221b998ade140d8b940a, reversing
changes made to 29f63dcc3efc7913d3f0682a8038171b7907cf65.

### Testing

none

### Metrics

none

### Release Plan

- [ ] Merge this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Simplified production and staging deployment workflows by removing manual branch validation gates and unnecessary job dependencies, enabling more streamlined and efficient deployment processes.
* Expanded automated deployment trigger logic by including additional service paths in change detection, ensuring deployments are triggered appropriately for a comprehensive set of code modifications across services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->