### PR TITLE
fix(core): sort duplicate patient candidates by full timestamp instea…

### DIFF
--- a/packages/core/src/mpi/__tests__/get-patient-by-demo.test.ts
+++ b/packages/core/src/mpi/__tests__/get-patient-by-demo.test.ts
@@ -1,0 +1,105 @@
+import { PatientLoader } from "../../command/patient-loader";
+import { Patient, PatientData } from "../../domain/patient";
+import { getPatientByDemo } from "../get-patient-by-demo";
+
+const CX_ID = "cx-1";
+
+const sharedDemo: PatientData = {
+  firstName: "Jane",
+  lastName: "Doe",
+  dob: "1990-01-01",
+  genderAtBirth: "F",
+  personalIdentifiers: [{ type: "ssn", value: "999-99-9999" }],
+  address: [
+    {
+      addressLine1: "123 Main St",
+      city: "Springfield",
+      state: "IL",
+      zip: "62701",
+      country: "USA",
+    },
+  ],
+};
+
+function makePatient({
+  id,
+  createdAt,
+  ssn,
+}: {
+  id: string;
+  createdAt: Date;
+  ssn: string;
+}): Patient {
+  return {
+    id,
+    cxId: CX_ID,
+    facilityIds: ["facility-1"],
+    eTag: "etag",
+    createdAt,
+    updatedAt: createdAt,
+    data: {
+      firstName: "Jane",
+      lastName: "Doe",
+      dob: "1990-01-01",
+      genderAtBirth: "F",
+      personalIdentifiers: [{ type: "ssn", value: ssn }],
+      address: sharedDemo.address,
+    },
+  } as Patient;
+}
+
+function makePatientLoader(patients: Patient[]): PatientLoader {
+  async function getStatesFromPatientIds() {
+    return [];
+  }
+
+  async function getOneOrFail({ id, cxId }: { id: string; cxId: string }) {
+    const patient = patients.find(function (p) {
+      return p.id === id && p.cxId === cxId;
+    });
+    if (!patient) {
+      throw new Error(`Patient not found: ${id}`);
+    }
+    return patient;
+  }
+
+  async function findBySimilarityAcrossAllCxs() {
+    return patients;
+  }
+
+  async function findBySimilarity() {
+    return patients;
+  }
+
+  return {
+    getStatesFromPatientIds,
+    getOneOrFail,
+    findBySimilarityAcrossAllCxs,
+    findBySimilarity,
+  };
+}
+
+describe("getPatientByDemo", () => {
+  it("returns the oldest patient when multiple demographic matches exist", async () => {
+    const oldestPatient = makePatient({
+      id: "patient-oldest",
+      createdAt: new Date("2020-06-01T10:00:00.800Z"),
+      ssn: "111-11-1111",
+    });
+    const newerPatient = makePatient({
+      id: "patient-newer",
+      createdAt: new Date("2023-01-15T14:30:00.200Z"),
+      ssn: "222-22-2222",
+    });
+
+    const patientLoader = makePatientLoader([newerPatient, oldestPatient]);
+
+    const result = await getPatientByDemo({
+      cxId: CX_ID,
+      demo: sharedDemo,
+      patientLoader,
+    });
+
+    expect(result?.id).toBe("patient-oldest");
+  });
+});

--- a/packages/core/src/mpi/get-patient-by-demo.ts
+++ b/packages/core/src/mpi/get-patient-by-demo.ts
@@ -43,7 +43,7 @@ export async function getPatientByDemo({
   });
 
   foundPatients.sort(
-    (a: Patient, b: Patient) => a.createdAt.getMilliseconds() - b.createdAt.getMilliseconds()
+    (a: Patient, b: Patient) => a.createdAt.getTime() - b.createdAt.getTime()
   );
 
   // Convert patients to proper datatype


### PR DESCRIPTION
Ref: #4975

### Description

`getPatientByDemo` (packages/core/src/mpi/get-patient-by-demo.ts) sorts `foundPatients` using `createdAt.getMilliseconds()` instead of `createdAt.getTime()`. `getMilliseconds()` returns only the 0-999ms sub-second component of a timestamp, not epoch time, so when multiple demographic matches exist (same dob/genderAtBirth, pass Jaro-Winkler similarity, different identifiers), `useFirstMatchingPatient` can return an effectively arbitrary duplicate instead of the oldest/original patient.

This replaced a working `ORDER BY created_at ASC` from an earlier version (commit 87fa0f051f) during a same-day refactor (0caae2aeac) — looks like a straightforward typo, not intentional tie-breaking.

No caller (`createPatient`, `getOrCreateMetriportPatient`, `confirmEhrPatientDemographicsMatchMetriport`) narrows the candidate set to a single match before this sort runs, so it's reachable whenever true duplicate patients exist for a `cxId`.

Fix is a one-line change: `getMilliseconds()` → `getTime()`.

### Testing

- Local
  - [x] Added `packages/core/src/mpi/__tests__/get-patient-by-demo.test.ts`, reproducing the bug with an oldest patient whose timestamp has a smaller millisecond component than a newer patient's. Confirmed red on the old code (returns wrong patient), green on the fix.
  - [x] Ran the broader `mpi` test suite (`packages/core`) — 69 passing, no regressions. (`filter-patients.test.ts` fails in this environment on a pre-existing/unrelated workspace module resolution issue — `@metriport/api-sdk` not resolvable locally.)
  - [ ] Could not run `lint`/`typecheck` in this environment due to a broken local workspace install (`@metriport/eslint-plugin-eslint-rules` not resolvable).

### Release Plan

No DB migration, no API contract changes, no feature flags. This is a behavioral bugfix contained entirely within `packages/core`'s MPI matching logic — no staged rollout needed beyond normal review/merge.

### Note

I'm an external contributor (not on the Metriport team), so I don't have access to Linear or your internal environments — left those sections out. 

Happy to adapt this PR to whatever process you'd prefer, or split it up if useful.