### PR TITLE
fix(fhir-converter): emit valid occurrenceDateTime

### DIFF
--- a/packages/fhir-converter/src/templates/cda/Resources/ServiceRequest.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/ServiceRequest.hbs
@@ -40,7 +40,7 @@
         "intent": "original-order",
         "code":{{>DataType/CodeableConcept.hbs code=serviceEntry.code}},   
         "priority":"{{serviceEntry.priorityCode.displayName}}",
-        "occuranceDateTime":"{{formatAsDateTime serviceEntry.effectiveTime.value}}",
+        "occurrenceDateTime":"{{formatAsDateTime serviceEntry.effectiveTime.value}}",
     },
     "request":{
         "method":"PUT",


### PR DESCRIPTION
Issues:

- #4978
- https://linear.app/metriport/issue/ENG-3189

### Dependencies

- Upstream: none
- Downstream: none

### Description

- Correct the ServiceRequest date-time key from `occuranceDateTime` to the FHIR R4 field `occurrenceDateTime`.
- Prevent strict FHIR validators from rejecting converted ServiceRequest resources.

Closes #4978

### Testing

- [x] Confirmed the template emits `occurrenceDateTime` for `serviceEntry.effectiveTime.value`.
- [x] Confirmed the misspelled key is no longer present in the ServiceRequest template.
- [x] Ran `git diff --check`.
- [ ] Run E2E tests locally.

### Release Plan

- Ship with the normal FHIR converter release. No database, configuration, or infrastructure changes are required.